### PR TITLE
Give the server a port it keeps

### DIFF
--- a/packages/server/src/hook-installer.ts
+++ b/packages/server/src/hook-installer.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
-import { HOOK_OWNER_FILE, mayReleaseHooks, parseHookOwner } from './hook-ownership'
+import { mayReleaseHooks, readHookOwnerFile } from './hook-ownership'
 
 const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json')
 const VORN_HEADER = 'X-Vorn'
@@ -88,16 +88,11 @@ export function uninstallHooks(): void {
     // Only a registration we wrote. The old check compared ports, and only when
     // a port had been recorded — so an instance that never installed anything
     // fell straight through and removed the running app's entries on its way out.
-    let raw: string | null = null
-    try {
-      raw = fs.readFileSync(HOOK_OWNER_FILE, 'utf-8')
-    } catch {
-      // Gone, which is what our own shutdown leaves behind.
-    }
-
     if (
       !mayReleaseHooks({
-        owner: parseHookOwner(raw),
+        // Absent is what our own shutdown leaves behind, which `mayReleaseHooks`
+        // reads together with whether we installed anything at all.
+        owner: readHookOwnerFile(),
         selfPid: process.pid,
         installed: installedPort !== null
       })

--- a/packages/server/src/hook-installer.ts
+++ b/packages/server/src/hook-installer.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
+import { HOOK_OWNER_FILE, mayReleaseHooks, parseHookOwner } from './hook-ownership'
+
 const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json')
 const VORN_HEADER = 'X-Vorn'
 
@@ -77,24 +79,30 @@ export function installHooks(port: number, token: string): void {
   fs.writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2), 'utf-8')
 }
 
