### PR TITLE
Stop one bad hook payload from ending the session

### DIFF
--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -37,16 +37,22 @@ function isHookEvent(value: unknown): value is HookEvent {
   const event = value as Record<string, unknown>
   if (typeof event.hook_event_name !== 'string' || event.hook_event_name === '') return false
   if (typeof event.session_id !== 'string' || event.session_id === '') return false
-  return typeof event.cwd === 'string' && event.cwd !== ''
+  // A string, but not necessarily a full one. `copilot-hook-installer` posts
+  // `cwd: d.cwd||''` and its sessions are force-linked, so they resolve from the
+  // session map and never needed a directory -- an empty one has always worked
+  // and rejecting it would 400 every Copilot event. Only `undefined` was ever
+  // the problem: `normalizePath('')` resolves, `normalizePath(undefined)` throws.
+  return typeof event.cwd === 'string'
 }
 
 /** Enough of a rejected payload to recognise it, without logging a whole body. */
 function describe(value: unknown): string {
   if (typeof value !== 'object' || value === null) return `not an object (${typeof value})`
   const event = value as Record<string, unknown>
-  const missing = (['hook_event_name', 'session_id', 'cwd'] as const).filter(
+  const missing = (['hook_event_name', 'session_id'] as const).filter(
     (key) => typeof event[key] !== 'string' || event[key] === ''
   )
+  if (typeof event.cwd !== 'string') missing.push('cwd' as never)
   return `${String(event.hook_event_name ?? 'no name')} missing ${missing.join(', ')}`
 }
 
@@ -93,7 +99,15 @@ export class HookServer extends EventEmitter {
     return true
   }
 
-  start(): Promise<number> {
+  /**
+   * @param preferredPort The port to try first, falling back to an OS-assigned
+   * one if it is taken. Defaults to the fixed port that keeps `settings.json`
+   * stable across restarts. Tests pass `0` to take any free port: two servers
+   * both reaching for the fixed one is a collision that depends on whether
+   * anything else on the machine already holds it, which is not a thing a test
+   * should be deciding by accident.
+   */
+  start(preferredPort: number = HookServer.PREFERRED_PORT): Promise<number> {
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
         if (req.method !== 'POST') {
@@ -162,7 +176,7 @@ export class HookServer extends EventEmitter {
       this.server.once('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EADDRINUSE') {
           // Preferred port taken -- fall back to OS-assigned
-          log.info(`[hooks] port ${HookServer.PREFERRED_PORT} in use, falling back to random port`)
+          log.info(`[hooks] port ${preferredPort} in use, falling back to random port`)
           this.server!.removeAllListeners('error')
           this.server!.on('error', reject)
           tryListen(0)
@@ -171,7 +185,7 @@ export class HookServer extends EventEmitter {
         }
       })
 
-      tryListen(HookServer.PREFERRED_PORT)
+      tryListen(preferredPort)
     })
   }
 

--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -19,6 +19,37 @@ export interface PendingPermission {
   createdAt: number
 }
 
+/**
+ * Whether a parsed body is an event, rather than merely JSON.
+ *
+ * `JSON.parse(body) as HookEvent` was a cast over a payload posted by another
+ * process, and `HookEvent` declares `session_id` and `cwd` as required -- so
+ * every consumer downstream is entitled to assume they are there, and none of
+ * them look. One `Notification` arrived with both undefined, reached
+ * `normalizePath(cwd)` by way of the status mapper, and threw.
+ *
+ * Checked here rather than at each consumer: the mapper, `cancelSessionPermissions`
+ * and the task-linking block all read these fields, and a boundary that keeps the
+ * promise its type makes is worth more than three guards that each remember to.
+ */
+function isHookEvent(value: unknown): value is HookEvent {
+  if (typeof value !== 'object' || value === null) return false
+  const event = value as Record<string, unknown>
+  if (typeof event.hook_event_name !== 'string' || event.hook_event_name === '') return false
+  if (typeof event.session_id !== 'string' || event.session_id === '') return false
+  return typeof event.cwd === 'string' && event.cwd !== ''
+}
+
+/** Enough of a rejected payload to recognise it, without logging a whole body. */
+function describe(value: unknown): string {
+  if (typeof value !== 'object' || value === null) return `not an object (${typeof value})`
+  const event = value as Record<string, unknown>
+  const missing = (['hook_event_name', 'session_id', 'cwd'] as const).filter(
+    (key) => typeof event[key] !== 'string' || event[key] === ''
+  )
+  return `${String(event.hook_event_name ?? 'no name')} missing ${missing.join(', ')}`
+}
+
 export class HookServer extends EventEmitter {
   private server: http.Server | null = null
   private pendingPermissions = new Map<string, PendingPermission>()
@@ -92,9 +123,23 @@ export class HookServer extends EventEmitter {
         req.on('end', () => {
           if (aborted) return
           try {
-            const event = JSON.parse(body) as HookEvent
-            this.handleEvent(event, res)
-          } catch {
+            const parsed: unknown = JSON.parse(body)
+            if (!isHookEvent(parsed)) {
+              log.warn(`[hooks] ignoring a malformed event: ${describe(parsed)}`)
+              res.writeHead(400, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: 'Malformed hook event' }))
+              return
+            }
+            this.handleEvent(parsed, res)
+          } catch (err) {
+            // Only if nothing has been sent. `handleEvent` answers before it
+            // emits, so by the time anything downstream can fail the response is
+            // finished -- and `writeHead` on a finished response throws
+            // ERR_HTTP_HEADERS_SENT *from inside this handler*, with nothing
+            // above it to catch it. That is what ended the process: not the
+            // original error, but this line answering it.
+            log.error({ err }, '[hooks] failed to handle an event')
+            if (res.headersSent) return
             res.writeHead(400)
             res.end()
           }
@@ -155,7 +200,17 @@ export class HookServer extends EventEmitter {
       // Fire-and-forget: respond immediately
       res.writeHead(200, { 'Content-Type': 'application/json' })
       res.end('{}')
-      this.emit('hook-event', event)
+      // Contained, because a listener is somebody else's code running on this
+      // process's stack. `emit` is synchronous, so a throw in one unwinds
+      // through here and out of the request handler -- and the answer has
+      // already been sent, so there is nothing left to report it with. A
+      // listener that fails is a status that does not update, not a server that
+      // stops.
+      try {
+        this.emit('hook-event', event)
+      } catch (err) {
+        log.error({ err }, `[hooks] a listener threw on ${event.hook_event_name}`)
+      }
     }
   }
 

--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -53,7 +53,10 @@ function describe(value: unknown): string {
     (key) => typeof event[key] !== 'string' || event[key] === ''
   )
   if (typeof event.cwd !== 'string') missing.push('cwd' as never)
-  return `${String(event.hook_event_name ?? 'no name')} missing ${missing.join(', ')}`
+  // Not `??`: an empty name is not a missing one to `??`, so the line would
+  // begin with a space and say nothing about what arrived.
+  const name = typeof event.hook_event_name === 'string' && event.hook_event_name !== ''
+  return `${name ? String(event.hook_event_name) : 'no name'} missing ${missing.join(', ')}`
 }
 
 export class HookServer extends EventEmitter {

--- a/src/main/server/server-bridge.ts
+++ b/src/main/server/server-bridge.ts
@@ -52,8 +52,29 @@ export class ServerBridge extends EventEmitter {
   retarget(url: string): void {
     if (url === this.url) return
     this.url = url
-    this.ws?.close()
+
+    // The old socket's listeners come off before it is closed. `close` is
+    // asynchronous, so its handler would otherwise run after the new socket
+    // exists and set `this.ws = null` on it -- leaving the bridge holding no
+    // reference to a connection that is open, rejecting whatever was in flight,
+    // and scheduling a reconnect on top of the one just made.
+    const previous = this.ws
     this.ws = null
+    if (previous) {
+      previous.removeAllListeners()
+      previous.close()
+      // Said here rather than left to each request's own timeout: they were sent
+      // on a socket that is gone, and the answer is never coming.
+      this.rejectAllPending('Server moved')
+    }
+
+    // A reconnect already queued would fire into the new socket and early-return,
+    // but it would also be a second attempt nobody asked for.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+
     this.connect()
   }
 

--- a/src/main/server/server-bridge.ts
+++ b/src/main/server/server-bridge.ts
@@ -62,6 +62,14 @@ export class ServerBridge extends EventEmitter {
     this.ws = null
     if (previous) {
       previous.removeAllListeners()
+      // One listener goes straight back on. An EventEmitter with nothing
+      // listening for `error` throws when one is emitted, and a socket being
+      // torn down is exactly when that happens -- closing mid-CONNECTING, or a
+      // reconnect that was already failing. Detaching everything would turn a
+      // socket's last gasp into an uncaught exception, which is the failure this
+      // whole branch is about. It has nothing left to tell us; it just must not
+      // throw on the way out.
+      previous.on('error', () => {})
       previous.close()
       // Said here rather than left to each request's own timeout: they were sent
       // on a socket that is gone, and the answer is never coming.

--- a/src/main/server/server-bridge.ts
+++ b/src/main/server/server-bridge.ts
@@ -35,6 +35,28 @@ export class ServerBridge extends EventEmitter {
     this.credential = credential
   }
 
+  /** Where this bridge is pointed, so a caller can tell whether it has moved. */
+  target(): string {
+    return this.url
+  }
+
+  /**
+   * Point at a different port and reconnect there.
+   *
+   * A restarted server usually comes back on the port it had, and the reconnect
+   * loop finds it without help. This is for when it does not — the old port
+   * taken in the moment between the two — where the loop would otherwise retry a
+   * stale address forever, which looks exactly like a server that never came
+   * back.
+   */
+  retarget(url: string): void {
+    if (url === this.url) return
+    this.url = url
+    this.ws?.close()
+    this.ws = null
+    this.connect()
+  }
+
   connect(): void {
     if (this.ws) return
 

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -7,9 +7,27 @@ import log from '../logger'
 import { BOOTSTRAP_ENV_VAR, SERVER_PORT_ENV_VAR } from '@vornrun/shared/protocol'
 import { ServerBridge } from './server-bridge'
 import { readHostSettings } from './host-store'
+import { attemptsAfterExit, decideRelaunch } from './server-relaunch'
 
 let serverProcess: ChildProcess | UtilityProcess | null = null
 let bridge: ServerBridge | null = null
+
+/**
+ * The credential the server is spawned with, kept for as long as the app runs.
+ *
+ * It was a local in `launchServer`, which was fine while a server was started
+ * exactly once. A relaunch has to spawn the replacement with the same one: the
+ * bridge holds it and re-sends it on every reconnect, so a fresh token would
+ * leave it authenticating against a server that had never heard of it.
+ */
+let bootstrapToken: string | null = null
+
+/** Reset whenever a server has run long enough to look healthy. */
+let relaunchAttempts = 0
+/** When the current server was spawned, to tell a crash loop from bad luck. */
+let lastSpawnAt = 0
+/** Set by `stopServer`, so an exit we asked for is not treated as a failure. */
+let stoppingDeliberately = false
 
 /**
  * Connect to a server running on another machine.
@@ -96,26 +114,24 @@ function readDevPort(): string | undefined {
   return String(port)
 }
 
-export async function launchServer(): Promise<ServerBridge> {
-  const host = readHostSettings()
-  if (host.mode === 'host' && host.url) {
-    // Configured for a host but holding no credential — safeStorage was
-    // unavailable when it was saved, or the keychain has moved since. Falling
-    // through to a local server would quietly open a different database than the
-    // one the user asked for, and everything would look empty rather than wrong.
-    // Failing here puts the connect window up asking for the token.
-    if (!host.token) throw new Error(`No stored token for ${host.url}`)
-    return connectToHost(host.url, host.token)
-  }
-
+/**
+ * Start a server process and wait for it to say where it is listening.
+ *
+ * Extracted from `launchServer` so a relaunch can run it again. Everything the
+ * bridge needs afterwards -- the port -- comes back from here; everything it
+ * already has -- the credential -- is module state now, because a replacement
+ * server must be given the same one.
+ */
+async function spawnServer(): Promise<number> {
+  lastSpawnAt = Date.now()
   const serverEntryPoint = resolveServerEntry()
   log.info(`[launcher] starting server: ${serverEntryPoint}`)
 
-  // A per-launch credential for the server we are about to spawn. Generated here
-  // rather than persisted: nothing to leak at rest, and it dies with the process.
-  // The name is stripped unconditionally by `filterEnv`, so it never reaches a
-  // PTY, headless agent or script node.
-  const bootstrapToken = randomBytes(32).toString('base64url')
+  // A per-run credential for the servers we spawn. Generated here rather than
+  // persisted: nothing to leak at rest, and it dies with the app. The name is
+  // stripped unconditionally by `filterEnv`, so it never reaches a PTY, headless
+  // agent or script node. Reused across a relaunch -- see the declaration.
+  bootstrapToken ??= randomBytes(32).toString('base64url')
 
   // Deliberately does NOT pass --data-dir. Vorn's data directory is ~/.vorn —
   // that is where the database, ws-port file and scheduler locks have always
@@ -165,8 +181,7 @@ export async function launchServer(): Promise<ServerBridge> {
     port = await readServerPort(child)
 
     child.on('exit', (code, signal) => {
-      log.warn(`[launcher] server exited (code=${code}, signal=${signal})`)
-      serverProcess = null
+      onServerExit(`code=${code}, signal=${signal}`)
     })
 
     serverProcess = child
@@ -201,17 +216,85 @@ export async function launchServer(): Promise<ServerBridge> {
     port = await readServerPort(child)
 
     child.on('exit', (code) => {
-      log.warn(`[launcher] server exited (code=${code})`)
-      serverProcess = null
+      onServerExit(`code=${code}`)
     })
 
     serverProcess = child
   }
 
+  return port
+}
+
+/**
+ * A server process has gone. Decide whether another should take its place.
+ *
+ * Recovery is only half missing: `ServerBridge` has always reconnected every two
+ * seconds and never given up, so once something is listening again the app
+ * reattaches itself. What was absent was anything to listen again -- this
+ * handler logged the exit code and stopped, and a server that died took the
+ * session with it until the app was quit and reopened.
+ *
+ * The bridge is kept and repointed rather than replaced, because `main` holds
+ * the instance `launchServer` returned and would go on using the old one.
+ */
+function onServerExit(detail: string): void {
+  const uptimeMs = lastSpawnAt === 0 ? 0 : Date.now() - lastSpawnAt
+  log.warn(`[launcher] server exited (${detail}) after ${Math.round(uptimeMs / 1000)}s`)
+  serverProcess = null
+  relaunchAttempts = attemptsAfterExit(relaunchAttempts, uptimeMs)
+
+  const decision = decideRelaunch({
+    deliberate: stoppingDeliberately,
+    hostMode: readHostSettings().mode === 'host',
+    attempts: relaunchAttempts
+  })
+
+  if (!decision.relaunch) {
+    log.warn(`[launcher] not restarting the server: ${decision.reason}`)
+    return
+  }
+
+  relaunchAttempts += 1
+  log.info(
+    `[launcher] restarting the server in ${decision.delayMs}ms (attempt ${relaunchAttempts})`
+  )
+
+  setTimeout(() => {
+    void spawnServer()
+      .then((port) => {
+        const url = `ws://127.0.0.1:${port}/ws`
+        // Usually a no-op now that the port is remembered across restarts, which
+        // is the case the reconnect loop already handles on its own. It matters
+        // when the old port was taken in the moment between the two.
+        if (bridge && bridge.target() !== url) {
+          log.info(`[launcher] server came back on ${port}; repointing the bridge`)
+          bridge.retarget(url)
+        }
+      })
+      .catch((err) => {
+        log.error({ err }, '[launcher] restart failed')
+        onServerExit('restart failed')
+      })
+  }, decision.delayMs)
+}
+
+export async function launchServer(): Promise<ServerBridge> {
+  const host = readHostSettings()
+  if (host.mode === 'host' && host.url) {
+    // Configured for a host but holding no credential — safeStorage was
+    // unavailable when it was saved, or the keychain has moved since. Falling
+    // through to a local server would quietly open a different database than the
+    // one the user asked for, and everything would look empty rather than wrong.
+    // Failing here puts the connect window up asking for the token.
+    if (!host.token) throw new Error(`No stored token for ${host.url}`)
+    return connectToHost(host.url, host.token)
+  }
+
+  const port = await spawnServer()
   log.info(`[launcher] server started on port ${port}`)
 
   // Connect bridge
-  bridge = new ServerBridge(`ws://127.0.0.1:${port}/ws`, bootstrapToken)
+  bridge = new ServerBridge(`ws://127.0.0.1:${port}/ws`, bootstrapToken ?? undefined)
   bridge.connect()
 
   // Wait for connection
@@ -231,6 +314,9 @@ export function getServerBridge(): ServerBridge | null {
 }
 
 export async function stopServer(): Promise<void> {
+  // Before anything else: an exit we asked for must not look like a crash.
+  stoppingDeliberately = true
+
   if (bridge) {
     // Only ask a server to stop if this app is the one that started it.
     //

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -28,6 +28,8 @@ let relaunchAttempts = 0
 let lastSpawnAt = 0
 /** Set by `stopServer`, so an exit we asked for is not treated as a failure. */
 let stoppingDeliberately = false
+/** A relaunch waiting to happen, so shutting down can call it off. */
+let relaunchTimer: NodeJS.Timeout | null = null
 
 /**
  * Connect to a server running on another machine.
@@ -178,13 +180,19 @@ async function spawnServer(): Promise<number> {
       })
     }
 
-    port = await readServerPort(child)
-
+    // Tracked before anything is awaited. `readServerPort` can reject on a ten
+    // second timeout with the child still running, and a child assigned only
+    // after that is one nothing holds a reference to -- unkillable by
+    // `stopServer`, invisible to the relaunch logic, and still on the port.
+    serverProcess = child
     child.on('exit', (code, signal) => {
       onServerExit(`code=${code}, signal=${signal}`)
     })
 
-    serverProcess = child
+    port = await readServerPort(child).catch((err) => {
+      child.kill('SIGKILL')
+      throw err
+    })
   } else {
     // Production: use Electron's utilityProcess.fork() to run the bundled
     // server as a proper Node.js child process (NOT another Electron instance)
@@ -213,13 +221,15 @@ async function spawnServer(): Promise<number> {
       })
     }
 
-    port = await readServerPort(child)
-
+    serverProcess = child
     child.on('exit', (code) => {
       onServerExit(`code=${code}`)
     })
 
-    serverProcess = child
+    port = await readServerPort(child).catch((err) => {
+      child.kill()
+      throw err
+    })
   }
 
   return port
@@ -259,7 +269,15 @@ function onServerExit(detail: string): void {
     `[launcher] restarting the server in ${decision.delayMs}ms (attempt ${relaunchAttempts})`
   )
 
-  setTimeout(() => {
+  relaunchTimer = setTimeout(() => {
+    relaunchTimer = null
+    // Asked again, because fifteen seconds is long enough for the answer to have
+    // changed. The app may have begun quitting since, and spawning a server on
+    // the way out is the one thing this must never do.
+    if (stoppingDeliberately) {
+      log.info('[launcher] not restarting after all: the app is shutting down')
+      return
+    }
     void spawnServer()
       .then((port) => {
         const url = `ws://127.0.0.1:${port}/ws`
@@ -272,8 +290,11 @@ function onServerExit(detail: string): void {
         }
       })
       .catch((err) => {
+        // Not re-entered here. The child now carries its own `exit` handler from
+        // the moment it is spawned, so a failed start already routes back
+        // through `onServerExit` -- calling it again would spend two attempts on
+        // one failure.
         log.error({ err }, '[launcher] restart failed')
-        onServerExit('restart failed')
       })
   }, decision.delayMs)
 }
@@ -314,8 +335,13 @@ export function getServerBridge(): ServerBridge | null {
 }
 
 export async function stopServer(): Promise<void> {
-  // Before anything else: an exit we asked for must not look like a crash.
+  // Before anything else: an exit we asked for must not look like a crash, and
+  // a relaunch already counting down must not outlive the decision to quit.
   stoppingDeliberately = true
+  if (relaunchTimer) {
+    clearTimeout(relaunchTimer)
+    relaunchTimer = null
+  }
 
   if (bridge) {
     // Only ask a server to stop if this app is the one that started it.

--- a/src/main/server/server-relaunch.ts
+++ b/src/main/server/server-relaunch.ts
@@ -1,0 +1,75 @@
+/**
+ * Whether a server that has just exited should be started again.
+ *
+ * It never was. `child.on('exit')` logged the code, set `serverProcess = null`
+ * and stopped there, in both the dev and production branches — so a server that
+ * died took the session with it. That is not theoretical: one malformed hook
+ * payload killed it, and Vorn sat with live terminals and a dead server for two
+ * and a half minutes, every call failing, until the app was quit and reopened.
+ *
+ * The other half of the recovery has been there all along. `ServerBridge`
+ * reconnects every two seconds and never gives up, which is what that wall of
+ * ECONNREFUSED in the log is — the client half working perfectly against a
+ * server that was never coming back.
+ *
+ * Kept apart from the launcher because a decision with four inputs and three
+ * ways to be wrong should be readable on its own, and because the launcher
+ * itself cannot be unit-tested: it forks processes and talks to Electron.
+ */
+export interface RelaunchDecision {
+  relaunch: boolean
+  /** Milliseconds to wait first. Zero for the first attempt. */
+  delayMs: number
+  /** Why not, when not — for the log line that explains a session ending. */
+  reason?: string
+}
+
+/** Backoff, and the point at which trying again is just spinning. */
+export const RELAUNCH_DELAYS_MS = [0, 1_000, 5_000, 15_000]
+
+export function decideRelaunch(input: {
+  /** `stopServer` ran, or the app is quitting. The exit was the point. */
+  deliberate: boolean
+  /** No server of our own — we are pointed at someone else's. */
+  hostMode: boolean
+  /** How many times we have already relaunched in this run. */
+  attempts: number
+}): RelaunchDecision {
+  if (input.deliberate) {
+    return { relaunch: false, delayMs: 0, reason: 'the server was asked to stop' }
+  }
+  // Host mode has no server of its own: `serverProcess` is null because another
+  // machine is running it. Starting one here would be answering a question
+  // nobody asked, and `stopServer` already refuses to shut that server down for
+  // the same reason.
+  if (input.hostMode) {
+    return { relaunch: false, delayMs: 0, reason: 'this app is connected to another host' }
+  }
+  if (input.attempts >= RELAUNCH_DELAYS_MS.length) {
+    // A server that dies this reliably dies on startup, and relaunching it
+    // forever turns one broken thing into a process being spawned every few
+    // seconds for as long as the app is open.
+    return {
+      relaunch: false,
+      delayMs: 0,
+      reason: `it failed ${input.attempts} times in a row`
+    }
+  }
+
+  return { relaunch: true, delayMs: RELAUNCH_DELAYS_MS[input.attempts] as number }
+}
+
+/**
+ * How long a server must have run before its death counts as a fresh problem.
+ *
+ * Without this the budget is spent once and never returns: a machine left open
+ * for a week, with three unrelated crashes days apart, would refuse to restart
+ * on the third. And resetting on connection alone is worse -- a server that
+ * starts, connects and dies immediately would reset the budget every time and
+ * relaunch forever, which is the loop the cap exists to stop.
+ */
+export const HEALTHY_UPTIME_MS = 60_000
+
+export function attemptsAfterExit(attempts: number, uptimeMs: number): number {
+  return uptimeMs >= HEALTHY_UPTIME_MS ? 0 : attempts
+}

--- a/tests/hook-payload.test.ts
+++ b/tests/hook-payload.test.ts
@@ -63,7 +63,12 @@ afterEach(() => {
 async function startHookServer() {
   const { HookServer } = await import('../packages/server/src/hook-server')
   const instance = new HookServer()
-  const port = await instance.start()
+  // Any free port, never the fixed one. `server-integration.test.ts` starts a
+  // server that claims the fixed port too, and vitest runs files in parallel --
+  // so on a machine where nothing else holds it the two collide and requests
+  // come back as `socket hang up`. Locally that never happened, because the
+  // running Vorn already had it and both fell back. CI had no such accident.
+  const port = await instance.start(0)
   return {
     instance,
     port,
@@ -114,6 +119,7 @@ describe('the payload that crashed the server', () => {
     ['no session', '{"hook_event_name":"Notification","cwd":"/tmp"}'],
     ['no cwd', '{"hook_event_name":"Notification","session_id":"s1"}'],
     ['empty session', '{"hook_event_name":"Stop","session_id":"","cwd":"/tmp"}'],
+    ['a cwd that is not a string', '{"hook_event_name":"Stop","session_id":"s1","cwd":42}'],
     ['no name', '{"session_id":"s1","cwd":"/tmp"}'],
     ['not an object', '"just a string"'],
     ['null', 'null']
@@ -122,6 +128,28 @@ describe('the payload that crashed the server', () => {
     server = started
 
     expect(await post(started.port, started.token, body)).toBe(400)
+  })
+
+  it('accepts an empty cwd, which is what Copilot sends', async () => {
+    // `copilot-hook-installer` bakes `cwd: d.cwd||''` into the scripts it writes
+    // into another tool's configuration, and those sessions are force-linked, so
+    // they resolve from the session map without ever needing a directory. An
+    // empty string has always worked; only `undefined` reached the throw. A
+    // guard strict enough to reject `''` would 400 every Copilot hook event.
+    const started = await startHookServer()
+    server = started
+
+    const seen: unknown[] = []
+    started.instance.on('hook-event', (event) => seen.push(event))
+
+    const status = await post(
+      started.port,
+      started.token,
+      JSON.stringify({ hook_event_name: 'PostToolUse', session_id: 'copilot-1', cwd: '' })
+    )
+
+    expect(status).toBe(200)
+    expect(seen).toHaveLength(1)
   })
 
   it('still accepts a well-formed event', async () => {

--- a/tests/hook-payload.test.ts
+++ b/tests/hook-payload.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import { normalizePath } from '../packages/server/src/process-utils'
+
+/**
+ * The event that took the server down, and why answering it was the fatal part.
+ *
+ * A `Notification` arrived with `session_id` and `cwd` undefined. `HookEvent`
+ * declares both as required and `hook-server` cast the parsed body straight to
+ * it, so the status mapper read them, handed `cwd` to `normalizePath`, and threw.
+ *
+ * That throw alone should have been survivable — the call sat inside a
+ * try/catch. The catch answered with `res.writeHead(400)`, on a response
+ * `handleEvent` had already ended before emitting. Writing headers to a finished
+ * response throws `ERR_HTTP_HEADERS_SENT`, from inside the handler, with nothing
+ * above it. The error handler is what ended the process, three milliseconds
+ * after the event arrived.
+ *
+ * So there are three separate things to hold: the payload never reaches the code
+ * that throws, a listener that throws anyway cannot escape, and the catch cannot
+ * make things worse than what it is catching.
+ */
+
+vi.mock('node-pty', () => ({ default: { spawn: vi.fn() }, spawn: vi.fn() }))
+
+/**
+ * A home directory of its own, because a real `HookServer` writes to one.
+ *
+ * `start()` claims `~/.vorn/{hook-owner,port,token}`, and those paths come from
+ * `os.homedir()` — no data directory involved. Left alone, this file would
+ * repoint the machine's hook endpoint at a server that exists for one assertion
+ * and then exits. It happens to be refused today, because the ownership check
+ * sees the running Vorn and declines, but that is the machine's state saving the
+ * test rather than the test being safe.
+ *
+ * Set before the first import of `hook-server`, since it reads `homedir()` once
+ * at module scope — which is why the import below is dynamic.
+ */
+let home: string | null = null
+let realHome: string | undefined
+
+beforeAll(() => {
+  realHome = process.env.HOME
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-hooks-'))
+  process.env.HOME = home
+})
+
+afterAll(() => {
+  process.env.HOME = realHome
+  if (home) fs.rmSync(home, { recursive: true, force: true })
+})
+
+let server: { stop: () => void; port: number; token: string } | null = null
+
+afterEach(() => {
+  server?.stop()
+  server = null
+})
+
+async function startHookServer() {
+  const { HookServer } = await import('../packages/server/src/hook-server')
+  const instance = new HookServer()
+  const port = await instance.start()
+  return {
+    instance,
+    port,
+    token: instance.getAuthToken(),
+    stop: () => instance.stop()
+  }
+}
+
+function post(port: number, token: string, body: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/hooks',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
+      },
+      (res) => {
+        res.resume()
+        resolve(res.statusCode ?? 0)
+      }
+    )
+    req.on('error', reject)
+    req.end(body)
+  })
+}
+
+describe('the payload that crashed the server', () => {
+  it('is refused, and the server is still there afterwards', async () => {
+    const started = await startHookServer()
+    server = started
+
+    // Exactly what the log recorded: a name, and nothing else.
+    const status = await post(started.port, started.token, '{"hook_event_name":"Notification"}')
+    expect(status).toBe(400)
+
+    // The assertion that matters. Before the fix the process was gone by now.
+    const after = await post(
+      started.port,
+      started.token,
+      JSON.stringify({ hook_event_name: 'Stop', session_id: 's1', cwd: '/tmp' })
+    )
+    expect(after).toBe(200)
+  })
+
+  it.each([
+    ['no session', '{"hook_event_name":"Notification","cwd":"/tmp"}'],
+    ['no cwd', '{"hook_event_name":"Notification","session_id":"s1"}'],
+    ['empty session', '{"hook_event_name":"Stop","session_id":"","cwd":"/tmp"}'],
+    ['no name', '{"session_id":"s1","cwd":"/tmp"}'],
+    ['not an object', '"just a string"'],
+    ['null', 'null']
+  ])('refuses a payload with %s', async (_label, body) => {
+    const started = await startHookServer()
+    server = started
+
+    expect(await post(started.port, started.token, body)).toBe(400)
+  })
+
+  it('still accepts a well-formed event', async () => {
+    const started = await startHookServer()
+    server = started
+
+    const seen: unknown[] = []
+    started.instance.on('hook-event', (event) => seen.push(event))
+
+    const status = await post(
+      started.port,
+      started.token,
+      JSON.stringify({ hook_event_name: 'PreToolUse', session_id: 's1', cwd: '/tmp' })
+    )
+
+    expect(status).toBe(200)
+    expect(seen).toHaveLength(1)
+  })
+
+  it('survives a listener that throws, without reaching the top of the process', async () => {
+    // `emit` is synchronous, so a listener runs on the request handler's stack,
+    // and the response has already been sent by the time it runs. That is what
+    // made the throw fatal: the catch above answered it with `writeHead(400)` on
+    // a finished response, which threw again with nothing left to catch it.
+    //
+    // The status codes alone cannot show this. Both requests are answered before
+    // anything fails, so they return 200 either way — checked by mutation, and
+    // an earlier version of this test passed against the unfixed code for
+    // exactly that reason. What has to be watched is whether anything reaches
+    // `uncaughtException`, because in the real server that is the process ending.
+    const started = await startHookServer()
+    server = started
+    started.instance.on('hook-event', () => {
+      throw new Error('a listener blew up')
+    })
+
+    const escaped: Error[] = []
+    const watch = (err: Error) => escaped.push(err)
+    process.on('uncaughtException', watch)
+
+    try {
+      expect(
+        await post(
+          started.port,
+          started.token,
+          JSON.stringify({ hook_event_name: 'Stop', session_id: 's1', cwd: '/tmp' })
+        )
+      ).toBe(200)
+
+      // A tick for anything thrown after the response was flushed.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      expect(escaped.map((err) => (err as NodeJS.ErrnoException).code ?? err.message)).toEqual([])
+    } finally {
+      process.off('uncaughtException', watch)
+    }
+
+    // And it is still answering.
+    expect(
+      await post(
+        started.port,
+        started.token,
+        JSON.stringify({ hook_event_name: 'Stop', session_id: 's2', cwd: '/tmp' })
+      )
+    ).toBe(200)
+  })
+})
+
+describe('this test file itself', () => {
+  it('writes nothing outside its own home directory', () => {
+    // The claim above, checked rather than asserted in a comment. If the sandbox
+    // ever stops working, this is what says so — instead of the machine's real
+    // hook registration quietly moving.
+    expect(process.env.HOME).toBe(home)
+    expect(os.homedir()).toBe(home)
+  })
+})
+
+describe('the utility underneath it', () => {
+  it('still refuses a path that is not one', () => {
+    // Pinned deliberately. The guard belongs at the boundary, where an untrusted
+    // body is turned into a typed event — not in a general path helper, which
+    // would then quietly absorb the next caller's mistake instead of this one.
+    expect(() => normalizePath(undefined as unknown as string)).toThrow(TypeError)
+  })
+})

--- a/tests/hook-payload.test.ts
+++ b/tests/hook-payload.test.ts
@@ -55,9 +55,22 @@ beforeAll(() => {
   process.env.USERPROFILE = home
 })
 
+/**
+ * Put a variable back, including putting it back to not existing.
+ *
+ * `process.env.X = undefined` does not unset X — it sets it to the *string*
+ * "undefined", and every later reader gets a home directory by that name. On a
+ * machine where one of these was never set to begin with, restoring it by
+ * assignment is how a test leaves the process dirtier than it found it.
+ */
+function restore(name: 'HOME' | 'USERPROFILE', value: string | undefined): void {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
 afterAll(() => {
-  process.env.HOME = realHome
-  process.env.USERPROFILE = realProfile
+  restore('HOME', realHome)
+  restore('USERPROFILE', realProfile)
   if (home) fs.rmSync(home, { recursive: true, force: true })
 })
 
@@ -227,6 +240,15 @@ describe('the payload that crashed the server', () => {
 })
 
 describe('this test file itself', () => {
+  it('names a malformed event even when the name itself is empty', async () => {
+    // `??` treats '' as present, so the log line began with a space and said
+    // nothing about what had arrived — the one job of that message.
+    const started = await startHookServer()
+    server = started
+
+    expect(await post(started.port, started.token, '{"hook_event_name":"","cwd":"/tmp"}')).toBe(400)
+  })
+
   it('writes nothing outside its own home directory', () => {
     // The claim above, checked rather than asserted in a comment. If the sandbox
     // ever stops working, this is what says so — instead of the machine's real

--- a/tests/hook-payload.test.ts
+++ b/tests/hook-payload.test.ts
@@ -42,14 +42,22 @@ vi.mock('node-pty', () => ({ default: { spawn: vi.fn() }, spawn: vi.fn() }))
 let home: string | null = null
 let realHome: string | undefined
 
+let realProfile: string | undefined
+
 beforeAll(() => {
   realHome = process.env.HOME
+  realProfile = process.env.USERPROFILE
   home = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-hooks-'))
+  // Both, because `os.homedir()` reads HOME on POSIX and USERPROFILE on Windows.
+  // Setting only HOME leaves a developer on Windows running this suite against
+  // their real home directory — the isolation would look present and not be.
   process.env.HOME = home
+  process.env.USERPROFILE = home
 })
 
 afterAll(() => {
   process.env.HOME = realHome
+  process.env.USERPROFILE = realProfile
   if (home) fs.rmSync(home, { recursive: true, force: true })
 })
 
@@ -224,6 +232,7 @@ describe('this test file itself', () => {
     // ever stops working, this is what says so — instead of the machine's real
     // hook registration quietly moving.
     expect(process.env.HOME).toBe(home)
+    expect(process.env.USERPROFILE).toBe(home)
     expect(os.homedir()).toBe(home)
   })
 })

--- a/tests/hook-payload.test.ts
+++ b/tests/hook-payload.test.ts
@@ -249,13 +249,23 @@ describe('this test file itself', () => {
     expect(await post(started.port, started.token, '{"hook_event_name":"","cwd":"/tmp"}')).toBe(400)
   })
 
-  it('writes nothing outside its own home directory', () => {
-    // The claim above, checked rather than asserted in a comment. If the sandbox
-    // ever stops working, this is what says so — instead of the machine's real
-    // hook registration quietly moving.
-    expect(process.env.HOME).toBe(home)
-    expect(process.env.USERPROFILE).toBe(home)
+  it('writes its claim inside its own home directory', async () => {
+    // Behavioural on purpose. Asserting the environment variables only proves
+    // they are set now; `hook-server` resolves `~/.vorn` into module-level
+    // constants at import time, so what matters is where the constants landed —
+    // and if some future import graph or an `isolate: false` in the vitest config
+    // loaded that module before `beforeAll` ran, they would point at the real
+    // home while every env check still passed.
+    //
+    // So: start a server, let it claim, and look for the evidence here rather
+    // than there. This failing is the sandbox failing, which is the only warning
+    // anyone gets before a test repoints a real machine's hook registration.
+    const started = await startHookServer()
+    server = started
+
     expect(os.homedir()).toBe(home)
+    expect(fs.existsSync(path.join(home as string, '.vorn', 'hook-owner'))).toBe(true)
+    expect(fs.existsSync(path.join(home as string, '.vorn', 'port'))).toBe(true)
   })
 })
 

--- a/tests/server-bridge-retarget.test.ts
+++ b/tests/server-bridge-retarget.test.ts
@@ -69,6 +69,37 @@ describe('retargeting the bridge', () => {
     await expect(bridge.request('anything', undefined, 200)).rejects.toThrow(/timeout|timed out/i)
   })
 
+  it('lets the old socket fail on its way out without throwing', async () => {
+    // Detaching every listener leaves nothing handling `error`, and an
+    // EventEmitter with no `error` listener throws when one is emitted — which
+    // is precisely what a socket closing mid-CONNECTING does. Retargeting while
+    // the first connection is still being established is the ordinary case here:
+    // the server has just died, so the bridge is usually mid-attempt.
+    const second = await listen()
+
+    // Nothing is listening on this port, so the first socket is CONNECTING and
+    // then failing when it is torn out from under.
+    const bridge = new ServerBridge('ws://127.0.0.1:1/ws')
+    bridges.push(bridge)
+    bridge.connect()
+
+    const escaped: Error[] = []
+    const watch = (err: Error) => escaped.push(err)
+    process.on('uncaughtException', watch)
+
+    try {
+      const arrived = connected(bridge)
+      bridge.retarget(`ws://127.0.0.1:${second.port}/ws`)
+      await arrived
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      expect(escaped.map((err) => err.message)).toEqual([])
+      expect(second.connections).toHaveLength(1)
+    } finally {
+      process.off('uncaughtException', watch)
+    }
+  })
+
   it('does nothing when asked for the address it already has', async () => {
     const only = await listen()
     const bridge = new ServerBridge(`ws://127.0.0.1:${only.port}/ws`)

--- a/tests/server-bridge-retarget.test.ts
+++ b/tests/server-bridge-retarget.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws'
+import { ServerBridge } from '../src/main/server/server-bridge'
+
+/**
+ * Moving the bridge to a different port without losing the connection it makes.
+ *
+ * A restarted server usually comes back on the port it had — that is the point
+ * of remembering it — and the reconnect loop finds it unaided. This is for when
+ * it does not, and the bridge would otherwise retry a stale address forever,
+ * which looks exactly like a server that never came back.
+ *
+ * The subtlety is that `close()` is asynchronous. A first version closed the old
+ * socket and connected the new one in the same tick, so the old socket's `close`
+ * handler ran afterwards and set `this.ws = null` on the *new* connection — the
+ * bridge holding no reference to a socket that was open, everything in flight
+ * rejected, and a reconnect queued on top of the one just made. Detaching the
+ * old listeners first is what stops that, and it is what this pins.
+ */
+
+const servers: WebSocketServer[] = []
+const bridges: ServerBridge[] = []
+
+afterEach(() => {
+  for (const bridge of bridges) bridge.close()
+  bridges.length = 0
+  for (const server of servers) server.close()
+  servers.length = 0
+})
+
+/** A socket server that answers nothing, which is all these need. */
+async function listen(): Promise<{ port: number; connections: WsSocket[] }> {
+  const connections: WsSocket[] = []
+  const server = new WebSocketServer({ port: 0, host: '127.0.0.1' })
+  servers.push(server)
+  server.on('connection', (socket) => connections.push(socket))
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()))
+  const address = server.address()
+  return { port: typeof address === 'object' && address ? address.port : 0, connections }
+}
+
+function connected(bridge: ServerBridge): Promise<void> {
+  return new Promise((resolve) => bridge.once('connected', () => resolve()))
+}
+
+describe('retargeting the bridge', () => {
+  it('ends up connected to the new address, and stays that way', async () => {
+    const first = await listen()
+    const second = await listen()
+
+    const bridge = new ServerBridge(`ws://127.0.0.1:${first.port}/ws`)
+    bridges.push(bridge)
+    bridge.connect()
+    await connected(bridge)
+    expect(first.connections).toHaveLength(1)
+
+    const arrived = connected(bridge)
+    bridge.retarget(`ws://127.0.0.1:${second.port}/ws`)
+    await arrived
+
+    expect(bridge.target()).toBe(`ws://127.0.0.1:${second.port}/ws`)
+    expect(second.connections).toHaveLength(1)
+
+    // The assertion the bug was hiding behind. The old socket's close handler
+    // fires around now; give it room, then check the bridge still holds the new
+    // connection rather than having been nulled out by a dead socket's listener.
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    expect(second.connections[0]?.readyState).toBe(1) // OPEN
+    await expect(bridge.request('anything', undefined, 200)).rejects.toThrow(/timeout|timed out/i)
+  })
+
+  it('does nothing when asked for the address it already has', async () => {
+    const only = await listen()
+    const bridge = new ServerBridge(`ws://127.0.0.1:${only.port}/ws`)
+    bridges.push(bridge)
+    bridge.connect()
+    await connected(bridge)
+
+    bridge.retarget(`ws://127.0.0.1:${only.port}/ws`)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+
+    // One connection, not a second one made for no reason.
+    expect(only.connections).toHaveLength(1)
+  })
+})

--- a/tests/server-relaunch.test.ts
+++ b/tests/server-relaunch.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  attemptsAfterExit,
+  decideRelaunch,
+  HEALTHY_UPTIME_MS,
+  RELAUNCH_DELAYS_MS
+} from '../src/main/server/server-relaunch'
+
+/**
+ * Whether a server that has died should be replaced.
+ *
+ * It never was. `child.on('exit')` logged the code and stopped, in both the dev
+ * and production branches, so one crash ended the session — the app kept running
+ * with live terminals and a dead server, every call failing, until it was quit
+ * and reopened.
+ *
+ * Only half the recovery was missing. `ServerBridge.scheduleReconnect` has
+ * always retried every two seconds and never given up; the wall of ECONNREFUSED
+ * in the log was the client half working perfectly against a server nobody was
+ * bringing back.
+ *
+ * The launcher itself forks processes and talks to Electron, so it cannot be
+ * unit-tested here. The decision can, and it is where the ways to be wrong are.
+ */
+describe('deciding whether to restart', () => {
+  it('restarts immediately the first time', () => {
+    expect(decideRelaunch({ deliberate: false, hostMode: false, attempts: 0 })).toEqual({
+      relaunch: true,
+      delayMs: 0
+    })
+  })
+
+  it('waits longer each time', () => {
+    const delays = RELAUNCH_DELAYS_MS.map(
+      (_, attempts) => decideRelaunch({ deliberate: false, hostMode: false, attempts }).delayMs
+    )
+
+    expect(delays).toEqual([...RELAUNCH_DELAYS_MS])
+    for (let i = 1; i < delays.length; i++) {
+      expect(delays[i]).toBeGreaterThan(delays[i - 1] as number)
+    }
+  })
+
+  it('gives up rather than spinning', () => {
+    // A server that dies this reliably dies on startup. Retrying forever turns
+    // one broken thing into a process spawned every few seconds for as long as
+    // the app is open.
+    const decision = decideRelaunch({
+      deliberate: false,
+      hostMode: false,
+      attempts: RELAUNCH_DELAYS_MS.length
+    })
+
+    expect(decision.relaunch).toBe(false)
+    expect(decision.reason).toContain('in a row')
+  })
+
+  it('does not restart a server that was asked to stop', () => {
+    // Quitting the app kills the server on purpose. Starting another one while
+    // the app is on its way out is the opposite of what was asked.
+    expect(decideRelaunch({ deliberate: true, hostMode: false, attempts: 0 }).relaunch).toBe(false)
+  })
+
+  it('starts nothing when the app is pointed at another machine', () => {
+    // Host mode has no server of its own. `stopServer` already refuses to shut
+    // a host's server down for the same reason — one person closing a laptop
+    // must not take it away from everyone else.
+    const decision = decideRelaunch({ deliberate: false, hostMode: true, attempts: 0 })
+
+    expect(decision.relaunch).toBe(false)
+    expect(decision.reason).toContain('another host')
+  })
+
+  it('is refused for the right reason when more than one applies', () => {
+    expect(decideRelaunch({ deliberate: true, hostMode: true, attempts: 99 }).reason).toContain(
+      'asked to stop'
+    )
+  })
+})
+
+describe('spending and refilling the budget', () => {
+  it('forgets past failures once a server has run properly', () => {
+    // Otherwise the budget is spent once and never returns: a machine left open
+    // for a week, with three unrelated crashes days apart, would refuse to
+    // restart on the third.
+    expect(attemptsAfterExit(3, HEALTHY_UPTIME_MS)).toBe(0)
+    expect(attemptsAfterExit(3, HEALTHY_UPTIME_MS + 60_000)).toBe(0)
+  })
+
+  it('keeps counting when a server dies quickly', () => {
+    // And resetting on connection alone would be worse — a server that starts,
+    // connects and dies immediately would refill the budget every time and
+    // relaunch forever, which is the loop the cap exists to stop.
+    expect(attemptsAfterExit(3, 1_000)).toBe(3)
+    expect(attemptsAfterExit(3, HEALTHY_UPTIME_MS - 1)).toBe(3)
+  })
+})


### PR DESCRIPTION
Vorn froze mid-session. The Network screen said it could not read the device list — true, and forty seconds beside the point. The server had died at `18:46:10` and nothing brought it back, so `token:list` had nothing to talk to.

```
[hooks] Notification: session=undefined cwd=undefined
[launcher] server exited (code=1)
```

Three milliseconds apart, then two and a half minutes of a running app with live terminals and no server, until it was quit and reopened.

## The throw is the boring half

`hook-server` cast a body POSTed by another process straight to `HookEvent`, which declares `session_id` and `cwd` as **required** — so the status mapper read them, handed `cwd` to `normalizePath`, and got `Cannot read properties of undefined (reading 'startsWith')`.

## The fatal half is the error handling

`handleEvent` answers and calls `res.end()` **before** it emits. So by the time a listener throws there is nothing left to reply with — and the catch above replied anyway, with `res.writeHead(400)` on a finished response. That throws `ERR_HTTP_HEADERS_SENT`, from inside the request handler, with nothing above it to catch it.

**The process died of its own error handler, not of the original error.**

Reproduced against a real server on a throwaway data dir, both ways:

| | shipped code | this branch |
|---|---|---|
| the killer payload | `200`, then **dead** | `400`, alive |
| well-formed event afterwards | — | `200` |

So: validate at the boundary, because the cast was the lie and four consumers downstream were entitled to believe it; never write headers to a response already sent; and contain a listener throw where it happens.

Mutation says the `headersSent` guard **alone** is enough to survive — the try/catch around the emit is kept for a log line that names the event, not because the fix needs it. Happy to drop it if you'd rather.

Guarding inside `normalizePath` was the other option and is worse: it is a general path helper, and teaching it to swallow `undefined` absorbs the next caller's bug instead of surfacing this one. A test pins that it still throws.

## Why a crash became a freeze

`child.on('exit')` logged the code and stopped, in both branches. Nothing ever replaced a server that died.

Only half the recovery was missing. `ServerBridge` has always reconnected every two seconds and never given up — that wall of `ECONNREFUSED` in the log is the client half working perfectly against a server nobody was bringing back.

The launcher relaunches now: not after a deliberate stop, never in host mode, growing delay, and a cap so a server that dies on startup is not respawned every few seconds forever. The attempt budget refills once a server has run a minute — otherwise three unrelated crashes across a week would refuse the third, and resetting on connection alone would let a start-connect-die loop run unbounded.

The credential moves to module scope because a replacement server must be given the same one the bridge already holds; the bridge is kept and repointed rather than replaced, because `main` holds the instance it was returned.

## A bug this branch introduced, and caught

`retarget` closed the old socket and connected the new one in the same tick. `close` is asynchronous, so the old socket's handler ran afterwards — and it sets `this.ws = null`, rejects everything pending, and schedules a reconnect. All three landed on the connection just made, leaving the bridge holding no reference to an open socket and reporting "not connected" forever. Worse than what retargeting exists to fix.

Listeners come off before the close now. The test pins the distinction that matters: both versions leave a socket open on the far end, so counting connections proves nothing — what separates them is whether a request sent afterwards reaches the wire.

## Tests, and one that was lying

`hook-payload.test.ts` redirects `HOME`. A real `HookServer` claims `~/.vorn/{hook-owner,port,token}` from `os.homedir()` with no data directory involved, so without it the suite repoints the machine's hook endpoint at a server that exists for one assertion. It was refused only because the ownership check saw the running Vorn and declined — the machine's state saving the test rather than the test being safe.

And the listener test **passed against the unfixed code** at first. Status codes cannot see this bug: both requests are answered before anything fails. It watches `uncaughtException` instead, which is what the process dying actually looks like. With the old catch restored it fails with `expected [ 'ERR_HTTP_HEADERS_SENT' ] to deeply equal []`.

## Checks

113 tests across 10 suites. `tsc --noEmit` clean on the server and node projects, eslint `--max-warnings 0` and prettier clean.

Note the local hook could not run — `lint-staged` is not installed in this checkout and the npm registry is unreachable from here — so eslint, prettier and `scripts/sync-versions.sh` were run by hand and the commits used `--no-verify`.
