### PR TITLE
Let the server outlive the app, and adopt it on relaunch

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1205,6 +1205,10 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
     // user has toggled it, so absence means "not yet decided", not "off".
     domBlockRendering: (map.domBlockRendering as boolean) ?? true,
     minimalShellPrompt: (map.minimalShellPrompt as boolean) ?? true,
+    // Sessions outlive the window. Default on, same reasoning as above: the key
+    // only appears once the user has turned it off, so absence is "not yet
+    // decided". Read by the main process at quit, not by the renderer.
+    keepSessionsRunning: (map.keepSessionsRunning as boolean) ?? true,
     ...(map.widgetEnabled !== undefined && { widgetEnabled: map.widgetEnabled as boolean }),
     ...(map.taskViewMode !== undefined && {
       taskViewMode: map.taskViewMode as AppConfig['defaults']['taskViewMode']

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,7 +10,7 @@ import type { FastifyReply, FastifyRequest } from 'fastify'
 const _dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(process.argv[1])
 import websocket from '@fastify/websocket'
 import fastifyStatic from '@fastify/static'
-import { handleConnection, registerMethod } from './ws-handler'
+import { handleConnection, registerMethod, setServerIdentity } from './ws-handler'
 import { parseTopics, clientRegistry } from './broadcast'
 import { IPC } from '@vornrun/shared/types'
 import { registerAllMethods, setServerPort } from './register-methods'
@@ -18,7 +18,7 @@ import { configManager } from './config-manager'
 import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
 import { getDataDir } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
-import { DEFAULT_SERVER_PORT } from '@vornrun/shared/protocol'
+import { DEFAULT_SERVER_PORT, WS_PORT_FILENAME } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
@@ -47,6 +47,20 @@ async function refreshTrustedOrigins(): Promise<void> {
   }
 }
 
+/**
+ * `dev` or `packaged`, preferring what the launcher told us.
+ *
+ * The fallback reads the entry point rather than NODE_ENV: NODE_ENV is set to
+ * 'production' by the packaged launcher AND left at whatever the shell had for a
+ * CLI run, so it answers a different question than the one being asked. The entry
+ * extension is the fact itself — `.ts` only runs under tsx from a checkout.
+ */
+function resolveBuildChannel(): 'dev' | 'packaged' {
+  const declared = process.env.VORN_BUILD_CHANNEL
+  if (declared === 'dev' || declared === 'packaged') return declared
+  return process.argv[1]?.endsWith('.ts') ? 'dev' : 'packaged'
+}
+
 export async function startServer(
   options: { host?: string; port?: number; dataDir?: string } = {}
 ) {
@@ -60,6 +74,19 @@ export async function startServer(
   // Anything launched from a session inherits VORN_DATA_DIR and can then find the
   // port and credential files even when --data-dir moved them.
   setLaunchDataDir(dataDir)
+
+  // Who this server is, so a desktop can decide whether to adopt it instead of
+  // starting a second one on the same data directory. The channel is passed by
+  // the launcher when there is one; a server started from the CLI infers it from
+  // its own entry point, which is TypeScript in a checkout and bundled CJS in a
+  // packaged app. Getting this wrong is not cosmetic: dev and packaged builds
+  // deliberately share ~/.vorn, so a wrong answer lets one adopt the other's.
+  setServerIdentity({
+    ...(process.env.VORN_APP_VERSION ? { appVersion: process.env.VORN_APP_VERSION } : {}),
+    dataDir,
+    pid: process.pid,
+    buildChannel: resolveBuildChannel()
+  })
 
   // Register built-in connectors
   const { connectorRegistry } = await import('./connectors')
@@ -329,7 +356,7 @@ export async function startServer(
   // Use JSON with PID so multiple instances don't clobber each other's port files.
   // Lives beside the database rather than always in ~/.vorn, so a server on its
   // own data dir advertises itself there instead of over the desktop's file.
-  const wsPortFile = path.join(dataDir, 'ws-port')
+  const wsPortFile = path.join(dataDir, WS_PORT_FILENAME)
   let ownsPortFile = true
   try {
     fs.mkdirSync(path.dirname(wsPortFile), { recursive: true })
@@ -399,6 +426,12 @@ export async function startServer(
 
   process.on('SIGTERM', shutdown)
   process.on('SIGINT', shutdown)
+  // Why: this process outlives the app that started it, so a hangup on the
+  // terminal or the departure of a parent must not take the sessions with it.
+  // SIGTERM stays honoured — that is a request to stop, not an accident.
+  process.on('SIGHUP', () => {
+    log.info('[server] ignoring SIGHUP; sessions keep running')
+  })
   process.on('message', (msg) => {
     if (msg === 'shutdown') shutdown()
   })

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -142,7 +142,15 @@ export async function startServer(
       }
     },
     (socket, req) => {
-      handleConnection(socket, bearerFrom(req.headers.authorization), parseTopics(req.query))
+      handleConnection(
+        socket,
+        bearerFrom(req.headers.authorization),
+        parseTopics(req.query),
+        // Decides whether the greeting carries this server's identity. Only a
+        // desktop on this machine has any use for it, and only loopback can be
+        // trusted not to be a stranger on the tailnet.
+        req.socket.remoteAddress
+      )
       scheduler.deliverPendingConnectorInbox()
     }
   )

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -82,7 +82,10 @@ export async function startServer(
   // packaged app. Getting this wrong is not cosmetic: dev and packaged builds
   // deliberately share ~/.vorn, so a wrong answer lets one adopt the other's.
   setServerIdentity({
-    ...(process.env.VORN_APP_VERSION ? { appVersion: process.env.VORN_APP_VERSION } : {}),
+    // The launcher passes the app's version; a CLI server has none to report and
+    // says so rather than omitting the field, since every field on this frame is
+    // required and a reader that has it should be done checking.
+    appVersion: process.env.VORN_APP_VERSION ?? 'unknown',
     dataDir,
     pid: process.pid,
     buildChannel: resolveBuildChannel()

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -50,19 +50,52 @@ let identity: Pick<ServerHello, 'appVersion' | 'dataDir' | 'pid' | 'buildChannel
 export function setServerIdentity(next: typeof identity): void {
   identity = next
   helloFrameCache = null
+  loopbackHelloFrameCache = null
 }
 
-function helloFrame(): string {
+let loopbackHelloFrameCache: string | null = null
+
+/**
+ * The greeting, which every socket receives before it has authenticated.
+ *
+ * That timing is deliberate — a client that must authenticate by message needs
+ * to know so before it is refused for not having — and it is also why the
+ * identity fields are withheld from anything that is not on loopback. They exist
+ * for one caller: a desktop on this machine deciding whether to adopt this
+ * server rather than start a second one. `dataDir` names the user's home
+ * directory, so it carries the account name, and with remote access enabled the
+ * server binds `0.0.0.0`, where the Origin allowlist does not apply to a peer
+ * that simply sends no Origin at all. A LAN peer would have read both before
+ * being disconnected.
+ */
+function helloFrame(fromLoopback: boolean): string {
   // Built on first use, not at module load: another module may still be
   // registering a capability at import time. It never varies after that.
-  helloFrameCache ??= JSON.stringify(
-    createNotification('server:hello', {
-      protocolVersion: RUNTIME_PROTOCOL_VERSION,
-      capabilities: Object.fromEntries(capabilities),
-      ...identity
-    })
+  const base = {
+    protocolVersion: RUNTIME_PROTOCOL_VERSION,
+    capabilities: Object.fromEntries(capabilities)
+  }
+  if (!fromLoopback) {
+    helloFrameCache ??= JSON.stringify(createNotification('server:hello', base))
+    return helloFrameCache
+  }
+  loopbackHelloFrameCache ??= JSON.stringify(
+    createNotification('server:hello', { ...base, ...identity })
   )
-  return helloFrameCache
+  return loopbackHelloFrameCache
+}
+
+/**
+ * Whether a peer address is this machine talking to itself.
+ *
+ * IPv4-mapped IPv6 (`::ffff:127.0.0.1`) is what a dual-stack listener actually
+ * reports for a v4 loopback connection, so matching only `127.0.0.1` would fail
+ * open in the common case -- and failing open here means withholding nothing.
+ */
+export function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false
+  const bare = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
+  return bare === '::1' || bare === '127.0.0.1' || bare.startsWith('127.')
 }
 
 // Handler registry: method name → async handler function
@@ -181,11 +214,12 @@ export function resetTokenTracking(): void {
 export function handleConnection(
   ws: WebSocket,
   credential?: string,
-  initialTopics?: readonly string[]
+  initialTopics?: readonly string[],
+  peerAddress?: string
 ): void {
   // Announce the contract first, so a client that has to authenticate by message
   // knows that it must before it is refused for not having.
-  ws.send(helloFrame())
+  ws.send(helloFrame(isLoopbackAddress(peerAddress)))
 
   let authTimer: NodeJS.Timeout | null = null
 

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -14,7 +14,8 @@ import {
   CLOSE_CREDENTIAL_REJECTED,
   RPC_NOT_AUTHENTICATED,
   type ClientNotification,
-  type ClientNotifications
+  type ClientNotifications,
+  type ServerHello
 } from '@vornrun/shared/protocol'
 import { authenticateCredential, AUTH_TIMEOUT_MS, type Authenticated } from './ws-auth'
 import { clientRegistry } from './broadcast'
@@ -36,13 +37,29 @@ export function registerCapability(name: string, version: number): void {
 
 let helloFrameCache: string | null = null
 
+/**
+ * Who this server is, for a desktop deciding whether to adopt it.
+ *
+ * Set once at startup by the entry point, which is the only place that knows the
+ * resolved data directory. Left unset in tests and in any embedding that does not
+ * call it, and a hello without identity simply is not adoptable — the launcher
+ * spawns its own rather than guessing.
+ */
+let identity: Pick<ServerHello, 'appVersion' | 'dataDir' | 'pid' | 'buildChannel'> = {}
+
+export function setServerIdentity(next: typeof identity): void {
+  identity = next
+  helloFrameCache = null
+}
+
 function helloFrame(): string {
   // Built on first use, not at module load: another module may still be
   // registering a capability at import time. It never varies after that.
   helloFrameCache ??= JSON.stringify(
     createNotification('server:hello', {
       protocolVersion: RUNTIME_PROTOCOL_VERSION,
-      capabilities: Object.fromEntries(capabilities)
+      capabilities: Object.fromEntries(capabilities),
+      ...identity
     })
   )
   return helloFrameCache

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -15,7 +15,7 @@ import {
   RPC_NOT_AUTHENTICATED,
   type ClientNotification,
   type ClientNotifications,
-  type ServerHello
+  type ServerIdentity
 } from '@vornrun/shared/protocol'
 import { authenticateCredential, AUTH_TIMEOUT_MS, type Authenticated } from './ws-auth'
 import { clientRegistry } from './broadcast'
@@ -45,44 +45,39 @@ let helloFrameCache: string | null = null
  * call it, and a hello without identity simply is not adoptable — the launcher
  * spawns its own rather than guessing.
  */
-let identity: Pick<ServerHello, 'appVersion' | 'dataDir' | 'pid' | 'buildChannel'> = {}
+let identity: ServerIdentity | null = null
+let identityFrameCache: string | null = null
 
-export function setServerIdentity(next: typeof identity): void {
+export function setServerIdentity(next: ServerIdentity): void {
   identity = next
-  helloFrameCache = null
-  loopbackHelloFrameCache = null
+  identityFrameCache = null
 }
 
-let loopbackHelloFrameCache: string | null = null
-
-/**
- * The greeting, which every socket receives before it has authenticated.
- *
- * That timing is deliberate — a client that must authenticate by message needs
- * to know so before it is refused for not having — and it is also why the
- * identity fields are withheld from anything that is not on loopback. They exist
- * for one caller: a desktop on this machine deciding whether to adopt this
- * server rather than start a second one. `dataDir` names the user's home
- * directory, so it carries the account name, and with remote access enabled the
- * server binds `0.0.0.0`, where the Origin allowlist does not apply to a peer
- * that simply sends no Origin at all. A LAN peer would have read both before
- * being disconnected.
- */
-function helloFrame(fromLoopback: boolean): string {
+function helloFrame(): string {
   // Built on first use, not at module load: another module may still be
   // registering a capability at import time. It never varies after that.
-  const base = {
-    protocolVersion: RUNTIME_PROTOCOL_VERSION,
-    capabilities: Object.fromEntries(capabilities)
-  }
-  if (!fromLoopback) {
-    helloFrameCache ??= JSON.stringify(createNotification('server:hello', base))
-    return helloFrameCache
-  }
-  loopbackHelloFrameCache ??= JSON.stringify(
-    createNotification('server:hello', { ...base, ...identity })
+  helloFrameCache ??= JSON.stringify(
+    createNotification('server:hello', {
+      protocolVersion: RUNTIME_PROTOCOL_VERSION,
+      capabilities: Object.fromEntries(capabilities)
+    })
   )
-  return loopbackHelloFrameCache
+  return helloFrameCache
+}
+
+/**
+ * Who this server is — sent only to a peer on this machine.
+ *
+ * `dataDir` names the user's home directory, so it carries the account name,
+ * and with remote access enabled the server binds `0.0.0.0` where the Origin
+ * allowlist does not apply to a peer that simply sends no Origin at all. The
+ * one caller with any use for these fields is a desktop on this machine
+ * deciding whether to adopt this server rather than start a second one.
+ */
+function identityFrame(): string | null {
+  if (!identity) return null
+  identityFrameCache ??= JSON.stringify(createNotification('server:identity', identity))
+  return identityFrameCache
 }
 
 /**
@@ -219,7 +214,11 @@ export function handleConnection(
 ): void {
   // Announce the contract first, so a client that has to authenticate by message
   // knows that it must before it is refused for not having.
-  ws.send(helloFrame(isLoopbackAddress(peerAddress)))
+  ws.send(helloFrame())
+  if (isLoopbackAddress(peerAddress)) {
+    const frame = identityFrame()
+    if (frame) ws.send(frame)
+  }
 
   let authTimer: NodeJS.Timeout | null = null
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -83,29 +83,43 @@ export interface ServerHello {
    * `auth:authenticate` message.
    */
   capabilities: Record<string, number>
-  /**
-   * Who this server is, for a desktop deciding whether to adopt it rather than
-   * start its own. All four are optional: a server that predates them is simply
-   * not adoptable, which is the safe answer rather than a broken one.
-   *
-   * Adoption turns on `protocolVersion` above, never on `appVersion`. The two
-   * move independently on purpose — `protocolVersion` changes when the messages
-   * change, `appVersion` changes every release — and gating on the release would
-   * end every running session on every update for no reason. The same split is
-   * why a mismatch here is never resolved by killing the incumbent: the server
-   * holding the PTYs is the one with the user's work in it, so a client that
-   * cannot speak to it declines and says so.
-   */
-  appVersion?: string
+}
+
+/**
+ * Who this server is, for a desktop deciding whether to adopt it rather than
+ * start its own.
+ *
+ * A separate frame from `server:hello` because the audience is different, and
+ * that difference is the whole design. Capabilities go to every client;
+ * identity goes only to a peer on loopback, because `dataDir` names the user's
+ * home directory and the server may be bound to `0.0.0.0`. Folding it into the
+ * greeting meant one message with two audiences — a frame that had to be built
+ * per-peer and cached twice, and fields that had to be optional for readers who
+ * would never receive them.
+ *
+ * Every field is required, so a reader that has this frame is done checking. A
+ * server too old to send one simply does not, and "no identity" is already the
+ * answer that declines adoption.
+ *
+ * Adoption turns on `ServerHello.protocolVersion`, never on `appVersion`. The
+ * two move independently on purpose — the protocol changes when the messages
+ * change, the release changes every time anything ships — and gating on the
+ * release would end every running session on every update for no reason. The
+ * same reasoning is why a mismatch is never settled by killing the incumbent:
+ * the server holding the PTYs holds the user's work, so a client that cannot
+ * speak to it declines and says so.
+ */
+export interface ServerIdentity {
+  appVersion: string
   /** Resolved data directory. Two servers on one directory is the case to catch. */
-  dataDir?: string
-  pid?: number
+  dataDir: string
+  pid: number
   /**
    * A dev build and a packaged build deliberately share `~/.vorn` while keeping
    * separate Electron user data, so without this a `yarn dev` launch would adopt
    * the packaged app's bundled server, or the reverse.
    */
-  buildChannel?: 'dev' | 'packaged'
+  buildChannel: 'dev' | 'packaged'
 }
 
 // ─── Authentication ─────────────────────────────────────────────
@@ -903,6 +917,8 @@ export interface RequestMethods {
 export interface ServerNotifications {
   /** First frame on every connection, before anything is dispatched. */
   'server:hello': ServerHello
+  /** Follows the greeting, on loopback only. Absent from an older server. */
+  'server:identity': ServerIdentity
   /** Sent once a socket is admitted, so a client knows it may start sending. */
   'auth:ok': { userId: string }
   'terminal:data': { id: string; data: string }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -83,6 +83,29 @@ export interface ServerHello {
    * `auth:authenticate` message.
    */
   capabilities: Record<string, number>
+  /**
+   * Who this server is, for a desktop deciding whether to adopt it rather than
+   * start its own. All four are optional: a server that predates them is simply
+   * not adoptable, which is the safe answer rather than a broken one.
+   *
+   * Adoption turns on `protocolVersion` above, never on `appVersion`. The two
+   * move independently on purpose — `protocolVersion` changes when the messages
+   * change, `appVersion` changes every release — and gating on the release would
+   * end every running session on every update for no reason. The same split is
+   * why a mismatch here is never resolved by killing the incumbent: the server
+   * holding the PTYs is the one with the user's work in it, so a client that
+   * cannot speak to it declines and says so.
+   */
+  appVersion?: string
+  /** Resolved data directory. Two servers on one directory is the case to catch. */
+  dataDir?: string
+  pid?: number
+  /**
+   * A dev build and a packaged build deliberately share `~/.vorn` while keeping
+   * separate Electron user data, so without this a `yarn dev` launch would adopt
+   * the packaged app's bundled server, or the reverse.
+   */
+  buildChannel?: 'dev' | 'packaged'
 }
 
 // ─── Authentication ─────────────────────────────────────────────
@@ -136,6 +159,16 @@ export const SERVER_PORT_ENV_VAR = 'VORN_SERVER_PORT'
 
 /** Filename, under the resolved data dir, of the credential same-machine tools read. */
 export const LOCAL_TOKEN_FILENAME = 'local-token'
+
+/**
+ * Filename, under the resolved data dir, of the running server's `{port, pid}`.
+ *
+ * Named here because three packages now depend on the exact string: the server
+ * writes it, `packages/mcp` reads it to find a server it did not start, and the
+ * desktop launcher reads it to decide whether to adopt one instead of spawning a
+ * second. It was a bare literal in the first two until the third arrived.
+ */
+export const WS_PORT_FILENAME = 'ws-port'
 
 // ─── JSON-RPC 2.0 Envelope Types ────────────────────────────────
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1086,8 +1086,9 @@ export interface AppConfig {
      * With this on, quitting closes a window and nothing else; the next launch
      * reconnects to the sessions that were already running.
      *
-     * Defaults to on. Turning it off restores the old behaviour exactly, which
-     * is also what the "End them instead" action on the quit notice does once.
+     * Defaults to on. Turning it off restores the old behaviour exactly, and
+     * "Stop Sessions and Server" in the File menu does it once without changing
+     * the setting.
      */
     keepSessionsRunning?: boolean
     /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1077,6 +1077,20 @@ export interface AppConfig {
      */
     domBlockRendering?: boolean
     /**
+     * Whether the server keeps running after the last window closes.
+     *
+     * The agents are the point. A PTY belongs to the server process, so while
+     * the server was a child of the app, quitting killed every session and
+     * reopening could only relaunch them from their transcripts — losing the
+     * process, the turn in flight, and any prompt waiting for an answer.
+     * With this on, quitting closes a window and nothing else; the next launch
+     * reconnects to the sessions that were already running.
+     *
+     * Defaults to on. Turning it off restores the old behaviour exactly, which
+     * is also what the "End them instead" action on the quit notice does once.
+     */
+    keepSessionsRunning?: boolean
+    /**
      * Set to `true` after the seeded "Default Task Workflow" has been inserted
      * once. Ensures deleting the workflow sticks — we don't resurrect it on
      * the next launch.

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -405,6 +405,11 @@ export function createApiShim(wsUrl: string) {
       rpc.on('config:changed', (p: unknown) => callback(withViewerSettings(p as AppConfig))),
 
     // ── Menu Events (Electron-only, no-op in web) ──
+    // Desktop only. A browser or phone connects to a server; it never launches
+    // one, so there is no adoption to refuse and nothing to stop.
+    onAdoptionRefused: (_callback: (notice: unknown) => void) => () => {},
+    stopRefusedServer: async () => false,
+
     onMenuNewAgent: (_callback: () => void) => () => {},
 
     // ── Sessions ──

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -406,9 +406,9 @@ export function createApiShim(wsUrl: string) {
 
     // ── Menu Events (Electron-only, no-op in web) ──
     // Desktop only. A browser or phone connects to a server; it never launches
-    // one, so there is no adoption to refuse and nothing to stop.
-    onAdoptionRefused: (_callback: (notice: unknown) => void) => () => {},
-    stopRefusedServer: async () => false,
+    // one, so there is no local server for it to be looking away from.
+    onLocalServerStillRunning: (_callback: (notice: unknown) => void) => () => {},
+    stopLocalServer: async () => ({ ok: false, error: 'Not available here.' }),
 
     onMenuNewAgent: (_callback: () => void) => () => {},
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -226,11 +226,6 @@ function toggleWidget(): void {
 }
 
 /**
- * Wire up server notification forwarding.
- * When the server pushes events via WebSocket, forward them to the
- * renderer and widget windows.
- */
-/**
  * Whether quitting should leave the sessions running.
  *
  * Cached rather than fetched at quit: `before-quit` is not a good place to start
@@ -248,6 +243,11 @@ function rememberKeepSessionsRunning(config: unknown): void {
   keepSessionsRunning = value ?? true
 }
 
+/**
+ * Wire up server notification forwarding.
+ * When the server pushes events via WebSocket, forward them to the
+ * renderer and widget windows.
+ */
 function wireServerNotifications(bridge: ServerBridge): void {
   bridge.on('server-notification', (method: string, params: unknown) => {
     if (method === IPC.CONFIG_CHANGED) rememberKeepSessionsRunning(params)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,10 +7,15 @@ import { installCompanionQuitHook } from './device-companion'
 import { installConnectorCredentialsSync } from './connector-credentials-sync'
 import { createMenu } from './menu'
 import { updateManager } from './update-manager'
-import { IPC, PermissionRequestInfo } from '../shared/types'
+import { IPC, PermissionRequestInfo, type AppConfig } from '../shared/types'
 import { setArtifactNotify } from './artifact-watcher'
 import { SURFACE } from '../shared/surface'
-import { launchServer, stopServer, getServerBridge } from './server/server-launcher'
+import {
+  launchServer,
+  stopServer,
+  detachFromServer,
+  getServerBridge
+} from './server/server-launcher'
 import { readHostSettings } from './server/host-store'
 import { registerConnectHandlers, showConnectWindow } from './server/connect-window'
 import type { ServerBridge } from './server/server-bridge'
@@ -225,8 +230,27 @@ function toggleWidget(): void {
  * When the server pushes events via WebSocket, forward them to the
  * renderer and widget windows.
  */
+/**
+ * Whether quitting should leave the sessions running.
+ *
+ * Cached rather than fetched at quit: `before-quit` is not a good place to start
+ * a round trip, and the answer decides whether a user's agents survive. Primed
+ * from the first config load and kept current by the `config:changed` broadcast
+ * that already passes through here.
+ *
+ * Defaults to true, matching the stored default — an unreadable config must not
+ * silently start ending sessions.
+ */
+let keepSessionsRunning = true
+
+function rememberKeepSessionsRunning(config: unknown): void {
+  const value = (config as AppConfig | null)?.defaults?.keepSessionsRunning
+  keepSessionsRunning = value ?? true
+}
+
 function wireServerNotifications(bridge: ServerBridge): void {
   bridge.on('server-notification', (method: string, params: unknown) => {
+    if (method === IPC.CONFIG_CHANGED) rememberKeepSessionsRunning(params)
     switch (method) {
       // Terminal data/exit → forward to renderer
       case IPC.TERMINAL_DATA:
@@ -421,7 +445,13 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.WINDOW_CLOSE, () => mainWindow?.close())
   ipcMain.handle(IPC.WINDOW_IS_MAXIMIZED, () => mainWindow?.isMaximized() ?? false)
 
-  createMenu(toggleWidget)
+  createMenu(toggleWidget, async () => {
+    // Ends the sessions and the server on purpose, then closes the app, which is
+    // the only combination that leaves nothing running. Distinct from quitting,
+    // which now leaves everything running.
+    await stopServer()
+    app.quit()
+  })
   createWindow()
 
   if (!mainWindow) {
@@ -442,16 +472,14 @@ app.whenReady().then(async () => {
   let updateChannel: 'stable' | 'beta' = 'stable'
   let updateAutoDownload = true
   try {
-    const config = await bridge.request<{
-      defaults: {
-        widgetEnabled?: boolean
-        updateChannel?: 'stable' | 'beta'
-        updateAutoDownload?: boolean
-      }
-    }>(IPC.CONFIG_LOAD)
+    const config = await bridge.request<AppConfig>(IPC.CONFIG_LOAD)
     widgetEnabled = config.defaults.widgetEnabled !== false
     updateChannel = config.defaults.updateChannel ?? 'stable'
     updateAutoDownload = config.defaults.updateAutoDownload !== false
+    // Primed here, not only from `config:changed`: that fires on save, so a user
+    // who turned this off in an earlier session and never touched it again would
+    // otherwise have their sessions kept running against their wish.
+    rememberKeepSessionsRunning(config)
   } catch {
     // Config not available yet, use defaults
   }
@@ -593,7 +621,19 @@ app.on('before-quit', async () => {
   // Killing the companions leaves the simulators Vorn booted running: nothing
   // releases a claim on the way out, and `bootedByVorn` is only honoured by
   // release. Detached, so this outlives the process rather than delaying it.
+  //
+  // Deliberately unchanged now that the server outlives the app: device
+  // ownership lives in this process (`device-registry.ts`) and every `device:*`
+  // RPC relays back here, so the server holds no device state and could not keep
+  // a claim even if it wanted to. Server-owned devices are their own piece of
+  // work, not a side effect of this one.
   deviceRegistry.shutdownOwnedDevices()
+  if (keepSessionsRunning) {
+    // A window closing, not a process dying. The agents keep working and the
+    // next launch adopts the same server.
+    detachFromServer()
+    return
+  }
   await stopServer()
 })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,17 +10,18 @@ import { updateManager } from './update-manager'
 import { IPC, PermissionRequestInfo, type AppConfig } from '../shared/types'
 import { setArtifactNotify } from './artifact-watcher'
 import { SURFACE } from '../shared/surface'
-import { ADOPTION_REFUSED_CHANNEL, ADOPTION_STOP_CHANNEL } from '../shared/adoption-channels'
+import { LOCAL_SERVER_RUNNING_CHANNEL } from '../shared/adoption-channels'
 import {
   launchServer,
   stopServer,
   detachFromServer,
   getServerBridge,
   getLastAdoptionRefusal,
-  stopRefusedServer
+  AdoptionRefusedError
 } from './server/server-launcher'
 import { readHostSettings } from './server/host-store'
 import { registerConnectHandlers, showConnectWindow } from './server/connect-window'
+import { readPortFile } from './server/server-adoption'
 import type { ServerBridge } from './server/server-bridge'
 import log from './logger'
 
@@ -229,6 +230,34 @@ function toggleWidget(): void {
 }
 
 /**
+ * What a refused adoption means, in Vorn's own words.
+ *
+ * Built from the reason alone. The refusal `detail` reads well and belongs in
+ * the log, but it interpolates strings out of the other server's greeting, and
+ * that server is the one party this app just decided it could not trust.
+ */
+function explainRefusal(reason: string): string {
+  if (reason === 'protocol-mismatch') {
+    return (
+      'Another Vorn server is already running, from a different version, and this ' +
+      'app cannot talk to it. Your sessions are still alive inside it. Stop that ' +
+      'server to start fresh here, or reopen the version that started it.'
+    )
+  }
+  if (reason === 'different-build') {
+    return (
+      'Another Vorn server is already running from a different build — a packaged ' +
+      'app beside a dev one, or the reverse. They share one database, so this app ' +
+      'will not start a second server beside it. Stop that one first.'
+    )
+  }
+  return (
+    'Another Vorn server is already running that this app cannot use, and both ' +
+    'would share one database. Stop that server to start fresh here.'
+  )
+}
+
+/**
  * Whether quitting should leave the sessions running.
  *
  * Cached rather than fetched at quit: `before-quit` is not a good place to start
@@ -406,6 +435,14 @@ app.whenReady().then(async () => {
       showConnectWindow(err instanceof Error ? err.message : String(err))
       return
     }
+    // A server this app may not use is not a failure to start — it is a running
+    // server holding the user's agents. Quitting silently would look like Vorn
+    // refusing to open for no reason, so it gets a window that names the reason
+    // and offers to end that server, which is the only thing that resolves it.
+    if (err instanceof AdoptionRefusedError) {
+      showConnectWindow(explainRefusal(err.refusal.reason), 'local-server-refused')
+      return
+    }
     app.quit()
     return
   }
@@ -470,19 +507,18 @@ app.whenReady().then(async () => {
   // Wire server notifications → renderer/widget
   wireServerNotifications(bridge)
 
-  // A refused adoption leaves the user's agents alive in a server this app
-  // cannot speak to, while the window in front of them is empty. Without this it
-  // is explained only by a line in a log nobody is reading.
-  const refusal = getLastAdoptionRefusal()
-  if (refusal) {
-    mainWindow.webContents.once('did-finish-load', () => {
-      mainWindow?.webContents.send(ADOPTION_REFUSED_CHANNEL, {
-        reason: refusal.reason,
-        canStop: refusal.incumbentPid !== null
+  // Pointed at a host while a server is still running here. Its sessions keep
+  // working and switching back to local reconnects to them -- but an agent
+  // running on a machine whose app is showing somebody else's is invisible, and
+  // invisible is the thing this whole phase exists to avoid.
+  if (readHostSettings().mode === 'host') {
+    const local = readPortFile()
+    if (local) {
+      mainWindow.webContents.once('did-finish-load', () => {
+        mainWindow?.webContents.send(LOCAL_SERVER_RUNNING_CHANNEL, { sessions: null })
       })
-    })
+    }
   }
-  ipcMain.handle(ADOPTION_STOP_CHANNEL, () => stopRefusedServer())
 
   // Decrypt connector credentials via safeStorage and push plaintext into
   // the server's in-memory store. Runs once on boot, re-syncs on every

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,11 +10,14 @@ import { updateManager } from './update-manager'
 import { IPC, PermissionRequestInfo, type AppConfig } from '../shared/types'
 import { setArtifactNotify } from './artifact-watcher'
 import { SURFACE } from '../shared/surface'
+import { ADOPTION_REFUSED_CHANNEL, ADOPTION_STOP_CHANNEL } from '../shared/adoption-channels'
 import {
   launchServer,
   stopServer,
   detachFromServer,
-  getServerBridge
+  getServerBridge,
+  getLastAdoptionRefusal,
+  stopRefusedServer
 } from './server/server-launcher'
 import { readHostSettings } from './server/host-store'
 import { registerConnectHandlers, showConnectWindow } from './server/connect-window'
@@ -463,6 +466,20 @@ app.whenReady().then(async () => {
 
   // Wire server notifications → renderer/widget
   wireServerNotifications(bridge)
+
+  // A refused adoption leaves the user's agents alive in a server this app
+  // cannot speak to, while the window in front of them is empty. Without this it
+  // is explained only by a line in a log nobody is reading.
+  const refusal = getLastAdoptionRefusal()
+  if (refusal) {
+    mainWindow.webContents.once('did-finish-load', () => {
+      mainWindow?.webContents.send(ADOPTION_REFUSED_CHANNEL, {
+        reason: refusal.reason,
+        canStop: refusal.incumbentPid !== null
+      })
+    })
+  }
+  ipcMain.handle(ADOPTION_STOP_CHANNEL, () => stopRefusedServer())
 
   // Decrypt connector credentials via safeStorage and push plaintext into
   // the server's in-memory store. Runs once on boot, re-syncs on every

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -445,11 +445,12 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.WINDOW_CLOSE, () => mainWindow?.close())
   ipcMain.handle(IPC.WINDOW_IS_MAXIMIZED, () => mainWindow?.isMaximized() ?? false)
 
-  createMenu(toggleWidget, async () => {
-    // Ends the sessions and the server on purpose, then closes the app, which is
-    // the only combination that leaves nothing running. Distinct from quitting,
-    // which now leaves everything running.
-    await stopServer()
+  createMenu(toggleWidget, () => {
+    // Ends the sessions and the server on purpose. Expressed as "quit, but do
+    // not keep them" rather than as its own shutdown, so there is exactly one
+    // path that stops a server and exactly one place that holds the quit open
+    // until it has finished.
+    keepSessionsRunning = false
     app.quit()
   })
   createWindow()
@@ -614,7 +615,10 @@ updateManager.onQuitForUpdate(() => {
   isQuitting = true
 })
 
-app.on('before-quit', async () => {
+/** Set once the deliberate shutdown has finished, so the re-entered quit proceeds. */
+let serverStopped = false
+
+app.on('before-quit', async (event) => {
   isQuitting = true
   globalShortcut.unregisterAll()
   updateManager.stop()
@@ -630,11 +634,25 @@ app.on('before-quit', async () => {
   deviceRegistry.shutdownOwnedDevices()
   if (keepSessionsRunning) {
     // A window closing, not a process dying. The agents keep working and the
-    // next launch adopts the same server.
+    // next launch adopts the same server. Synchronous, so nothing here races the
+    // quit that is already underway.
     detachFromServer()
     return
   }
-  await stopServer()
+
+  // Ending the sessions has to actually finish. Electron does not await this
+  // handler, and `stopServer` waits on a five second RPC before it signals --
+  // so without holding the quit open, the app could exit first and leave the
+  // detached server running, which is the opposite of what was asked for. This
+  // did not matter while the server died with its parent.
+  if (serverStopped) return
+  event.preventDefault()
+  try {
+    await stopServer()
+  } finally {
+    serverStopped = true
+    app.quit()
+  }
 })
 
 app.on('window-all-closed', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -253,6 +253,9 @@ function rememberKeepSessionsRunning(config: unknown): void {
  */
 function wireServerNotifications(bridge: ServerBridge): void {
   bridge.on('server-notification', (method: string, params: unknown) => {
+    // Before the switch rather than inside it: `CONFIG_CHANGED` is one label in a
+    // fall-through group that forwards seventeen events identically, so giving it
+    // a body of its own would mean splitting it out and repeating the forward.
     if (method === IPC.CONFIG_CHANGED) rememberKeepSessionsRunning(params)
     switch (method) {
       // Terminal data/exit → forward to renderer

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -5,7 +5,7 @@ const isMac = process.platform === 'darwin'
 
 export function createMenu(
   onToggleWidget?: () => void,
-  onStopServer?: () => Promise<void> | void
+  onStopServer?: () => void
 ): void {
   app.setAboutPanelOptions({
     applicationName: 'Vorn',
@@ -49,7 +49,7 @@ export function createMenu(
           // anything. Quitting is a window closing; this is the switch.
           label: 'Stop Sessions and Server',
           click: (): void => {
-            void onStopServer?.()
+            onStopServer?.()
           }
         },
         { type: 'separator' },

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -3,10 +3,7 @@ import { app, Menu, BrowserWindow } from 'electron'
 
 const isMac = process.platform === 'darwin'
 
-export function createMenu(
-  onToggleWidget?: () => void,
-  onStopServer?: () => void
-): void {
+export function createMenu(onToggleWidget?: () => void, onStopServer?: () => void): void {
   app.setAboutPanelOptions({
     applicationName: 'Vorn',
     applicationVersion: app.getVersion(),

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -3,7 +3,10 @@ import { app, Menu, BrowserWindow } from 'electron'
 
 const isMac = process.platform === 'darwin'
 
-export function createMenu(onToggleWidget?: () => void): void {
+export function createMenu(
+  onToggleWidget?: () => void,
+  onStopServer?: () => Promise<void> | void
+): void {
   app.setAboutPanelOptions({
     applicationName: 'Vorn',
     applicationVersion: app.getVersion(),
@@ -38,6 +41,15 @@ export function createMenu(onToggleWidget?: () => void): void {
           click: (): void => {
             const win = BrowserWindow.getFocusedWindow()
             win?.webContents.send('menu:new-agent')
+          }
+        },
+        { type: 'separator' },
+        {
+          // The deliberate end, kept reachable now that quitting no longer ends
+          // anything. Quitting is a window closing; this is the switch.
+          label: 'Stop Sessions and Server',
+          click: (): void => {
+            void onStopServer?.()
           }
         },
         { type: 'separator' },

--- a/src/main/server/connect-window.ts
+++ b/src/main/server/connect-window.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, ipcMain, app } from 'electron'
 import path from 'node:path'
 import log from '../logger'
 import { readHostSettings, writeHostSettings, clearHostSettings } from './host-store'
+import { stopLocalServer } from './server-launcher'
 
 /**
  * The window shown when this desktop is pointed at a server it cannot reach.
@@ -51,6 +52,8 @@ export function registerConnectHandlers(): void {
     return { ok: true }
   })
 
+  ipcMain.handle('connect:stopLocal', () => stopLocalServer())
+
   ipcMain.handle('connect:useLocal', () => {
     clearHostSettings()
     restart()
@@ -80,7 +83,12 @@ export function normaliseHostUrl(input: string): string {
   return `${secure ? 'wss:' : 'ws:'}//${parsed.host}/ws`
 }
 
-export function showConnectWindow(reason: string): void {
+export type ConnectWindowCause = 'host-unreachable' | 'local-server-refused'
+
+export function showConnectWindow(
+  reason: string,
+  cause: ConnectWindowCause = 'host-unreachable'
+): void {
   if (connectWindow && !connectWindow.isDestroyed()) {
     connectWindow.focus()
     return
@@ -110,7 +118,7 @@ export function showConnectWindow(reason: string): void {
 
   log.info('[connect] showing the connect window')
   void connectWindow.loadURL(
-    `data:text/html;charset=utf-8,${encodeURIComponent(connectMarkup(reason))}`
+    `data:text/html;charset=utf-8,${encodeURIComponent(connectMarkup(reason, cause))}`
   )
 }
 
@@ -122,7 +130,19 @@ function escapeHtml(value: string): string {
     .replace(/"/g, '&quot;')
 }
 
-function connectMarkup(reason: string): string {
+function connectMarkup(reason: string, cause: ConnectWindowCause): string {
+  // Two situations reach this window, and only one of them can be resolved by
+  // running a server here: when another one already holds this machine's data
+  // directory, "run a server on this machine" is the thing that just failed.
+  const refused = cause === 'local-server-refused'
+  const heading = refused ? 'Another Vorn server is running' : 'Cannot reach that Vorn'
+  const lede = refused
+    ? 'Your sessions are alive inside it. This app will not start a second server ' +
+      'beside it, because both would share one database.'
+    : 'The server this app is pointed at did not answer.'
+  const localButton = refused
+    ? '<button id="stop-local">Stop it and start fresh</button>'
+    : '<button id="local" class="quiet">Run a server on this machine</button>'
   return `<!doctype html>
 <html><head><meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'">
@@ -158,8 +178,8 @@ function connectMarkup(reason: string): string {
   .err { color: #c9922a; font-size: 11px; min-height: 15px; margin-bottom: 6px }
 </style></head>
 <body>
-  <h1>Cannot reach that Vorn</h1>
-  <p>The server this app is pointed at did not answer.</p>
+  <h1>${escapeHtml(heading)}</h1>
+  <p>${escapeHtml(lede)}</p>
   <div class="reason">${escapeHtml(reason)}</div>
 
   <label for="url">Server address</label>
@@ -170,7 +190,7 @@ function connectMarkup(reason: string): string {
 
   <div class="err" id="err"></div>
   <button id="connect">Connect</button>
-  <button id="local" class="quiet">Run a server on this machine</button>
+  ${localButton}
 
   <div class="note">
     A host runs your sessions and holds your data. Workflows and schedules still
@@ -191,7 +211,15 @@ function connectMarkup(reason: string): string {
   }
 
   $('connect').addEventListener('click', connect)
-  $('local').addEventListener('click', () => window.api.useLocalServer())
+  $('local')?.addEventListener('click', () => window.api.useLocalServer())
+  $('stop-local')?.addEventListener('click', async () => {
+    $('err').textContent = ''
+    const result = await window.api.stopLocalServer()
+    // Restarting is the server-picking decision run again from the top, which is
+    // what this window is for; with the incumbent gone it lands on a fresh spawn.
+    if (result.ok) window.api.useLocalServer()
+    else $('err').textContent = result.error
+  })
   document.addEventListener('keydown', (e) => { if (e.key === 'Enter') connect() })
 </script>
 </body></html>`

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -25,9 +25,18 @@ import {
  * declines and says so — it never resolves the disagreement by killing.
  */
 
-/** The data directory both the server and MCP resolve to, unless --data-dir moved it. */
+/**
+ * The data directory the server this app spawns will use.
+ *
+ * Deliberately NOT `VORN_DATA_DIR`, even though `packages/mcp` reads that. The
+ * launcher never passes `--data-dir`, so its server always resolves `~/.vorn` --
+ * and the server injects `VORN_DATA_DIR` into everything it launches, so a Vorn
+ * started from a terminal *inside* a Vorn session inherits a value describing
+ * somebody else's data directory. Honouring it here would send the launcher
+ * looking for a port file that its own server is never going to write.
+ */
 export function resolveDataDir(): string {
-  return process.env.VORN_DATA_DIR || path.join(os.homedir(), '.vorn')
+  return path.join(os.homedir(), '.vorn')
 }
 
 export type PortFile = { port: number; pid?: number }
@@ -107,7 +116,15 @@ export function judgeAdoption(
   // A server old enough to predate these fields cannot be told apart from one on
   // another data directory, so it is not adoptable. Declining costs a spawn;
   // guessing costs two servers on one database.
-  if (hello.dataDir === undefined || hello.buildChannel === undefined) {
+  // The pid is required, not decorative: it is the only way to tell a server
+  // that died from a bridge that is merely reconnecting, and the only handle
+  // left for stopping one this app did not spawn. Adopting without it yields a
+  // server that can be neither recovered nor ended.
+  if (
+    hello.dataDir === undefined ||
+    hello.buildChannel === undefined ||
+    typeof hello.pid !== 'number'
+  ) {
     return {
       kind: 'refuse',
       reason: 'no-identity',

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -51,14 +51,29 @@ export type PortFile = { port: number; pid?: number }
 export function readPortFile(dataDir = resolveDataDir()): PortFile | null {
   try {
     const raw = JSON.parse(fs.readFileSync(path.join(dataDir, WS_PORT_FILENAME), 'utf-8'))
-    const port = typeof raw?.port === 'number' ? raw.port : null
+    // Range-checked, not just typeof'd. The server writes this with a plain
+    // writeFileSync rather than tmp-then-rename, so a crash can leave something
+    // odd behind -- and a nonsense value here is not inert. `port: 0` sends the
+    // launcher at a port nothing can serve, and `pid: 0` is worse: see
+    // `isPidAlive`. Anything unreadable is treated as no record at all, which is
+    // the answer that leads to a fresh spawn rather than a stuck launch.
+    const port = isPort(raw?.port) ? raw.port : null
     if (port === null) return null
-    const pid = typeof raw?.pid === 'number' ? raw.pid : undefined
+    if (raw?.pid !== undefined && !isPid(raw.pid)) return null
+    const pid: number | undefined = raw?.pid
     if (pid !== undefined && !isPidAlive(pid)) return null
     return pid === undefined ? { port } : { port, pid }
   } catch {
     return null
   }
+}
+
+function isPort(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 1 && (value as number) <= 65535
+}
+
+function isPid(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0
 }
 
 /**
@@ -69,6 +84,13 @@ export function readPortFile(dataDir = resolveDataDir()): PortFile | null {
  * that answer is how a healthy server gets replaced.
  */
 export function isPidAlive(pid: number): boolean {
+  // Zero and negatives are not processes, they are *groups*: `process.kill(0, 0)`
+  // signals this process's own group and always succeeds, and a negative targets
+  // the group of that id. Passing either through would report a server that does
+  // not exist as permanently alive -- and since a live incumbent is refused
+  // rather than replaced, one bad byte in a file would stop the app from
+  // starting at all.
+  if (!isPid(pid)) return false
   try {
     process.kill(pid, 0)
     return true
@@ -109,6 +131,27 @@ export type RefusalReason =
  * session on every update for no reason at all, which is exactly the trap zellij
  * avoids by keeping `CLIENT_SERVER_CONTRACT_VERSION` separate from `VERSION`.
  */
+/**
+ * Whether a greeting is shaped like an identity at all.
+ *
+ * The frame is `JSON.parse`d off a socket and cast, so the type is a claim
+ * rather than a fact -- and the sender is a process this app has not yet decided
+ * to trust. Reading `dataDir` off a malformed one put `undefined` into
+ * `path.resolve`, which throws: the launcher would die where it meant to
+ * decline, and a throw that is not an AdoptionRefusedError quits the app.
+ */
+function isServerIdentity(value: ServerIdentity | null): value is ServerIdentity {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Partial<ServerIdentity>
+  return (
+    typeof v.dataDir === 'string' &&
+    v.dataDir.length > 0 &&
+    typeof v.appVersion === 'string' &&
+    (v.buildChannel === 'dev' || v.buildChannel === 'packaged') &&
+    isPid(v.pid)
+  )
+}
+
 export function judgeAdoption(
   identity: ServerIdentity | null,
   protocolVersion: number | undefined,
@@ -118,7 +161,7 @@ export function judgeAdoption(
   // another data directory, so it is not adoptable. Declining costs a spawn;
   // guessing costs two servers on one database. Nothing further needs checking
   // for undefined: every field on this frame is required.
-  if (!identity) {
+  if (!isServerIdentity(identity)) {
     return {
       kind: 'refuse',
       reason: 'no-identity',

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -189,10 +189,22 @@ export function judgeAdoption(
       detail: `it is a ${identity.buildChannel} build, this app is ${self.buildChannel}`
     }
   }
-  // Both values name the same server when everything is honest. Only one of them
-  // was written by a process this app can attribute -- the port file -- and this
-  // pid is later handed to `process.kill`, so that is the one to believe.
-  if (identity.pid !== self.expectedPid) {
+  // Both values name the same server when everything is honest, and only one of
+  // them was written by a process this app can attribute -- so where the port
+  // file has a pid, that is the one to believe, and a disagreement is refused.
+  //
+  // Where it has none, this does NOT refuse. A record without a pid is written
+  // by `packages/mcp` itself: `discoverAndHeal` finds a live server by port and
+  // rewrites the file as `{ port }` alone. Treating that as a mismatch compared
+  // a number against `undefined`, refused, and -- since a refusal now stops the
+  // launch rather than starting a rival -- locked the app out of opening at all,
+  // because one of its own components had healed a file.
+  //
+  // Adopting on the remaining evidence is sound: the identity still has to match
+  // this data directory, this build channel and this protocol, and the socket
+  // still has to accept a credential readable only by this user. Anything that
+  // clears all four already holds the user's privileges.
+  if (self.expectedPid !== undefined && identity.pid !== self.expectedPid) {
     return {
       kind: 'refuse',
       reason: 'pid-mismatch',

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -97,6 +97,8 @@ export type RefusalReason =
   | 'different-data-dir'
   | 'different-build'
   | 'pid-mismatch'
+  /** Reachable, but this app cannot authenticate to it. */
+  | 'unusable'
 
 /**
  * Whether the greeting on the other end belongs to a server this app may use.

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -5,7 +5,7 @@ import {
   LOCAL_TOKEN_FILENAME,
   WS_PORT_FILENAME,
   RUNTIME_PROTOCOL_VERSION,
-  type ServerHello
+  type ServerIdentity
 } from '@vornrun/shared/protocol'
 
 /**
@@ -96,6 +96,7 @@ export type RefusalReason =
   | 'protocol-mismatch'
   | 'different-data-dir'
   | 'different-build'
+  | 'pid-mismatch'
 
 /**
  * Whether the greeting on the other end belongs to a server this app may use.
@@ -107,49 +108,50 @@ export type RefusalReason =
  * avoids by keeping `CLIENT_SERVER_CONTRACT_VERSION` separate from `VERSION`.
  */
 export function judgeAdoption(
-  hello: ServerHello | null,
-  self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
+  identity: ServerIdentity | null,
+  protocolVersion: number | undefined,
+  self: { dataDir: string; buildChannel: 'dev' | 'packaged'; expectedPid: number | undefined }
 ): AdoptionVerdict {
-  if (!hello) {
-    return { kind: 'refuse', reason: 'no-identity', detail: 'no greeting arrived' }
-  }
-  // A server old enough to predate these fields cannot be told apart from one on
+  // A server too old to send an identity frame cannot be told apart from one on
   // another data directory, so it is not adoptable. Declining costs a spawn;
-  // guessing costs two servers on one database.
-  // The pid is required, not decorative: it is the only way to tell a server
-  // that died from a bridge that is merely reconnecting, and the only handle
-  // left for stopping one this app did not spawn. Adopting without it yields a
-  // server that can be neither recovered nor ended.
-  if (
-    hello.dataDir === undefined ||
-    hello.buildChannel === undefined ||
-    typeof hello.pid !== 'number'
-  ) {
+  // guessing costs two servers on one database. Nothing further needs checking
+  // for undefined: every field on this frame is required.
+  if (!identity) {
     return {
       kind: 'refuse',
       reason: 'no-identity',
-      detail: 'the running server does not report its identity'
+      detail: 'the running server did not say who it is'
     }
   }
-  if (hello.protocolVersion !== RUNTIME_PROTOCOL_VERSION) {
+  if (protocolVersion !== RUNTIME_PROTOCOL_VERSION) {
     return {
       kind: 'refuse',
       reason: 'protocol-mismatch',
-      detail: `it speaks protocol ${hello.protocolVersion}, this app speaks ${RUNTIME_PROTOCOL_VERSION}`
+      detail: `it speaks protocol ${protocolVersion}, this app speaks ${RUNTIME_PROTOCOL_VERSION}`
     }
   }
-  if (path.resolve(hello.dataDir) !== path.resolve(self.dataDir)) {
+  if (path.resolve(identity.dataDir) !== path.resolve(self.dataDir)) {
     return {
       kind: 'refuse',
       reason: 'different-data-dir',
-      detail: `it holds ${hello.dataDir}, this app wants ${self.dataDir}`
+      detail: `it holds ${identity.dataDir}, this app wants ${self.dataDir}`
     }
   }
-  if (hello.buildChannel !== self.buildChannel) {
+  if (identity.buildChannel !== self.buildChannel) {
     return {
       kind: 'refuse',
       reason: 'different-build',
-      detail: `it is a ${hello.buildChannel} build, this app is ${self.buildChannel}`
+      detail: `it is a ${identity.buildChannel} build, this app is ${self.buildChannel}`
+    }
+  }
+  // Both values name the same server when everything is honest. Only one of them
+  // was written by a process this app can attribute -- the port file -- and this
+  // pid is later handed to `process.kill`, so that is the one to believe.
+  if (identity.pid !== self.expectedPid) {
+    return {
+      kind: 'refuse',
+      reason: 'pid-mismatch',
+      detail: `it reports pid ${identity.pid}, the port file says ${self.expectedPid}`
     }
   }
   return { kind: 'adopt' }

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  LOCAL_TOKEN_FILENAME,
+  WS_PORT_FILENAME,
+  RUNTIME_PROTOCOL_VERSION,
+  type ServerHello
+} from '@vornrun/shared/protocol'
+
+/**
+ * Deciding whether a server that is already running is ours to use.
+ *
+ * The question only exists because the server now outlives the app. While it was
+ * a child, "is one running" had one answer per launch; detached, an updater
+ * restart, a crash respawn, a second launch and a `yarn dev` beside a packaged
+ * build all reach this code against a live incumbent.
+ *
+ * The rule this file exists to hold, taken from the terminal multiplexers that
+ * have lived with it longest: **the incumbent wins.** tmux answers a bad protocol
+ * version by marking the peer bad and letting the *client* exit; zellij keeps the
+ * wire contract in its socket directory name so mismatched pairs never meet. In
+ * neither does a starting process end a running one. The server holding the PTYs
+ * is the one with the user's work in it, so a client that cannot speak to it
+ * declines and says so — it never resolves the disagreement by killing.
+ */
+
+/** The data directory both the server and MCP resolve to, unless --data-dir moved it. */
+export function resolveDataDir(): string {
+  return process.env.VORN_DATA_DIR || path.join(os.homedir(), '.vorn')
+}
+
+export type PortFile = { port: number; pid?: number }
+
+/**
+ * The `{port, pid}` a running server publishes, or null.
+ *
+ * A stale file is the normal case after a SIGKILL — the server deletes it on an
+ * orderly exit only. So a record whose pid is dead is treated as absent rather
+ * than trusted; the port it names may since have been taken by anything.
+ */
+export function readPortFile(dataDir = resolveDataDir()): PortFile | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(dataDir, WS_PORT_FILENAME), 'utf-8'))
+    const port = typeof raw?.port === 'number' ? raw.port : null
+    if (port === null) return null
+    const pid = typeof raw?.pid === 'number' ? raw.pid : undefined
+    if (pid !== undefined && !isPidAlive(pid)) return null
+    return pid === undefined ? { port } : { port, pid }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Whether a pid is running.
+ *
+ * `EPERM` means alive and owned by somebody else, which is still alive — the
+ * mistake to avoid is collapsing "cannot tell" into "dead", because acting on
+ * that answer is how a healthy server gets replaced.
+ */
+export function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/** The credential a server publishes for same-machine callers, or null. */
+export function readLocalToken(dataDir = resolveDataDir()): string | null {
+  try {
+    const token = fs.readFileSync(path.join(dataDir, LOCAL_TOKEN_FILENAME), 'utf-8').trim()
+    return token.length > 0 ? token : null
+  } catch {
+    return null
+  }
+}
+
+export type AdoptionVerdict =
+  | { kind: 'adopt' }
+  | { kind: 'refuse'; reason: RefusalReason; detail: string }
+
+export type RefusalReason =
+  | 'no-identity'
+  | 'protocol-mismatch'
+  | 'different-data-dir'
+  | 'different-build'
+
+/**
+ * Whether the greeting on the other end belongs to a server this app may use.
+ *
+ * Gated on `protocolVersion`, never on `appVersion`. The two move independently
+ * on purpose: the protocol changes when the messages change, the release changes
+ * every time anything ships. Gating on the release would end every running
+ * session on every update for no reason at all, which is exactly the trap zellij
+ * avoids by keeping `CLIENT_SERVER_CONTRACT_VERSION` separate from `VERSION`.
+ */
+export function judgeAdoption(
+  hello: ServerHello | null,
+  self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
+): AdoptionVerdict {
+  if (!hello) {
+    return { kind: 'refuse', reason: 'no-identity', detail: 'no greeting arrived' }
+  }
+  // A server old enough to predate these fields cannot be told apart from one on
+  // another data directory, so it is not adoptable. Declining costs a spawn;
+  // guessing costs two servers on one database.
+  if (hello.dataDir === undefined || hello.buildChannel === undefined) {
+    return {
+      kind: 'refuse',
+      reason: 'no-identity',
+      detail: 'the running server does not report its identity'
+    }
+  }
+  if (hello.protocolVersion !== RUNTIME_PROTOCOL_VERSION) {
+    return {
+      kind: 'refuse',
+      reason: 'protocol-mismatch',
+      detail: `it speaks protocol ${hello.protocolVersion}, this app speaks ${RUNTIME_PROTOCOL_VERSION}`
+    }
+  }
+  if (path.resolve(hello.dataDir) !== path.resolve(self.dataDir)) {
+    return {
+      kind: 'refuse',
+      reason: 'different-data-dir',
+      detail: `it holds ${hello.dataDir}, this app wants ${self.dataDir}`
+    }
+  }
+  if (hello.buildChannel !== self.buildChannel) {
+    return {
+      kind: 'refuse',
+      reason: 'different-build',
+      detail: `it is a ${hello.buildChannel} build, this app is ${self.buildChannel}`
+    }
+  }
+  return { kind: 'adopt' }
+}

--- a/src/main/server/server-bridge.ts
+++ b/src/main/server/server-bridge.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws'
 import { EventEmitter } from 'node:events'
-import type { RpcResponse, RpcNotification } from '@vornrun/shared/protocol'
+import type { RpcResponse, RpcNotification, ServerHello } from '@vornrun/shared/protocol'
 import { createRequest, createNotification } from '@vornrun/shared/protocol'
 import log from '../logger'
 
@@ -28,6 +28,16 @@ export class ServerBridge extends EventEmitter {
   private reconnectTimer: NodeJS.Timeout | null = null
   private shouldReconnect = true
   private inbound = new Map<string, (params: unknown) => unknown>()
+  /**
+   * The greeting, once it has arrived. The server sends it as the first frame on
+   * every socket and before authentication, so a caller deciding whether to adopt
+   * this server can read it without first proving who it is.
+   */
+  private hello: ServerHello | null = null
+
+  get serverHello(): ServerHello | null {
+    return this.hello
+  }
 
   constructor(url: string, credential?: string) {
     super()
@@ -77,9 +87,9 @@ export class ServerBridge extends EventEmitter {
           this.handleResponse(msg as RpcResponse)
         } else if ('method' in msg) {
           if (msg.method === 'server:hello') {
-            // Recorded in the log only. Pass B adds the field that gates on a
-            // capability, at the point where something actually reads it.
-            log.info({ hello: (msg as RpcNotification).params }, '[bridge] server protocol')
+            this.hello = (msg as RpcNotification).params as ServerHello
+            this.emit('hello', this.hello)
+            log.info({ hello: this.hello }, '[bridge] server protocol')
           }
           this.emit('server-notification', msg.method, (msg as RpcNotification).params)
         }

--- a/src/main/server/server-bridge.ts
+++ b/src/main/server/server-bridge.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws'
 import { EventEmitter } from 'node:events'
-import type { RpcResponse, RpcNotification, ServerHello } from '@vornrun/shared/protocol'
+import type { RpcResponse, RpcNotification, ServerIdentity } from '@vornrun/shared/protocol'
 import { createRequest, createNotification } from '@vornrun/shared/protocol'
 import log from '../logger'
 
@@ -29,14 +29,22 @@ export class ServerBridge extends EventEmitter {
   private shouldReconnect = true
   private inbound = new Map<string, (params: unknown) => unknown>()
   /**
-   * The greeting, once it has arrived. The server sends it as the first frame on
-   * every socket and before authentication, so a caller deciding whether to adopt
-   * this server can read it without first proving who it is.
+   * Who the server said it is, once it has said so.
+   *
+   * Follows the greeting, before authentication, and only on loopback — so a
+   * caller deciding whether to adopt this server can read it without first
+   * proving who it is, and a stranger on the network never sees it at all.
    */
-  private hello: ServerHello | null = null
+  private identity: ServerIdentity | null = null
+  /** From the greeting, which every socket receives. Undefined until it lands. */
+  private helloVersion: number | undefined
 
-  get serverHello(): ServerHello | null {
-    return this.hello
+  get serverIdentity(): ServerIdentity | null {
+    return this.identity
+  }
+
+  get serverHelloVersion(): number | undefined {
+    return this.helloVersion
   }
 
   constructor(url: string, credential?: string) {
@@ -138,9 +146,13 @@ export class ServerBridge extends EventEmitter {
           this.handleResponse(msg as RpcResponse)
         } else if ('method' in msg) {
           if (msg.method === 'server:hello') {
-            this.hello = (msg as RpcNotification).params as ServerHello
-            this.emit('hello', this.hello)
-            log.info({ hello: this.hello }, '[bridge] server protocol')
+            const hello = (msg as RpcNotification).params as { protocolVersion?: number }
+            this.helloVersion = hello?.protocolVersion
+            log.info({ hello }, '[bridge] server protocol')
+          }
+          if (msg.method === 'server:identity') {
+            this.identity = (msg as RpcNotification).params as ServerIdentity
+            this.emit('identity', this.identity)
           }
           this.emit('server-notification', msg.method, (msg as RpcNotification).params)
         }

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -708,17 +708,22 @@ export async function stopServer(): Promise<void> {
 
   if (serverProcess) {
     const child = serverProcess
-    if (!child.killed) {
-      if (process.platform === 'win32') {
-        child.kill()
-      } else {
-        child.kill('SIGTERM')
-        setTimeout(() => {
-          if (child && !child.killed) {
-            child.kill('SIGKILL')
-          }
-        }, 3000)
-      }
+    if (process.platform === 'win32') {
+      child.kill()
+    } else {
+      child.kill('SIGTERM')
+      setTimeout(() => {
+        // Asked whether the process is still there, not whether we asked it to
+        // go. `child.killed` is true the moment a signal is *delivered*, even to
+        // a process that ignores it -- so gating on it made this fallback
+        // unreachable and left a server running after the user chose to stop it.
+        // That was survivable while the server died with its parent anyway; a
+        // detached one just keeps going.
+        if (child.pid && isPidAlive(child.pid)) {
+          log.warn(`[launcher] server ${child.pid} ignored SIGTERM; sending SIGKILL`)
+          child.kill('SIGKILL')
+        }
+      }, 3000)
     }
     serverProcess = null
   } else if (adoptedPid !== null && isPidAlive(adoptedPid)) {

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
-import { mkdirSync } from 'node:fs'
-import path from 'node:path'
+import { closeSync, mkdirSync, openSync } from 'node:fs'
+import path, { join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { app } from 'electron'
 import log from '../logger'
@@ -85,23 +85,6 @@ function buildChannel(): 'dev' | 'packaged' {
  */
 function identityEnv(): Record<string, string> {
   return { VORN_BUILD_CHANNEL: buildChannel(), VORN_APP_VERSION: app.getVersion() }
-}
-
-/**
- * Let go of a detached child's pipes once it has reported for duty.
- *
- * Both are `Socket`s, and an open one references this process's event loop --
- * `child.unref()` does not cover them, so leaving either attached keeps Electron
- * alive at quit waiting on a server that is never going to close them.
- *
- * They exist at all for the reason abduco keeps a pipe across its own fork: a
- * daemon that fails during startup has nowhere to say so, and a silent failure
- * to start is far worse to debug than a noisy one. So they stay open exactly as
- * long as the answer takes.
- */
-function releaseChildStreams(child: ChildProcess): void {
-  child.stdout?.destroy()
-  child.stderr?.destroy()
 }
 
 /**
@@ -201,6 +184,7 @@ function readDevPort(): string | undefined {
  */
 async function spawnServer(): Promise<number> {
   lastSpawnAt = Date.now()
+  const dataDir = ensureDataDir()
   const serverEntryPoint = resolveServerEntry()
   log.info(`[launcher] starting server: ${serverEntryPoint}`)
 
@@ -272,10 +256,6 @@ async function spawnServer(): Promise<number> {
       child.kill('SIGKILL')
       throw err
     })
-    // Streams released for the same reason as production -- an open pipe refs
-    // this process's event loop -- but the child is left ref'd, because in dev
-    // it is meant to go when the app goes.
-    releaseChildStreams(child)
   } else {
     // Deliberately NOT utilityProcess.fork: a utility process is tied to this
     // app's lifetime by design, so it can never outlive the window -- which is
@@ -294,8 +274,21 @@ async function spawnServer(): Promise<number> {
     // here and passed through the environment for the server to use.
     const asarUnpacked = path.join(app.getAppPath() + '.unpacked', 'node_modules')
 
+    // Straight to a file, not to pipes.
+    //
+    // A pipe held by this process dies with this process, and the server is
+    // meant to outlive it: the next write to stderr after that raises EPIPE, and
+    // the server installs no uncaughtException handler, so it exits. Its logger
+    // writes to `process.stderr` on every request, so the window is one log line
+    // wide. Measured both ways -- destroying the parent's end and merely
+    // unref'ing it both killed the child on its next write.
+    //
+    // A file descriptor does not care that the parent is gone, and the startup
+    // diagnostics a pipe existed to carry end up somewhere durable rather than
+    // in a log that stops the moment the app does.
+    const logFd = openSync(join(dataDir, SERVER_LOG_FILENAME), 'a')
     const child = spawn(process.execPath, [serverEntryPoint], {
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', logFd, logFd],
       detached: true,
       // A daemon must not hold open a directory that can be deleted underneath
       // it, so not the app bundle and not a worktree. The data dir is where the
@@ -303,7 +296,7 @@ async function spawnServer(): Promise<number> {
       // to serve -- but on a first run it does not exist yet: the *server*
       // creates it, and it has not started. `spawn` with a missing cwd fails
       // ENOENT, so it is created here first.
-      cwd: ensureDataDir(),
+      cwd: dataDir,
       env: {
         ...process.env,
         ELECTRON_RUN_AS_NODE: '1',
@@ -315,16 +308,25 @@ async function spawnServer(): Promise<number> {
       }
     })
 
+    // Closed here as soon as the child holds its own copy; leaving it open would
+    // keep a descriptor in this process for a file only the server writes to.
+    closeSync(logFd)
+
     serverProcess = child
     child.on('exit', (code) => {
       onServerExit(`code=${code}`)
     })
+    child.on('error', (err) => {
+      log.error({ err }, '[launcher] could not start the server')
+    })
 
-    port = await readServerPort(child).catch((err) => {
+    // Nothing to read from: the port arrives through the file the server writes
+    // for MCP, and the same watcher that waits for it proves the server got as
+    // far as listening.
+    port = await waitForPublishedPort(child).catch((err) => {
       child.kill('SIGKILL')
       throw err
     })
-    releaseChildStreams(child)
     child.unref()
   }
 
@@ -400,8 +402,8 @@ function onServerExit(detail: string): void {
 
 /** Long enough for a busy event loop, short enough not to stall a cold launch. */
 const ADOPT_HELLO_TIMEOUT_MS = 3_000
-/** How long a socket must stay open to count as accepted. Loopback, so short. */
-const ADOPT_SETTLE_MS = 250
+/** How long to wait for the round trip that proves the credential was accepted. */
+const ADOPT_AUTH_TIMEOUT_MS = 5_000
 
 /**
  * Connect to a server that is already running and decide whether to keep it.
@@ -448,21 +450,14 @@ async function tryAdopt(
   // greeting resolves and proves nothing -- an earlier version of this checked
   // exactly that and could never have been false.
   //
-  // What a rejection does do is close the socket promptly, so the honest test is
-  // whether it stays open. On loopback, against a server that has already sent a
-  // frame, a short settle is enough.
-  const rejected = await new Promise<boolean>((resolve) => {
-    const timer = setTimeout(() => {
-      candidate.off('disconnected', onDrop)
-      resolve(false)
-    }, ADOPT_SETTLE_MS)
-    function onDrop(): void {
-      clearTimeout(timer)
-      resolve(true)
-    }
-    candidate.once('disconnected', onDrop)
-  })
-  if (rejected || !candidate.isConnected) {
+  // A timer would only guess. An authenticated round trip is the question
+  // itself: `config:load` is refused outright without a credential, so a reply
+  // to it *is* the proof, and it is a read this app makes moments later anyway.
+  const accepted = await candidate
+    .request('config:load', undefined, ADOPT_AUTH_TIMEOUT_MS)
+    .then(() => true)
+    .catch(() => false)
+  if (!accepted) {
     candidate.close()
     log.warn('[launcher] the running server did not accept this app; starting our own')
     return null
@@ -570,8 +565,18 @@ export function detachFromServer(): void {
 
   bridge?.close()
   bridge = null
-  // Dropped without killing. The child is unref'd and in its own process group,
-  // so nothing here holds it and nothing here will end it.
+
+  // In dev the child is not detached, and on POSIX nothing kills a plain child
+  // when its parent exits -- it is simply reparented. Walking away would leave
+  // the `npx tsx` server running for the next `yarn dev` to adopt, which is the
+  // stale-source trap the dev spawn is written to avoid. Dev keeps the old
+  // lifetime in full: the server goes when the app goes.
+  if (serverProcess && process.env.ELECTRON_RENDERER_URL) {
+    serverProcess.kill('SIGTERM')
+  }
+
+  // Otherwise dropped without killing: a packaged child is unref'd and in its
+  // own process group, so nothing here holds it and nothing here will end it.
   serverProcess = null
   adoptedPid = null
 }
@@ -622,6 +627,17 @@ export async function stopServer(): Promise<void> {
       }
     }
     serverProcess = null
+  } else if (adoptedPid !== null && isPidAlive(adoptedPid)) {
+    // An adopted server has no child handle, so the RPC above was the only way
+    // to ask -- and if it threw or timed out, nothing has happened yet. Without
+    // this the user picks "Stop Sessions and Server", the app quits, and every
+    // session carries on with nothing to say so. The pid is the handle left.
+    log.warn('[launcher] the adopted server did not answer; signalling it directly')
+    try {
+      process.kill(adoptedPid, 'SIGTERM')
+    } catch (err) {
+      log.warn({ err }, '[launcher] could not signal the adopted server')
+    }
   }
   adoptedPid = null
 }
@@ -635,6 +651,53 @@ function resolveServerEntry(): string {
   }
   return path.join(process.resourcesPath, 'server', 'index.cjs')
 }
+
+/**
+ * Wait for a server we just spawned to publish its port.
+ *
+ * Only ever satisfied by a file naming *this* child. The same file is what
+ * `launchServer` reads before deciding whether to adopt, so a launch that
+ * declined an incumbent -- wrong protocol, wrong build -- would otherwise find
+ * the incumbent's record still sitting there and resolve to its port, handing
+ * the bridge a credential that server never had while the child we actually
+ * started ran unwatched somewhere else.
+ */
+function waitForPublishedPort(child: ChildProcess): Promise<number> {
+  const deadline = Date.now() + SPAWN_READY_TIMEOUT_MS
+  return new Promise((resolve, reject) => {
+    let exited: number | null = null
+    child.once('exit', (code) => {
+      exited = code ?? -1
+    })
+
+    const poll = (): void => {
+      const published = readPortFile()
+      if (published && published.pid === child.pid) {
+        resolve(published.port)
+        return
+      }
+      if (exited !== null) {
+        reject(new Error(`Server exited before reporting port (code=${exited})`))
+        return
+      }
+      if (Date.now() >= deadline) {
+        reject(
+          new Error(
+            `Timeout waiting for the server to start. Its output is in ${SERVER_LOG_FILENAME}.`
+          )
+        )
+        return
+      }
+      setTimeout(poll, SPAWN_POLL_MS).unref?.()
+    }
+    poll()
+  })
+}
+
+/** Where a detached server's stdout and stderr go, under the data directory. */
+const SERVER_LOG_FILENAME = 'server.log'
+const SPAWN_READY_TIMEOUT_MS = 20_000
+const SPAWN_POLL_MS = 100
 
 /**
  * Wait for the server to say which port it took.

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -51,11 +51,41 @@ let relaunchTimer: NodeJS.Timeout | null = null
  */
 let adoptedPid: number | null = null
 
-/** What the last adoption attempt refused, for the UI to explain. Null when none did. */
-let lastRefusal: (AdoptionVerdict & { kind: 'refuse' }) | null = null
+/**
+ * What the last adoption attempt refused, and the pid still holding the sessions.
+ *
+ * Kept because a refusal is the user's problem, not just a log line: their agents
+ * are alive in a server this app cannot speak to, and the app they are looking at
+ * is empty. The pid is what lets them end it on purpose -- the one actor allowed
+ * to, since this code never ends an incumbent on its own.
+ */
+export type AdoptionRefusal = AdoptionVerdict & { kind: 'refuse' } & { incumbentPid: number | null }
 
-export function getLastAdoptionRefusal(): (AdoptionVerdict & { kind: 'refuse' }) | null {
+let lastRefusal: AdoptionRefusal | null = null
+
+export function getLastAdoptionRefusal(): AdoptionRefusal | null {
   return lastRefusal
+}
+
+/**
+ * End the server this app refused to adopt, because the user asked.
+ *
+ * The doctrine is that a starting app never ends a running server -- it holds
+ * somebody's work and cannot be judged from outside. It says nothing about the
+ * person whose work it is, who is the only one in a position to decide.
+ */
+export function stopRefusedServer(): boolean {
+  const pid = lastRefusal?.incumbentPid
+  if (pid == null || !isPidAlive(pid)) return false
+  try {
+    process.kill(pid, 'SIGTERM')
+    log.info(`[launcher] stopped the refused server (pid ${pid}) at the user's request`)
+    lastRefusal = null
+    return true
+  } catch (err) {
+    log.warn({ err }, '[launcher] could not stop the refused server')
+    return false
+  }
 }
 
 /**
@@ -415,6 +445,7 @@ const ADOPT_AUTH_TIMEOUT_MS = 5_000
  */
 async function tryAdopt(
   port: number,
+  expectedPid: number | undefined,
   self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
 ): Promise<{ bridge: ServerBridge } | { refusal: AdoptionVerdict & { kind: 'refuse' } } | null> {
   const token = readLocalToken(self.dataDir)
@@ -471,7 +502,17 @@ async function tryAdopt(
   // forever against a healthy server, rejected every time.
   bootstrapToken = token
 
-  adoptedPid = hello?.pid ?? null
+  // The port file's pid, not the greeting's. Both name the same server when
+  // everything is honest, but only one of them was written by a process this
+  // app can attribute -- and this value is later handed to `process.kill`.
+  if (hello?.pid !== expectedPid) {
+    candidate.close()
+    log.warn(
+      `[launcher] the server on port ${port} reports pid ${hello?.pid}, but the port file says ${expectedPid}; starting our own`
+    )
+    return null
+  }
+  adoptedPid = expectedPid ?? null
   // An adopted server has no child handle, so nothing would ever call
   // `onServerExit` for it. Watching the socket is the only signal available, and
   // the pid distinguishes the two reasons it drops: a server that died, and one
@@ -508,13 +549,16 @@ export async function launchServer(): Promise<ServerBridge> {
   lastRefusal = null
   const published = readPortFile(dataDir)
   if (published) {
-    const outcome = await tryAdopt(published.port, { dataDir, buildChannel: buildChannel() })
+    const outcome = await tryAdopt(published.port, published.pid, {
+      dataDir,
+      buildChannel: buildChannel()
+    })
     if (outcome && 'bridge' in outcome) {
       bridge = outcome.bridge
       return bridge
     }
     if (outcome && 'refusal' in outcome) {
-      lastRefusal = outcome.refusal
+      lastRefusal = { ...outcome.refusal, incumbentPid: published.pid ?? null }
       log.warn(
         `[launcher] declined to adopt the running server (${outcome.refusal.reason}): ` +
           `${outcome.refusal.detail}. It keeps running and keeps its sessions.`

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -5,7 +5,11 @@ import path, { join } from 'node:path'
 import { createInterface } from 'node:readline'
 import { app } from 'electron'
 import log from '../logger'
-import { BOOTSTRAP_ENV_VAR, SERVER_PORT_ENV_VAR, type ServerHello } from '@vornrun/shared/protocol'
+import {
+  BOOTSTRAP_ENV_VAR,
+  SERVER_PORT_ENV_VAR,
+  type ServerIdentity
+} from '@vornrun/shared/protocol'
 import { ServerBridge } from './server-bridge'
 import { readHostSettings } from './host-store'
 import { attemptsAfterExit, decideRelaunch } from './server-relaunch'
@@ -214,7 +218,6 @@ function readDevPort(): string | undefined {
  */
 async function spawnServer(): Promise<number> {
   lastSpawnAt = Date.now()
-  const dataDir = ensureDataDir()
   const serverEntryPoint = resolveServerEntry()
   log.info(`[launcher] starting server: ${serverEntryPoint}`)
 
@@ -230,7 +233,7 @@ async function spawnServer(): Promise<number> {
   // Electron's userData, which the server then ignored for everything except
   // task images, so it was inert. Passing it once the server honours it would
   // point the database at an empty directory and read as total data loss.
-  const isDev = !!process.env.ELECTRON_RENDERER_URL
+  const isDev = buildChannel() === 'dev'
 
   let port: number
 
@@ -278,9 +281,7 @@ async function spawnServer(): Promise<number> {
     // after that is one nothing holds a reference to -- unkillable by
     // `stopServer`, invisible to the relaunch logic, and still on the port.
     serverProcess = child
-    child.on('exit', (code, signal) => {
-      onServerExit(`code=${code}, signal=${signal}`)
-    })
+    child.on('exit', onChildExit)
 
     port = await readServerPort(child).catch((err) => {
       child.kill('SIGKILL')
@@ -302,6 +303,11 @@ async function spawnServer(): Promise<number> {
     // The main process has Electron's ASAR patching so it can resolve native
     // modules. A plain Node child does NOT, so the absolute paths are resolved
     // here and passed through the environment for the server to use.
+    // Created here rather than at the top of this function: only this branch
+    // reads it, and the dev branch would otherwise pay a blocking recursive
+    // mkdirSync on every spawn -- including every crash relaunch during a
+    // `yarn dev` session -- for a value it never touches.
+    const dataDir = ensureDataDir()
     const asarUnpacked = path.join(app.getAppPath() + '.unpacked', 'node_modules')
 
     // Straight to a file, not to pipes.
@@ -343,9 +349,7 @@ async function spawnServer(): Promise<number> {
     closeSync(logFd)
 
     serverProcess = child
-    child.on('exit', (code) => {
-      onServerExit(`code=${code}`)
-    })
+    child.on('exit', onChildExit)
     child.on('error', (err) => {
       log.error({ err }, '[launcher] could not start the server')
     })
@@ -381,7 +385,12 @@ async function spawnServer(): Promise<number> {
 function onServerExit(detail: string): void {
   const uptimeMs = lastSpawnAt === 0 ? 0 : Date.now() - lastSpawnAt
   log.warn(`[launcher] server exited (${detail}) after ${Math.round(uptimeMs / 1000)}s`)
+  // Both, not just the child handle. "How are we holding this server" is one
+  // fact stored in two variables -- a child we spawned, or a pid we adopted --
+  // and until this cleared only one of them, the caller on the adopted path had
+  // to clear the other itself. One invariant with two owners is how they drift.
   serverProcess = null
+  adoptedPid = null
   relaunchAttempts = attemptsAfterExit(relaunchAttempts, uptimeMs)
 
   const decision = decideRelaunch({
@@ -430,8 +439,13 @@ function onServerExit(detail: string): void {
   }, decision.delayMs)
 }
 
-/** Long enough for a busy event loop, short enough not to stall a cold launch. */
-const ADOPT_HELLO_TIMEOUT_MS = 3_000
+/**
+ * Long enough for a busy event loop, short enough not to stall a cold launch.
+ *
+ * A server that sends no identity frame at all -- too old, or not on loopback --
+ * costs exactly this before the launch gives up and spawns its own.
+ */
+const ADOPT_IDENTITY_TIMEOUT_MS = 3_000
 /** How long to wait for the round trip that proves the credential was accepted. */
 const ADOPT_AUTH_TIMEOUT_MS = 5_000
 
@@ -461,15 +475,18 @@ async function tryAdopt(
   // authentication, so this resolves even against a server that would reject the
   // credential. A timeout means "cannot tell", which must not be read as "dead":
   // that reading is how a second server gets started on a live port.
-  const hello = await new Promise<ServerHello | null>((resolve) => {
-    const timer = setTimeout(() => resolve(null), ADOPT_HELLO_TIMEOUT_MS)
-    candidate.once('hello', (h: ServerHello) => {
+  const identity = await new Promise<ServerIdentity | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), ADOPT_IDENTITY_TIMEOUT_MS)
+    candidate.once('identity', (found: ServerIdentity) => {
       clearTimeout(timer)
-      resolve(h)
+      resolve(found)
     })
   })
 
-  const verdict = judgeAdoption(hello, self)
+  const verdict = judgeAdoption(identity, candidate.serverHelloVersion, {
+    ...self,
+    expectedPid
+  })
   if (verdict.kind === 'refuse') {
     candidate.close()
     return { refusal: verdict }
@@ -502,16 +519,6 @@ async function tryAdopt(
   // forever against a healthy server, rejected every time.
   bootstrapToken = token
 
-  // The port file's pid, not the greeting's. Both name the same server when
-  // everything is honest, but only one of them was written by a process this
-  // app can attribute -- and this value is later handed to `process.kill`.
-  if (hello?.pid !== expectedPid) {
-    candidate.close()
-    log.warn(
-      `[launcher] the server on port ${port} reports pid ${hello?.pid}, but the port file says ${expectedPid}; starting our own`
-    )
-    return null
-  }
   adoptedPid = expectedPid ?? null
   // An adopted server has no child handle, so nothing would ever call
   // `onServerExit` for it. Watching the socket is the only signal available, and
@@ -520,9 +527,7 @@ async function tryAdopt(
   candidate.on('disconnected', () => {
     if (adoptedPid === null || stoppingDeliberately) return
     if (isPidAlive(adoptedPid)) return
-    const pid = adoptedPid
-    adoptedPid = null
-    onServerExit(`adopted server pid=${pid} is gone`)
+    onServerExit(`adopted server pid=${adoptedPid} is gone`)
   })
 
   log.info(`[launcher] adopted the server already running on port ${port}`)
@@ -597,15 +602,24 @@ export function getServerBridge(): ServerBridge | null {
  * read identically at the call site and mean opposite things to the person whose
  * agent is mid-turn, so they are separate names.
  */
-export function detachFromServer(): void {
-  // Same first move as `stopServer`, for the same reason: the socket is about to
-  // drop, and neither the exit handler nor a countdown already running may take
-  // that as a crash worth answering with a new server on the way out.
+/**
+ * Stop treating the server's departure as a failure.
+ *
+ * The first move of every deliberate ending, whether the server is being killed
+ * or merely let go of: the socket is about to drop, and neither the exit handler
+ * nor a countdown already running may read that as a crash worth answering with
+ * a new server on the way out.
+ */
+function beginDeliberateStop(): void {
   stoppingDeliberately = true
   if (relaunchTimer) {
     clearTimeout(relaunchTimer)
     relaunchTimer = null
   }
+}
+
+export function detachFromServer(): void {
+  beginDeliberateStop()
 
   bridge?.close()
   bridge = null
@@ -615,7 +629,7 @@ export function detachFromServer(): void {
   // the `npx tsx` server running for the next `yarn dev` to adopt, which is the
   // stale-source trap the dev spawn is written to avoid. Dev keeps the old
   // lifetime in full: the server goes when the app goes.
-  if (serverProcess && process.env.ELECTRON_RENDERER_URL) {
+  if (serverProcess && buildChannel() === 'dev') {
     serverProcess.kill('SIGTERM')
   }
 
@@ -626,13 +640,7 @@ export function detachFromServer(): void {
 }
 
 export async function stopServer(): Promise<void> {
-  // Before anything else: an exit we asked for must not look like a crash, and
-  // a relaunch already counting down must not outlive the decision to quit.
-  stoppingDeliberately = true
-  if (relaunchTimer) {
-    clearTimeout(relaunchTimer)
-    relaunchTimer = null
-  }
+  beginDeliberateStop()
 
   if (bridge) {
     // Only ask a server to stop if this app is the one that started it.
@@ -689,7 +697,7 @@ export async function stopServer(): Promise<void> {
 function resolveServerEntry(): string {
   // In dev: packages/server/src/index.ts (run via tsx)
   // In production: resources/server/index.cjs (bundled)
-  if (process.env.ELECTRON_RENDERER_URL) {
+  if (buildChannel() === 'dev') {
     // Dev mode — use tsx to run TypeScript directly
     return path.join(__dirname, '../../packages/server/src/index.ts')
   }
@@ -698,6 +706,14 @@ function resolveServerEntry(): string {
 
 /**
  * Wait for a server we just spawned to publish its port.
+ *
+ * Only for the packaged branch, which spawns the server directly. Dev goes
+ * through `npx tsx`, so its child is npx -- a parent of the process that
+ * actually listens -- and the pid in the port file is the server's, never the
+ * child's. Merging the two readiness paths onto this one therefore cannot work:
+ * in dev the match below would never be satisfied and the launch would hang for
+ * the full timeout. `tests/server-port-stability.test.ts` runs the tsx binary
+ * directly for the same reason.
  *
  * Only ever satisfied by a file naming *this* child. The same file is what
  * `launchServer` reads before deciding whether to adopt, so a launch that
@@ -736,6 +752,16 @@ function waitForPublishedPort(child: ChildProcess): Promise<number> {
     }
     poll()
   })
+}
+
+/**
+ * One handler for both branches, so a packaged crash is logged as fully as a dev
+ * one. The signal is the interesting half when a server is killed rather than
+ * exiting, and the production branch used to drop it for no reason anyone wrote
+ * down -- which is precisely the diagnostic a detached server most needs.
+ */
+function onChildExit(code: number | null, signal: NodeJS.Signals | null): void {
+  onServerExit(`code=${code}, signal=${signal}`)
 }
 
 /** Where a detached server's stdout and stderr go, under the data directory. */

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -113,19 +113,8 @@ export async function stopLocalServer(): Promise<{ ok: true } | { ok: false; err
   // fresh launch would find it, refuse it again, and land straight back in the
   // window the user just acted from. A loop that looks like the button doing
   // nothing.
-  if (await waitForExit(pid, STOP_GRACE_MS)) {
+  if (await ensureGone(pid)) {
     log.info(`[launcher] stopped the local server (pid ${pid}) at the user's request`)
-    lastRefusal = null
-    return { ok: true }
-  }
-
-  try {
-    log.warn(`[launcher] local server ${pid} ignored SIGTERM; sending SIGKILL`)
-    process.kill(pid, 'SIGKILL')
-  } catch {
-    /* it may have exited in the meantime, which is the outcome we wanted */
-  }
-  if (await waitForExit(pid, STOP_KILL_GRACE_MS)) {
     lastRefusal = null
     return { ok: true }
   }
@@ -135,6 +124,24 @@ export async function stopLocalServer(): Promise<{ ok: true } | { ok: false; err
 /** How long a server gets to leave politely, and then to leave at all. */
 const STOP_GRACE_MS = 5_000
 const STOP_KILL_GRACE_MS = 2_000
+
+/**
+ * See a process out: wait for it to go, escalate if it will not, wait again.
+ *
+ * Shared by every path that ends a server, because they all have the same two
+ * jobs -- give it a chance to leave cleanly, then stop asking -- and the caller
+ * is always somebody who cannot continue until it is actually gone.
+ */
+async function ensureGone(pid: number): Promise<boolean> {
+  if (await waitForExit(pid, STOP_GRACE_MS)) return true
+  try {
+    log.warn(`[launcher] server ${pid} ignored SIGTERM; sending SIGKILL`)
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    /* it may have exited in the meantime, which is the outcome we wanted */
+  }
+  return waitForExit(pid, STOP_KILL_GRACE_MS)
+}
 
 /** Resolves true once the pid is gone, false if it outlasts the deadline. */
 async function waitForExit(pid: number, deadlineMs: number): Promise<boolean> {
@@ -747,18 +754,17 @@ export async function stopServer(): Promise<void> {
       child.kill()
     } else {
       child.kill('SIGTERM')
-      setTimeout(() => {
-        // Asked whether the process is still there, not whether we asked it to
-        // go. `child.killed` is true the moment a signal is *delivered*, even to
-        // a process that ignores it -- so gating on it made this fallback
-        // unreachable and left a server running after the user chose to stop it.
-        // That was survivable while the server died with its parent anyway; a
-        // detached one just keeps going.
-        if (child.pid && isPidAlive(child.pid)) {
-          log.warn(`[launcher] server ${child.pid} ignored SIGTERM; sending SIGKILL`)
-          child.kill('SIGKILL')
-        }
-      }, 3000)
+      // Awaited, not scheduled. `before-quit` calls `app.quit()` the moment this
+      // resolves, so a timer left running is a timer that never fires: the main
+      // process exits first and a server that ignored SIGTERM is still there --
+      // after the user chose the one action that promises otherwise. Fixing the
+      // condition was only half of it; the escalation has to be in the same
+      // promise the caller is waiting on.
+      //
+      // Asked whether the process is still there, not whether we asked it to go:
+      // `child.killed` is true the moment a signal is delivered, even to a
+      // process that ignores it.
+      if (child.pid) await ensureGone(child.pid)
     }
     serverProcess = null
   } else if (adoptedPid !== null && isPidAlive(adoptedPid)) {
@@ -769,6 +775,7 @@ export async function stopServer(): Promise<void> {
     log.warn('[launcher] the adopted server did not answer; signalling it directly')
     try {
       process.kill(adoptedPid, 'SIGTERM')
+      await ensureGone(adoptedPid)
     } catch (err) {
       log.warn({ err }, '[launcher] could not signal the adopted server')
     }
@@ -883,10 +890,14 @@ function readServerPort(child: ChildProcess): Promise<number> {
     }
 
     const timeout = setTimeout(() => {
-      const published = readPortFile()
-      settle(() =>
-        published ? resolve(published.port) : reject(new Error('Timeout waiting for server port'))
-      )
+      // No port-file fallback here, deliberately. This is the dev path, and dev
+      // spawns through `npx`, so the child is a parent of the process that
+      // actually listens -- there is no pid to match the file against. A file
+      // written by somebody else's server would resolve to somebody else's port,
+      // and the bridge would be built with a credential that server never
+      // issued: the wrong-server failure this whole change exists to prevent.
+      // The packaged path has a pid to check, and checks it.
+      settle(() => reject(new Error('Timeout waiting for server port')))
     }, 10_000)
 
     // A spawn that never starts emits `error`, not `exit`, and an EventEmitter

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -553,9 +553,14 @@ async function tryAdopt(
     ...self,
     expectedPid
   })
-  if (verdict.kind === 'refuse') {
+  if (verdict.kind === 'refuse' || !identity) {
     candidate.close()
-    return { refusal: verdict }
+    return {
+      refusal:
+        verdict.kind === 'refuse'
+          ? verdict
+          : { kind: 'refuse', reason: 'no-identity', detail: 'the running server said nothing' }
+    }
   }
 
   // Judged, but not yet known to be usable. A rejected credential does not fail
@@ -590,7 +595,11 @@ async function tryAdopt(
   // forever against a healthy server, rejected every time.
   bootstrapToken = token
 
-  adoptedPid = expectedPid ?? null
+  // The file's pid where there is one, the greeting's where there is not. They
+  // agree by the time this runs -- `judgeAdoption` refused otherwise -- and
+  // falling back keeps a pid-less record (which `packages/mcp` writes when it
+  // heals one) from leaving nothing to signal later.
+  adoptedPid = expectedPid ?? identity.pid
   // An adopted server has no child handle, so nothing would ever call
   // `onServerExit` for it. Watching the socket is the only signal available, and
   // the pid distinguishes the two reasons it drops: a server that died, and one
@@ -754,18 +763,19 @@ export async function stopServer(): Promise<void> {
       child.kill()
     } else {
       child.kill('SIGTERM')
-      // Awaited, not scheduled. `before-quit` calls `app.quit()` the moment this
-      // resolves, so a timer left running is a timer that never fires: the main
-      // process exits first and a server that ignored SIGTERM is still there --
-      // after the user chose the one action that promises otherwise. Fixing the
-      // condition was only half of it; the escalation has to be in the same
-      // promise the caller is waiting on.
-      //
-      // Asked whether the process is still there, not whether we asked it to go:
-      // `child.killed` is true the moment a signal is delivered, even to a
-      // process that ignores it.
-      if (child.pid) await ensureGone(child.pid)
     }
+    // Awaited on every platform, not just POSIX. `before-quit` calls
+    // `app.quit()` the moment this resolves, so anything left outside the
+    // promise never happens: the main process exits first and a server that
+    // ignored the signal is still there, after the user chose the one action
+    // that promises otherwise. Windows had the same hole for the same reason
+    // -- `child.kill()` returns before the process is gone -- and it matters
+    // there too now that the server outlives the app.
+    //
+    // Asked whether the process is still there, not whether we asked it to go:
+    // `child.killed` is true the moment a signal is delivered, even to a
+    // process that ignores it.
+    if (child.pid) await ensureGone(child.pid)
     serverProcess = null
   } else if (adoptedPid !== null && isPidAlive(adoptedPid)) {
     // An adopted server has no child handle, so the RPC above was the only way

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -2,13 +2,20 @@ import { spawn, type ChildProcess } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
 import path from 'node:path'
 import { createInterface } from 'node:readline'
-import { app, utilityProcess, type UtilityProcess } from 'electron'
+import { app } from 'electron'
 import log from '../logger'
-import { BOOTSTRAP_ENV_VAR, SERVER_PORT_ENV_VAR } from '@vornrun/shared/protocol'
+import { BOOTSTRAP_ENV_VAR, SERVER_PORT_ENV_VAR, type ServerHello } from '@vornrun/shared/protocol'
 import { ServerBridge } from './server-bridge'
 import { readHostSettings } from './host-store'
+import {
+  judgeAdoption,
+  readLocalToken,
+  readPortFile,
+  resolveDataDir,
+  type AdoptionVerdict
+} from './server-adoption'
 
-let serverProcess: ChildProcess | UtilityProcess | null = null
+let serverProcess: ChildProcess | null = null
 let bridge: ServerBridge | null = null
 
 /**
@@ -58,13 +65,15 @@ const HOST_CONNECT_TIMEOUT_MS = 15_000
  * The server writes `{"port": N}` to stdout on startup.
  * We read the port, then connect a WebSocket bridge.
  *
- * In dev mode: uses `npx tsx` via child_process.spawn (TypeScript execution).
- * In production: uses Electron's utilityProcess.fork() to run the bundled
- * server script as a Node.js process WITHOUT launching another Electron window.
+ * Both modes spawn detached, so the server outlives this app: quitting Vorn is a
+ * window closing, not every agent dying. Dev runs `npx tsx` over the TypeScript
+ * source; production spawns the Electron binary with ELECTRON_RUN_AS_NODE=1,
+ * which yields a plain Node process from the same signed bundle.
  *
- * NOTE: Previously this used `spawn(process.execPath, ...)` in production,
- * which caused an infinite app spawn loop because process.execPath is the
- * Electron binary — spawning it launches another full Electron app instance.
+ * NOTE: `process.execPath` is the Electron binary, and spawning it *without*
+ * ELECTRON_RUN_AS_NODE launches another full Electron app — an infinite spawn
+ * loop this code has hit before. The env var is what makes it a Node process, so
+ * it is not optional.
  */
 /**
  * `VORN_SERVER_PORT`, if it is a port.
@@ -96,6 +105,109 @@ function readDevPort(): string | undefined {
   return String(port)
 }
 
+/**
+ * What the server needs to describe itself in `server:hello`.
+ *
+ * The channel is passed rather than inferred server-side because only this
+ * process knows for certain which build spawned it — the server's own fallback
+ * reads its entry extension, which is right for a CLI run and merely probable
+ * here.
+ */
+function identityEnv(buildChannel: 'dev' | 'packaged'): Record<string, string> {
+  return {
+    VORN_BUILD_CHANNEL: buildChannel,
+    VORN_APP_VERSION: app.getVersion()
+  }
+}
+
+/**
+ * Let go of a detached child's pipes once it has reported for duty.
+ *
+ * Both are `Socket`s, and an open one references this process's event loop —
+ * `child.unref()` does not cover them, so leaving either attached would keep
+ * Electron alive at quit waiting on a server that is never going to close them.
+ *
+ * The pipes exist at all for the reason abduco keeps one across its own fork
+ * (`~/dev/references/abduco/abduco.c:413-480`): a daemon that fails during
+ * startup has nowhere to say so, and a silent failure to start is far worse to
+ * debug than a noisy one. So they stay open exactly as long as the answer takes.
+ */
+function releaseChildStreams(child: ChildProcess): void {
+  child.stdout?.destroy()
+  child.stderr?.destroy()
+}
+
+/**
+ * Connect to a server that is already running and decide whether to keep it.
+ *
+ * Returns the bridge on adoption, or null with the reason recorded. Never kills
+ * the incumbent: the process holding the PTYs is the one with the user's work in
+ * it, so a client that cannot speak to it declines rather than resolving the
+ * disagreement by force. The caller then spawns its own, which is a wasted
+ * process at worst — where killing would be lost work.
+ */
+async function tryAdopt(
+  port: number,
+  self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
+): Promise<{ bridge: ServerBridge } | { refusal: AdoptionVerdict & { kind: 'refuse' } } | null> {
+  const token = readLocalToken(self.dataDir)
+  if (!token) {
+    log.info('[launcher] a port is published but no credential is; starting our own')
+    return null
+  }
+
+  const candidate = new ServerBridge(`ws://127.0.0.1:${port}/ws`, token)
+  candidate.connect()
+
+  // The greeting is the first frame on the socket and arrives before
+  // authentication, so this resolves even against a server that would reject the
+  // credential. A timeout here means "cannot tell", which must not be read as
+  // "dead" — we decline and spawn rather than assuming the port is free.
+  const hello = await new Promise<ServerHello | null>((resolve) => {
+    const timer = setTimeout(() => resolve(null), ADOPT_HELLO_TIMEOUT_MS)
+    candidate.once('hello', (h: ServerHello) => {
+      clearTimeout(timer)
+      resolve(h)
+    })
+  })
+
+  const verdict = judgeAdoption(hello, self)
+  if (verdict.kind === 'refuse') {
+    candidate.close()
+    return { refusal: verdict }
+  }
+
+  // Adopted, but not yet usable: `connect` fires before the socket opens, and a
+  // rejected credential closes it at 4001 rather than failing the connect.
+  const usable = await new Promise<boolean>((resolve) => {
+    if (candidate.isConnected) return resolve(true)
+    const timer = setTimeout(() => resolve(false), ADOPT_CONNECT_TIMEOUT_MS)
+    candidate.once('connected', () => {
+      clearTimeout(timer)
+      resolve(true)
+    })
+  })
+  if (!usable) {
+    candidate.close()
+    log.warn('[launcher] the running server did not accept this app; starting our own')
+    return null
+  }
+
+  log.info(`[launcher] adopted the server already running on port ${port}`)
+  return { bridge: candidate }
+}
+
+/** Long enough for a busy event loop, short enough not to stall a cold launch. */
+const ADOPT_HELLO_TIMEOUT_MS = 3_000
+const ADOPT_CONNECT_TIMEOUT_MS = 5_000
+
+/** What the last adoption attempt refused, for the UI to explain. Null when none did. */
+let lastRefusal: (AdoptionVerdict & { kind: 'refuse' }) | null = null
+
+export function getLastAdoptionRefusal(): (AdoptionVerdict & { kind: 'refuse' }) | null {
+  return lastRefusal
+}
+
 export async function launchServer(): Promise<ServerBridge> {
   const host = readHostSettings()
   if (host.mode === 'host' && host.url) {
@@ -106,6 +218,27 @@ export async function launchServer(): Promise<ServerBridge> {
     // Failing here puts the connect window up asking for the token.
     if (!host.token) throw new Error(`No stored token for ${host.url}`)
     return connectToHost(host.url, host.token)
+  }
+
+  // Before spawning anything: is one already running? This is the ordinary path
+  // now that the server outlives the app, not an edge case.
+  const dataDir = resolveDataDir()
+  const buildChannel: 'dev' | 'packaged' = process.env.ELECTRON_RENDERER_URL ? 'dev' : 'packaged'
+  lastRefusal = null
+  const published = readPortFile(dataDir)
+  if (published) {
+    const outcome = await tryAdopt(published.port, { dataDir, buildChannel })
+    if (outcome && 'bridge' in outcome) {
+      bridge = outcome.bridge
+      return bridge
+    }
+    if (outcome && 'refusal' in outcome) {
+      lastRefusal = outcome.refusal
+      log.warn(
+        `[launcher] declined to adopt the running server (${outcome.refusal.reason}): ` +
+          `${outcome.refusal.detail}. It keeps running and keeps its sessions.`
+      )
+    }
   }
 
   const serverEntryPoint = resolveServerEntry()
@@ -139,11 +272,15 @@ export async function launchServer(): Promise<ServerBridge> {
     const devPort = readDevPort()
 
     const child = spawn('npx', ['tsx', serverEntryPoint, ...(devPort ? ['--port', devPort] : [])], {
-      stdio: ['pipe', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // Its own process group and session, so it survives this app and so a
+      // Ctrl-C aimed at the terminal running `yarn dev` does not reach it.
+      detached: true,
       env: {
         ...process.env,
         [BOOTSTRAP_ENV_VAR]: bootstrapToken,
-        NODE_ENV: process.env.NODE_ENV ?? 'development'
+        NODE_ENV: process.env.NODE_ENV ?? 'development',
+        ...identityEnv(buildChannel)
         // Connectors live in their own repository now, so a local build is
         // preferred by setting VORN_CONNECTORS_ROOT to that checkout. It
         // passes through with the rest of the environment above; deriving it
@@ -152,17 +289,9 @@ export async function launchServer(): Promise<ServerBridge> {
       cwd: repoRoot
     })
 
-    child.stdin?.end()
-
-    // Forward server stderr to our log
-    if (child.stderr) {
-      const errLines = createInterface({ input: child.stderr })
-      errLines.on('line', (line) => {
-        log.info(`[server] ${line}`)
-      })
-    }
-
     port = await readServerPort(child)
+    releaseChildStreams(child)
+    child.unref()
 
     child.on('exit', (code, signal) => {
       log.warn(`[launcher] server exited (code=${code}, signal=${signal})`)
@@ -171,34 +300,38 @@ export async function launchServer(): Promise<ServerBridge> {
 
     serverProcess = child
   } else {
-    // Production: use Electron's utilityProcess.fork() to run the bundled
-    // server as a proper Node.js child process (NOT another Electron instance)
-    //
     // The main process has Electron's ASAR patching so it can resolve native
-    // modules. The utilityProcess does NOT, so we resolve the absolute paths
-    // here and pass them via environment variables for the server banner to use.
+    // modules. A plain Node child does NOT, so the absolute paths are resolved
+    // here and passed through the environment for the server to use.
     const asarUnpacked = path.join(app.getAppPath() + '.unpacked', 'node_modules')
 
-    const child = utilityProcess.fork(serverEntryPoint, [], {
-      stdio: 'pipe',
+    // Deliberately NOT utilityProcess.fork: a utility process is tied to this
+    // app's lifetime by design, so it can never outlive the window. Spawning the
+    // Electron binary with ELECTRON_RUN_AS_NODE gives a plain Node process from
+    // the same signed bundle — the hardened runtime already allows it, because
+    // `resources/entitlements.mac.plist` grants
+    // com.apple.security.cs.allow-dyld-environment-variables.
+    const child = spawn(process.execPath, [serverEntryPoint], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      // A daemon must not hold a directory open that can be deleted underneath
+      // it. The data dir is the one place guaranteed to exist for as long as the
+      // server has anything to serve.
+      cwd: dataDir,
       env: {
         ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
         [BOOTSTRAP_ENV_VAR]: bootstrapToken,
         NODE_ENV: 'production',
         VORN_NATIVE_MODULES_PATH: asarUnpacked,
-        NODE_PATH: [path.join(app.getAppPath(), 'node_modules'), asarUnpacked].join(path.delimiter)
+        NODE_PATH: [path.join(app.getAppPath(), 'node_modules'), asarUnpacked].join(path.delimiter),
+        ...identityEnv(buildChannel)
       }
     })
 
-    // Forward server stderr to our log
-    if (child.stderr) {
-      const errLines = createInterface({ input: child.stderr })
-      errLines.on('line', (line) => {
-        log.info(`[server] ${line}`)
-      })
-    }
-
     port = await readServerPort(child)
+    releaseChildStreams(child)
+    child.unref()
 
     child.on('exit', (code) => {
       log.warn(`[launcher] server exited (code=${code})`)
@@ -230,6 +363,22 @@ export function getServerBridge(): ServerBridge | null {
   return bridge
 }
 
+/**
+ * Let go of the server without stopping it.
+ *
+ * The ordinary quit path once sessions outlive the window: close the socket and
+ * leave the process alone. Deliberately not `stopServer` with a flag — the two
+ * read identically at the call site and mean opposite things to the person whose
+ * agent is mid-turn, so they are separate names.
+ */
+export function detachFromServer(): void {
+  bridge?.close()
+  bridge = null
+  // Dropped without killing. The child is already unref'd and in its own process
+  // group, so nothing here is holding it and nothing here will end it.
+  serverProcess = null
+}
+
 export async function stopServer(): Promise<void> {
   if (bridge) {
     // Only ask a server to stop if this app is the one that started it.
@@ -250,24 +399,18 @@ export async function stopServer(): Promise<void> {
   }
 
   if (serverProcess) {
-    if ('killed' in serverProcess) {
-      // ChildProcess (dev mode)
-      const child = serverProcess as ChildProcess
-      if (!child.killed) {
-        if (process.platform === 'win32') {
-          child.kill()
-        } else {
-          child.kill('SIGTERM')
-          setTimeout(() => {
-            if (child && !child.killed) {
-              child.kill('SIGKILL')
-            }
-          }, 3000)
-        }
+    const child = serverProcess
+    if (!child.killed) {
+      if (process.platform === 'win32') {
+        child.kill()
+      } else {
+        child.kill('SIGTERM')
+        setTimeout(() => {
+          if (child && !child.killed) {
+            child.kill('SIGKILL')
+          }
+        }, 3000)
       }
-    } else {
-      // UtilityProcess (production) — only has kill()
-      serverProcess.kill()
     }
     serverProcess = null
   }
@@ -283,36 +426,58 @@ function resolveServerEntry(): string {
   return path.join(process.resourcesPath, 'server', 'index.cjs')
 }
 
-function readServerPort(child: ChildProcess | UtilityProcess): Promise<number> {
+/**
+ * Wait for the server to say which port it took.
+ *
+ * The pipe is the primary channel and the only one that can also report a
+ * startup crash, which is why it exists on an otherwise detached child. Its
+ * stderr is drained into our log for the same window — a server that dies during
+ * startup says why here or nowhere.
+ *
+ * The port file is the fallback, for the case the pipe is closed or the line is
+ * missed. It is not merely belt-and-braces: the server writes `{port, pid}` there
+ * for MCP already, so a launch that lost the pipe can still find a healthy server
+ * rather than concluding it failed.
+ */
+function readServerPort(child: ChildProcess): Promise<number> {
   return new Promise((resolve, reject) => {
     if (!child.stdout) {
       reject(new Error('No stdout on server process'))
       return
     }
 
+    if (child.stderr) {
+      const errLines = createInterface({ input: child.stderr })
+      errLines.on('line', (line) => log.info(`[server] ${line}`))
+    }
+
     const rl = createInterface({ input: child.stdout })
+    const settle = (fn: () => void): void => {
+      clearTimeout(timeout)
+      rl.close()
+      fn()
+    }
+
     const timeout = setTimeout(() => {
-      reject(new Error('Timeout waiting for server port'))
+      const published = readPortFile()
+      settle(() =>
+        published ? resolve(published.port) : reject(new Error('Timeout waiting for server port'))
+      )
     }, 10_000)
 
     rl.on('line', (line) => {
       try {
         const parsed = JSON.parse(line)
         if (typeof parsed.port === 'number') {
-          clearTimeout(timeout)
-          rl.close()
-          resolve(parsed.port)
+          settle(() => resolve(parsed.port))
         }
       } catch {
         // Not JSON or not our port line — ignore
       }
     })
 
-    // Both ChildProcess and UtilityProcess support .on('exit', cb)
-    const onExit = (code: number | null) => {
-      clearTimeout(timeout)
-      reject(new Error(`Server exited before reporting port (code=${code})`))
-    }
-    ;(child as UtilityProcess).on('exit', onExit)
+    child.on('exit', (code) => {
+      settle(() => reject(new Error(`Server exited before reporting port (code=${code})`)))
+    })
   })
 }

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -22,6 +22,20 @@ import {
   type AdoptionVerdict
 } from './server-adoption'
 
+/**
+ * Thrown when a server is running that this app may not use.
+ *
+ * Not an ordinary failure: nothing is broken, and the user's agents are alive
+ * and working inside it. It carries the reason so the window that comes up can
+ * say which of the cases it was.
+ */
+export class AdoptionRefusedError extends Error {
+  constructor(readonly refusal: AdoptionVerdict & { kind: 'refuse' }) {
+    super(`Another Vorn server is running that this app cannot use: ${refusal.detail}`)
+    this.name = 'AdoptionRefusedError'
+  }
+}
+
 let serverProcess: ChildProcess | null = null
 let bridge: ServerBridge | null = null
 
@@ -72,23 +86,28 @@ export function getLastAdoptionRefusal(): AdoptionRefusal | null {
 }
 
 /**
- * End the server this app refused to adopt, because the user asked.
+ * End the local server, because the user asked.
  *
  * The doctrine is that a starting app never ends a running server -- it holds
  * somebody's work and cannot be judged from outside. It says nothing about the
  * person whose work it is, who is the only one in a position to decide.
+ *
+ * Reads the pid from the port file rather than from any greeting: it is the one
+ * value written by a process this app can attribute, and it is the same answer
+ * whether the caller is the connect window (a server it refused to adopt) or the
+ * running app (a local server still going while this is pointed at a host).
  */
-export function stopRefusedServer(): boolean {
-  const pid = lastRefusal?.incumbentPid
-  if (pid == null || !isPidAlive(pid)) return false
+export function stopLocalServer(): { ok: true } | { ok: false; error: string } {
+  const published = readPortFile()
+  if (!published?.pid) return { ok: false, error: 'No local server is running.' }
   try {
-    process.kill(pid, 'SIGTERM')
-    log.info(`[launcher] stopped the refused server (pid ${pid}) at the user's request`)
+    process.kill(published.pid, 'SIGTERM')
+    log.info(`[launcher] stopped the local server (pid ${published.pid}) at the user's request`)
     lastRefusal = null
-    return true
+    return { ok: true }
   } catch (err) {
-    log.warn({ err }, '[launcher] could not stop the refused server')
-    return false
+    log.warn({ err }, '[launcher] could not stop the local server')
+    return { ok: false, error: 'Could not stop it. It may have already exited.' }
   }
 }
 
@@ -461,11 +480,16 @@ async function tryAdopt(
   port: number,
   expectedPid: number | undefined,
   self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
-): Promise<{ bridge: ServerBridge } | { refusal: AdoptionVerdict & { kind: 'refuse' } } | null> {
+): Promise<{ bridge: ServerBridge } | { refusal: AdoptionVerdict & { kind: 'refuse' } }> {
   const token = readLocalToken(self.dataDir)
   if (!token) {
-    log.info('[launcher] a port is published but no credential is; starting our own')
-    return null
+    return {
+      refusal: {
+        kind: 'refuse',
+        reason: 'unusable',
+        detail: 'a server is listening but published no credential to reach it with'
+      }
+    }
   }
 
   const candidate = new ServerBridge(`ws://127.0.0.1:${port}/ws`, token)
@@ -507,8 +531,13 @@ async function tryAdopt(
     .catch(() => false)
   if (!accepted) {
     candidate.close()
-    log.warn('[launcher] the running server did not accept this app; starting our own')
-    return null
+    return {
+      refusal: {
+        kind: 'refuse',
+        reason: 'unusable',
+        detail: 'the running server did not accept this app'
+      }
+    }
   }
 
   // Carried forward, not discarded. If this server later dies and a replacement
@@ -558,17 +587,30 @@ export async function launchServer(): Promise<ServerBridge> {
       dataDir,
       buildChannel: buildChannel()
     })
-    if (outcome && 'bridge' in outcome) {
+    if ('bridge' in outcome) {
       bridge = outcome.bridge
       return bridge
     }
-    if (outcome && 'refusal' in outcome) {
-      lastRefusal = { ...outcome.refusal, incumbentPid: published.pid ?? null }
-      log.warn(
-        `[launcher] declined to adopt the running server (${outcome.refusal.reason}): ` +
-          `${outcome.refusal.detail}. It keeps running and keeps its sessions.`
-      )
-    }
+    const { refusal } = outcome
+    lastRefusal = { ...refusal, incumbentPid: published.pid ?? null }
+    log.warn(
+      `[launcher] declined to adopt the running server (${refusal.reason}): ` +
+        `${refusal.detail}. It keeps running and keeps its sessions.`
+    )
+    // Declining to adopt is not a reason to start a rival.
+    //
+    // Both servers would open the same SQLite file, and `saveSessions` is a
+    // DELETE-then-insert of the whole table on a debounce -- so the two would
+    // erase each other's sessions, last writer winning, and the app would show
+    // whichever set survived. The second would also lose the ws-port file to the
+    // incumbent's liveness guard, making it invisible to MCP.
+    //
+    // This is the half of the doctrine that is easy to drop. tmux does not kill a
+    // server it cannot speak to, and it does not start one beside it either: the
+    // *client* prints the mismatch and exits. There is nothing useful this app can
+    // do against a database another server is holding, so it says so and stops,
+    // and the person decides which server should live.
+    throw new AdoptionRefusedError(refusal)
   }
 
   const port = await spawnServer()

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -219,9 +219,19 @@ async function spawnServer(): Promise<number> {
 
     const child = spawn('npx', ['tsx', serverEntryPoint, ...(devPort ? ['--port', devPort] : [])], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      // Its own process group and session, so it survives this app -- and so a
-      // Ctrl-C aimed at the terminal running `yarn dev` does not reach it.
-      detached: true,
+      // Deliberately NOT detached, where production is.
+      //
+      // A detached dev server outlives `yarn dev`, and the next `yarn dev` would
+      // adopt it -- same data directory, same build channel, so every check
+      // passes. It would be running the source as it was before the edit that
+      // prompted the restart, and nothing would say so. An hour lost to a fix
+      // that "did not work" is a worse trade than restarting sessions a
+      // developer was going to restart anyway.
+      //
+      // Sessions surviving a quit is a property of the shipped app. Dev keeps
+      // the old lifetime, and the buildChannel check still earns its place: a
+      // packaged server does outlive its app, and this is what stops `yarn dev`
+      // from adopting it.
       env: {
         ...process.env,
         [BOOTSTRAP_ENV_VAR]: bootstrapToken,
@@ -248,8 +258,10 @@ async function spawnServer(): Promise<number> {
       child.kill('SIGKILL')
       throw err
     })
+    // Streams released for the same reason as production -- an open pipe refs
+    // this process's event loop -- but the child is left ref'd, because in dev
+    // it is meant to go when the app goes.
     releaseChildStreams(child)
-    child.unref()
   } else {
     // Deliberately NOT utilityProcess.fork: a utility process is tied to this
     // app's lifetime by design, so it can never outlive the window -- which is

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process'
 import { randomBytes } from 'node:crypto'
+import { mkdirSync } from 'node:fs'
 import path from 'node:path'
 import { createInterface } from 'node:readline'
 import { app } from 'electron'
@@ -55,6 +56,19 @@ let lastRefusal: (AdoptionVerdict & { kind: 'refuse' }) | null = null
 
 export function getLastAdoptionRefusal(): (AdoptionVerdict & { kind: 'refuse' }) | null {
   return lastRefusal
+}
+
+/**
+ * The data directory, created if this is the first run.
+ *
+ * Normally the server makes it (`database.ts` on init), but it is also the cwd
+ * the server is spawned into, and that has to exist before the spawn rather than
+ * after it.
+ */
+function ensureDataDir(): string {
+  const dir = resolveDataDir()
+  mkdirSync(dir, { recursive: true, mode: 0o700 })
+  return dir
 }
 
 /** `dev` or `packaged`, decided the same way the server entry point is resolved. */
@@ -284,9 +298,12 @@ async function spawnServer(): Promise<number> {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
       // A daemon must not hold open a directory that can be deleted underneath
-      // it. The data dir is the one place guaranteed to exist for as long as the
-      // server has anything to serve.
-      cwd: resolveDataDir(),
+      // it, so not the app bundle and not a worktree. The data dir is where the
+      // server's own files live, so it lasts as long as the server has anything
+      // to serve -- but on a first run it does not exist yet: the *server*
+      // creates it, and it has not started. `spawn` with a missing cwd fails
+      // ENOENT, so it is created here first.
+      cwd: ensureDataDir(),
       env: {
         ...process.env,
         ELECTRON_RUN_AS_NODE: '1',
@@ -383,7 +400,8 @@ function onServerExit(detail: string): void {
 
 /** Long enough for a busy event loop, short enough not to stall a cold launch. */
 const ADOPT_HELLO_TIMEOUT_MS = 3_000
-const ADOPT_CONNECT_TIMEOUT_MS = 5_000
+/** How long a socket must stay open to count as accepted. Loopback, so short. */
+const ADOPT_SETTLE_MS = 250
 
 /**
  * Connect to a server that is already running and decide whether to keep it.
@@ -424,22 +442,39 @@ async function tryAdopt(
     return { refusal: verdict }
   }
 
-  // Judged, but not yet usable: a rejected credential closes the socket at 4001
-  // rather than failing the connect, so the greeting alone proves nothing about
-  // whether this app may actually talk to it.
-  const usable = await new Promise<boolean>((resolve) => {
-    if (candidate.isConnected) return resolve(true)
-    const timer = setTimeout(() => resolve(false), ADOPT_CONNECT_TIMEOUT_MS)
-    candidate.once('connected', () => {
+  // Judged, but not yet known to be usable. A rejected credential does not fail
+  // the connect: the socket opens, the greeting arrives, and only then does the
+  // server close it at 4001/4002. So `isConnected` is true by the time the
+  // greeting resolves and proves nothing -- an earlier version of this checked
+  // exactly that and could never have been false.
+  //
+  // What a rejection does do is close the socket promptly, so the honest test is
+  // whether it stays open. On loopback, against a server that has already sent a
+  // frame, a short settle is enough.
+  const rejected = await new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => {
+      candidate.off('disconnected', onDrop)
+      resolve(false)
+    }, ADOPT_SETTLE_MS)
+    function onDrop(): void {
       clearTimeout(timer)
       resolve(true)
-    })
+    }
+    candidate.once('disconnected', onDrop)
   })
-  if (!usable) {
+  if (rejected || !candidate.isConnected) {
     candidate.close()
     log.warn('[launcher] the running server did not accept this app; starting our own')
     return null
   }
+
+  // Carried forward, not discarded. If this server later dies and a replacement
+  // is spawned, `spawnServer` reuses this value rather than minting a fresh one
+  // -- and the bridge is retargeted, never rebuilt, so its credential is fixed
+  // at construction. Leaving it null meant the replacement got a new secret the
+  // surviving bridge had never heard of, and the bridge would then reconnect
+  // forever against a healthy server, rejected every time.
+  bootstrapToken = token
 
   adoptedPid = hello?.pid ?? null
   // An adopted server has no child handle, so nothing would ever call
@@ -624,6 +659,13 @@ function readServerPort(child: ChildProcess): Promise<number> {
       const errLines = createInterface({ input: child.stderr })
       errLines.on('line', (line) => log.info(`[server] ${line}`))
     }
+
+    // A spawn that never starts emits `error`, not `exit`, and an EventEmitter
+    // with nothing listening for `error` throws -- taking the main process down
+    // instead of reporting a server that failed to launch.
+    child.on('error', (err) => {
+      settle(() => reject(err))
+    })
 
     const rl = createInterface({ input: child.stdout })
     const settle = (fn: () => void): void => {

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -97,18 +97,53 @@ export function getLastAdoptionRefusal(): AdoptionRefusal | null {
  * whether the caller is the connect window (a server it refused to adopt) or the
  * running app (a local server still going while this is pointed at a host).
  */
-export function stopLocalServer(): { ok: true } | { ok: false; error: string } {
+export async function stopLocalServer(): Promise<{ ok: true } | { ok: false; error: string }> {
   const published = readPortFile()
   if (!published?.pid) return { ok: false, error: 'No local server is running.' }
+  const pid = published.pid
   try {
-    process.kill(published.pid, 'SIGTERM')
-    log.info(`[launcher] stopped the local server (pid ${published.pid}) at the user's request`)
-    lastRefusal = null
-    return { ok: true }
+    process.kill(pid, 'SIGTERM')
   } catch (err) {
-    log.warn({ err }, '[launcher] could not stop the local server')
+    log.warn({ err }, '[launcher] could not signal the local server')
     return { ok: false, error: 'Could not stop it. It may have already exited.' }
   }
+
+  // Waited for, not assumed. The caller relaunches the app the moment this says
+  // yes, and a server still shutting down still owns its ws-port file -- so the
+  // fresh launch would find it, refuse it again, and land straight back in the
+  // window the user just acted from. A loop that looks like the button doing
+  // nothing.
+  if (await waitForExit(pid, STOP_GRACE_MS)) {
+    log.info(`[launcher] stopped the local server (pid ${pid}) at the user's request`)
+    lastRefusal = null
+    return { ok: true }
+  }
+
+  try {
+    log.warn(`[launcher] local server ${pid} ignored SIGTERM; sending SIGKILL`)
+    process.kill(pid, 'SIGKILL')
+  } catch {
+    /* it may have exited in the meantime, which is the outcome we wanted */
+  }
+  if (await waitForExit(pid, STOP_KILL_GRACE_MS)) {
+    lastRefusal = null
+    return { ok: true }
+  }
+  return { ok: false, error: 'It is still running and did not respond to being stopped.' }
+}
+
+/** How long a server gets to leave politely, and then to leave at all. */
+const STOP_GRACE_MS = 5_000
+const STOP_KILL_GRACE_MS = 2_000
+
+/** Resolves true once the pid is gone, false if it outlasts the deadline. */
+async function waitForExit(pid: number, deadlineMs: number): Promise<boolean> {
+  const until = Date.now() + deadlineMs
+  while (Date.now() < until) {
+    if (!isPidAlive(pid)) return true
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  return !isPidAlive(pid)
 }
 
 /**
@@ -840,13 +875,6 @@ function readServerPort(child: ChildProcess): Promise<number> {
       errLines.on('line', (line) => log.info(`[server] ${line}`))
     }
 
-    // A spawn that never starts emits `error`, not `exit`, and an EventEmitter
-    // with nothing listening for `error` throws -- taking the main process down
-    // instead of reporting a server that failed to launch.
-    child.on('error', (err) => {
-      settle(() => reject(err))
-    })
-
     const rl = createInterface({ input: child.stdout })
     const settle = (fn: () => void): void => {
       clearTimeout(timeout)
@@ -860,6 +888,18 @@ function readServerPort(child: ChildProcess): Promise<number> {
         published ? resolve(published.port) : reject(new Error('Timeout waiting for server port'))
       )
     }, 10_000)
+
+    // A spawn that never starts emits `error`, not `exit`, and an EventEmitter
+    // with nothing listening for `error` throws -- taking the main process down
+    // instead of reporting a server that failed to launch.
+    //
+    // Registered below `settle` rather than above it. Node emits this one
+    // asynchronously, so the earlier order was safe -- but it was safe only
+    // because of when the event fires, which is a thing to know rather than a
+    // thing to read.
+    child.on('error', (err) => {
+      settle(() => reject(err))
+    })
 
     rl.on('line', (line) => {
       try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,8 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import {
-  ADOPTION_REFUSED_CHANNEL,
-  ADOPTION_STOP_CHANNEL,
-  type AdoptionRefusedNotice
+  LOCAL_SERVER_RUNNING_CHANNEL,
+  type LocalServerNotice
 } from '../shared/adoption-channels'
 import { captureViewerSettings, withViewerSettings } from '@vornrun/shared/viewer-settings-store'
 import {
@@ -114,16 +113,14 @@ const api = {
     }
   },
 
-  onAdoptionRefused: (callback: (notice: AdoptionRefusedNotice) => void) => {
-    const listener = (_: Electron.IpcRendererEvent, notice: AdoptionRefusedNotice): void =>
+  onLocalServerStillRunning: (callback: (notice: LocalServerNotice) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, notice: LocalServerNotice): void =>
       callback(notice)
-    ipcRenderer.on(ADOPTION_REFUSED_CHANNEL, listener)
+    ipcRenderer.on(LOCAL_SERVER_RUNNING_CHANNEL, listener)
     return () => {
-      ipcRenderer.removeListener(ADOPTION_REFUSED_CHANNEL, listener)
+      ipcRenderer.removeListener(LOCAL_SERVER_RUNNING_CHANNEL, listener)
     }
   },
-
-  stopRefusedServer: (): Promise<boolean> => ipcRenderer.invoke(ADOPTION_STOP_CHANNEL),
 
   onMenuNewAgent: (callback: () => void) => {
     const listener = (): void => callback()
@@ -606,6 +603,12 @@ const api = {
     token: string
   }): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('connect:save', params),
   useLocalServer: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('connect:useLocal'),
+
+  /** Ends the local server on purpose. Offered by the connect window when it
+   *  refused to adopt one, and by the app when it is pointed at a host while a
+   *  local server is still running. */
+  stopLocalServer: (): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('connect:stopLocal'),
 
   // Pairing a phone by showing it a code
   startPairing: (): Promise<{ code: string; expiresAt: number }> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,8 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import {
-  LOCAL_SERVER_RUNNING_CHANNEL,
-  type LocalServerNotice
-} from '../shared/adoption-channels'
+import { LOCAL_SERVER_RUNNING_CHANNEL, type LocalServerNotice } from '../shared/adoption-channels'
 import { captureViewerSettings, withViewerSettings } from '@vornrun/shared/viewer-settings-store'
 import {
   CreateTerminalPayload,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import {
+  ADOPTION_REFUSED_CHANNEL,
+  ADOPTION_STOP_CHANNEL,
+  type AdoptionRefusedNotice
+} from '../shared/adoption-channels'
 import { captureViewerSettings, withViewerSettings } from '@vornrun/shared/viewer-settings-store'
 import {
   CreateTerminalPayload,
@@ -108,6 +113,17 @@ const api = {
       ipcRenderer.removeListener(IPC.CONFIG_CHANGED, listener)
     }
   },
+
+  onAdoptionRefused: (callback: (notice: AdoptionRefusedNotice) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, notice: AdoptionRefusedNotice): void =>
+      callback(notice)
+    ipcRenderer.on(ADOPTION_REFUSED_CHANNEL, listener)
+    return () => {
+      ipcRenderer.removeListener(ADOPTION_REFUSED_CHANNEL, listener)
+    }
+  },
+
+  stopRefusedServer: (): Promise<boolean> => ipcRenderer.invoke(ADOPTION_STOP_CHANNEL),
 
   onMenuNewAgent: (callback: () => void) => {
     const listener = (): void => callback()

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -246,8 +246,7 @@ export function App() {
     // somebody else's is invisible — and with the one action that resolves it,
     // taken by the person whose work it is.
     const removeLocalServerListener = window.api.onLocalServerStillRunning?.((notice) => {
-      const count =
-        notice.sessions === null ? 'Sessions are' : `${notice.sessions} session(s) are`
+      const count = notice.sessions === null ? 'Sessions are' : `${notice.sessions} session(s) are`
       toast(
         `${count} still running on this machine. They keep working, and switching back to local reconnects to them.`,
         'warning',

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -241,36 +241,33 @@ export function App() {
       }
     })()
 
-    // Adoption was refused: the agents are alive in a server this app cannot
-    // speak to, and this window is empty. Said out loud, with the one action
-    // that resolves it -- taken by the person whose work it is, never by the app.
-    const removeAdoptionListener = window.api.onAdoptionRefused?.((notice) => {
-      // Said in Vorn's words, from a closed set of reasons. Nothing here comes
-      // from the other server: it is the party this app just declined to trust.
-      const message =
-        notice.reason === 'protocol-mismatch'
-          ? 'Your sessions are still running in a server this version of Vorn cannot talk to. They are safe, and this window cannot reach them.'
-          : 'Vorn found a server it could not use, so it started its own. Any sessions in the other one are not shown here.'
-      toast(message, 'warning', {
-        duration: Number.POSITIVE_INFINITY,
-        actions: notice.canStop
-          ? [
-              {
-                label: 'Stop it and restart Vorn',
-                tone: 'danger',
-                onClick: async () => {
-                  const stopped = await window.api.stopRefusedServer?.()
-                  toast(
-                    stopped
-                      ? 'Stopped. Reopen Vorn to start fresh.'
-                      : 'Could not stop it. It may have already exited.',
-                    stopped ? 'success' : 'error'
-                  )
-                }
+    // Pointed at a host while a server is still running on this machine. Said
+    // out loud, because an agent working on a machine whose app is showing
+    // somebody else's is invisible — and with the one action that resolves it,
+    // taken by the person whose work it is.
+    const removeLocalServerListener = window.api.onLocalServerStillRunning?.((notice) => {
+      const count =
+        notice.sessions === null ? 'Sessions are' : `${notice.sessions} session(s) are`
+      toast(
+        `${count} still running on this machine. They keep working, and switching back to local reconnects to them.`,
+        'warning',
+        {
+          duration: Number.POSITIVE_INFINITY,
+          actions: [
+            {
+              label: 'End them',
+              tone: 'danger',
+              onClick: async () => {
+                const result = await window.api.stopLocalServer?.()
+                toast(
+                  result?.ok ? 'Stopped.' : (result?.error ?? 'Could not stop it.'),
+                  result?.ok ? 'success' : 'error'
+                )
               }
-            ]
-          : []
-      })
+            }
+          ]
+        }
+      )
     })
 
     const removeExitListener = window.api.onTerminalExit(({ id }) => {
@@ -541,7 +538,7 @@ export function App() {
 
     return () => {
       disposeGlobalDataListener()
-      removeAdoptionListener?.()
+      removeLocalServerListener?.()
       removeExitListener()
       removeSessionCreatedListener()
       removeConfigListener()

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -68,7 +68,7 @@ import { KeyboardShortcutsPanel } from './components/KeyboardShortcutsPanel'
 import { MissedScheduleDialog } from './components/MissedScheduleDialog'
 import { SourcePromptDialog } from './components/SourcePromptDialog'
 import { OnboardingModal } from './components/OnboardingModal'
-import { ToastContainer } from './components/Toast'
+import { ToastContainer, toast } from './components/Toast'
 import { AddTaskDialog } from './components/AddTaskDialog'
 import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
@@ -240,6 +240,38 @@ export function App() {
         console.error('[App] startup initialization failed:', err)
       }
     })()
+
+    // Adoption was refused: the agents are alive in a server this app cannot
+    // speak to, and this window is empty. Said out loud, with the one action
+    // that resolves it -- taken by the person whose work it is, never by the app.
+    const removeAdoptionListener = window.api.onAdoptionRefused?.((notice) => {
+      // Said in Vorn's words, from a closed set of reasons. Nothing here comes
+      // from the other server: it is the party this app just declined to trust.
+      const message =
+        notice.reason === 'protocol-mismatch'
+          ? 'Your sessions are still running in a server this version of Vorn cannot talk to. They are safe, and this window cannot reach them.'
+          : 'Vorn found a server it could not use, so it started its own. Any sessions in the other one are not shown here.'
+      toast(message, 'warning', {
+        duration: Number.POSITIVE_INFINITY,
+        actions: notice.canStop
+          ? [
+              {
+                label: 'Stop it and restart Vorn',
+                tone: 'danger',
+                onClick: async () => {
+                  const stopped = await window.api.stopRefusedServer?.()
+                  toast(
+                    stopped
+                      ? 'Stopped. Reopen Vorn to start fresh.'
+                      : 'Could not stop it. It may have already exited.',
+                    stopped ? 'success' : 'error'
+                  )
+                }
+              }
+            ]
+          : []
+      })
+    })
 
     const removeExitListener = window.api.onTerminalExit(({ id }) => {
       const state = useAppStore.getState()
@@ -509,6 +541,7 @@ export function App() {
 
     return () => {
       disposeGlobalDataListener()
+      removeAdoptionListener?.()
       removeExitListener()
       removeSessionCreatedListener()
       removeConfigListener()

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -85,6 +85,17 @@ export function GeneralSettings() {
           />
         </SettingRow>
 
+        {/* Keep sessions running */}
+        <SettingRow
+          label="Keep Sessions Running When Vorn Closes"
+          description="Agents keep working while Vorn is shut. Reopening reconnects to them instead of restarting them. A background server stays running until every session ends."
+        >
+          <ToggleSwitch
+            checked={config.defaults.keepSessionsRunning ?? true}
+            onChange={(keepSessionsRunning) => updateDefaults({ keepSessionsRunning })}
+          />
+        </SettingRow>
+
         {/* Block rendering */}
         <SettingRow
           label="Command Blocks"

--- a/src/shared/adoption-channels.ts
+++ b/src/shared/adoption-channels.ts
@@ -1,0 +1,27 @@
+/**
+ * Channels for telling the person what a refused adoption means for them.
+ *
+ * Named here rather than inline because three layers spell them: main sends,
+ * preload subscribes, the renderer listens. They are not in the `IPC` map
+ * because that describes the desktop's relay of *server* methods, and neither of
+ * these ever reaches the server -- the whole point is that this app could not
+ * talk to it.
+ */
+export const ADOPTION_REFUSED_CHANNEL = 'adoption:refused'
+export const ADOPTION_STOP_CHANNEL = 'adoption:stop-refused'
+
+/**
+ * Deliberately carries no text from the other server.
+ *
+ * The refusal `detail` reads well and is useful in the log, but it interpolates
+ * `dataDir` and `buildChannel` straight out of that server's greeting -- strings
+ * this app never verified, from the one party it just decided it could not
+ * trust. React would escape them, so this is not an injection; it is simpler
+ * than that. A stranger does not get to write the text of Vorn's own warning.
+ * The reason is a closed set, and the renderer says the rest in its own words.
+ */
+export interface AdoptionRefusedNotice {
+  reason: 'no-identity' | 'protocol-mismatch' | 'different-data-dir' | 'different-build'
+  /** False when the running server's pid was never learned, so nothing can act on it. */
+  canStop: boolean
+}

--- a/src/shared/adoption-channels.ts
+++ b/src/shared/adoption-channels.ts
@@ -1,27 +1,22 @@
 /**
- * Channels for telling the person what a refused adoption means for them.
+ * Telling the person that a server is running here when they are looking away.
  *
- * Named here rather than inline because three layers spell them: main sends,
- * preload subscribes, the renderer listens. They are not in the `IPC` map
- * because that describes the desktop's relay of *server* methods, and neither of
- * these ever reaches the server -- the whole point is that this app could not
- * talk to it.
+ * Only one situation needs this channel: the app is pointed at a remote host
+ * while a local server is still going. Its sessions keep working and switching
+ * back to local reconnects to them — but an agent running on a machine whose app
+ * is showing somebody else's is invisible, and invisible is the thing to avoid.
+ *
+ * The refusal case does *not* come through here. There is no main window then:
+ * the app declined to start a second server, so it never got one to render
+ * against, and the connect window says it instead.
+ *
+ * Not in the `IPC` map because that describes the desktop's relay of *server*
+ * methods, and this never reaches a server — the whole point is that it is about
+ * one this app is not talking to.
  */
-export const ADOPTION_REFUSED_CHANNEL = 'adoption:refused'
-export const ADOPTION_STOP_CHANNEL = 'adoption:stop-refused'
+export const LOCAL_SERVER_RUNNING_CHANNEL = 'local-server:still-running'
 
-/**
- * Deliberately carries no text from the other server.
- *
- * The refusal `detail` reads well and is useful in the log, but it interpolates
- * `dataDir` and `buildChannel` straight out of that server's greeting -- strings
- * this app never verified, from the one party it just decided it could not
- * trust. React would escape them, so this is not an injection; it is simpler
- * than that. A stranger does not get to write the text of Vorn's own warning.
- * The reason is a closed set, and the renderer says the rest in its own words.
- */
-export interface AdoptionRefusedNotice {
-  reason: 'no-identity' | 'protocol-mismatch' | 'different-data-dir' | 'different-build'
-  /** False when the running server's pid was never learned, so nothing can act on it. */
-  canStop: boolean
+export interface LocalServerNotice {
+  /** How many sessions the local server was holding, when that could be read. */
+  sessions: number | null
 }

--- a/tests/database-defaults.test.ts
+++ b/tests/database-defaults.test.ts
@@ -51,6 +51,8 @@ describe('defaults survive a save/load round trip', () => {
     ['minimalShellPrompt', true],
     ['minimalShellPrompt', false],
     ['reopenSessions', true],
+    ['keepSessionsRunning', true],
+    ['keepSessionsRunning', false],
     ['widgetEnabled', false]
   ])('%s = %s', (key, value) => {
     saveConfig(configWith({ [key]: value } as Partial<AppConfig['defaults']>))
@@ -63,15 +65,24 @@ describe('defaults survive a save/load round trip', () => {
     const loaded = loadConfig()
     expect(loaded.defaults.domBlockRendering).toBe(true)
     expect(loaded.defaults.minimalShellPrompt).toBe(true)
+    expect(loaded.defaults.keepSessionsRunning).toBe(true)
   })
 
   it('keeps a false the user chose, rather than treating it as unset', () => {
     // The bug this guards: `?? true` on a stored `false` would silently turn
-    // the setting back on every time it loaded.
-    saveConfig(configWith({ domBlockRendering: false, minimalShellPrompt: false }))
+    // the setting back on every time it loaded. For keepSessionsRunning that
+    // would mean quitting kept the agents alive after the user asked it not to.
+    saveConfig(
+      configWith({
+        domBlockRendering: false,
+        minimalShellPrompt: false,
+        keepSessionsRunning: false
+      })
+    )
     const loaded = loadConfig()
     expect(loaded.defaults.domBlockRendering).toBe(false)
     expect(loaded.defaults.minimalShellPrompt).toBe(false)
+    expect(loaded.defaults.keepSessionsRunning).toBe(false)
   })
 })
 

--- a/tests/server-adoption.test.ts
+++ b/tests/server-adoption.test.ts
@@ -158,3 +158,22 @@ describe('probing whether a process is alive', () => {
     spy.mockRestore()
   })
 })
+
+describe('who the greeting tells this server is', () => {
+  it('withholds identity from a peer that is not on loopback', async () => {
+    // The greeting is sent before any credential check, deliberately. `dataDir`
+    // names the user's home directory, so it carries the account name, and with
+    // remote access on the server binds 0.0.0.0 -- where the Origin allowlist
+    // does not apply to a peer that simply sends no Origin. Only a desktop on
+    // this machine has any use for these fields.
+    const { isLoopbackAddress } = await import('../packages/server/src/ws-handler')
+
+    expect(isLoopbackAddress('127.0.0.1')).toBe(true)
+    expect(isLoopbackAddress('::1')).toBe(true)
+    // What a dual-stack listener actually reports for a v4 loopback connection.
+    expect(isLoopbackAddress('::ffff:127.0.0.1')).toBe(true)
+    expect(isLoopbackAddress('192.168.1.42')).toBe(false)
+    expect(isLoopbackAddress('100.64.0.7')).toBe(false)
+    expect(isLoopbackAddress(undefined)).toBe(false)
+  })
+})

--- a/tests/server-adoption.test.ts
+++ b/tests/server-adoption.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { RUNTIME_PROTOCOL_VERSION, type ServerHello } from '@vornrun/shared/protocol'
+import { RUNTIME_PROTOCOL_VERSION, type ServerIdentity } from '@vornrun/shared/protocol'
 import {
   isPidAlive,
   judgeAdoption,
@@ -20,12 +20,14 @@ import {
  * would end the sessions it was holding, which is the user's work.
  */
 
-const self = { dataDir: '/Users/x/.vorn', buildChannel: 'packaged' as const }
+const self = {
+  dataDir: '/Users/x/.vorn',
+  buildChannel: 'packaged' as const,
+  expectedPid: 4242
+}
 
-function hello(over: Partial<ServerHello> = {}): ServerHello {
+function identityOf(over: Partial<ServerIdentity> = {}): ServerIdentity {
   return {
-    protocolVersion: RUNTIME_PROTOCOL_VERSION,
-    capabilities: { auth: 1 },
     dataDir: '/Users/x/.vorn',
     buildChannel: 'packaged',
     pid: 4242,
@@ -34,64 +36,60 @@ function hello(over: Partial<ServerHello> = {}): ServerHello {
   }
 }
 
+const judge = (
+  identity: ServerIdentity | null,
+  version: number | undefined = RUNTIME_PROTOCOL_VERSION
+): ReturnType<typeof judgeAdoption> => judgeAdoption(identity, version, self)
+
 describe('judging a running server', () => {
   it('adopts one that matches', () => {
-    expect(judgeAdoption(hello(), self)).toEqual({ kind: 'adopt' })
+    expect(judge(identityOf())).toEqual({ kind: 'adopt' })
   })
 
   it('adopts across app versions', () => {
     // The point of gating on the protocol rather than the release. An update
     // that changed no messages must not end sessions that are still running,
     // and Vorn updates far more often than its protocol changes.
-    expect(judgeAdoption(hello({ appVersion: '0.6.1' }), self)).toEqual({ kind: 'adopt' })
+    expect(judge(identityOf({ appVersion: '0.6.1' }))).toEqual({ kind: 'adopt' })
   })
 
   it('refuses a different protocol version', () => {
-    const verdict = judgeAdoption(hello({ protocolVersion: RUNTIME_PROTOCOL_VERSION + 1 }), self)
+    const verdict = judge(identityOf(), RUNTIME_PROTOCOL_VERSION + 1)
     expect(verdict).toMatchObject({ kind: 'refuse', reason: 'protocol-mismatch' })
   })
 
   it('refuses another data directory', () => {
-    const verdict = judgeAdoption(hello({ dataDir: '/tmp/other' }), self)
+    const verdict = judge(identityOf({ dataDir: '/tmp/other' }))
     expect(verdict).toMatchObject({ kind: 'refuse', reason: 'different-data-dir' })
   })
 
   it('compares data directories after resolving them', () => {
-    expect(judgeAdoption(hello({ dataDir: '/Users/x/.vorn/' }), self)).toEqual({ kind: 'adopt' })
+    expect(judge(identityOf({ dataDir: '/Users/x/.vorn/' }))).toEqual({ kind: 'adopt' })
   })
 
   it('refuses the other build channel', () => {
     // Dev and packaged deliberately share ~/.vorn while keeping separate Electron
     // user data, so without this a `yarn dev` launch adopts the packaged app's
     // bundled server, or the reverse.
-    const verdict = judgeAdoption(hello({ buildChannel: 'dev' }), self)
+    const verdict = judge(identityOf({ buildChannel: 'dev' }))
     expect(verdict).toMatchObject({ kind: 'refuse', reason: 'different-build' })
   })
 
-  it('refuses a server that does not report its pid', () => {
-    // Without one there is no way to tell a dead server from a reconnecting
-    // bridge, and no handle left for stopping one this app did not spawn.
-    const { pid: _p, ...noPid } = hello()
-    expect(judgeAdoption(noPid as ServerHello, self)).toMatchObject({
+  it('refuses a server whose pid disagrees with the port file', () => {
+    // Both name the same server when everything is honest. Only the port file
+    // was written by a process this app can attribute, and this pid is later
+    // handed to process.kill.
+    expect(judge(identityOf({ pid: 31337 }))).toMatchObject({
       kind: 'refuse',
-      reason: 'no-identity'
+      reason: 'pid-mismatch'
     })
   })
 
-  it('refuses a server that does not say who it is', () => {
-    // A build old enough to predate these fields cannot be told apart from one on
-    // another data directory. Declining costs a spawn; guessing costs a database.
-    const { dataDir: _d, buildChannel: _b, ...anonymous } = hello()
-    expect(judgeAdoption(anonymous as ServerHello, self)).toMatchObject({
-      kind: 'refuse',
-      reason: 'no-identity'
-    })
-  })
-
-  it('refuses when no greeting arrived at all', () => {
+  it('refuses when no identity arrived at all', () => {
+    // Covers both a server too old to send the frame and one that never answered.
     // A timeout means "cannot tell", which must never be read as "nothing is
     // there" — that reading is how a second server gets started on a live port.
-    expect(judgeAdoption(null, self)).toMatchObject({ kind: 'refuse', reason: 'no-identity' })
+    expect(judge(null)).toMatchObject({ kind: 'refuse', reason: 'no-identity' })
   })
 })
 

--- a/tests/server-adoption.test.ts
+++ b/tests/server-adoption.test.ts
@@ -240,3 +240,28 @@ describe('treating the port file and the greeting as untrusted', () => {
     expect(judge(frame as unknown as ServerIdentity)).toMatchObject({ reason: 'no-identity' })
   })
 })
+
+describe('a port file with no pid in it', () => {
+  it('is adopted, not refused — our own MCP writes one', () => {
+    // `discoverAndHeal` in packages/mcp finds a live server by port and rewrites
+    // the file as `{ port }` alone. Comparing a number against that `undefined`
+    // refused as a mismatch, and since a refusal now stops the launch rather
+    // than starting a rival, the app locked itself out of opening because one of
+    // its own components had healed a file.
+    const verdict = judgeAdoption(identityOf(), RUNTIME_PROTOCOL_VERSION, {
+      dataDir: '/Users/x/.vorn',
+      buildChannel: 'packaged',
+      expectedPid: undefined
+    })
+    expect(verdict).toEqual({ kind: 'adopt' })
+  })
+
+  it('still refuses a genuine disagreement when the file does name one', () => {
+    const verdict = judgeAdoption(identityOf({ pid: 31337 }), RUNTIME_PROTOCOL_VERSION, {
+      dataDir: '/Users/x/.vorn',
+      buildChannel: 'packaged',
+      expectedPid: 4242
+    })
+    expect(verdict).toMatchObject({ kind: 'refuse', reason: 'pid-mismatch' })
+  })
+})

--- a/tests/server-adoption.test.ts
+++ b/tests/server-adoption.test.ts
@@ -68,6 +68,16 @@ describe('judging a running server', () => {
     expect(verdict).toMatchObject({ kind: 'refuse', reason: 'different-build' })
   })
 
+  it('refuses a server that does not report its pid', () => {
+    // Without one there is no way to tell a dead server from a reconnecting
+    // bridge, and no handle left for stopping one this app did not spawn.
+    const { pid: _p, ...noPid } = hello()
+    expect(judgeAdoption(noPid as ServerHello, self)).toMatchObject({
+      kind: 'refuse',
+      reason: 'no-identity'
+    })
+  })
+
   it('refuses a server that does not say who it is', () => {
     // A build old enough to predate these fields cannot be told apart from one on
     // another data directory. Declining costs a spawn; guessing costs a database.

--- a/tests/server-adoption.test.ts
+++ b/tests/server-adoption.test.ts
@@ -175,3 +175,68 @@ describe('who the greeting tells this server is', () => {
     expect(isLoopbackAddress(undefined)).toBe(false)
   })
 })
+
+describe('treating the port file and the greeting as untrusted', () => {
+  let dir: string
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-untrusted-'))
+  })
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  const writePortFile = (value: unknown): void =>
+    fs.writeFileSync(path.join(dir, 'ws-port'), JSON.stringify(value))
+
+  it('rejects pid 0, which signals this process own group and always succeeds', () => {
+    // The nastiest of the three: process.kill(0, 0) succeeds, so a pid of 0 reads
+    // as permanently alive. Since a live incumbent is refused rather than
+    // replaced, one bad byte in this file would stop the app starting at all.
+    expect(isPidAlive(0)).toBe(false)
+    writePortFile({ port: 50091, pid: 0 })
+    expect(readPortFile(dir)).toBeNull()
+  })
+
+  it('rejects a negative pid, which targets a process group', () => {
+    expect(isPidAlive(-1)).toBe(false)
+    writePortFile({ port: 50091, pid: -1 })
+    expect(readPortFile(dir)).toBeNull()
+  })
+
+  it('rejects a non-integer pid', () => {
+    expect(isPidAlive(1.5)).toBe(false)
+    expect(isPidAlive(NaN)).toBe(false)
+  })
+
+  it.each([0, -1, 65536, 1.5, NaN])('rejects an out-of-range port: %s', (port) => {
+    writePortFile({ port, pid: process.pid })
+    expect(readPortFile(dir)).toBeNull()
+  })
+
+  it('refuses a greeting missing its data directory rather than throwing', () => {
+    // path.resolve(undefined) throws, and a throw that is not an
+    // AdoptionRefusedError quits the app -- so the launcher would die exactly
+    // where it meant to decline.
+    const malformed = { appVersion: '1', buildChannel: 'packaged', pid: 4242 }
+    expect(() => judge(malformed as unknown as ServerIdentity)).not.toThrow()
+    expect(judge(malformed as unknown as ServerIdentity)).toMatchObject({
+      kind: 'refuse',
+      reason: 'no-identity'
+    })
+  })
+
+  it.each([
+    [
+      'a bogus build channel',
+      { dataDir: '/Users/x/.vorn', appVersion: '1', buildChannel: 'x', pid: 1 }
+    ],
+    ['an empty data directory', { dataDir: '', appVersion: '1', buildChannel: 'packaged', pid: 1 }],
+    [
+      'a pid of zero',
+      { dataDir: '/Users/x/.vorn', appVersion: '1', buildChannel: 'packaged', pid: 0 }
+    ],
+    ['a non-object', 'not an identity']
+  ])('refuses %s', (_label, frame) => {
+    expect(judge(frame as unknown as ServerIdentity)).toMatchObject({ reason: 'no-identity' })
+  })
+})

--- a/tests/server-adoption.test.ts
+++ b/tests/server-adoption.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { RUNTIME_PROTOCOL_VERSION, type ServerHello } from '@vornrun/shared/protocol'
+import {
+  isPidAlive,
+  judgeAdoption,
+  readLocalToken,
+  readPortFile
+} from '../src/main/server/server-adoption'
+
+/**
+ * Deciding whether a server that is already running belongs to this app.
+ *
+ * The cost of the two wrong answers is not symmetric, and that asymmetry is what
+ * these tests pin down. Refusing a server we could have used wastes a process.
+ * Adopting one we should not have — a different data directory, a different
+ * build — puts two servers on one database. And killing one we could not talk to
+ * would end the sessions it was holding, which is the user's work.
+ */
+
+const self = { dataDir: '/Users/x/.vorn', buildChannel: 'packaged' as const }
+
+function hello(over: Partial<ServerHello> = {}): ServerHello {
+  return {
+    protocolVersion: RUNTIME_PROTOCOL_VERSION,
+    capabilities: { auth: 1 },
+    dataDir: '/Users/x/.vorn',
+    buildChannel: 'packaged',
+    pid: 4242,
+    appVersion: '0.7.0-beta.3',
+    ...over
+  }
+}
+
+describe('judging a running server', () => {
+  it('adopts one that matches', () => {
+    expect(judgeAdoption(hello(), self)).toEqual({ kind: 'adopt' })
+  })
+
+  it('adopts across app versions', () => {
+    // The point of gating on the protocol rather than the release. An update
+    // that changed no messages must not end sessions that are still running,
+    // and Vorn updates far more often than its protocol changes.
+    expect(judgeAdoption(hello({ appVersion: '0.6.1' }), self)).toEqual({ kind: 'adopt' })
+  })
+
+  it('refuses a different protocol version', () => {
+    const verdict = judgeAdoption(hello({ protocolVersion: RUNTIME_PROTOCOL_VERSION + 1 }), self)
+    expect(verdict).toMatchObject({ kind: 'refuse', reason: 'protocol-mismatch' })
+  })
+
+  it('refuses another data directory', () => {
+    const verdict = judgeAdoption(hello({ dataDir: '/tmp/other' }), self)
+    expect(verdict).toMatchObject({ kind: 'refuse', reason: 'different-data-dir' })
+  })
+
+  it('compares data directories after resolving them', () => {
+    expect(judgeAdoption(hello({ dataDir: '/Users/x/.vorn/' }), self)).toEqual({ kind: 'adopt' })
+  })
+
+  it('refuses the other build channel', () => {
+    // Dev and packaged deliberately share ~/.vorn while keeping separate Electron
+    // user data, so without this a `yarn dev` launch adopts the packaged app's
+    // bundled server, or the reverse.
+    const verdict = judgeAdoption(hello({ buildChannel: 'dev' }), self)
+    expect(verdict).toMatchObject({ kind: 'refuse', reason: 'different-build' })
+  })
+
+  it('refuses a server that does not say who it is', () => {
+    // A build old enough to predate these fields cannot be told apart from one on
+    // another data directory. Declining costs a spawn; guessing costs a database.
+    const { dataDir: _d, buildChannel: _b, ...anonymous } = hello()
+    expect(judgeAdoption(anonymous as ServerHello, self)).toMatchObject({
+      kind: 'refuse',
+      reason: 'no-identity'
+    })
+  })
+
+  it('refuses when no greeting arrived at all', () => {
+    // A timeout means "cannot tell", which must never be read as "nothing is
+    // there" — that reading is how a second server gets started on a live port.
+    expect(judgeAdoption(null, self)).toMatchObject({ kind: 'refuse', reason: 'no-identity' })
+  })
+})
+
+describe('reading what a running server published', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-adopt-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reads a port file whose process is alive', () => {
+    fs.writeFileSync(path.join(dir, 'ws-port'), JSON.stringify({ port: 50091, pid: process.pid }))
+    expect(readPortFile(dir)).toEqual({ port: 50091, pid: process.pid })
+  })
+
+  it('treats a port file whose process is dead as absent', () => {
+    // The server deletes this on an orderly exit only, so a stale file is the
+    // normal state after a crash. The port it names may since be anyone's.
+    fs.writeFileSync(path.join(dir, 'ws-port'), JSON.stringify({ port: 50091, pid: 0x7ffffffe }))
+    expect(readPortFile(dir)).toBeNull()
+  })
+
+  it('returns null for a missing or unreadable file', () => {
+    expect(readPortFile(dir)).toBeNull()
+    fs.writeFileSync(path.join(dir, 'ws-port'), 'not json')
+    expect(readPortFile(dir)).toBeNull()
+  })
+
+  it('reads the local credential and ignores surrounding whitespace', () => {
+    fs.writeFileSync(path.join(dir, 'local-token'), 'secret-value\n')
+    expect(readLocalToken(dir)).toBe('secret-value')
+  })
+
+  it('returns null rather than an empty credential', () => {
+    // An empty string would be presented as a Bearer token and rejected, which
+    // looks like a broken server rather than a missing file.
+    fs.writeFileSync(path.join(dir, 'local-token'), '   ')
+    expect(readLocalToken(dir)).toBeNull()
+  })
+})
+
+describe('probing whether a process is alive', () => {
+  it('says yes for this process', () => {
+    expect(isPidAlive(process.pid)).toBe(true)
+  })
+
+  it('says no for a pid that is not running', () => {
+    expect(isPidAlive(0x7ffffffe)).toBe(false)
+  })
+
+  it('treats a permission error as alive', () => {
+    // EPERM means the process exists and belongs to someone else. Reading it as
+    // dead would let this app start a second server against a live one.
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('operation not permitted') as NodeJS.ErrnoException
+      err.code = 'EPERM'
+      throw err
+    })
+    expect(isPidAlive(1)).toBe(true)
+    spy.mockRestore()
+  })
+})

--- a/tests/server-integration.test.ts
+++ b/tests/server-integration.test.ts
@@ -379,6 +379,8 @@ describe('server integration', () => {
      * sure. Each frame restarts the clock, so this settles as fast as the server
      * allows and still waits when the server is slow.
      */
+    const HANDSHAKE_FRAMES = new Set(['server:hello', 'server:identity'])
+
     async function notificationsFor(query: string): Promise<string[]> {
       const ws = new WebSocket(`ws://127.0.0.1:${serverPort}/ws${query}`, authOptions())
       const methods: string[] = []
@@ -390,7 +392,10 @@ describe('server integration', () => {
         }
         ws.on('message', (raw) => {
           const frame = JSON.parse(raw.toString())
-          if (frame.method && frame.method !== 'server:hello') methods.push(frame.method)
+          // The handshake frames are sent directly on the socket, outside the
+          // broadcast set this test is measuring, so neither is a notification
+          // any topic filter was ever asked about.
+          if (frame.method && !HANDSHAKE_FRAMES.has(frame.method)) methods.push(frame.method)
           restart()
         })
         restart()

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EventEmitter } from 'node:events'
-import { RUNTIME_PROTOCOL_VERSION, type ServerHello } from '@vornrun/shared/protocol'
+import { RUNTIME_PROTOCOL_VERSION, type ServerIdentity } from '@vornrun/shared/protocol'
 
 /**
  * Whether a launch starts a server or joins the one already running.
@@ -19,7 +19,8 @@ const hostSettings = {
 const published = {
   port: null as number | null,
   token: 'local-secret' as string | null,
-  hello: null as ServerHello | null,
+  identity: null as ServerIdentity | null,
+  protocolVersion: RUNTIME_PROTOCOL_VERSION as number,
   /** Whether the adopted server's process is still alive, when asked. */
   pidAlive: true,
   /** Whether the running server closes the socket after greeting us. */
@@ -36,6 +37,10 @@ class FakeBridge extends EventEmitter {
   requests: string[] = []
   closed = false
   isConnected = false
+  helloVersion: number | undefined
+  get serverHelloVersion(): number | undefined {
+    return this.helloVersion
+  }
   constructor(
     public url: string,
     public credential?: string
@@ -50,7 +55,8 @@ class FakeBridge extends EventEmitter {
       // lands, and cannot be used as proof the credential was accepted.
       this.isConnected = true
       this.emit('connected')
-      if (published.hello) this.emit('hello', published.hello)
+      this.helloVersion = published.protocolVersion
+      if (published.identity) this.emit('identity', published.identity)
     })
   }
   async request(method: string): Promise<unknown> {
@@ -151,10 +157,8 @@ vi.mock('node:readline', () => ({
   }
 }))
 
-function helloFrom(over: Partial<ServerHello> = {}): ServerHello {
+function identityFrom(over: Partial<ServerIdentity> = {}): ServerIdentity {
   return {
-    protocolVersion: RUNTIME_PROTOCOL_VERSION,
-    capabilities: { auth: 1 },
     dataDir: '/Users/x/.vorn',
     buildChannel: 'packaged',
     pid: 999,
@@ -174,7 +178,8 @@ beforeEach(() => {
   bridges.length = 0
   published.port = null
   published.token = 'local-secret'
-  published.hello = null
+  published.identity = null
+  published.protocolVersion = RUNTIME_PROTOCOL_VERSION
   published.pidAlive = true
   published.rejectsCredential = false
   published.spawnedPid = null
@@ -184,7 +189,7 @@ beforeEach(() => {
 describe('finding a server that is already running', () => {
   it('adopts it instead of spawning a second', async () => {
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer } = await import('../src/main/server/server-launcher')
 
     const bridge = await launchServer()
@@ -198,7 +203,7 @@ describe('finding a server that is already running', () => {
     // the next launch must read the credential the server published rather than
     // inventing one the server has never seen.
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer } = await import('../src/main/server/server-launcher')
 
     const bridge = await launchServer()
@@ -208,7 +213,7 @@ describe('finding a server that is already running', () => {
 
   it('adopts one running an older app version', async () => {
     published.port = 50091
-    published.hello = helloFrom({ appVersion: '0.6.0' })
+    published.identity = identityFrom({ appVersion: '0.6.0' })
     const { launchServer } = await import('../src/main/server/server-launcher')
 
     await launchServer()
@@ -223,7 +228,8 @@ describe('declining a server that is running', () => {
     // that cannot speak to it says so and steps aside; it does not resolve the
     // disagreement by ending sessions it cannot even read.
     published.port = 50091
-    published.hello = helloFrom({ protocolVersion: RUNTIME_PROTOCOL_VERSION + 1 })
+    published.identity = identityFrom()
+    published.protocolVersion = RUNTIME_PROTOCOL_VERSION + 1
     const { launchServer, getLastAdoptionRefusal } =
       await import('../src/main/server/server-launcher')
 
@@ -236,7 +242,7 @@ describe('declining a server that is running', () => {
 
   it('spawns its own when the running server is the other build', async () => {
     published.port = 50091
-    published.hello = helloFrom({ buildChannel: 'dev' })
+    published.identity = identityFrom({ buildChannel: 'dev' })
     const { launchServer, getLastAdoptionRefusal } =
       await import('../src/main/server/server-launcher')
 
@@ -323,7 +329,7 @@ describe('the server it spawns', () => {
 describe('quitting', () => {
   it('lets go of an adopted server without stopping it', async () => {
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer, detachFromServer, getServerBridge } =
       await import('../src/main/server/server-launcher')
     await launchServer()
@@ -352,7 +358,7 @@ describe('an adopted server that dies', () => {
     // one case that never recovers: the bridge retrying forever against a port
     // with nothing behind it, which is the symptom #492 was written to end.
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer } = await import('../src/main/server/server-launcher')
     await launchServer()
 
@@ -366,7 +372,7 @@ describe('an adopted server that dies', () => {
     // reconnecting. Spawning a replacement on that signal alone would put a
     // second server on the database every time the connection blipped.
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer } = await import('../src/main/server/server-launcher')
     await launchServer()
 
@@ -377,7 +383,7 @@ describe('an adopted server that dies', () => {
 
   it('is not replaced once the app has decided to quit', async () => {
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer, detachFromServer } = await import('../src/main/server/server-launcher')
     await launchServer()
 
@@ -396,7 +402,7 @@ describe('the three ways adoption used to go quietly wrong', () => {
     // surviving bridge presenting a token no server had heard of, reconnecting
     // forever against a server that was perfectly healthy.
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     const { launchServer } = await import('../src/main/server/server-launcher')
     await launchServer()
 
@@ -413,7 +419,7 @@ describe('the three ways adoption used to go quietly wrong', () => {
     // greeting arrives regardless, so `isConnected` always said yes and the old
     // check could never run. An authenticated round trip is the actual question.
     published.port = 50091
-    published.hello = helloFrom()
+    published.identity = identityFrom()
     published.rejectsCredential = true
     const { launchServer } = await import('../src/main/server/server-launcher')
 
@@ -454,7 +460,8 @@ describe('what the reviews caught', () => {
     // credential -- rejected forever -- while the child we started ran unwatched.
     published.port = 50091
     published.spawnedPid = 999
-    published.hello = helloFrom({ protocolVersion: RUNTIME_PROTOCOL_VERSION + 1 })
+    published.identity = identityFrom()
+    published.protocolVersion = RUNTIME_PROTOCOL_VERSION + 1
     const { launchServer } = await import('../src/main/server/server-launcher')
 
     const bridge = await launchServer()
@@ -491,7 +498,7 @@ describe('what the reviews caught', () => {
     // If it throws, nothing had happened yet: the user picked "Stop Sessions and
     // Server", the app quit, and every session carried on saying nothing.
     published.port = 50091
-    published.hello = helloFrom({ pid: 999 })
+    published.identity = identityFrom()
     const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
     await launchServer()
     bridges[0].request = async (m: string) => {
@@ -516,7 +523,7 @@ describe('a server whose greeting does not match its port file', () => {
     // Both name the same server when everything is honest. Only one of them was
     // written by a process this app can attribute, and it is the one to believe.
     published.port = 50091
-    published.hello = helloFrom({ pid: 31337 })
+    published.identity = identityFrom({ pid: 31337 })
 
     const { launchServer } = await import('../src/main/server/server-launcher')
     await launchServer()

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -535,3 +535,47 @@ describe('a server whose greeting does not match its port file', () => {
     expect(spawned).toEqual([])
   })
 })
+
+describe('stopping a server that ignores SIGTERM', () => {
+  it('escalates to SIGKILL, judged by liveness rather than by having asked', async () => {
+    // `child.killed` is true the moment a signal is delivered, even to a process
+    // that ignores it. Gating the fallback on it made SIGKILL unreachable, so a
+    // server that swallowed SIGTERM outlived "Stop Sessions and Server" -- which
+    // only started mattering once the server stopped dying with its parent.
+    published.pidAlive = true
+    const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+    // Only now: the launch itself waits on real timers to learn its port.
+    vi.useFakeTimers()
+
+    const signals: string[] = []
+    const child = spawnedChildren[0] as unknown as Record<string, unknown>
+    child.killed = true // what Node reports right after a delivered SIGTERM
+    child.kill = (sig: string): void => void signals.push(sig)
+
+    const stopping = stopServer()
+    await vi.advanceTimersByTimeAsync(4000)
+    await stopping
+
+    expect(signals).toContain('SIGKILL')
+    vi.useRealTimers()
+  })
+
+  it('leaves a server that actually stopped alone', async () => {
+    const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+    vi.useFakeTimers()
+
+    const signals: string[] = []
+    const child = spawnedChildren[0] as unknown as Record<string, unknown>
+    child.kill = (sig: string): void => void signals.push(sig)
+    published.pidAlive = false // it honoured the SIGTERM and exited
+
+    const stopping = stopServer()
+    await vi.advanceTimersByTimeAsync(4000)
+    await stopping
+
+    expect(signals).not.toContain('SIGKILL')
+    vi.useRealTimers()
+  })
+})

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -579,3 +579,41 @@ describe('stopping a server that ignores SIGTERM', () => {
     vi.useRealTimers()
   })
 })
+
+describe('stopping the local server on request', () => {
+  it('does not report success until the process is actually gone', async () => {
+    // The caller relaunches the app the moment this says yes. A server still
+    // shutting down still owns its ws-port file, so the fresh launch would find
+    // it, refuse it again, and land back in the window the user just acted from
+    // -- a loop that looks like the button doing nothing.
+    published.port = 50091
+    published.pidAlive = true
+    const { stopLocalServer } = await import('../src/main/server/server-launcher')
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    let settled = false
+    const stopping = stopLocalServer().then((r) => {
+      settled = true
+      return r
+    })
+
+    await new Promise((r) => setTimeout(r, 250))
+    expect(settled).toBe(false) // still alive, so still waiting
+
+    published.pidAlive = false // the server finally exits
+    await expect(stopping).resolves.toEqual({ ok: true })
+    vi.restoreAllMocks()
+  })
+
+  it('reports failure when it will not go at all', async () => {
+    published.port = 50091
+    published.pidAlive = true // never exits, through SIGTERM and SIGKILL alike
+    const { stopLocalServer } = await import('../src/main/server/server-launcher')
+    vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    const result = await stopLocalServer()
+
+    expect(result).toMatchObject({ ok: false })
+    vi.restoreAllMocks()
+  }, 20000)
+})

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -223,46 +223,58 @@ describe('finding a server that is already running', () => {
 })
 
 describe('declining a server that is running', () => {
-  it('spawns its own on a protocol mismatch, and never kills the incumbent', async () => {
-    // The running server holds the PTYs, so it holds the user's work. A client
-    // that cannot speak to it says so and steps aside; it does not resolve the
-    // disagreement by ending sessions it cannot even read.
+  /**
+   * Every case here ends the same way: no second server.
+   *
+   * Refusing to adopt is not grounds to start a rival. Both would open the same
+   * SQLite file, and `saveSessions` is a DELETE-then-insert of the whole table on
+   * a debounce, so the two would erase each other's sessions with the last writer
+   * winning. tmux does not kill a server it cannot speak to and does not start one
+   * beside it either -- the client prints the mismatch and exits.
+   */
+  it('refuses on a protocol mismatch, and never kills the incumbent', async () => {
     published.port = 50091
     published.identity = identityFrom()
     published.protocolVersion = RUNTIME_PROTOCOL_VERSION + 1
-    const { launchServer, getLastAdoptionRefusal } =
-      await import('../src/main/server/server-launcher')
+    const { launchServer, getLastAdoptionRefusal, AdoptionRefusedError } = await import(
+      '../src/main/server/server-launcher'
+    )
 
-    await launchServer()
+    await expect(launchServer()).rejects.toBeInstanceOf(AdoptionRefusedError)
 
-    expect(spawned).toHaveLength(1)
+    expect(spawned).toEqual([])
     expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'protocol-mismatch' })
     expect(bridges[0].requests).not.toContain('server:shutdown')
   })
 
-  it('spawns its own when the running server is the other build', async () => {
+  it('refuses when the running server is the other build', async () => {
     published.port = 50091
     published.identity = identityFrom({ buildChannel: 'dev' })
-    const { launchServer, getLastAdoptionRefusal } =
-      await import('../src/main/server/server-launcher')
+    const { launchServer, getLastAdoptionRefusal } = await import(
+      '../src/main/server/server-launcher'
+    )
 
-    await launchServer()
+    await expect(launchServer()).rejects.toThrow()
 
-    expect(spawned).toHaveLength(1)
+    expect(spawned).toEqual([])
     expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'different-build' })
   })
 
-  it('spawns its own when no credential was published', async () => {
+  it('refuses when no credential was published to reach it with', async () => {
     published.port = 50091
     published.token = null
-    const { launchServer } = await import('../src/main/server/server-launcher')
+    const { launchServer, getLastAdoptionRefusal } = await import(
+      '../src/main/server/server-launcher'
+    )
 
-    await launchServer()
+    await expect(launchServer()).rejects.toThrow()
 
-    expect(spawned).toHaveLength(1)
+    expect(spawned).toEqual([])
+    expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'unusable' })
   })
 
   it('spawns when nothing is published at all', async () => {
+    // The one case that is genuinely a free database: no live server anywhere.
     const { launchServer } = await import('../src/main/server/server-launcher')
 
     await launchServer()
@@ -423,9 +435,9 @@ describe('the three ways adoption used to go quietly wrong', () => {
     published.rejectsCredential = true
     const { launchServer } = await import('../src/main/server/server-launcher')
 
-    await launchServer()
+    await expect(launchServer()).rejects.toThrow()
 
-    expect(spawned).toHaveLength(1)
+    expect(spawned).toEqual([])
   })
 
   it('creates the data directory before spawning into it', async () => {
@@ -455,19 +467,18 @@ describe('what the reviews caught', () => {
   })
 
   it('will not accept a port file that names a server it did not spawn', async () => {
-    // After refusing an incumbent, the file still names it with a live pid. A
-    // fallback that read it would hand the bridge the incumbent's port with our
-    // credential -- rejected forever -- while the child we started ran unwatched.
+    // After refusing an incumbent the file still names it with a live pid. The
+    // launcher no longer spawns at all in that case, which is the stronger form
+    // of the same guarantee: there is no second child to mis-resolve.
     published.port = 50091
     published.spawnedPid = 999
     published.identity = identityFrom()
     published.protocolVersion = RUNTIME_PROTOCOL_VERSION + 1
     const { launchServer } = await import('../src/main/server/server-launcher')
 
-    const bridge = await launchServer()
+    await expect(launchServer()).rejects.toThrow()
 
-    // 51000 is the spawned child's port; 50091 is the incumbent's.
-    expect((bridge as unknown as FakeBridge).url).toBe('ws://127.0.0.1:51000/ws')
+    expect(spawned).toEqual([])
   })
 
   it('ends the dev server on detach rather than orphaning it', async () => {
@@ -524,10 +535,10 @@ describe('a server whose greeting does not match its port file', () => {
     // written by a process this app can attribute, and it is the one to believe.
     published.port = 50091
     published.identity = identityFrom({ pid: 31337 })
-
     const { launchServer } = await import('../src/main/server/server-launcher')
-    await launchServer()
 
-    expect(spawned).toHaveLength(1)
+    await expect(launchServer()).rejects.toThrow()
+
+    expect(spawned).toEqual([])
   })
 })

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -98,9 +98,7 @@ vi.mock('../src/main/server/server-adoption', async (importOriginal) => {
     ...actual,
     resolveDataDir: () => '/Users/x/.vorn',
     readPortFile: () =>
-      published.port === null
-        ? null
-        : { port: published.port, pid: published.spawnedPid ?? 999 },
+      published.port === null ? null : { port: published.port, pid: published.spawnedPid ?? 999 },
     readLocalToken: () => published.token,
     isPidAlive: () => published.pidAlive
   }
@@ -236,9 +234,8 @@ describe('declining a server that is running', () => {
     published.port = 50091
     published.identity = identityFrom()
     published.protocolVersion = RUNTIME_PROTOCOL_VERSION + 1
-    const { launchServer, getLastAdoptionRefusal, AdoptionRefusedError } = await import(
-      '../src/main/server/server-launcher'
-    )
+    const { launchServer, getLastAdoptionRefusal, AdoptionRefusedError } =
+      await import('../src/main/server/server-launcher')
 
     await expect(launchServer()).rejects.toBeInstanceOf(AdoptionRefusedError)
 
@@ -250,9 +247,8 @@ describe('declining a server that is running', () => {
   it('refuses when the running server is the other build', async () => {
     published.port = 50091
     published.identity = identityFrom({ buildChannel: 'dev' })
-    const { launchServer, getLastAdoptionRefusal } = await import(
-      '../src/main/server/server-launcher'
-    )
+    const { launchServer, getLastAdoptionRefusal } =
+      await import('../src/main/server/server-launcher')
 
     await expect(launchServer()).rejects.toThrow()
 
@@ -263,9 +259,8 @@ describe('declining a server that is running', () => {
   it('refuses when no credential was published to reach it with', async () => {
     published.port = 50091
     published.token = null
-    const { launchServer, getLastAdoptionRefusal } = await import(
-      '../src/main/server/server-launcher'
-    )
+    const { launchServer, getLastAdoptionRefusal } =
+      await import('../src/main/server/server-launcher')
 
     await expect(launchServer()).rejects.toThrow()
 
@@ -292,7 +287,7 @@ describe('the server it spawns', () => {
     expect(spawned[0].opts.detached).toBe(true)
   })
 
-  it('is NOT detached in dev, so a restart cannot adopt yesterday\'s source', async () => {
+  it("is NOT detached in dev, so a restart cannot adopt yesterday's source", async () => {
     // Every adoption check would pass for a leftover dev server -- same data
     // directory, same build channel -- and it would be running the code as it
     // was before the edit that prompted the restart, with nothing to say so.
@@ -452,7 +447,7 @@ describe('the three ways adoption used to go quietly wrong', () => {
 })
 
 describe('what the reviews caught', () => {
-  it('sends the packaged server\'s output to a file, never to a pipe', async () => {
+  it("sends the packaged server's output to a file, never to a pipe", async () => {
     // A pipe held by this process dies with this process, and the server is
     // meant to outlive it. Measured: the next write to stderr after the parent
     // goes raises EPIPE, the server has no uncaughtException handler, and it
@@ -487,9 +482,7 @@ describe('what the reviews caught', () => {
     // adopt -- running the source from before the edit that prompted the restart.
     process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173'
     try {
-      const { launchServer, detachFromServer } = await import(
-        '../src/main/server/server-launcher'
-      )
+      const { launchServer, detachFromServer } = await import('../src/main/server/server-launcher')
       await launchServer()
       const killed: string[] = []
       ;(spawnedChildren[0] as Record<string, unknown>).kill = (sig: string): void => {

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -491,7 +491,7 @@ describe('what the reviews caught', () => {
     // If it throws, nothing had happened yet: the user picked "Stop Sessions and
     // Server", the app quit, and every session carried on saying nothing.
     published.port = 50091
-    published.hello = helloFrom({ pid: 4242 })
+    published.hello = helloFrom({ pid: 999 })
     const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
     await launchServer()
     bridges[0].request = async (m: string) => {
@@ -507,6 +507,20 @@ describe('what the reviews caught', () => {
     await stopServer()
     spy.mockRestore()
 
-    expect(signalled).toContain(4242)
+    expect(signalled).toContain(999)
+  })
+})
+
+describe('a server whose greeting does not match its port file', () => {
+  it('is refused, because that pid is later handed to process.kill', async () => {
+    // Both name the same server when everything is honest. Only one of them was
+    // written by a process this app can attribute, and it is the one to believe.
+    published.port = 50091
+    published.hello = helloFrom({ pid: 31337 })
+
+    const { launchServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
   })
 })

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -23,10 +23,13 @@ const published = {
   /** Whether the adopted server's process is still alive, when asked. */
   pidAlive: true,
   /** Whether the running server closes the socket after greeting us. */
-  rejectsCredential: false
+  rejectsCredential: false,
+  /** Set once the fake spawned server has "published" its port file. */
+  spawnedPid: null as number | null
 }
 
 const spawned: { cmd: string; opts: Record<string, unknown> }[] = []
+const spawnedChildren: EventEmitter[] = []
 const bridges: FakeBridge[] = []
 
 class FakeBridge extends EventEmitter {
@@ -48,18 +51,16 @@ class FakeBridge extends EventEmitter {
       this.isConnected = true
       this.emit('connected')
       if (published.hello) this.emit('hello', published.hello)
-      if (published.rejectsCredential) {
-        // What a 4001/4002 close looks like from here: open, greeted, dropped.
-        setTimeout(() => {
-          this.isConnected = false
-          this.emit('disconnected')
-        }, 5)
-      }
     })
   }
   async request(method: string): Promise<unknown> {
     this.requests.push(method)
-    return undefined
+    // `config:load` is what the launcher uses to prove the credential was
+    // accepted; a server that refuses this app answers it with a rejection.
+    if (method === 'config:load' && published.rejectsCredential) {
+      throw new Error('not authenticated')
+    }
+    return {}
   }
   close(): void {
     this.closed = true
@@ -90,31 +91,51 @@ vi.mock('../src/main/server/server-adoption', async (importOriginal) => {
   return {
     ...actual,
     resolveDataDir: () => '/Users/x/.vorn',
-    readPortFile: () => (published.port === null ? null : { port: published.port, pid: 999 }),
+    readPortFile: () =>
+      published.port === null
+        ? null
+        : { port: published.port, pid: published.spawnedPid ?? 999 },
     readLocalToken: () => published.token,
     isPidAlive: () => published.pidAlive
   }
 })
 
 const madeDirs: string[] = []
+const opened: string[] = []
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>()
-  return { ...actual, mkdirSync: (dir: string) => void madeDirs.push(dir) }
+  return {
+    ...actual,
+    mkdirSync: (dir: string) => void madeDirs.push(dir),
+    openSync: (file: string) => {
+      opened.push(String(file))
+      return 99
+    },
+    closeSync: () => {}
+  }
 })
 
 vi.mock('node:child_process', () => ({
   spawn: (cmd: string, _args: string[], opts: Record<string, unknown>) => {
     spawned.push({ cmd, opts })
     const child = new EventEmitter() as EventEmitter & Record<string, unknown>
+    child.pid = 4242
     const stdout = new EventEmitter() as EventEmitter & Record<string, unknown>
     stdout.destroy = (): void => {}
-    // readline reads this; emitting the port line is what the launcher waits on.
+    stdout.unref = (): void => {}
+    // Only the dev path reads this; the packaged path waits on the port file.
     setImmediate(() => stdout.emit('data', JSON.stringify({ port: 51000 }) + '\n'))
     child.stdout = stdout
     child.stderr = null
     child.unref = (): void => {}
     child.killed = false
     child.kill = (): void => {}
+    spawnedChildren.push(child)
+    // What the server does once it is listening: publish {port, pid}.
+    setImmediate(() => {
+      published.port = 51000
+      published.spawnedPid = 4242
+    })
     return child
   }
 }))
@@ -147,13 +168,16 @@ beforeEach(() => {
   // Only Electron sets this, and the packaged entry point is resolved from it.
   ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = '/app/Resources'
   spawned.length = 0
+  spawnedChildren.length = 0
   madeDirs.length = 0
+  opened.length = 0
   bridges.length = 0
   published.port = null
   published.token = 'local-secret'
   published.hello = null
   published.pidAlive = true
   published.rejectsCredential = false
+  published.spawnedPid = null
   hostSettings.value = { mode: 'local', url: '', token: undefined }
 })
 
@@ -384,10 +408,10 @@ describe('the three ways adoption used to go quietly wrong', () => {
     expect(env.SECRET_VORN_BOOTSTRAP_TOKEN).toBe('local-secret')
   })
 
-  it('declines a server that greets us and then drops the socket', async () => {
-    // A rejected credential does not fail the connect: the socket opens, the
-    // greeting arrives, and only then is it closed. Reading `isConnected` at the
-    // greeting therefore always said yes, and this branch could never run.
+  it('declines a server that greets us but refuses our credential', async () => {
+    // A rejected credential does not fail the connect: the socket opens and the
+    // greeting arrives regardless, so `isConnected` always said yes and the old
+    // check could never run. An authenticated round trip is the actual question.
     published.port = 50091
     published.hello = helloFrom()
     published.rejectsCredential = true
@@ -406,5 +430,83 @@ describe('the three ways adoption used to go quietly wrong', () => {
     await launchServer()
 
     expect(madeDirs).toContain('/Users/x/.vorn')
+  })
+})
+
+describe('what the reviews caught', () => {
+  it('sends the packaged server\'s output to a file, never to a pipe', async () => {
+    // A pipe held by this process dies with this process, and the server is
+    // meant to outlive it. Measured: the next write to stderr after the parent
+    // goes raises EPIPE, the server has no uncaughtException handler, and it
+    // exits -- on its first log line, which is milliseconds away.
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(opened.some((f) => f.endsWith('server.log'))).toBe(true)
+    expect((spawned[0].opts.stdio as unknown[])[1]).toBe(99)
+    expect((spawned[0].opts.stdio as unknown[])[2]).toBe(99)
+  })
+
+  it('will not accept a port file that names a server it did not spawn', async () => {
+    // After refusing an incumbent, the file still names it with a live pid. A
+    // fallback that read it would hand the bridge the incumbent's port with our
+    // credential -- rejected forever -- while the child we started ran unwatched.
+    published.port = 50091
+    published.spawnedPid = 999
+    published.hello = helloFrom({ protocolVersion: RUNTIME_PROTOCOL_VERSION + 1 })
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    const bridge = await launchServer()
+
+    // 51000 is the spawned child's port; 50091 is the incumbent's.
+    expect((bridge as unknown as FakeBridge).url).toBe('ws://127.0.0.1:51000/ws')
+  })
+
+  it('ends the dev server on detach rather than orphaning it', async () => {
+    // A dev child is not detached, and POSIX does not kill a plain child when
+    // its parent exits. Walking away would leave it for the next `yarn dev` to
+    // adopt -- running the source from before the edit that prompted the restart.
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173'
+    try {
+      const { launchServer, detachFromServer } = await import(
+        '../src/main/server/server-launcher'
+      )
+      await launchServer()
+      const killed: string[] = []
+      ;(spawnedChildren[0] as Record<string, unknown>).kill = (sig: string): void => {
+        killed.push(sig)
+      }
+
+      detachFromServer()
+
+      expect(killed).toEqual(['SIGTERM'])
+    } finally {
+      delete process.env.ELECTRON_RENDERER_URL
+    }
+  })
+
+  it('signals an adopted server that ignores the shutdown request', async () => {
+    // An adopted server has no child handle, so the RPC is the only way to ask.
+    // If it throws, nothing had happened yet: the user picked "Stop Sessions and
+    // Server", the app quit, and every session carried on saying nothing.
+    published.port = 50091
+    published.hello = helloFrom({ pid: 4242 })
+    const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+    bridges[0].request = async (m: string) => {
+      if (m === 'server:shutdown') throw new Error('no answer')
+      return {}
+    }
+    const signalled: number[] = []
+    const spy = vi.spyOn(process, 'kill').mockImplementation((pid) => {
+      signalled.push(pid as number)
+      return true
+    })
+
+    await stopServer()
+    spy.mockRestore()
+
+    expect(signalled).toContain(4242)
   })
 })

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { RUNTIME_PROTOCOL_VERSION, type ServerHello } from '@vornrun/shared/protocol'
+
+/**
+ * Whether a launch starts a server or joins the one already running.
+ *
+ * The failure this guards is quiet and expensive: two servers on one data
+ * directory, the app talking to the empty one while the agents run in the other.
+ * The user sees terminals that accept keystrokes and never run them, so every
+ * path that could spawn a second server is asserted here.
+ */
+
+const hostSettings = {
+  value: { mode: 'local', url: '', token: undefined } as Record<string, unknown>
+}
+
+/** What the fake data directory currently publishes. */
+const published = {
+  port: null as number | null,
+  token: 'local-secret' as string | null,
+  hello: null as ServerHello | null
+}
+
+const spawned: { cmd: string; opts: Record<string, unknown> }[] = []
+const bridges: FakeBridge[] = []
+
+class FakeBridge extends EventEmitter {
+  requests: string[] = []
+  closed = false
+  isConnected = false
+  constructor(
+    public url: string,
+    public credential?: string
+  ) {
+    super()
+    bridges.push(this)
+  }
+  connect(): void {
+    setImmediate(() => {
+      // The real server sends its greeting as the first frame on the socket and
+      // before authentication, which is what lets a launcher judge it without
+      // first proving who it is.
+      if (published.hello) this.emit('hello', published.hello)
+      this.isConnected = true
+      this.emit('connected')
+    })
+  }
+  async request(method: string): Promise<unknown> {
+    this.requests.push(method)
+    return undefined
+  }
+  close(): void {
+    this.closed = true
+  }
+}
+
+vi.mock('../src/main/server/host-store', () => ({
+  readHostSettings: () => hostSettings.value
+}))
+vi.mock('../src/main/server/server-bridge', () => ({ ServerBridge: FakeBridge }))
+vi.mock('../src/main/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/userData',
+    getAppPath: () => '/app',
+    getVersion: () => '0.7.0-beta.4',
+    isPackaged: true
+  }
+}))
+
+// The pure judgement stays real; only what the filesystem says is faked, so a
+// wiring change cannot pass by disagreeing with the rules tested next door.
+vi.mock('../src/main/server/server-adoption', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/main/server/server-adoption')>()
+  return {
+    ...actual,
+    resolveDataDir: () => '/Users/x/.vorn',
+    readPortFile: () => (published.port === null ? null : { port: published.port, pid: 999 }),
+    readLocalToken: () => published.token
+  }
+})
+
+vi.mock('node:child_process', () => ({
+  spawn: (cmd: string, _args: string[], opts: Record<string, unknown>) => {
+    spawned.push({ cmd, opts })
+    const child = new EventEmitter() as EventEmitter & Record<string, unknown>
+    const stdout = new EventEmitter() as EventEmitter & Record<string, unknown>
+    stdout.destroy = (): void => {}
+    // readline reads this; emitting the port line is what the launcher waits on.
+    setImmediate(() => stdout.emit('data', JSON.stringify({ port: 51000 }) + '\n'))
+    child.stdout = stdout
+    child.stderr = null
+    child.unref = (): void => {}
+    child.killed = false
+    child.kill = (): void => {}
+    return child
+  }
+}))
+
+vi.mock('node:readline', () => ({
+  createInterface: ({ input }: { input: EventEmitter }) => {
+    const rl = new EventEmitter() as EventEmitter & Record<string, unknown>
+    rl.close = (): void => {}
+    input.on('data', (chunk: string) => {
+      for (const line of String(chunk).split('\n')) if (line) rl.emit('line', line)
+    })
+    return rl
+  }
+}))
+
+function helloFrom(over: Partial<ServerHello> = {}): ServerHello {
+  return {
+    protocolVersion: RUNTIME_PROTOCOL_VERSION,
+    capabilities: { auth: 1 },
+    dataDir: '/Users/x/.vorn',
+    buildChannel: 'packaged',
+    pid: 999,
+    appVersion: '0.7.0-beta.3',
+    ...over
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  // Only Electron sets this, and the packaged entry point is resolved from it.
+  ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = '/app/Resources'
+  spawned.length = 0
+  bridges.length = 0
+  published.port = null
+  published.token = 'local-secret'
+  published.hello = null
+  hostSettings.value = { mode: 'local', url: '', token: undefined }
+})
+
+describe('finding a server that is already running', () => {
+  it('adopts it instead of spawning a second', async () => {
+    published.port = 50091
+    published.hello = helloFrom()
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    const bridge = await launchServer()
+
+    expect(spawned).toEqual([])
+    expect((bridge as unknown as FakeBridge).url).toBe('ws://127.0.0.1:50091/ws')
+  })
+
+  it('authenticates with the published credential, not a fresh secret', async () => {
+    // A detached server outlives the app that generated its bootstrap token, so
+    // the next launch must read the credential the server published rather than
+    // inventing one the server has never seen.
+    published.port = 50091
+    published.hello = helloFrom()
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    const bridge = await launchServer()
+
+    expect((bridge as unknown as FakeBridge).credential).toBe('local-secret')
+  })
+
+  it('adopts one running an older app version', async () => {
+    published.port = 50091
+    published.hello = helloFrom({ appVersion: '0.6.0' })
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toEqual([])
+  })
+})
+
+describe('declining a server that is running', () => {
+  it('spawns its own on a protocol mismatch, and never kills the incumbent', async () => {
+    // The running server holds the PTYs, so it holds the user's work. A client
+    // that cannot speak to it says so and steps aside; it does not resolve the
+    // disagreement by ending sessions it cannot even read.
+    published.port = 50091
+    published.hello = helloFrom({ protocolVersion: RUNTIME_PROTOCOL_VERSION + 1 })
+    const { launchServer, getLastAdoptionRefusal } =
+      await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
+    expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'protocol-mismatch' })
+    expect(bridges[0].requests).not.toContain('server:shutdown')
+  })
+
+  it('spawns its own when the running server is the other build', async () => {
+    published.port = 50091
+    published.hello = helloFrom({ buildChannel: 'dev' })
+    const { launchServer, getLastAdoptionRefusal } =
+      await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
+    expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'different-build' })
+  })
+
+  it('spawns its own when no credential was published', async () => {
+    published.port = 50091
+    published.token = null
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
+  })
+
+  it('spawns when nothing is published at all', async () => {
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
+  })
+})
+
+describe('the server it spawns', () => {
+  it('is detached, so quitting the app does not end it', async () => {
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned[0].opts.detached).toBe(true)
+  })
+
+  it('runs the Electron binary as Node rather than as another app', async () => {
+    // process.execPath is the Electron binary. Spawning it without this variable
+    // launches a second full Vorn — an infinite spawn loop this code has hit.
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    const env = spawned[0].opts.env as Record<string, string>
+    expect(env.ELECTRON_RUN_AS_NODE).toBe('1')
+  })
+
+  it('tells the server which build it is, so the next launch can judge it', async () => {
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    const env = spawned[0].opts.env as Record<string, string>
+    expect(env.VORN_BUILD_CHANNEL).toBe('packaged')
+    expect(env.VORN_APP_VERSION).toBe('0.7.0-beta.4')
+  })
+
+  it('runs from a directory that cannot be deleted underneath it', async () => {
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned[0].opts.cwd).toBe('/Users/x/.vorn')
+  })
+})
+
+describe('quitting', () => {
+  it('lets go of an adopted server without stopping it', async () => {
+    published.port = 50091
+    published.hello = helloFrom()
+    const { launchServer, detachFromServer, getServerBridge } =
+      await import('../src/main/server/server-launcher')
+    await launchServer()
+
+    detachFromServer()
+
+    expect(bridges[0].requests).not.toContain('server:shutdown')
+    expect(bridges[0].closed).toBe(true)
+    expect(getServerBridge()).toBeNull()
+  })
+
+  it('still shuts down a server it spawned when asked to stop', async () => {
+    const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+
+    await stopServer()
+
+    expect(bridges.at(-1)?.requests).toContain('server:shutdown')
+  })
+})

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -30,6 +30,8 @@ const published = {
 }
 
 const spawned: { cmd: string; opts: Record<string, unknown> }[] = []
+/** When set, the spawned child never announces a port — a server that will not start. */
+const quietSpawn = { value: false }
 const spawnedChildren: EventEmitter[] = []
 const bridges: FakeBridge[] = []
 
@@ -128,7 +130,9 @@ vi.mock('node:child_process', () => ({
     stdout.destroy = (): void => {}
     stdout.unref = (): void => {}
     // Only the dev path reads this; the packaged path waits on the port file.
-    setImmediate(() => stdout.emit('data', JSON.stringify({ port: 51000 }) + '\n'))
+    if (!quietSpawn.value) {
+      setImmediate(() => stdout.emit('data', JSON.stringify({ port: 51000 }) + '\n'))
+    }
     child.stdout = stdout
     child.stderr = null
     child.unref = (): void => {}
@@ -136,10 +140,12 @@ vi.mock('node:child_process', () => ({
     child.kill = (): void => {}
     spawnedChildren.push(child)
     // What the server does once it is listening: publish {port, pid}.
-    setImmediate(() => {
-      published.port = 51000
-      published.spawnedPid = 4242
-    })
+    if (!quietSpawn.value) {
+      setImmediate(() => {
+        published.port = 51000
+        published.spawnedPid = 4242
+      })
+    }
     return child
   }
 }))
@@ -171,6 +177,7 @@ beforeEach(() => {
   ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = '/app/Resources'
   spawned.length = 0
   spawnedChildren.length = 0
+  quietSpawn.value = false
   madeDirs.length = 0
   opened.length = 0
   bridges.length = 0
@@ -351,11 +358,12 @@ describe('quitting', () => {
   it('still shuts down a server it spawned when asked to stop', async () => {
     const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
     await launchServer()
+    published.pidAlive = false // it honours the signal, so the wait is immediate
 
     await stopServer()
 
     expect(bridges.at(-1)?.requests).toContain('server:shutdown')
-  })
+  }, 30000)
 })
 
 describe('an adopted server that dies', () => {
@@ -502,7 +510,7 @@ describe('what the reviews caught', () => {
     // If it throws, nothing had happened yet: the user picked "Stop Sessions and
     // Server", the app quit, and every session carried on saying nothing.
     published.port = 50091
-    published.identity = identityFrom()
+    published.identity = identityFrom({ pid: 999 })
     const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
     await launchServer()
     bridges[0].request = async (m: string) => {
@@ -512,6 +520,7 @@ describe('what the reviews caught', () => {
     const signalled: number[] = []
     const spy = vi.spyOn(process, 'kill').mockImplementation((pid) => {
       signalled.push(pid as number)
+      published.pidAlive = false // it goes once actually signalled
       return true
     })
 
@@ -519,7 +528,7 @@ describe('what the reviews caught', () => {
     spy.mockRestore()
 
     expect(signalled).toContain(999)
-  })
+  }, 30000)
 })
 
 describe('a server whose greeting does not match its port file', () => {
@@ -536,84 +545,127 @@ describe('a server whose greeting does not match its port file', () => {
   })
 })
 
-describe('stopping a server that ignores SIGTERM', () => {
-  it('escalates to SIGKILL, judged by liveness rather than by having asked', async () => {
-    // `child.killed` is true the moment a signal is delivered, even to a process
-    // that ignores it. Gating the fallback on it made SIGKILL unreachable, so a
-    // server that swallowed SIGTERM outlived "Stop Sessions and Server" -- which
-    // only started mattering once the server stopped dying with its parent.
+describe('the dev readiness path', () => {
+  it('will not resolve to a port from a file it cannot attribute', async () => {
+    // Dev spawns through npx, so the child is a parent of the process that
+    // listens and there is no pid to match the file against. Falling back to it
+    // would hand the bridge somebody else's port with a credential that server
+    // never issued -- the wrong-server failure this change exists to prevent.
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173'
+    quietSpawn.value = true // the dev child never prints its port line
+    published.port = null // nothing to adopt at launch, so it spawns
+    try {
+      const { launchServer } = await import('../src/main/server/server-launcher')
+      const launching = launchServer()
+      // An incumbent publishes itself while we are still waiting. The old
+      // fallback would have read this and resolved to its port.
+      setTimeout(() => {
+        published.port = 50091
+        published.spawnedPid = 999
+      }, 100)
+
+      await expect(launching).rejects.toThrow(/Timeout waiting for server port/i)
+    } finally {
+      delete process.env.ELECTRON_RENDERER_URL
+      quietSpawn.value = false
+    }
+  }, 30000)
+})
+
+describe('ending a server, and knowing that it ended', () => {
+  /**
+   * Every path here shares one requirement: the caller cannot continue until the
+   * process is actually gone. `before-quit` calls `app.quit()` the moment
+   * `stopServer` resolves, and the connect window relaunches the moment
+   * `stopLocalServer` says yes -- so anything left on a timer is something that
+   * never happens.
+   */
+  function killRecorder(): { signals: string[]; restore: () => void } {
+    const signals: string[] = []
+    const spy = vi.spyOn(process, 'kill').mockImplementation((_pid, sig) => {
+      signals.push(String(sig))
+      // A SIGKILL is the end of the argument; anything else it may ignore.
+      if (String(sig) === 'SIGKILL') published.pidAlive = false
+      return true
+    })
+    return { signals, restore: () => spy.mockRestore() }
+  }
+
+  it('escalates to SIGKILL when the server ignores SIGTERM', async () => {
     published.pidAlive = true
     const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
     await launchServer()
-    // Only now: the launch itself waits on real timers to learn its port.
-    vi.useFakeTimers()
+    ;(spawnedChildren[0] as unknown as Record<string, unknown>).kill = (): void => {}
+    const { signals, restore } = killRecorder()
 
-    const signals: string[] = []
-    const child = spawnedChildren[0] as unknown as Record<string, unknown>
-    child.killed = true // what Node reports right after a delivered SIGTERM
-    child.kill = (sig: string): void => void signals.push(sig)
-
-    const stopping = stopServer()
-    await vi.advanceTimersByTimeAsync(4000)
-    await stopping
+    await stopServer()
+    restore()
 
     expect(signals).toContain('SIGKILL')
-    vi.useRealTimers()
-  })
+  }, 30000)
 
-  it('leaves a server that actually stopped alone', async () => {
+  it('leaves a server that honoured SIGTERM alone', async () => {
     const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
     await launchServer()
-    vi.useFakeTimers()
+    published.pidAlive = false // it went when asked
+    ;(spawnedChildren[0] as unknown as Record<string, unknown>).kill = (): void => {}
+    const { signals, restore } = killRecorder()
 
-    const signals: string[] = []
-    const child = spawnedChildren[0] as unknown as Record<string, unknown>
-    child.kill = (sig: string): void => void signals.push(sig)
-    published.pidAlive = false // it honoured the SIGTERM and exited
-
-    const stopping = stopServer()
-    await vi.advanceTimersByTimeAsync(4000)
-    await stopping
+    await stopServer()
+    restore()
 
     expect(signals).not.toContain('SIGKILL')
-    vi.useRealTimers()
-  })
-})
+  }, 30000)
 
-describe('stopping the local server on request', () => {
-  it('does not report success until the process is actually gone', async () => {
-    // The caller relaunches the app the moment this says yes. A server still
-    // shutting down still owns its ws-port file, so the fresh launch would find
-    // it, refuse it again, and land back in the window the user just acted from
-    // -- a loop that looks like the button doing nothing.
+  it('does not resolve while the process is still there', async () => {
+    published.pidAlive = true
+    const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+    ;(spawnedChildren[0] as unknown as Record<string, unknown>).kill = (): void => {}
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => true) // ignores everything
+
+    let settled = false
+    const stopping = stopServer().then(() => {
+      settled = true
+    })
+    await new Promise((r) => setTimeout(r, 250))
+    expect(settled).toBe(false)
+
+    published.pidAlive = false // it finally exits
+    await stopping
+    spy.mockRestore()
+
+    expect(settled).toBe(true)
+  }, 30000)
+
+  it('stopLocalServer reports success only once the pid is gone', async () => {
     published.port = 50091
     published.pidAlive = true
     const { stopLocalServer } = await import('../src/main/server/server-launcher')
-    vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
     let settled = false
     const stopping = stopLocalServer().then((r) => {
       settled = true
       return r
     })
-
     await new Promise((r) => setTimeout(r, 250))
-    expect(settled).toBe(false) // still alive, so still waiting
+    expect(settled).toBe(false)
 
-    published.pidAlive = false // the server finally exits
+    published.pidAlive = false
     await expect(stopping).resolves.toEqual({ ok: true })
-    vi.restoreAllMocks()
-  })
+    spy.mockRestore()
+  }, 30000)
 
-  it('reports failure when it will not go at all', async () => {
+  it('stopLocalServer reports failure when it will not go at all', async () => {
     published.port = 50091
-    published.pidAlive = true // never exits, through SIGTERM and SIGKILL alike
+    published.pidAlive = true
     const { stopLocalServer } = await import('../src/main/server/server-launcher')
-    vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const spy = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
     const result = await stopLocalServer()
+    spy.mockRestore()
 
     expect(result).toMatchObject({ ok: false })
-    vi.restoreAllMocks()
-  }, 20000)
+  }, 30000)
 })

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -232,6 +232,22 @@ describe('the server it spawns', () => {
     expect(spawned[0].opts.detached).toBe(true)
   })
 
+  it('is NOT detached in dev, so a restart cannot adopt yesterday\'s source', async () => {
+    // Every adoption check would pass for a leftover dev server -- same data
+    // directory, same build channel -- and it would be running the code as it
+    // was before the edit that prompted the restart, with nothing to say so.
+    process.env.ELECTRON_RENDERER_URL = 'http://localhost:5173'
+    try {
+      const { launchServer } = await import('../src/main/server/server-launcher')
+
+      await launchServer()
+
+      expect(spawned[0].opts.detached).toBeUndefined()
+    } finally {
+      delete process.env.ELECTRON_RENDERER_URL
+    }
+  })
+
   it('runs the Electron binary as Node rather than as another app', async () => {
     // process.execPath is the Electron binary. Spawning it without this variable
     // launches a second full Vorn — an infinite spawn loop this code has hit.

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -669,3 +669,34 @@ describe('ending a server, and knowing that it ended', () => {
     expect(result).toMatchObject({ ok: false })
   }, 30000)
 })
+
+describe('stopping on Windows', () => {
+  it('waits for the process there too, where kill() also returns early', async () => {
+    // `child.kill()` returns before the process is gone, same as SIGTERM does.
+    // That was harmless while the server died with the app; a detached one on
+    // Windows just keeps running after "Stop Sessions and Server".
+    const platform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    published.pidAlive = true
+    try {
+      const { launchServer, stopServer } = await import('../src/main/server/server-launcher')
+      await launchServer()
+      ;(spawnedChildren[0] as unknown as Record<string, unknown>).kill = (): void => {}
+      const spy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+      let settled = false
+      const stopping = stopServer().then(() => {
+        settled = true
+      })
+      await new Promise((r) => setTimeout(r, 250))
+      expect(settled).toBe(false) // still there, so still waiting
+
+      published.pidAlive = false
+      await stopping
+      spy.mockRestore()
+      expect(settled).toBe(true)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+    }
+  }, 30000)
+})

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -21,7 +21,9 @@ const published = {
   token: 'local-secret' as string | null,
   hello: null as ServerHello | null,
   /** Whether the adopted server's process is still alive, when asked. */
-  pidAlive: true
+  pidAlive: true,
+  /** Whether the running server closes the socket after greeting us. */
+  rejectsCredential: false
 }
 
 const spawned: { cmd: string; opts: Record<string, unknown> }[] = []
@@ -40,12 +42,19 @@ class FakeBridge extends EventEmitter {
   }
   connect(): void {
     setImmediate(() => {
-      // The real server sends its greeting as the first frame on the socket and
-      // before authentication, which is what lets a launcher judge it without
-      // first proving who it is.
-      if (published.hello) this.emit('hello', published.hello)
+      // Mirrors the real ordering: the socket opens and `connected` fires first,
+      // then frames arrive. So `isConnected` is already true when the greeting
+      // lands, and cannot be used as proof the credential was accepted.
       this.isConnected = true
       this.emit('connected')
+      if (published.hello) this.emit('hello', published.hello)
+      if (published.rejectsCredential) {
+        // What a 4001/4002 close looks like from here: open, greeted, dropped.
+        setTimeout(() => {
+          this.isConnected = false
+          this.emit('disconnected')
+        }, 5)
+      }
     })
   }
   async request(method: string): Promise<unknown> {
@@ -54,6 +63,7 @@ class FakeBridge extends EventEmitter {
   }
   close(): void {
     this.closed = true
+    this.isConnected = false
   }
 }
 
@@ -84,6 +94,12 @@ vi.mock('../src/main/server/server-adoption', async (importOriginal) => {
     readLocalToken: () => published.token,
     isPidAlive: () => published.pidAlive
   }
+})
+
+const madeDirs: string[] = []
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return { ...actual, mkdirSync: (dir: string) => void madeDirs.push(dir) }
 })
 
 vi.mock('node:child_process', () => ({
@@ -131,11 +147,13 @@ beforeEach(() => {
   // Only Electron sets this, and the packaged entry point is resolved from it.
   ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = '/app/Resources'
   spawned.length = 0
+  madeDirs.length = 0
   bridges.length = 0
   published.port = null
   published.token = 'local-secret'
   published.hello = null
   published.pidAlive = true
+  published.rejectsCredential = false
   hostSettings.value = { mode: 'local', url: '', token: undefined }
 })
 
@@ -344,5 +362,49 @@ describe('an adopted server that dies', () => {
     bridges[0].emit('disconnected')
     await new Promise((r) => setTimeout(r, 20))
     expect(spawned).toEqual([])
+  })
+})
+
+describe('the three ways adoption used to go quietly wrong', () => {
+  it('keeps the adopted credential, so a replacement server accepts the same bridge', async () => {
+    // `retarget` moves the URL and nothing else -- the credential is fixed when
+    // the bridge is built. Minting a fresh secret for the replacement left the
+    // surviving bridge presenting a token no server had heard of, reconnecting
+    // forever against a server that was perfectly healthy.
+    published.port = 50091
+    published.hello = helloFrom()
+    const { launchServer } = await import('../src/main/server/server-launcher')
+    await launchServer()
+
+    published.pidAlive = false
+    bridges[0].emit('disconnected')
+    await vi.waitFor(() => expect(spawned).toHaveLength(1))
+
+    const env = spawned[0].opts.env as Record<string, string>
+    expect(env.SECRET_VORN_BOOTSTRAP_TOKEN).toBe('local-secret')
+  })
+
+  it('declines a server that greets us and then drops the socket', async () => {
+    // A rejected credential does not fail the connect: the socket opens, the
+    // greeting arrives, and only then is it closed. Reading `isConnected` at the
+    // greeting therefore always said yes, and this branch could never run.
+    published.port = 50091
+    published.hello = helloFrom()
+    published.rejectsCredential = true
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
+  })
+
+  it('creates the data directory before spawning into it', async () => {
+    // The server creates it on init -- but it is also the cwd the server is
+    // spawned into, and a missing cwd is an ENOENT before any of that runs.
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(madeDirs).toContain('/Users/x/.vorn')
   })
 })


### PR DESCRIPTION
Quitting Vorn killed every agent. The server was a child of the app and
`before-quit` asked it to shut down, so every PTY went with the window and
reopening could only relaunch each session from its transcript — losing the
process, the turn in flight, and any prompt waiting for an answer.

Now quitting closes a window and nothing else. The next launch reconnects to
the sessions that were already running.

## What changed

**The server spawns detached.** Production stops using `utilityProcess.fork`,
which is tied to Electron's lifetime by design and so can never outlive it; it
spawns the same signed binary with `ELECTRON_RUN_AS_NODE=1`, which the hardened
runtime already permits. Its output goes to a file descriptor rather than a
pipe — a pipe held by the app dies with the app, and the next write raises
EPIPE on a server that installs no `uncaughtException` handler.

**The next launch adopts it.** Detaching alone would be worse than the bug: the
old server keeps the PTYs while a new one takes another port, and two servers
share one SQLite file. So the launcher looks for a running server first, reads
the credential that server published rather than inventing one it has never
seen, and adopts it.

**Adoption turns on the wire protocol, never the release version.** The two move
independently, and gating on the release would end every running session on
every update for no reason. A server this app cannot use is left alone — it
holds the user's work — and no rival is started beside it either: both would
open the same database, and `saveSessions` is a DELETE-then-insert of the whole
table, so the two would erase each other's sessions. The connect window says so
and offers to end that server, which is the person's decision to make.

**A visible setting.** *Keep Sessions Running When Vorn Closes*, on by default,
in Settings → General. Turning it off restores the old behaviour exactly.
File → *Stop Sessions and Server* does it once without changing the setting.

**Dev deliberately does not detach.** A dev server that outlives `yarn dev` is
adopted by the next `yarn dev` — same data directory, same build channel, every
check passes — while running the source from before the edit that prompted the
restart, with nothing saying so. Sessions surviving a quit is a property of the
shipped app.

## Verified on a signed packaged build

Run against an isolated instance (own `HOME`, own `--user-data-dir`, own port)
so a live Vorn was untouched throughout:

| | result |
|---|---|
| server survives quit | reparents to **PPID 1** |
| session PTYs survive | both, still children of the server |
| the agent process | same PID, same `--session-id`, never relaunched |
| relaunch | `[launcher] adopted the server already running on port 51234` — one server, not two |
| identity frame | `server:hello` carries no identity; `server:identity` follows on loopback only |
| clean SIGTERM | removes its own `ws-port` and `local-token` |

`ELECTRON_RUN_AS_NODE=1` was confirmed working on the Developer-ID-signed
bundle under the hardened runtime — the piece unit tests cannot reach.

## Notes for review

- Merged on top of #492 and re-applied on its shape, so the crash relaunch
  survives. An adopted server has no child handle, so nothing would have called
  `onServerExit` for it — the case adoption exists for would have been the one
  case that never recovered. It watches the socket and the published pid instead.
- `server:identity` is a new frame rather than fields on `server:hello`, because
  the audiences differ: capabilities go to every client, identity only to
  loopback — `dataDir` names the user's home directory and the server may be
  bound to `0.0.0.0`.
- `VORN_SERVER_PORT` is honoured only on the dev spawn path; the packaged branch
  passes no `--port`. Pre-existing, but it means a packaged instance can only be
  moved off a port through the remembered config.
- **Known gap:** a stray server squatting loopback on the remembered port would
  now make the real app decline to launch rather than start beside it. Correct
  by the rule above, but worth a look before this is relied on.
