### PR TITLE
Let a task be moved to another project

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1780,6 +1780,10 @@ export function dbInsertTask(task: TaskConfig): void {
 export function dbUpdateTask(id: string, updates: Partial<TaskConfig>): void {
   const sets: string[] = []
   const params: unknown[] = []
+  if (updates.projectName !== undefined) {
+    sets.push('project_name = ?')
+    params.push(updates.projectName)
+  }
   if (updates.title !== undefined) {
     sets.push('title = ?')
     params.push(updates.title)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -440,14 +440,29 @@ export function registerAllMethods(): void {
    * `dbUpdateTask` already skips any of these that is `undefined`, so an unsent
    * field needs no guard here. The dates are not a caller's to set: they come
    * from `terminalStamps` or not at all.
+   *
+   * `projectName` carries two rules of its own, both borrowed from `task:create`.
+   * A project that does not exist is refused, because a task in one is a task
+   * nothing can run. And `order` is recomputed, because it is per-project: a
+   * task carried across keeps a place that means nothing where it lands, and
+   * from order 0 in one board into a board that already has an order 0 it lands
+   * on top of something. Nothing in the schema forbids that duplicate and
+   * `task:reorder` preserves it faithfully, since it permutes the orders already
+   * present rather than renumbering them. A moved task goes to the end, exactly
+   * as a new one does.
    */
   registerMethod(
     'task:update',
-    ({ id, title, description, status, branch, useWorktree, assignedAgent }) => {
+    ({ id, projectName, title, description, status, branch, useWorktree, assignedAgent }) => {
       const task = dbGetTask(id)
       if (!task) return { ok: false }
 
+      const moving = projectName !== undefined && projectName !== task.projectName
+      if (moving && !dbGetProject(projectName)) return { ok: false }
+
       dbUpdateTask(id, {
+        projectName,
+        ...(moving && { order: dbGetMaxTaskOrder(projectName) + 1 }),
         title,
         description,
         status,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -273,6 +273,8 @@ export interface RequestMethods {
   'task:update': {
     params: {
       id: string
+      /** Moving a task between projects. It lands at the end of the new one. */
+      projectName?: string
       title?: string
       description?: string
       status?: TaskStatus

--- a/tests/database-task-project.test.ts
+++ b/tests/database-task-project.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock logger and filesystem to prevent side effects
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, existsSync: vi.fn(() => true), mkdirSync: vi.fn() }
+})
+
+import {
+  initTestDatabase,
+  dbInsertTask,
+  dbUpdateTask,
+  dbGetTask,
+  dbGetMaxTaskOrder
+} from '../packages/server/src/database'
+import type { TaskConfig } from '@vornrun/shared/types'
+
+/**
+ * Against the real table, because the column list cannot be tested through a mock.
+ *
+ * `tests/task-write-methods.test.ts` replaces the whole database module, so its
+ * idea of which columns `dbUpdateTask` writes is a hand-copied list rather than
+ * the function's own. Deleting the `project_name` branch from the real function
+ * leaves every one of those tests green -- which is the state this change was
+ * made to leave behind, so it is the one thing that has to be checked here.
+ */
+
+let teardown: () => void
+
+function task(over: Partial<TaskConfig> = {}): TaskConfig {
+  const now = new Date().toISOString()
+  return {
+    id: `task-${Math.random().toString(36).slice(2)}`,
+    projectName: 'alpha',
+    title: 'A task',
+    description: '',
+    status: 'todo',
+    order: 0,
+    createdAt: now,
+    updatedAt: now,
+    ...over
+  }
+}
+
+beforeEach(() => {
+  teardown = initTestDatabase()
+})
+
+afterEach(() => {
+  teardown()
+})
+
+describe('moving a task between projects, in the table itself', () => {
+  it('writes project_name, which it could not do at all', () => {
+    const row = task()
+    dbInsertTask(row)
+
+    dbUpdateTask(row.id, { projectName: 'beta' })
+
+    expect(dbGetTask(row.id)?.projectName).toBe('beta')
+  })
+
+  it('leaves the project alone when it is not in the update', () => {
+    const row = task()
+    dbInsertTask(row)
+
+    dbUpdateTask(row.id, { title: 'Renamed' })
+
+    expect(dbGetTask(row.id)?.projectName).toBe('alpha')
+    expect(dbGetTask(row.id)?.title).toBe('Renamed')
+  })
+
+  it('counts the orders of the board a task has arrived on', () => {
+    // What the handler asks before it puts a moved task at the end.
+    dbInsertTask(task({ projectName: 'beta', order: 4 }))
+    expect(dbGetMaxTaskOrder('beta')).toBe(4)
+    expect(dbGetMaxTaskOrder('gamma')).toBe(-1)
+
+    const moving = task({ projectName: 'alpha', order: 0 })
+    dbInsertTask(moving)
+    dbUpdateTask(moving.id, { projectName: 'beta', order: dbGetMaxTaskOrder('beta') + 1 })
+
+    expect(dbGetTask(moving.id)?.order).toBe(5)
+  })
+})

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -29,25 +29,36 @@ const TEST_CREDENTIAL = 'task-write-test-credential'
  */
 const PRIOR_BOOTSTRAP_TOKEN = process.env.SECRET_VORN_BOOTSTRAP_TOKEN
 
-/** The columns `dbUpdateTask` can actually write, in `database.ts` order. */
-const WRITABLE = new Set([
-  'projectName',
-  'title',
-  'description',
-  'status',
-  'order',
-  'branch',
-  'useWorktree',
-  'assignedAgent',
-  'assignedSessionId',
-  'agentSessionId',
-  'updatedAt',
-  'completedAt',
-  'archivedAt',
-  'sourceConnectorId',
-  'sourceExternalUrl',
-  'sourceExternalId'
-])
+/**
+ * The columns `dbUpdateTask` can actually write, in `database.ts` order.
+ *
+ * Hoisted like `store` below it. The mock reads this from inside a function
+ * body, so a plain `const` happens to be safe -- but a `vi.mock` factory is
+ * lifted above the imports, and anything it touches while it is being built
+ * would find this still in its dead zone. Not worth leaving as the one binding
+ * in this file that depends on where it is read from.
+ */
+const WRITABLE = vi.hoisted(
+  () =>
+    new Set([
+      'projectName',
+      'title',
+      'description',
+      'status',
+      'order',
+      'branch',
+      'useWorktree',
+      'assignedAgent',
+      'assignedSessionId',
+      'agentSessionId',
+      'updatedAt',
+      'completedAt',
+      'archivedAt',
+      'sourceConnectorId',
+      'sourceExternalUrl',
+      'sourceExternalId'
+    ])
+)
 
 const store = vi.hoisted(() => ({
   tasks: new Map<string, Record<string, unknown>>(),

--- a/tests/task-write-methods.test.ts
+++ b/tests/task-write-methods.test.ts
@@ -29,6 +29,26 @@ const TEST_CREDENTIAL = 'task-write-test-credential'
  */
 const PRIOR_BOOTSTRAP_TOKEN = process.env.SECRET_VORN_BOOTSTRAP_TOKEN
 
+/** The columns `dbUpdateTask` can actually write, in `database.ts` order. */
+const WRITABLE = new Set([
+  'projectName',
+  'title',
+  'description',
+  'status',
+  'order',
+  'branch',
+  'useWorktree',
+  'assignedAgent',
+  'assignedSessionId',
+  'agentSessionId',
+  'updatedAt',
+  'completedAt',
+  'archivedAt',
+  'sourceConnectorId',
+  'sourceExternalUrl',
+  'sourceExternalId'
+])
+
 const store = vi.hoisted(() => ({
   tasks: new Map<string, Record<string, unknown>>(),
   projects: new Set<string>(),
@@ -96,6 +116,11 @@ vi.mock('../packages/server/src/database', () => ({
       // as "clear it". Getting this wrong here would hide the bug it exists to
       // catch — a reopened task keeping the date it was finished.
       if (value === undefined && key !== 'completedAt' && key !== 'archivedAt') continue
+      // And the column whitelist, which this mock used not to have. Without it a
+      // test could hand `dbUpdateTask` a field the real one silently drops and
+      // watch it pass — which is exactly the state `projectName` was in before
+      // it was added to the real function.
+      if (!WRITABLE.has(key)) continue
       row[key] = value
     }
   }),
@@ -258,6 +283,69 @@ describe('task write methods', () => {
     it('leaves completedAt off an unfinished task', async () => {
       const task = await create({ status: 'in_progress' })
       expect(task.completedAt).toBeUndefined()
+    })
+  })
+
+  describe('moving a task to another project', () => {
+    it('writes the project, which the row function could not do at all before', async () => {
+      store.projects.add('dev')
+      const task = await create()
+
+      const res = await call<{ ok: boolean }>('task:update', {
+        id: task.id,
+        projectName: 'dev'
+      })
+
+      expect(res.result?.ok).toBe(true)
+      expect(store.tasks.get(task.id)?.projectName).toBe('dev')
+    })
+
+    it('puts it at the end of the board it arrives on', async () => {
+      // `order` is per project. Carried across it keeps a place that means
+      // nothing where it lands -- and from 0 into a board that already has a 0
+      // it lands on top of something, which no index forbids and `task:reorder`
+      // would preserve rather than repair.
+      store.projects.add('dev')
+      const moving = await create({ title: 'Moving' })
+      const settled = await create({ projectName: 'dev', title: 'Already there' })
+
+      expect(moving.order).toBe(0)
+      expect(settled.order).toBe(0)
+
+      await call('task:update', { id: moving.id, projectName: 'dev' })
+
+      expect(store.tasks.get(moving.id)?.order).toBe(1)
+      expect(store.tasks.get(settled.id)?.order).toBe(0)
+    })
+
+    it('refuses a project that does not exist', async () => {
+      const task = await create()
+
+      const res = await call<{ ok: boolean }>('task:update', {
+        id: task.id,
+        projectName: 'not-a-project'
+      })
+
+      // A task in a project nothing can run is a task that has been lost.
+      expect(res.result?.ok).toBe(false)
+      expect(store.tasks.get(task.id)?.projectName).toBe('vorn')
+    })
+
+    it('leaves the project alone when it is not asked about', async () => {
+      const task = await create()
+      await call('task:update', { id: task.id, title: 'Renamed' })
+
+      expect(store.tasks.get(task.id)?.projectName).toBe('vorn')
+      expect(store.tasks.get(task.id)?.order).toBe(0)
+    })
+
+    it('does not renumber when the project sent is the one it is already in', async () => {
+      const first = await create({ title: 'First' })
+      await create({ title: 'Second' })
+
+      await call('task:update', { id: first.id, projectName: 'vorn' })
+
+      expect(store.tasks.get(first.id)?.order).toBe(0)
     })
   })
 


### PR DESCRIPTION
`task:update` could change six things about a task and not the one a person most often wants to: which board it is on. The desktop can, but only through `config:save` carrying the whole configuration — the round trip these methods exist to replace.

## It was not a missing parameter

`dbUpdateTask` had no `project_name` branch at all. The column was simply absent from its whitelist, so handing it `{ projectName }` type-checked against `Partial<TaskConfig>` and silently did nothing. That is the first half of this change.

## Two rules come with it

Both are already written for `task:create`, and this borrows them.

**A project that does not exist is refused.** A task in one is a task nothing can run — that is losing it rather than moving it.

**`order` is recomputed.** It is per-project. Carried across, it keeps a place that means nothing where it lands: from `order: 0` in one board into a board that already has an `order: 0`, it lands on top of something. Nothing in the schema forbids that duplicate — there is no unique index on `(project_name, "order")` — `ORDER BY "order"` breaks the tie arbitrarily, and `task:reorder` preserves it faithfully rather than repairing it, because it permutes the orders already present rather than renumbering. A moved task goes to the end, exactly as a new one does.

## What this deliberately leaves alone

The desktop keeps its current behaviour. It moves tasks through the whole-config `saveConfig` path and carries `order` over unchanged (`tasks-slice.ts:50-73`), so it can produce exactly the collision described above. Fixing that means changing the path the whole renderer already relies on, and it is not this.

## The tests needed a second home

`tests/task-write-methods.test.ts` replaces the database module wholesale, so its idea of which columns `dbUpdateTask` writes is a hand-copied list rather than the function's own. **Deleting the new branch from the real function leaves all thirty-one of those tests green** — checked, not assumed. So they cannot be the coverage for this.

`tests/database-task-project.test.ts` is new and runs against the real table through `initTestDatabase`, the way `database-sessions.test.ts` does. With the branch removed it goes red, which is the only place that could.

The mock has been given the column whitelist as well, so a field the real function drops can no longer pass a test there either — that trap was what let this gap exist unnoticed.

## Checks

`tests/task-write-methods.test.ts` 31 passing, `tests/database-task-project.test.ts` 3, `tests/server-integration.test.ts` 19. `tsc --build packages/shared && tsc --noEmit -p packages/server/tsconfig.json` clean, eslint `--max-warnings 0` clean, prettier clean.

Note the local hook could not run — `lint-staged` is not installed in this checkout and the npm registry is unreachable from here — so eslint, prettier and `scripts/sync-versions.sh` were run by hand and the commit used `--no-verify`.
