### PR TITLE
chore(release): 0.7.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.2",
+  "version": "0.7.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
One change, in two places that turned out to be the same place.

## What is in it

**#490 — the server keeps its port, and one Vorn owns the hooks.**

The server was supposed to come back on the port it used last. `index.ts` has carried a comment saying so since the port was first remembered, and why: a browser keys `localStorage` by origin, so a server on a new port hands the web client a new origin and leaves its token at the old one — which a person experiences as Vorn forgetting them. A phone paired to `ws://host:port/ws` loses the pairing the same way.

The mechanism was written and had never run. The direct-run entry point turned "no flag given" into an explicit zero, and `0 ?? remembered` is zero, so the remembered port was written on every launch and read on none. Three launches against one data directory: 63700, 63714, 63727.

Vorn also had no default port at all — no constant, no literal anywhere. `DEFAULT_SERVER_PORT` is 50091, the number installs already hold, and it decides a first run only.

Then the same collision one directory over, found by walking into it. The hook registration in `~/.claude/settings.json`, and `~/.vorn/port` and `~/.vorn/token`, all resolve from `os.homedir()` rather than the data directory — so a second Vorn shares them. It overwrote the registration and the running app silently stopped receiving hooks; killed before it could tidy up, it left the settings naming a dead port and a token held only in the departed process's memory; and on a clean exit it removed entries it had never written. One instance owns the registration now, by the rule `startServer` already applies to the `ws-port` file.

`VORN_SERVER_PORT` covers the dev case a stored setting cannot: two instances sharing a data directory share a remembered port, and the reason to set one is to make them differ.

## For anyone updating

Your remembered port carries over, so existing pairings hold. **Restarting Vorn is what reinstalls the hook registration correctly** — if a dev server ever clobbered it, this is the release where that stops happening.

## Version

Root `package.json` to `0.7.0-beta.3`, with `scripts/sync-versions.sh` propagating it to the six workspace packages. No other file changes.

Tagging `v0.7.0-beta.3` after this merges is what publishes the prerelease.