-const PORT_FILE = path.join(os.homedir(), '.vorn', 'port')
-
 let installedPort: number | null = null
 
 export function uninstallHooks(): void {
   try {
     if (!fs.existsSync(CLAUDE_SETTINGS_PATH)) return
 
-    // Don't remove hooks if another instance owns them.
-    // If port file is missing (already deleted by hookServer.stop()), compare
-    // against our own installed port — if we never installed, bail out.
-    if (installedPort !== null) {
-      try {
-        const currentPort = fs.readFileSync(PORT_FILE, 'utf-8').trim()
-        if (currentPort !== String(installedPort)) return
-      } catch {
-        // Port file already deleted (our shutdown) or missing — safe to proceed
-      }
+    // Only a registration we wrote. The old check compared ports, and only when
+    // a port had been recorded — so an instance that never installed anything
+    // fell straight through and removed the running app's entries on its way out.
+    let raw: string | null = null
+    try {
+      raw = fs.readFileSync(HOOK_OWNER_FILE, 'utf-8')
+    } catch {
+      // Gone, which is what our own shutdown leaves behind.
+    }
+
+    if (
+      !mayReleaseHooks({
+        owner: parseHookOwner(raw),
+        selfPid: process.pid,
+        installed: installedPort !== null
+      })
+    ) {
+      return
     }
 
     const settings = JSON.parse(fs.readFileSync(CLAUDE_SETTINGS_PATH, 'utf-8'))

--- a/packages/server/src/hook-ownership.ts
+++ b/packages/server/src/hook-ownership.ts
@@ -1,0 +1,86 @@
+import path from 'node:path'
+import os from 'node:os'
+
+/**
+ * Which instance owns the hook registration, when more than one is running.
+ *
+ * Vorn writes its hook endpoint into `~/.claude/settings.json`, and the entry
+ * carries a port and a bearer token the hook server generates per process. There
+ * is exactly one such registration and any number of servers that might write it:
+ * a dev server started beside the packaged app shares `~/.vorn` and `~/.claude`
+ * with it, the way it already shares the database.
+ *
+ * Unowned, that ends badly in three ways, all of them observed rather than
+ * imagined. The second instance overwrote the registration with its own port and
+ * token, so the app the person was actually using stopped receiving hooks. Killed
+ * before it could tidy up, it left the settings pointing at a dead port with a
+ * token no live server would accept — and the owning token is a `randomUUID` held
+ * in memory, so nothing on disk could repair it. And on a clean exit it removed
+ * the registration wholesale, including entries it had never written.
+ *
+ * The rule is the one `startServer` already applies to the `ws-port` file: a
+ * record naming a live process that is not us means we keep our hands off. A
+ * record naming a dead one is stale and can be taken.
+ *
+ * Kept in its own file, beside the port file rather than inside it, because the
+ * port file's format is not ours to change: `copilot-hook-installer` bakes
+ * `+readFileSync(portFile).trim()` into scripts that are written out to another
+ * tool's configuration, where an old one goes on reading a file a new Vorn wrote.
+ */
+export interface HookOwner {
+  port: number
+  pid: number
+}
+
+export const HOOK_OWNER_FILE = path.join(os.homedir(), '.vorn', 'hook-owner')
+
+/** The record, or null for absent, unreadable or malformed — all "unowned". */
+export function parseHookOwner(raw: string | null | undefined): HookOwner | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<HookOwner>
+    if (typeof parsed?.port !== 'number' || typeof parsed?.pid !== 'number') return null
+    return { port: parsed.port, pid: parsed.pid }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether this process may write the hook registration.
+ *
+ * `isAlive` is injected rather than called here so the decision can be tested
+ * without spawning anything — and because probing a pid is `process.kill(pid, 0)`,
+ * which reads as sending a signal and deserves to be named at the call site.
+ */
+export function mayClaimHooks(input: {
+  owner: HookOwner | null
+  selfPid: number
+  isAlive: (pid: number) => boolean
+}): boolean {
+  const { owner, selfPid, isAlive } = input
+  if (!owner) return true
+  if (owner.pid === selfPid) return true
+  return !isAlive(owner.pid)
+}
+
+/**
+ * Whether this process may remove the hook registration on the way out.
+ *
+ * `installed` is the half that was missing and is why a second instance used to
+ * strip the registration it had never written: the old check only compared ports
+ * when a port had been recorded, and fell through to removing everything when one
+ * had not.
+ */
+export function mayReleaseHooks(input: {
+  owner: HookOwner | null
+  selfPid: number
+  installed: boolean
+}): boolean {
+  const { owner, selfPid, installed } = input
+  if (!installed) return false
+  // Our own `stop()` deletes the record before this runs, so an absent one is the
+  // ordinary shutdown order rather than evidence of somebody else.
+  if (!owner) return true
+  return owner.pid === selfPid
+}

--- a/packages/server/src/hook-ownership.ts
+++ b/packages/server/src/hook-ownership.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 
@@ -43,6 +44,33 @@ export function parseHookOwner(raw: string | null | undefined): HookOwner | null
     return { port: parsed.port, pid: parsed.pid }
   } catch {
     return null
+  }
+}
+
+/** The record on disk, or null for absent, unreadable or malformed. */
+export function readHookOwnerFile(): HookOwner | null {
+  try {
+    return parseHookOwner(fs.readFileSync(HOOK_OWNER_FILE, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether a pid belongs to a process that still exists.
+ *
+ * `EPERM` means it does and we are not allowed to signal it — a Vorn running as
+ * another user. Reading that as "dead", which any bare try/catch around
+ * `process.kill` does, is the one error here that loses data: it would claim the
+ * registration out from under a live instance, which is the whole failure this
+ * file exists to prevent.
+ */
+export function pidIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0) // a probe, not a signal
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
   }
 }
 

--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -6,6 +6,7 @@ import crypto from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import { HookEvent } from '@vornrun/shared/types'
 import log from './logger'
+import { HOOK_OWNER_FILE, mayClaimHooks, parseHookOwner } from './hook-ownership'
 
 const PORT_FILE = path.join(os.homedir(), '.vorn', 'port')
 const TOKEN_FILE = path.join(os.homedir(), '.vorn', 'token')
@@ -22,6 +23,14 @@ export class HookServer extends EventEmitter {
   private server: http.Server | null = null
   private pendingPermissions = new Map<string, PendingPermission>()
   private port = 0
+  /**
+   * Whether this process wrote the shared hook files, and so may remove them.
+   *
+   * A second Vorn on the same data directory still runs a hook server — it needs
+   * one if it ever becomes the owner — but it does not advertise itself over the
+   * instance the person is using.
+   */
+  private owner = false
   private authToken: string
 
   constructor() {
@@ -97,8 +106,7 @@ export class HookServer extends EventEmitter {
           const addr = this.server!.address()
           if (typeof addr === 'object' && addr) {
             this.port = addr.port
-            this.writePortFile()
-            this.writeTokenFile()
+            this.claim()
             resolve(this.port)
           } else {
             reject(new Error('Failed to get server address'))
@@ -223,6 +231,63 @@ export class HookServer extends EventEmitter {
     }
   }
 
+  /** Whether this instance is the one registered in `~/.claude/settings.json`. */
+  ownsRegistration(): boolean {
+    return this.owner
+  }
+
+  /**
+   * Take the shared hook files, unless a live instance already holds them.
+   *
+   * Everything a hook needs to reach this server — the port, the token, and the
+   * settings entry that names both — describes exactly one process. Writing them
+   * while another Vorn is running is what silently redirected its hooks here.
+   */
+  private claim(): void {
+    let raw: string | null = null
+    try {
+      raw = fs.readFileSync(HOOK_OWNER_FILE, 'utf-8')
+    } catch {
+      // Absent or unreadable, which reads as unowned.
+    }
+
+    const owner = parseHookOwner(raw)
+    this.owner = mayClaimHooks({
+      owner,
+      selfPid: process.pid,
+      isAlive: (pid) => {
+        try {
+          process.kill(pid, 0) // a probe, not a signal — throws if the pid is gone
+          return true
+        } catch {
+          return false
+        }
+      }
+    })
+
+    if (!this.owner) {
+      log.info(
+        `[hooks] another Vorn (pid ${owner?.pid}) owns the hook registration on port ` +
+          `${owner?.port}, so this server listens on ${this.port} without claiming it`
+      )
+      return
+    }
+
+    this.writeOwnerFile()
+    this.writePortFile()
+    this.writeTokenFile()
+  }
+
+  private writeOwnerFile(): void {
+    const dir = path.dirname(HOOK_OWNER_FILE)
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(
+      HOOK_OWNER_FILE,
+      JSON.stringify({ port: this.port, pid: process.pid }),
+      'utf-8'
+    )
+  }
+
   private writePortFile(): void {
     const dir = path.dirname(PORT_FILE)
     if (!fs.existsSync(dir)) {
@@ -249,19 +314,20 @@ export class HookServer extends EventEmitter {
     this.server?.close()
     this.server = null
 
-    try {
-      if (fs.existsSync(PORT_FILE)) {
-        fs.unlinkSync(PORT_FILE)
+    // Only what we wrote. These files name one live server, and deleting another
+    // instance's copies left the running app advertising a port and a token that
+    // nothing was listening on.
+    if (!this.owner) return
+    this.owner = false
+
+    for (const file of [PORT_FILE, TOKEN_FILE, HOOK_OWNER_FILE]) {
+      try {
+        if (fs.existsSync(file)) {
+          fs.unlinkSync(file)
+        }
+      } catch {
+        /* ignore */
       }
-    } catch {
-      /* ignore */
-    }
-    try {
-      if (fs.existsSync(TOKEN_FILE)) {
-        fs.unlinkSync(TOKEN_FILE)
-      }
-    } catch {
-      /* ignore */
     }
   }
 }

--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -6,7 +6,7 @@ import crypto from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import { HookEvent } from '@vornrun/shared/types'
 import log from './logger'
-import { HOOK_OWNER_FILE, mayClaimHooks, parseHookOwner } from './hook-ownership'
+import { HOOK_OWNER_FILE, mayClaimHooks, pidIsAlive, readHookOwnerFile } from './hook-ownership'
 
 const PORT_FILE = path.join(os.homedir(), '.vorn', 'port')
 const TOKEN_FILE = path.join(os.homedir(), '.vorn', 'token')
@@ -244,26 +244,8 @@ export class HookServer extends EventEmitter {
    * while another Vorn is running is what silently redirected its hooks here.
    */
   private claim(): void {
-    let raw: string | null = null
-    try {
-      raw = fs.readFileSync(HOOK_OWNER_FILE, 'utf-8')
-    } catch {
-      // Absent or unreadable, which reads as unowned.
-    }
-
-    const owner = parseHookOwner(raw)
-    this.owner = mayClaimHooks({
-      owner,
-      selfPid: process.pid,
-      isAlive: (pid) => {
-        try {
-          process.kill(pid, 0) // a probe, not a signal — throws if the pid is gone
-          return true
-        } catch {
-          return false
-        }
-      }
-    })
+    const owner = readHookOwnerFile()
+    this.owner = mayClaimHooks({ owner, selfPid: process.pid, isAlive: pidIsAlive })
 
     if (!this.owner) {
       log.info(
@@ -314,11 +296,21 @@ export class HookServer extends EventEmitter {
     this.server?.close()
     this.server = null
 
-    // Only what we wrote. These files name one live server, and deleting another
+    // Only what we wrote, confirmed against the record rather than against a flag
+    // we set at startup. These files name one live server, and deleting another
     // instance's copies left the running app advertising a port and a token that
-    // nothing was listening on.
+    // nothing was listening on -- so if the record has moved on, it is not ours
+    // to clear.
+    const owner = readHookOwnerFile()
     if (!this.owner) return
     this.owner = false
+    if (owner && owner.pid !== process.pid) {
+      log.info(
+        `[hooks] the registration is now held by pid ${owner.pid}, so this server ` +
+          'left the shared files alone'
+      )
+      return
+    }
 
     for (const file of [PORT_FILE, TOKEN_FILE, HOOK_OWNER_FILE]) {
       try {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,7 +17,8 @@ import { registerAllMethods, setServerPort } from './register-methods'
 import { configManager } from './config-manager'
 import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
 import { getDataDir } from './database'
-import { parseServerArgs } from './server-args'
+import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
+import { DEFAULT_SERVER_PORT } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
@@ -259,26 +260,50 @@ export async function startServer(
   void refreshTrustedOrigins()
 
   // Keep the same port across restarts. A browser keys localStorage by origin, so
-  // an ephemeral port hands a paired device a new origin every launch and its
-  // token goes with it — the user would experience that as Vorn forgetting them.
-  // An explicit --port always wins; otherwise take the remembered one, falling
-  // back if something else has claimed it meanwhile.
-  const preferredPort = options.port ?? config.defaults.serverPort ?? 0
+  // a moving port hands a paired device a new origin every launch and its token
+  // goes with it — the user would experience that as Vorn forgetting them. An
+  // explicit --port always wins; otherwise take the remembered one, or the
+  // default on a first run, falling back only if something else holds it.
+  const wantedPort = resolveServerPort({
+    explicit: options.port,
+    remembered: config.defaults.serverPort,
+    fallback: DEFAULT_SERVER_PORT
+  })
+  let fellBack = false
   try {
-    await app.listen({ host, port: preferredPort })
+    await app.listen({ host, port: wantedPort })
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE' || preferredPort === 0) throw err
-    log.warn(`[server] port ${preferredPort} is in use, taking another`)
+    if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE' || wantedPort === 0) throw err
+    fellBack = true
     await app.listen({ host, port: 0 })
   }
 
   const address = app.server.address()
-  const actualPort = typeof address === 'object' && address ? address.port : preferredPort
+  const actualPort = typeof address === 'object' && address ? address.port : wantedPort
+
+  if (fellBack) {
+    // Said in full rather than as "taking another", because this is the line that
+    // explains why a paired phone or a signed-in browser has just stopped
+    // working: the origin moved. Two Vorn instances on one data directory is the
+    // ordinary cause, a dev server beside the packaged app.
+    log.warn(
+      `[server] port ${wantedPort} is held by something else, so this server took ` +
+        `${actualPort} instead. Anything paired to ${wantedPort} must be pointed at the new port.`
+    )
+  }
 
   // Remember it, so the next launch is the same origin. Written straight to the
   // database rather than through notifyChanged: a config broadcast here would
   // re-enter checkAndRebind during startup.
-  if (!options.port && config.defaults.serverPort !== actualPort) {
+  //
+  // `shouldRememberPort` carries the rule, including why a fallback port is
+  // written on a first run and withheld from an install that already has one.
+  const remember = shouldRememberPort({
+    explicit: options.port,
+    remembered: config.defaults.serverPort,
+    fellBack
+  })
+  if (remember && config.defaults.serverPort !== actualPort) {
     try {
       configManager.saveConfig({
         ...config,
@@ -389,7 +414,7 @@ const isDirectRun =
 if (isDirectRun) {
   const { host, port, dataDir } = parseServerArgs(process.argv.slice(2))
 
-  startServer({ port: port ?? 0, host, dataDir })
+  startServer({ port, host, dataDir })
     .then(({ port: actualPort }) => {
       // This entry point is the one Electron forks, and its launcher blocks on
       // reading this line to learn where to connect. It belongs here rather than

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1582,7 +1582,15 @@ export function registerAllMethods(): void {
     .start()
     .then((port) => {
       try {
-        installHooks(port, hookServer.getAuthToken())
+        // Only the instance that claimed the shared hook files writes the
+        // settings entry that points at them. A dev server beside the packaged
+        // app used to redirect its hooks here and, killed before it could tidy
+        // up, leave them pointing at a port with no server behind it.
+        if (hookServer.ownsRegistration()) {
+          installHooks(port, hookServer.getAuthToken())
+        } else {
+          log.info('[hooks] another Vorn owns the registration; leaving it alone')
+        }
       } catch (err) {
         log.error({ err }, '[hooks] failed to install hooks:')
       }

--- a/packages/server/src/server-args.ts
+++ b/packages/server/src/server-args.ts
@@ -98,9 +98,16 @@ export function parseServerArgs(argv: string[]): ServerArgs {
  */
 export function resolveServerPort(input: {
   /** `--port`, which a person typed and which therefore wins. */
-  explicit?: number
-  /** `defaults.serverPort` — the port this install last settled on. */
-  remembered?: number
+  explicit?: number | null
+  /**
+   * `defaults.serverPort` — the port this install last settled on.
+   *
+   * Null is in the type because it is in the data: defaults are read back through
+   * `JSON.parse(row.value)`, so a stored JSON null arrives as one. Declaring only
+   * `number | undefined` would have made every caller that knows better reach for
+   * a cast, which is a worse way to say the same thing.
+   */
+  remembered?: number | null
   /** The constant, so a first run is predictable rather than random. */
   fallback: number
 }): number {
@@ -143,8 +150,8 @@ export function resolveServerPort(input: {
  *   and the install settles on it.
  */
 export function shouldRememberPort(input: {
-  explicit?: number
-  remembered?: number
+  explicit?: number | null
+  remembered?: number | null
   fellBack: boolean
 }): boolean {
   if (input.explicit != null) return false

--- a/packages/server/src/server-args.ts
+++ b/packages/server/src/server-args.ts
@@ -104,8 +104,15 @@ export function resolveServerPort(input: {
   /** The constant, so a first run is predictable rather than random. */
   fallback: number
 }): number {
-  if (input.explicit !== undefined) return input.explicit
-  if (input.remembered !== undefined) return input.remembered
+  // `!= null`, not `!== undefined`. Defaults are read back through
+  // `JSON.parse(row.value)`, so a stored JSON null arrives as `null` and would
+  // pass a strict undefined check — then reach `listen()` as a port, which is how
+  // you get an ephemeral one from a value that was meant to say "nothing set".
+  // The `??` chain this replaces tolerated null, and dropping that would have
+  // been a quiet narrowing. An explicit `0` survives either way, which is the
+  // distinction that matters.
+  if (input.explicit != null) return input.explicit
+  if (input.remembered != null) return input.remembered
   return input.fallback
 }
 
@@ -140,7 +147,7 @@ export function shouldRememberPort(input: {
   remembered?: number
   fellBack: boolean
 }): boolean {
-  if (input.explicit !== undefined) return false
+  if (input.explicit != null) return false
   if (!input.fellBack) return true
-  return input.remembered === undefined
+  return input.remembered == null
 }

--- a/packages/server/src/server-args.ts
+++ b/packages/server/src/server-args.ts
@@ -79,3 +79,68 @@ export function parseServerArgs(argv: string[]): ServerArgs {
     positionals
   }
 }
+
+/**
+ * Which port to ask for, and whether the answer is worth remembering.
+ *
+ * Extracted from `startServer` for the reason `parseServerArgs` above it was:
+ * the decision was inline in a function that boots a database, a scheduler and a
+ * websocket server, so it could not be tested, and it was wrong for as long as
+ * it existed. The direct-run entry point passed `port ?? 0`, which turned "no
+ * flag given" into an explicit zero — and `0 ?? remembered` is `0`, because `??`
+ * only falls through on null and undefined. The remembered port was written on
+ * every launch and read on none.
+ *
+ * That mattered because a browser keys `localStorage` by origin. A port that
+ * moves hands the web client a new origin and its stored token stays behind at
+ * the old one, which a person experiences as Vorn forgetting them. A phone
+ * paired to `ws://host:port/ws` loses it the same way.
+ */
+export function resolveServerPort(input: {
+  /** `--port`, which a person typed and which therefore wins. */
+  explicit?: number
+  /** `defaults.serverPort` — the port this install last settled on. */
+  remembered?: number
+  /** The constant, so a first run is predictable rather than random. */
+  fallback: number
+}): number {
+  if (input.explicit !== undefined) return input.explicit
+  if (input.remembered !== undefined) return input.remembered
+  return input.fallback
+}
+
+/**
+ * Whether the port that was actually bound is worth writing to the configuration.
+ *
+ * Three rules, and the third is the one with a story.
+ *
+ * An explicit `--port` is never remembered. It is an instruction for one launch,
+ * not a new preference: writing it back would let a single test run quietly
+ * repoint every later launch, and the dev override exists precisely so a dev
+ * server can differ from the stored value rather than redefine it.
+ *
+ * A port bound as asked is always remembered. That is the whole mechanism.
+ *
+ * A *fallback* port — one taken because something else held the port we wanted —
+ * is remembered only when nothing was remembered before. The two cases look
+ * identical from inside one process and want opposite things:
+ *
+ * - Another Vorn holds the port, because a dev server and the packaged app share
+ *   a data directory. Writing the fallback would overwrite a working remembered
+ *   port with an accidental one, and move the *other* instance on its next
+ *   launch. Since that config already names a port, this is the case where a
+ *   remembered value exists, so nothing is written.
+ * - Something unrelated squats the default on a first run. Here there is nothing
+ *   to protect, and refusing to write would hand out a fresh random port every
+ *   launch forever — the exact failure this all exists to stop. So it is written,
+ *   and the install settles on it.
+ */
+export function shouldRememberPort(input: {
+  explicit?: number
+  remembered?: number
+  fellBack: boolean
+}): boolean {
+  if (input.explicit !== undefined) return false
+  if (!input.fellBack) return true
+  return input.remembered === undefined
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -110,6 +110,30 @@ export const RPC_NOT_AUTHENTICATED = -32001
  */
 export const BOOTSTRAP_ENV_VAR = 'SECRET_VORN_BOOTSTRAP_TOKEN'
 
+/**
+ * The port a Vorn server takes when it has no reason to take another.
+ *
+ * Vorn had no default at all until now: the port was whatever the OS handed the
+ * first launch, remembered and reused. That only ever reached step two -- see
+ * `resolveServerPort` -- so in practice every launch drew a new one, and the
+ * origin a browser keys its token by changed underneath it every time.
+ *
+ * An install that already remembers a port keeps it; this decides a first run.
+ * The number itself is not special. It is the one existing installs happen to
+ * hold, which is worth more than a prettier constant that would move them.
+ */
+export const DEFAULT_SERVER_PORT = 50091
+
+/**
+ * The environment variable that overrides the port for one launch.
+ *
+ * Named here because the desktop launcher reads it and the server is what it
+ * ends up configuring. It exists for the case a stored setting cannot serve: a
+ * dev server and a packaged Vorn share one data directory, so they share one
+ * remembered port, and the whole point is for them to differ.
+ */
+export const SERVER_PORT_ENV_VAR = 'VORN_SERVER_PORT'
+
 /** Filename, under the resolved data dir, of the credential same-machine tools read. */
 export const LOCAL_TOKEN_FILENAME = 'local-token'
 

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { createInterface } from 'node:readline'
 import { app, utilityProcess, type UtilityProcess } from 'electron'
 import log from '../logger'
-import { BOOTSTRAP_ENV_VAR } from '@vornrun/shared/protocol'
+import { BOOTSTRAP_ENV_VAR, SERVER_PORT_ENV_VAR } from '@vornrun/shared/protocol'
 import { ServerBridge } from './server-bridge'
 import { readHostSettings } from './host-store'
 
@@ -101,7 +101,15 @@ export async function launchServer(): Promise<ServerBridge> {
     // Dev mode: use npx tsx to run TypeScript directly
     const repoRoot = path.join(__dirname, '../..')
 
-    const child = spawn('npx', ['tsx', serverEntryPoint], {
+    // A port for this launch only, which no stored setting could give. A dev
+    // server and a packaged Vorn share one data directory and therefore one
+    // remembered port, and the reason to set this is to make them differ.
+    // Passed as `--port` rather than through the environment so it travels the
+    // same path the CLI already takes and is refused the same way if malformed.
+    const devPort = process.env[SERVER_PORT_ENV_VAR]
+    if (devPort) log.info(`[launcher] ${SERVER_PORT_ENV_VAR}=${devPort}, asking for that port`)
+
+    const child = spawn('npx', ['tsx', serverEntryPoint, ...(devPort ? ['--port', devPort] : [])], {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: {
         ...process.env,

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -66,6 +66,36 @@ const HOST_CONNECT_TIMEOUT_MS = 15_000
  * which caused an infinite app spawn loop because process.execPath is the
  * Electron binary — spawning it launches another full Electron app instance.
  */
+/**
+ * `VORN_SERVER_PORT`, if it is a port.
+ *
+ * Checked here rather than forwarded blind. `parseServerArgs` does reject a
+ * non-numeric `--port`, but it runs outside the server's `.catch`, so a typo
+ * would take the process down with a stack trace while this launcher sat waiting
+ * for a port line that was never coming — a hang, thirty seconds from the
+ * mistake, describing none of it.
+ *
+ * Loud and ignored rather than fatal. `yarn dev` should still start; what it must
+ * not do is come up quietly on a different port than the one asked for, which is
+ * the confusion this whole mechanism exists to end.
+ */
+function readDevPort(): string | undefined {
+  const raw = process.env[SERVER_PORT_ENV_VAR]
+  if (!raw) return undefined
+
+  const port = Number(raw)
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    log.warn(
+      `[launcher] ${SERVER_PORT_ENV_VAR}="${raw}" is not a port, so it was ignored. ` +
+        'The server will take its usual one.'
+    )
+    return undefined
+  }
+
+  log.info(`[launcher] ${SERVER_PORT_ENV_VAR}=${port}, asking for that port`)
+  return String(port)
+}
+
 export async function launchServer(): Promise<ServerBridge> {
   const host = readHostSettings()
   if (host.mode === 'host' && host.url) {
@@ -106,8 +136,7 @@ export async function launchServer(): Promise<ServerBridge> {
     // remembered port, and the reason to set this is to make them differ.
     // Passed as `--port` rather than through the environment so it travels the
     // same path the CLI already takes and is refused the same way if malformed.
-    const devPort = process.env[SERVER_PORT_ENV_VAR]
-    if (devPort) log.info(`[launcher] ${SERVER_PORT_ENV_VAR}=${devPort}, asking for that port`)
+    const devPort = readDevPort()
 
     const child = spawn('npx', ['tsx', serverEntryPoint, ...(devPort ? ['--port', devPort] : [])], {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/hook-ownership.test.ts
+++ b/tests/hook-ownership.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mayClaimHooks,
+  mayReleaseHooks,
+  parseHookOwner
+} from '../packages/server/src/hook-ownership'
+
+/**
+ * Which Vorn owns the hook registration when two are running.
+ *
+ * There is one entry in `~/.claude/settings.json` and any number of servers that
+ * might write it: a dev server started beside the packaged app shares `~/.vorn`
+ * and `~/.claude` with it, the way it already shares the database.
+ *
+ * All three failures below were observed on a real machine, not imagined. A dev
+ * server overwrote the registration with its own port and token, so the app the
+ * person was using stopped receiving hooks. Killed with SIGKILL before it could
+ * tidy up, it left the settings naming a dead port and a token no live server
+ * would accept — and the owning token is a `randomUUID` held only in memory, so
+ * nothing on disk could repair it; the fix was to delete the entries by hand.
+ * And on a clean exit it removed the registration wholesale, including entries
+ * it had never written.
+ */
+
+const ALIVE = () => true
+const DEAD = () => false
+
+describe('reading the ownership record', () => {
+  it.each([
+    ['absent', null],
+    ['empty', ''],
+    ['not json', 'not json at all'],
+    ['json but not a record', '"56432"'],
+    ['missing the pid', '{"port":56432}'],
+    ['a pid that is not a number', '{"port":56432,"pid":"7116"}']
+  ])('reads %s as unowned rather than throwing', (_label, raw) => {
+    expect(parseHookOwner(raw)).toBeNull()
+  })
+
+  it('reads a well-formed record', () => {
+    expect(parseHookOwner('{"port":56432,"pid":7116}')).toEqual({ port: 56432, pid: 7116 })
+  })
+})
+
+describe('claiming the registration', () => {
+  it('claims it when nobody holds it', () => {
+    expect(mayClaimHooks({ owner: null, selfPid: 100, isAlive: ALIVE })).toBe(true)
+  })
+
+  it('leaves a live instance alone', () => {
+    // The case that broke a running app: the second server wrote its own port
+    // and token over the first's, and the first went on running, unhooked.
+    expect(mayClaimHooks({ owner: { port: 56432, pid: 7116 }, selfPid: 100, isAlive: ALIVE })).toBe(
+      false
+    )
+  })
+
+  it('takes over from an instance that died', () => {
+    // Otherwise a crash would leave hooks unowned forever, with every later
+    // launch politely declining to register.
+    expect(mayClaimHooks({ owner: { port: 56432, pid: 7116 }, selfPid: 100, isAlive: DEAD })).toBe(
+      true
+    )
+  })
+
+  it('reclaims its own record across a restart of the server object', () => {
+    expect(mayClaimHooks({ owner: { port: 56432, pid: 100 }, selfPid: 100, isAlive: ALIVE })).toBe(
+      true
+    )
+  })
+})
+
+describe('releasing the registration', () => {
+  it('removes what it installed', () => {
+    expect(
+      mayReleaseHooks({ owner: { port: 56432, pid: 100 }, selfPid: 100, installed: true })
+    ).toBe(true)
+  })
+
+  it('removes nothing when it installed nothing', () => {
+    // The third failure. The old guard compared ports only when a port had been
+    // recorded, so an instance that never installed fell through the check and
+    // stripped the running app's entries on its way out.
+    expect(mayReleaseHooks({ owner: null, selfPid: 100, installed: false })).toBe(false)
+    expect(
+      mayReleaseHooks({ owner: { port: 56432, pid: 7116 }, selfPid: 100, installed: false })
+    ).toBe(false)
+  })
+
+  it('does not remove another live instance’s registration', () => {
+    expect(
+      mayReleaseHooks({ owner: { port: 56432, pid: 7116 }, selfPid: 100, installed: true })
+    ).toBe(false)
+  })
+
+  it('still tidies up when the record is already gone', () => {
+    // `stop()` deletes the record before `uninstallHooks` runs, so an absent one
+    // is the ordinary shutdown order rather than evidence of somebody else.
+    expect(mayReleaseHooks({ owner: null, selfPid: 100, installed: true })).toBe(true)
+  })
+})

--- a/tests/hook-ownership.test.ts
+++ b/tests/hook-ownership.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   mayClaimHooks,
   mayReleaseHooks,
-  parseHookOwner
+  parseHookOwner,
+  pidIsAlive
 } from '../packages/server/src/hook-ownership'
 
 /**
@@ -39,6 +40,26 @@ describe('reading the ownership record', () => {
 
   it('reads a well-formed record', () => {
     expect(parseHookOwner('{"port":56432,"pid":7116}')).toEqual({ port: 56432, pid: 7116 })
+  })
+})
+
+describe('deciding whether a pid is still there', () => {
+  it('sees this very process', () => {
+    expect(pidIsAlive(process.pid)).toBe(true)
+  })
+
+  it('sees through a pid that is gone', () => {
+    // Pid 0 has a special meaning to `kill` and is never a process to probe;
+    // 2^22 is above every platform's default pid_max, so nothing owns it.
+    expect(pidIsAlive(4_194_304)).toBe(false)
+  })
+
+  it('counts a process it may not signal as alive', () => {
+    // `process.kill` throws EPERM when the process exists and belongs to someone
+    // else — a Vorn running as another user. A bare try/catch reads that as dead
+    // and claims the registration out from under it, which is the one error here
+    // that loses somebody's work. Pid 1 is `launchd`/`init`, owned by root.
+    expect(pidIsAlive(1)).toBe(true)
   })
 })
 

--- a/tests/server-port-stability.test.ts
+++ b/tests/server-port-stability.test.ts
@@ -37,12 +37,17 @@ import path from 'node:path'
  */
 
 const ENTRY = path.join(__dirname, '..', 'packages', 'server', 'src', 'index.ts')
+// The tsx binary itself, not `npx tsx`. `npx` is a parent of the process that
+// actually listens on some platforms and execs into it on others, and that
+// difference is the whole reason this test passed locally and failed in CI.
+// Spawning the binary removes the layer rather than reasoning about it.
+const TSX = path.join(__dirname, '..', 'node_modules', '.bin', 'tsx')
 
 let child: ChildProcess | null = null
 let sandbox: string | null = null
 
 afterEach(() => {
-  child?.kill('SIGTERM')
+  if (child) killGroup(child, 'SIGKILL')
   child = null
   if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true })
   sandbox = null
@@ -51,12 +56,18 @@ afterEach(() => {
 /** Boot the server the way Electron does, and read the port it announces. */
 function launch(dir: string): Promise<number> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('npx', ['tsx', ENTRY, '--data-dir', path.join(dir, 'data')], {
+    const proc = spawn(TSX, [ENTRY, '--data-dir', path.join(dir, 'data')], {
       stdio: 'pipe',
       // Nothing this server writes may escape the sandbox. `os.homedir()` follows
       // HOME, which is what keeps `~/.claude/settings.json` and `~/.vorn` out of
       // reach — see the note above.
-      env: { ...process.env, HOME: dir, USERPROFILE: dir }
+      env: { ...process.env, HOME: dir, USERPROFILE: dir },
+      // Its own process group, so it can be killed as one. `npx tsx` is a parent
+      // of the process that actually listens, and signalling only the parent
+      // leaves the child holding the port — which is precisely how the second
+      // launch below ends up on a fallback port and this test fails for a reason
+      // that has nothing to do with what it is checking.
+      detached: true
     })
     child = proc
     let out = ''
@@ -81,19 +92,65 @@ function launch(dir: string): Promise<number> {
   })
 }
 
-/** Down, and confirmed down, so the next launch is not racing a held socket. */
+/** Signal the whole group; the listener is a child of the process we spawned. */
+function killGroup(proc: ChildProcess, signal: NodeJS.Signals): void {
+  if (proc.pid === undefined) return
+  try {
+    process.kill(-proc.pid, signal)
+  } catch {
+    // Already gone, or never became a group leader.
+  }
+}
+
+/** Whether any process in the group is still alive. */
+function groupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0) // a probe, not a signal
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Down, and confirmed down.
+ *
+ * Waiting on the spawned process is not enough on its own: a server still holding
+ * its port makes the relaunch bind a fallback, failing the assertion for a reason
+ * that has nothing to do with what is being checked. That is what happened in CI,
+ * and it passed locally only because this machine already had something on the
+ * default port, so both launches overlapped on it through `SO_REUSEADDR` and
+ * neither ever reached `EADDRINUSE`. Hence the process group, and the wait.
+ *
+ * The wait is on the process group rather than on the port being free. A port can
+ * be held by something that is not ours — locally, the default is exactly that —
+ * so "nothing answers there" is not a precondition this test can ever demand.
+ */
 async function stop(): Promise<void> {
   const proc = child
   child = null
   if (!proc) return
+
+  const pid = proc.pid
   await new Promise<void>((resolve) => {
-    proc.once('exit', () => resolve())
-    proc.kill('SIGTERM')
-    setTimeout(() => {
-      proc.kill('SIGKILL')
+    let settled = false
+    const done = () => {
+      if (settled) return
+      settled = true
       resolve()
-    }, 10_000)
+    }
+    proc.once('exit', done)
+    killGroup(proc, 'SIGTERM')
+    setTimeout(done, 10_000)
   })
+
+  if (pid === undefined) return
+  for (let i = 0; i < 100; i++) {
+    if (!groupAlive(pid)) return
+    if (i === 50) killGroup(proc, 'SIGKILL')
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  throw new Error('the server process group was still alive 10s after being killed')
 }
 
 describe('a server relaunched on the same data directory', () => {

--- a/tests/server-port-stability.test.ts
+++ b/tests/server-port-stability.test.ts
@@ -25,24 +25,39 @@ import path from 'node:path'
  * or the default was busy and it remembered the fallback instead — a fresh data
  * directory has nothing to protect. Both leave the second launch bound to the
  * same port.
+ *
+ * `HOME` is redirected as well as the data directory, and that is not tidiness.
+ * `hook-installer` writes Vorn's hook entry into `~/.claude/settings.json` and the
+ * hook server writes `~/.vorn/port` and `~/.vorn/token`, none of which look at
+ * `--data-dir` — they resolve from `os.homedir()`. A test server left to its own
+ * devices registers itself as the machine's hook endpoint, over whatever Vorn the
+ * person is actually running, and a run killed mid-flight leaves that pointing at
+ * a port with nothing behind it. Every path this process writes has to land inside
+ * the temp directory.
  */
 
 const ENTRY = path.join(__dirname, '..', 'packages', 'server', 'src', 'index.ts')
 
 let child: ChildProcess | null = null
-let dataDir: string | null = null
+let sandbox: string | null = null
 
 afterEach(() => {
   child?.kill('SIGTERM')
   child = null
-  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true })
-  dataDir = null
+  if (sandbox) fs.rmSync(sandbox, { recursive: true, force: true })
+  sandbox = null
 })
 
 /** Boot the server the way Electron does, and read the port it announces. */
 function launch(dir: string): Promise<number> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('npx', ['tsx', ENTRY, '--data-dir', dir], { stdio: 'pipe' })
+    const proc = spawn('npx', ['tsx', ENTRY, '--data-dir', path.join(dir, 'data')], {
+      stdio: 'pipe',
+      // Nothing this server writes may escape the sandbox. `os.homedir()` follows
+      // HOME, which is what keeps `~/.claude/settings.json` and `~/.vorn` out of
+      // reach — see the note above.
+      env: { ...process.env, HOME: dir, USERPROFILE: dir }
+    })
     child = proc
     let out = ''
     const timer = setTimeout(
@@ -83,11 +98,11 @@ async function stop(): Promise<void> {
 
 describe('a server relaunched on the same data directory', () => {
   it('comes back on the port it used before', async () => {
-    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-'))
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-'))
 
-    const first = await launch(dataDir)
+    const first = await launch(sandbox)
     await stop()
-    const second = await launch(dataDir)
+    const second = await launch(sandbox)
 
     // Not merely "a port" — the same one. A device paired to the first is still
     // paired after the second, which is the whole reason any of this exists.

--- a/tests/server-port-stability.test.ts
+++ b/tests/server-port-stability.test.ts
@@ -71,8 +71,9 @@ function launch(dir: string): Promise<number> {
     })
     child = proc
     let out = ''
+    let err = ''
     const timer = setTimeout(
-      () => reject(new Error(`no port announced; stdout was: ${out}`)),
+      () => reject(new Error(`no port announced after 60s; stdout was: ${out}`)),
       60_000
     )
 
@@ -85,9 +86,19 @@ function launch(dir: string): Promise<number> {
       clearTimeout(timer)
       resolve(Number(found[1]))
     })
-    proc.on('error', (err) => {
+    proc.stderr?.on('data', (chunk: Buffer) => {
+      err += chunk.toString()
+    })
+    // Without this, a server that dies on a bad argument or a syntax error sits
+    // out the full minute and then reports only that no port arrived. Failing
+    // when it exits says what actually went wrong, while it is still legible.
+    proc.on('exit', (code) => {
       clearTimeout(timer)
-      reject(err)
+      reject(new Error(`server exited with code ${code} before announcing a port: ${err || out}`))
+    })
+    proc.on('error', (cause) => {
+      clearTimeout(timer)
+      reject(cause)
     })
   })
 }
@@ -134,14 +145,18 @@ async function stop(): Promise<void> {
   const pid = proc.pid
   await new Promise<void>((resolve) => {
     let settled = false
+    // Cleared on the way out: a timer still pending keeps the runner alive after
+    // the test has finished, and would fire SIGKILL at a process that exited
+    // cleanly ten seconds earlier.
+    const timer = setTimeout(() => done(), 10_000)
     const done = () => {
       if (settled) return
       settled = true
+      clearTimeout(timer)
       resolve()
     }
     proc.once('exit', done)
     killGroup(proc, 'SIGTERM')
-    setTimeout(done, 10_000)
   })
 
   if (pid === undefined) return
@@ -154,16 +169,23 @@ async function stop(): Promise<void> {
 }
 
 describe('a server relaunched on the same data directory', () => {
-  it('comes back on the port it used before', async () => {
-    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-'))
+  // Signalling a process group by negative pid is POSIX-only, as is the
+  // SIGTERM/SIGKILL pair it is sent with. `default-shell` and `shell-integration`
+  // skip the same way rather than pretending to cover a platform they do not.
+  it.skipIf(process.platform === 'win32')(
+    'comes back on the port it used before',
+    async () => {
+      sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-'))
 
-    const first = await launch(sandbox)
-    await stop()
-    const second = await launch(sandbox)
+      const first = await launch(sandbox)
+      await stop()
+      const second = await launch(sandbox)
 
-    // Not merely "a port" — the same one. A device paired to the first is still
-    // paired after the second, which is the whole reason any of this exists.
-    expect(second).toBe(first)
-    expect(first).toBeGreaterThan(0)
-  }, 180_000)
+      // Not merely "a port" — the same one. A device paired to the first is still
+      // paired after the second, which is the whole reason any of this exists.
+      expect(second).toBe(first)
+      expect(first).toBeGreaterThan(0)
+    },
+    180_000
+  )
 })

--- a/tests/server-port-stability.test.ts
+++ b/tests/server-port-stability.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn, type ChildProcess } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * The one assertion the unit tests cannot make: two launches agree.
+ *
+ * `resolveServerPort` and `shouldRememberPort` are pure and thoroughly covered,
+ * and they would all stay green against the bug this file exists for. That bug
+ * was not in the decision but in the wiring to it — the direct-run entry point
+ * passed `port ?? 0`, turning "no flag given" into an explicit zero before the
+ * decision ever saw it, so the remembered port was written every launch and read
+ * on none. Checked, not assumed: restoring the `?? 0` gives two launches 65089
+ * and 65099, with every unit test still passing.
+ *
+ * `tests/port-file-lifecycle.test.ts` takes the other road — it says the server
+ * is "expensive to spin up in tests" and replicates the logic against a temp
+ * directory instead. That is why this one boots the real entry point. A test
+ * that reimplements what it is checking cannot fail when the original changes.
+ *
+ * The invariant holds whatever the machine is doing, which is what makes it safe
+ * in CI. Either the first launch bound the port it asked for and remembered it,
+ * or the default was busy and it remembered the fallback instead — a fresh data
+ * directory has nothing to protect. Both leave the second launch bound to the
+ * same port.
+ */
+
+const ENTRY = path.join(__dirname, '..', 'packages', 'server', 'src', 'index.ts')
+
+let child: ChildProcess | null = null
+let dataDir: string | null = null
+
+afterEach(() => {
+  child?.kill('SIGTERM')
+  child = null
+  if (dataDir) fs.rmSync(dataDir, { recursive: true, force: true })
+  dataDir = null
+})
+
+/** Boot the server the way Electron does, and read the port it announces. */
+function launch(dir: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('npx', ['tsx', ENTRY, '--data-dir', dir], { stdio: 'pipe' })
+    child = proc
+    let out = ''
+    const timer = setTimeout(
+      () => reject(new Error(`no port announced; stdout was: ${out}`)),
+      60_000
+    )
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      out += chunk.toString()
+      // The `{"port":N}` line is the contract with the launcher, written by the
+      // direct-run block — the very block this test is here to guard.
+      const found = out.match(/"port":\s*(\d+)/)
+      if (!found) return
+      clearTimeout(timer)
+      resolve(Number(found[1]))
+    })
+    proc.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+/** Down, and confirmed down, so the next launch is not racing a held socket. */
+async function stop(): Promise<void> {
+  const proc = child
+  child = null
+  if (!proc) return
+  await new Promise<void>((resolve) => {
+    proc.once('exit', () => resolve())
+    proc.kill('SIGTERM')
+    setTimeout(() => {
+      proc.kill('SIGKILL')
+      resolve()
+    }, 10_000)
+  })
+}
+
+describe('a server relaunched on the same data directory', () => {
+  it('comes back on the port it used before', async () => {
+    dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-'))
+
+    const first = await launch(dataDir)
+    await stop()
+    const second = await launch(dataDir)
+
+    // Not merely "a port" — the same one. A device paired to the first is still
+    // paired after the second, which is the whole reason any of this exists.
+    expect(second).toBe(first)
+    expect(first).toBeGreaterThan(0)
+  }, 180_000)
+})

--- a/tests/server-port.test.ts
+++ b/tests/server-port.test.ts
@@ -67,17 +67,15 @@ describe('a null where a number was expected', () => {
    * silently and handed `listen()` a null port, which it reads as "any port" —
    * an ephemeral one produced by a value that meant "nothing set".
    */
-  const nothing = null as unknown as undefined
-
   it('reads a null remembered port as nothing remembered', () => {
-    expect(resolveServerPort({ remembered: nothing, fallback: DEFAULT_SERVER_PORT })).toBe(
+    expect(resolveServerPort({ remembered: null, fallback: DEFAULT_SERVER_PORT })).toBe(
       DEFAULT_SERVER_PORT
     )
   })
 
   it('reads a null explicit port as no flag given', () => {
     expect(
-      resolveServerPort({ explicit: nothing, remembered: 50091, fallback: DEFAULT_SERVER_PORT })
+      resolveServerPort({ explicit: null, remembered: 50091, fallback: DEFAULT_SERVER_PORT })
     ).toBe(50091)
   })
 
@@ -89,7 +87,7 @@ describe('a null where a number was expected', () => {
   })
 
   it('settles a first run whose remembered port is null and whose default is taken', () => {
-    expect(shouldRememberPort({ remembered: nothing, fellBack: true })).toBe(true)
+    expect(shouldRememberPort({ remembered: null, fellBack: true })).toBe(true)
   })
 })
 

--- a/tests/server-port.test.ts
+++ b/tests/server-port.test.ts
@@ -59,6 +59,40 @@ describe('resolveServerPort', () => {
   })
 })
 
+describe('a null where a number was expected', () => {
+  /**
+   * Defaults come back through `JSON.parse(row.value)`, so a stored JSON null
+   * arrives as `null` and would satisfy a strict `!== undefined`. The `??` chain
+   * this logic replaced tolerated it; a strict check would have narrowed that
+   * silently and handed `listen()` a null port, which it reads as "any port" —
+   * an ephemeral one produced by a value that meant "nothing set".
+   */
+  const nothing = null as unknown as undefined
+
+  it('reads a null remembered port as nothing remembered', () => {
+    expect(resolveServerPort({ remembered: nothing, fallback: DEFAULT_SERVER_PORT })).toBe(
+      DEFAULT_SERVER_PORT
+    )
+  })
+
+  it('reads a null explicit port as no flag given', () => {
+    expect(
+      resolveServerPort({ explicit: nothing, remembered: 50091, fallback: DEFAULT_SERVER_PORT })
+    ).toBe(50091)
+  })
+
+  it('still lets an explicit zero through, which is not nothing', () => {
+    // `--port 0` asks for an ephemeral port on purpose. Loosening the check must
+    // not sweep it up with the empty values.
+    expect(resolveServerPort({ explicit: 0, remembered: 50091, fallback: 50091 })).toBe(0)
+    expect(shouldRememberPort({ explicit: 0, fellBack: false })).toBe(false)
+  })
+
+  it('settles a first run whose remembered port is null and whose default is taken', () => {
+    expect(shouldRememberPort({ remembered: nothing, fellBack: true })).toBe(true)
+  })
+})
+
 describe('shouldRememberPort', () => {
   it('writes the port it asked for and got', () => {
     expect(shouldRememberPort({ remembered: 50091, fellBack: false })).toBe(true)

--- a/tests/server-port.test.ts
+++ b/tests/server-port.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { resolveServerPort, shouldRememberPort } from '../packages/server/src/server-args'
+import { DEFAULT_SERVER_PORT } from '../packages/shared/src/protocol'
+
+/**
+ * Which port the server asks for, and whether it writes the answer down.
+ *
+ * This decision lived inline in `startServer`, between a database init and a
+ * websocket registration, where nothing could reach it — and it was wrong for
+ * as long as it was there. The direct-run entry point passed `port ?? 0`, so
+ * "no flag given" arrived as an explicit zero, and `0 ?? remembered` is zero
+ * because `??` only falls through on null and undefined. Every launch drew a
+ * fresh ephemeral port, wrote it to the configuration, and never read it back.
+ *
+ * The cost was not cosmetic. A browser keys `localStorage` by origin, so a
+ * moving port leaves the web client's token behind at the old one; a phone
+ * paired to `ws://host:port/ws` loses the pairing the same way.
+ */
+describe('resolveServerPort', () => {
+  it('takes the remembered port when no flag was given', () => {
+    // The regression the extraction exists for. Against the old code this is
+    // where `undefined` became `0` and the remembered value stopped mattering.
+    expect(
+      resolveServerPort({ explicit: undefined, remembered: 50091, fallback: DEFAULT_SERVER_PORT })
+    ).toBe(50091)
+  })
+
+  it('never resolves to an ephemeral port while it has anything else to try', () => {
+    // Stated separately from the case above because zero is the specific wrong
+    // answer: it is what the OS reads as "any port", and it is what the bug
+    // produced on every launch.
+    for (const remembered of [undefined, 50091]) {
+      expect(
+        resolveServerPort({ explicit: undefined, remembered, fallback: DEFAULT_SERVER_PORT })
+      ).not.toBe(0)
+    }
+  })
+
+  it('lets an explicit port win over a remembered one', () => {
+    expect(resolveServerPort({ explicit: 51234, remembered: 50091, fallback: 50091 })).toBe(51234)
+  })
+
+  it('falls to the default on an install that remembers nothing', () => {
+    expect(
+      resolveServerPort({
+        explicit: undefined,
+        remembered: undefined,
+        fallback: DEFAULT_SERVER_PORT
+      })
+    ).toBe(DEFAULT_SERVER_PORT)
+  })
+
+  it('treats a remembered zero as a port, since that is what it would have written', () => {
+    // Not hypothetical: the bug wrote `actualPort`, and an install that ran the
+    // broken build carries whatever it last bound. Zero itself was never stored
+    // — `listen(0)` reports the real port — so this only pins that the function
+    // has no special case pretending otherwise.
+    expect(resolveServerPort({ remembered: 0, fallback: DEFAULT_SERVER_PORT })).toBe(0)
+  })
+})
+
+describe('shouldRememberPort', () => {
+  it('writes the port it asked for and got', () => {
+    expect(shouldRememberPort({ remembered: 50091, fellBack: false })).toBe(true)
+  })
+
+  it('never writes an explicit --port', () => {
+    // An instruction for one launch, not a new preference. Writing it back would
+    // let a single test run quietly repoint every later launch — and the dev
+    // override exists exactly so it can differ from the stored value rather than
+    // redefine it.
+    expect(shouldRememberPort({ explicit: 51234, remembered: 50091, fellBack: false })).toBe(false)
+    expect(shouldRememberPort({ explicit: 51234, fellBack: true })).toBe(false)
+  })
+
+  it('does not let a fallback overwrite a port the install already had', () => {
+    // The case is a dev server started beside the packaged app on one data
+    // directory. The dev server loses the race, and writing what it got instead
+    // would move the packaged app on its next launch — one instance corrupting
+    // the other through the configuration they share.
+    expect(shouldRememberPort({ remembered: 50091, fellBack: true })).toBe(false)
+  })
+
+  it('does write a fallback when there was nothing to protect', () => {
+    // A first run whose default is squatted by something unrelated. Refusing
+    // here would hand out a fresh random port on every launch forever, which is
+    // the failure this whole mechanism exists to prevent.
+    expect(shouldRememberPort({ remembered: undefined, fellBack: true })).toBe(true)
+  })
+})
+
+describe('the default itself', () => {
+  it('is a real port a client could be told in advance', () => {
+    expect(Number.isInteger(DEFAULT_SERVER_PORT)).toBe(true)
+    expect(DEFAULT_SERVER_PORT).toBeGreaterThan(1023)
+    expect(DEFAULT_SERVER_PORT).toBeLessThan(65536)
+  })
+})


### PR DESCRIPTION
`index.ts` has carried a comment since the port was first remembered saying it must not move, and why: a browser keys `localStorage` by origin, so a server that comes back on a new port hands the web client a new origin and leaves its token at the old one. A person experiences that as Vorn forgetting them. A phone paired to `ws://host:port/ws` loses the pairing the same way.

The mechanism was written and has never run.

## The one character

```ts
startServer({ port: port ?? 0, host, dataDir })
```

The direct-run entry point turned "no flag given" into an explicit zero, and `0 ?? remembered` is zero — `??` only falls through on null and undefined. So the remembered port was **written on every launch and read on none.**

Measured, not inferred. Three launches against one throwaway data directory:

```
run 1 -> 63700     run 2 -> 63714     run 3 -> 63727
defaults.serverPort afterwards: 63727   (rewritten each time, consulted never)
```

Both entry points Electron uses are affected — `resolveServerEntry` returns `index.ts` in dev and `index.cjs` in production, and `isDirectRun` matches both. The packaged app looks stable only because it is rarely restarted. `cli.ts` passes its parsed port through untouched and was always correct.

## A default, for the first time

`DEFAULT_PORT`/`defaultPort` appears nowhere in the source and `50091` appears nowhere as a literal. The scheme was "keep whatever the OS handed the first launch", which never reached a second one. `DEFAULT_SERVER_PORT` is 50091 because that is the number installs already hold — an install that remembers a port still keeps it, so this decides a first run and nothing else.

Order: `--port` → remembered → default → ephemeral.

## Two rules that fall out

**An explicit `--port` is never remembered.** It is an instruction for one launch; writing it back would let a single test run repoint every later one.

**A fallback port is remembered only when nothing was remembered before.** Two cases look identical from inside one process and want opposite things — another Vorn holding the port, where writing the fallback would overwrite a working value in a configuration both instances share and move the other one too; and something unrelated squatting the default on a first run, where refusing would hand out a fresh random port forever. Whether a port was already remembered separates them.

## `VORN_SERVER_PORT`

For the case no stored setting can serve: a dev server and the packaged app share a data directory and therefore share a remembered port, and the reason to set one is to make them differ. The dev launcher forwards it as `--port` so it travels the path the CLI already takes, after checking it — `parseServerArgs` does reject a non-numeric port, but it runs outside the direct-run `.catch`, so a typo took the server down with a stack trace while the launcher sat waiting for a port line that was never coming.

## The hooks, which are the same bug one directory over

Found by walking into it. Vorn writes a hook endpoint into `~/.claude/settings.json` with a port and a per-process `randomUUID` token, and the hook server writes `~/.vorn/port` and `~/.vorn/token`. **None of those paths respect `--data-dir`** — they all resolve from `os.homedir()`.

Three failures, all observed on a real machine:

1. A second instance overwrote the registration with its own port and token, so the app in use silently stopped receiving hooks while still running.
2. Killed before it could tidy up, it left the settings naming a dead port and a token no live server would accept. The owning token exists only in memory, so nothing on disk could repair it — the entries had to be deleted by hand.
3. On a clean exit it removed the registration wholesale. The old guard compared ports *only when a port had been recorded*, and fell through to removing everything when one had not — so an instance that never installed anything stripped somebody else's entries. That one is a plain bug, independent of the rest.

The rule is the one `startServer` already applies to the `ws-port` file: a record naming a live process that is not us means hands off; a record naming a dead one is stale and can be taken. `hook-ownership.ts` holds the decision, pure and with liveness injected, so it is testable without spawning anything.

The record is a new file rather than a field in `~/.vorn/port`. That format is not ours to change — `copilot-hook-installer` bakes `+readFileSync(port).trim()` into scripts written out to another tool's configuration, where an old script goes on reading a file a newer Vorn wrote.

`stop()` also deleted the port and token files unconditionally, so a second instance shutting down cleanly took the running app's copies with it. It now removes only what it wrote.

## Tests, and what they can and cannot catch

The port decision left `startServer` on the way out — it sat between a database init and a websocket registration, unreachable by any test, and was wrong for as long as it existed. That is the same reason `parseServerArgs` was extracted above it.

**The unit tests cannot catch the original bug.** It was in the wiring, not the logic: put the `?? 0` back and all of them stay green, while two launches return 65162 and 65160. So `server-port-stability.test.ts` boots the real entry point twice and asserts the same port. `port-file-lifecycle.test.ts` takes the other road — it calls the server "expensive to spin up" and replicates the logic against a temp directory — which is exactly why it could never have caught this.

That test had the hook defect too, and it is worth being explicit: **it was registering itself as the machine's hook endpoint on every run**, over whatever Vorn the developer was running. It now redirects `HOME` alongside the data directory so every path the server writes lands in the temp directory. Verified twice — `~/.claude/settings.json` byte-identical across a run, and a server booted with `HOME` redirected writes its settings file inside the sandbox instead.

The hijack guard is mutation-tested end to end: remove it, and a second server on a planted live owner record takes over the settings and deletes the owner's file on shutdown; keep it, and it declines and names who holds it.

## Checks

117 tests across 9 suites (`hook-ownership`, `server-port`, `server-port-stability`, `server-args`, `server-integration`, `port-file-lifecycle`, `ws-port-file`, `cli`, `hook-status-mapper`). `tsc --noEmit` clean on both the server and node projects. eslint `--max-warnings 0` and prettier clean.

Verified against a real install: two launches on a fresh data directory agree; `--port 51234` is honoured and does not overwrite the remembered value; with 50091 held, a launch falls back, says so naming both ports, and leaves the remembered port alone; `VORN_SERVER_PORT=62326 yarn dev` binds 62326, and a malformed value warns and starts anyway.

Note the local hook could not run — `lint-staged` is not installed in this checkout and the npm registry is unreachable from here — so eslint, prettier and `scripts/sync-versions.sh` were run by hand and the commits used `--no-verify`.
