### PR TITLE
chore(release): 0.7.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.1",
+  "version": "0.7.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
A beta, not a minor: nothing here changes what the desktop does. It changes what everything else can do to a board.

## What is in it

**#487 — the socket can write a task, not only read one.** `task:list`, `task:get` and `task:setStatus` were the whole of the task protocol. Every client speaking the wire protocol — the phone and the web client both — could read a task and move it between columns, and nothing more. Creating, editing, reordering, archiving and deleting were reachable only through the MCP tools, which call the row helpers directly. That is the reason an agent could delete a task and a person on a phone could not.

The row helpers were never the missing piece. `dbInsertTask`, `dbUpdateTask`, `dbDeleteTask` and `dbGetMaxTaskOrder` have been in `database.ts` the whole time. This is plumbing: five thin wrappers — `task:create`, `task:update`, `task:delete`, `task:reorder`, `task:archive`.

**#488 — a task can be moved to another project.** The field the plumbing had left out. `task:update` could change six things about a task and not the one most often wanted: which board it is on. That was not a missing parameter — `dbUpdateTask` had no `project_name` branch at all, so passing it type-checked and wrote nothing. A move now refuses a project that does not exist, and recomputes `order`, which counts within a project and means nothing carried across.

## Two things worth knowing before running this beta against a real board

`task:reorder` deduplicates the ids it is handed. It permutes the orders already present rather than renumbering, so a repeated id used to hand two tasks the same one. That was found by brute force — 408 collisions in 3900 shuffles — not by reading the code.

The desktop still moves tasks the way it always has, through the whole-config save path, which carries `order` across unchanged. It can therefore still produce the collision the socket now avoids. Changing that means changing the path the renderer already relies on, and it is deliberately not in this release.

## Version

Root `package.json` to `0.7.0-beta.2`, with `scripts/sync-versions.sh` propagating it to the six workspace packages. No other file changes.

Tagging `v0.7.0-beta.2` after this merges is what publishes the prerelease.
