### PR TITLE
Let the server leave when it has nothing left to do

### DIFF
--- a/packages/server/src/broadcast.ts
+++ b/packages/server/src/broadcast.ts
@@ -101,7 +101,7 @@ export class ClientRegistry {
   }
 
   /**
-   * How long since a client last did anything, or null while one is attached.
+   * How long since a client last did anything.
    *
    * A timestamp rather than the count below, because MCP opens a fresh socket
    * for every RPC call: the count drops to zero between two calls of a working

--- a/packages/server/src/broadcast.ts
+++ b/packages/server/src/broadcast.ts
@@ -88,6 +88,7 @@ export function parseTopics(query: unknown): readonly string[] | undefined {
 
 export class ClientRegistry {
   private clients = new Map<WebSocket, Subscription | null>()
+  private lastActivity = Date.now()
 
   add(ws: WebSocket, topics?: TopicFilter): void {
     this.clients.set(ws, subscriptionFrom(topics))
@@ -97,6 +98,33 @@ export class ClientRegistry {
   remove(ws: WebSocket): void {
     this.clients.delete(ws)
     log.info(`[ws] client disconnected (total: ${this.clients.size})`)
+  }
+
+  /**
+   * How long since a client last did anything, or null while one is attached.
+   *
+   * A timestamp rather than the count below, because MCP opens a fresh socket
+   * for every RPC call: the count drops to zero between two calls of a working
+   * agent, and anything sampling it at that instant reads a busy server as an
+   * empty one. Recording *when* also fixes the opposite hole — these sockets
+   * have no heartbeat and are only removed on close or error, so one half-open
+   * connection would otherwise hold the count above zero for ever.
+   */
+  msSinceActivity(): number {
+    return Date.now() - this.lastActivity
+  }
+
+  /**
+   * Mark a client as having done something.
+   *
+   * Only real traffic: connecting is not activity, and neither is disconnecting.
+   * Another Vorn deciding whether it may adopt this server opens a socket, reads
+   * the greeting and closes it again — counting that would let the very launches
+   * this feature exists to unblock keep the leftover alive for ever, one probe at
+   * a time.
+   */
+  touch(): void {
+    this.lastActivity = Date.now()
   }
 
   /**

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -111,7 +111,12 @@ async function runServe(args: ServerArgs, deps: CliDeps): Promise<number> {
   const { port } = await startServer({
     host: args.host,
     port: args.port,
-    dataDir: args.dataDir
+    dataDir: args.dataDir,
+    // A server somebody ran on purpose does not get to decide it is done. There
+    // is no app watching to restart it, and the next line hands out a token for
+    // other machines to connect with -- so exiting would strand exactly the
+    // clients this command exists to serve.
+    idleShutdown: false
   })
   deps.write(`Vorn server listening on port ${port}\n`)
 

--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -121,12 +121,6 @@ export class HookServer extends EventEmitter {
   start(preferredPort: number = HookServer.PREFERRED_PORT): Promise<number> {
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
-        // An agent run outside Vorn still posts here, because hooks are installed
-        // into `~/.claude/settings.json` globally. It has no terminal, no headless
-        // entry and no websocket, so this is the only trace it leaves -- and
-        // `shutdown()` uninstalls those hooks, which would break permission
-        // routing for the rest of that run.
-        this.lastRequestAt = Date.now()
         if (req.method !== 'POST') {
           res.writeHead(404)
           res.end()
@@ -135,6 +129,17 @@ export class HookServer extends EventEmitter {
 
         // Authenticate all requests with bearer token
         if (!this.authenticate(req, res)) return
+
+        // Recorded only past the checks above, and deliberately so. An agent run
+        // outside Vorn still posts here, because hooks are installed into the
+        // user's agent settings globally: it has no terminal, no headless entry
+        // and no websocket, so this is the only trace it leaves -- and
+        // `shutdown()` uninstalls those hooks, which would break its permission
+        // routing for the rest of the run. But that argument covers real hook
+        // traffic only. Counting a stray unauthenticated request would let
+        // anything on this machine hold the server open without ever proving it
+        // is an agent, which is a worse hole than the one this closes.
+        this.lastRequestAt = Date.now()
 
         let body = ''
         let bodySize = 0

--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -78,6 +78,14 @@ export class HookServer extends EventEmitter {
     this.authToken = crypto.randomUUID()
   }
 
+  /** When a hook last posted. See the note in the request handler. */
+  private lastRequestAt = Date.now()
+
+  /** How long since any agent, in this app or outside it, used the hook endpoint. */
+  msSinceHookActivity(): number {
+    return Date.now() - this.lastRequestAt
+  }
+
   getPort(): number {
     return this.port
   }
@@ -113,6 +121,12 @@ export class HookServer extends EventEmitter {
   start(preferredPort: number = HookServer.PREFERRED_PORT): Promise<number> {
     return new Promise((resolve, reject) => {
       this.server = http.createServer((req, res) => {
+        // An agent run outside Vorn still posts here, because hooks are installed
+        // into `~/.claude/settings.json` globally. It has no terminal, no headless
+        // entry and no websocket, so this is the only trace it leaves -- and
+        // `shutdown()` uninstalls those hooks, which would break permission
+        // routing for the rest of that run.
+        this.lastRequestAt = Date.now()
         if (req.method !== 'POST') {
           res.writeHead(404)
           res.end()

--- a/packages/server/src/idle.ts
+++ b/packages/server/src/idle.ts
@@ -209,7 +209,7 @@ export class IdleWatch {
 
   /** Idempotent, following the shape `scheduler.startInboxWorker` already uses. */
   start(): void {
-    if (this.timer) return
+    if (this.timer || this.decided) return
     this.timer = setInterval(() => this.tick(), this.checkEveryMs)
     // Nothing should stay alive merely because this is watching.
     this.timer.unref?.()
@@ -225,7 +225,11 @@ export class IdleWatch {
   /** When the last thing holding this server open let go. Null while busy. */
   private quietSince: number | null = null
 
+  /** Set once this has called for the exit. The verdict does not un-make itself. */
+  private decided = false
+
   tick(): IdleVerdict {
+    if (this.decided) return { exit: true }
     const snapshot = this.snapshot()
     // The most recent of the clocks wins. A client that spoke means somebody is
     // out there even with nothing running; a session that ended means the work
@@ -245,6 +249,14 @@ export class IdleWatch {
       else this.quietSince ??= Date.now()
       return verdict
     }
+    // Stopped before it acts, not after, and latched so a caller holding this
+    // watch cannot ask again. `shutdown()` is allowed to take up to its
+    // deadline, and this interval would otherwise go on firing throughout --
+    // announcing "nothing left to do" once per tick against a shutdown already
+    // in flight, and re-entering a path whose only answer is to refuse. The
+    // decision has been made; there is nothing left to watch for.
+    this.decided = true
+    this.stop()
     this.onIdle()
     return verdict
   }

--- a/packages/server/src/idle.ts
+++ b/packages/server/src/idle.ts
@@ -35,6 +35,16 @@ export interface IdleSnapshot {
    * agent.
    */
   msSinceClientActivity: number
+
+  /**
+   * How long since anything used the hook endpoint.
+   *
+   * Separate from the client clock because it catches what nothing else does: an
+   * agent the user started outside Vorn. Hooks are installed globally, so such a
+   * run has no terminal, no headless entry and no socket here -- and `shutdown()`
+   * uninstalls the hooks, which would break its permission routing mid-run.
+   */
+  msSinceHookActivity: number
   /** A Vorn desktop is driving this server through the browser/device bridge. */
   bridgeAttached: boolean
   /** Agents blocked on a permission prompt. Somebody is mid-decision. */
@@ -52,6 +62,16 @@ export interface IdleSnapshot {
    * does its work here.
    */
   enabledSchedules: number
+
+  /**
+   * Whether this server is bound wide, to be reached by something that is not
+   * this machine.
+   *
+   * Read every tick rather than captured at boot: Network Access is an ordinary
+   * toggle and the socket is rebound live, so a server can become -- or stop
+   * being -- a phone's only way in at any point after it started.
+   */
+  servesOthers: boolean
 }
 
 export interface IdlePolicy {
@@ -71,7 +91,21 @@ export interface IdlePolicy {
 
 export const DEFAULT_IDLE_WINDOW_MS = 30 * 60 * 1000
 
-export type IdleVerdict = { exit: true } | { exit: false; because: string }
+/** Named so the verdict can tell this hold apart from the ones that mean work. */
+const ATTACHED_DESKTOP = 'a desktop is attached'
+
+export type IdleVerdict =
+  | { exit: true }
+  /**
+   * `restartsCountdown` is not the same question as "is something holding it".
+   *
+   * Work restarts it: an agent that ran for three hours after the app closed
+   * must get the full window afterwards, not none of it. Presence does not --
+   * the attached-desktop flag is already gated on the client clock, and letting
+   * it also reset the countdown would mean a slept laptop needs two windows to
+   * release instead of the one that branch promises.
+   */
+  | { exit: false; because: string; restartsCountdown: boolean }
 
 /**
  * Is there anything at all to stay up for?
@@ -85,12 +119,28 @@ export function whatHoldsItOpen(s: IdleSnapshot, policy: IdlePolicy): string | n
   // seconds after its agent stops typing; that is a live terminal with a shell
   // in it, and `getActiveSessionsForWorktree` filters them out for a different
   // question entirely (whether a worktree is safe to delete).
+  // First, because it is the one hold that is about what this server is for
+  // rather than what it is doing. Nothing restarts a server a phone reaches, and
+  // "my phone could not reach my Mac this morning" is worse than a process that
+  // outstays its welcome. Said out loud in Settings, since it makes the promise
+  // there conditional.
+  if (s.servesOthers) return 'this server is bound to be reached from the network'
   if (s.sessions > 0) return `${s.sessions} session(s)`
   // Over-conservative on purpose: `headless-manager` keeps exited entries for
   // thirty seconds, so this can read non-zero just after one finishes. Waiting
   // an extra half-minute is the cheap direction to be wrong in.
   if (s.headless > 0) return `${s.headless} headless agent(s)`
-  if (s.bridgeAttached) return 'a desktop is attached'
+  // Presence, but never presence alone. Any authenticated socket may claim the
+  // bridge and there is no heartbeat behind it, so a laptop that slept with Vorn
+  // open leaves `isConnected` true for ever. An attached desktop that has said
+  // nothing for the whole window is not attached, whatever the flag says -- and a
+  // real one talks constantly, so this costs a live app nothing.
+  //
+  // Measured against the client clock rather than the caller's combined one:
+  // that clock is the only one this veto cannot itself hold still. Anything
+  // derived from "when the last hold let go" is reset by this very branch, so a
+  // stuck bridge would keep the countdown at zero and never reach its own escape.
+  if (s.bridgeAttached && s.msSinceClientActivity < policy.windowMs) return ATTACHED_DESKTOP
   if (s.pendingPermissions > 0) return 'an agent is waiting on a permission'
   if (s.pendingPairings > 0) return 'a pairing is in progress'
   if (s.connectorLeases > 0) return 'connector work is outstanding'
@@ -103,41 +153,41 @@ export function whatHoldsItOpen(s: IdleSnapshot, policy: IdlePolicy): string | n
 /**
  * Whether to stop now.
  *
- * The client test is a *timestamp*, not a count, because MCP opens a fresh
- * socket for every RPC call: the connected count oscillates between zero and one
- * while an agent is working, and sampling it at the wrong instant reads a busy
- * server as an empty one. The same timestamp covers the opposite failure — there
- * is no heartbeat on these sockets, so a half-open one would otherwise pin the
- * count at one for ever and the server would never exit.
+ * `quietForMs` is how long nothing has wanted this server, and the caller owns
+ * it because it is the later of two clocks. One is when the last thing let go:
+ * an agent that worked for three hours after the app closed must not leave the
+ * server exiting on the very next tick with none of the grace the setting
+ * implies. Another is when a hook last fired, which is the only trace an agent
+ * started outside Vorn leaves here. The last is when a client spoke, and it is a
+ * *duration* rather
+ * than a count because MCP opens a fresh socket per RPC call -- the connected
+ * count oscillates between zero and one while an agent works, and sampling it at
+ * the wrong instant reads a busy server as an empty one. That same duration is
+ * the only escape from the opposite failure: these sockets have no heartbeat, so
+ * a half-open one would pin any count at one for ever.
+ *
+ * This is the whole decision. `IdleWatch` supplies the clocks and acts on the
+ * answer; it does not get a second opinion.
  */
-export function shouldExitWhenIdle(s: IdleSnapshot, policy: IdlePolicy): IdleVerdict {
+export function shouldExitWhenIdle(
+  s: IdleSnapshot,
+  policy: IdlePolicy,
+  quietForMs: number
+): IdleVerdict {
   const holding = whatHoldsItOpen(s, policy)
-  if (holding) return { exit: false, because: holding }
-  if (s.msSinceClientActivity < policy.windowMs) {
+  if (holding) {
+    return { exit: false, because: holding, restartsCountdown: holding !== ATTACHED_DESKTOP }
+  }
+  if (quietForMs < policy.windowMs) {
     return {
       exit: false,
-      because: `quiet for only ${Math.round(s.msSinceClientActivity / 1000)}s`
+      because: `quiet for only ${Math.round(quietForMs / 1000)}s`,
+      restartsCountdown: false
     }
   }
   return { exit: true }
 }
 
-/**
- * The countdown that acts on the decision above.
- *
- * Deliberately dumb: it polls the snapshot, and the only judgement it makes is
- * the one `shouldExitWhenIdle` hands back. Two rules it does enforce, because
- * both are about *when* rather than *whether*:
- *
- * The exit is explicit, never a matter of letting the event loop drain. The
- * scheduler's inbox interval is not unref'd, so this process would sit there
- * for ever regardless of how empty it is.
- *
- * And the snapshot is taken twice — once to decide, once immediately before
- * acting. `shutdown()` calls `killAll()` on terminals and headless agents, so a
- * countdown that expires in the same instant a session starts would destroy it.
- * The second look costs nothing and closes that window.
- */
 export class IdleWatch {
   private timer: NodeJS.Timeout | null = null
 
@@ -177,26 +227,25 @@ export class IdleWatch {
 
   tick(): IdleVerdict {
     const snapshot = this.snapshot()
-    const holding = whatHoldsItOpen(snapshot, this.policy)
-    if (holding) {
-      // Busy again: the clock restarts from whenever this ends, not from
-      // whenever a client last spoke. Otherwise an agent working for three hours
-      // after the window closed would leave the server exiting on the very next
-      // tick, with none of the grace the setting implies.
-      this.quietSince = null
-      return { exit: false, because: holding }
-    }
-    this.quietSince ??= Date.now()
+    // The most recent of the clocks wins. A client that spoke means somebody is
+    // out there even with nothing running; a session that ended means the work
+    // only just stopped; a hook that fired means an agent is mid-run somewhere
+    // this server can otherwise not see.
+    const sinceLetGo = this.quietSince === null ? 0 : Date.now() - this.quietSince
+    const quietFor = Math.min(
+      sinceLetGo,
+      snapshot.msSinceClientActivity,
+      snapshot.msSinceHookActivity
+    )
 
-    // Two clocks, and the later one wins. A client that spoke recently means
-    // somebody is out there even with nothing running; a session that ended
-    // recently means the work only just stopped.
-    const quietFor = Math.min(Date.now() - this.quietSince, snapshot.msSinceClientActivity)
-    if (quietFor < this.policy.windowMs) {
-      return { exit: false, because: `quiet for only ${Math.round(quietFor / 1000)}s` }
+    const verdict = shouldExitWhenIdle(snapshot, this.policy, quietFor)
+    if (!verdict.exit) {
+      // Busy restarts the clock; merely quiet-but-not-long-enough leaves it run.
+      if (verdict.restartsCountdown) this.quietSince = null
+      else this.quietSince ??= Date.now()
+      return verdict
     }
-
     this.onIdle()
-    return { exit: true }
+    return verdict
   }
 }

--- a/packages/server/src/idle.ts
+++ b/packages/server/src/idle.ts
@@ -1,0 +1,202 @@
+/**
+ * Whether a server with nobody using it should stop.
+ *
+ * The server outlives the app now, and nothing made it stop — so the setting
+ * that promises "a background server stays running until every session ends"
+ * described an intention rather than the software. It also mattered more than
+ * tidiness: a server this app cannot use is refused rather than replaced, so a
+ * leftover one can stop Vorn opening at all, and a leftover was permanent.
+ *
+ * The decision lives here, apart from the timer that acts on it, for the reason
+ * `server-relaunch.ts` gives about its own: the wiring cannot be unit tested and
+ * the decision can, and the decision is where the ways to be wrong are.
+ *
+ * Both ways are expensive, differently. Exiting while something is live kills
+ * it — `shutdown()` calls `killAll()` on terminals and headless agents, so a
+ * wrong yes destroys the user's work. Never exiting leaves the leftover problem
+ * exactly where it was. So: prefer staying up, and only say yes to things that
+ * are positively, currently empty.
+ */
+
+export interface IdleSnapshot {
+  /** Live PTYs. A session whose *status* is 'idle' still counts — see below. */
+  sessions: number
+  /** Headless agents still running. */
+  headless: number
+  /**
+   * Milliseconds since a client last sent anything.
+   *
+   * A duration, never "is one connected". These sockets have no heartbeat and
+   * are removed only on close or error, so a laptop that sleeps or a NAT that
+   * drops the flow leaves an entry behind for ever — and any test of presence
+   * would then hold the server open for ever with it. Time since real traffic
+   * escapes that, and it covers the opposite hole too: MCP opens a fresh socket
+   * per RPC call, so a connected *count* is zero between two calls of a working
+   * agent.
+   */
+  msSinceClientActivity: number
+  /** A Vorn desktop is driving this server through the browser/device bridge. */
+  bridgeAttached: boolean
+  /** Agents blocked on a permission prompt. Somebody is mid-decision. */
+  pendingPermissions: number
+  /** Pairing flows part-way through. A human is looking at a code. */
+  pendingPairings: number
+  /** Connector inbox leases outstanding: work claimed and not finished. */
+  connectorLeases: number
+  /**
+   * Armed schedules this server can act on alone — connector polls only.
+   *
+   * A recurring or one-off trigger is executed by a renderer, so staying awake
+   * for one buys nothing: with no client the occurrence is emitted, the minute
+   * lock is written, and the run is lost either way. A connector poll really
+   * does its work here.
+   */
+  enabledSchedules: number
+}
+
+export interface IdlePolicy {
+  /** How long everything must stay empty before exiting. */
+  windowMs: number
+  /**
+   * Whether an armed schedule keeps the server alive.
+   *
+   * Only counts the schedules the server can actually service on its own — see
+   * `enabledSchedules`. Holding open for a renderer-executed trigger would be
+   * keeping a promise by dropping it: the run is lost with no client either way,
+   * and the wait costs every connector user a server that never exits. When
+   * server-side execution lands, more triggers earn this and the count widens.
+   */
+  schedulesHoldOpen: boolean
+}
+
+export const DEFAULT_IDLE_WINDOW_MS = 30 * 60 * 1000
+
+export type IdleVerdict = { exit: true } | { exit: false; because: string }
+
+/**
+ * Is there anything at all to stay up for?
+ *
+ * Separate from the window check so the caller can distinguish "busy" from
+ * "quiet but not for long enough" — the first disarms the countdown, the second
+ * lets it keep running.
+ */
+export function whatHoldsItOpen(s: IdleSnapshot, policy: IdlePolicy): string | null {
+  // Not filtered by session status. `pty-manager` marks a session 'idle' five
+  // seconds after its agent stops typing; that is a live terminal with a shell
+  // in it, and `getActiveSessionsForWorktree` filters them out for a different
+  // question entirely (whether a worktree is safe to delete).
+  if (s.sessions > 0) return `${s.sessions} session(s)`
+  // Over-conservative on purpose: `headless-manager` keeps exited entries for
+  // thirty seconds, so this can read non-zero just after one finishes. Waiting
+  // an extra half-minute is the cheap direction to be wrong in.
+  if (s.headless > 0) return `${s.headless} headless agent(s)`
+  if (s.bridgeAttached) return 'a desktop is attached'
+  if (s.pendingPermissions > 0) return 'an agent is waiting on a permission'
+  if (s.pendingPairings > 0) return 'a pairing is in progress'
+  if (s.connectorLeases > 0) return 'connector work is outstanding'
+  if (policy.schedulesHoldOpen && s.enabledSchedules > 0) {
+    return `${s.enabledSchedules} enabled schedule(s)`
+  }
+  return null
+}
+
+/**
+ * Whether to stop now.
+ *
+ * The client test is a *timestamp*, not a count, because MCP opens a fresh
+ * socket for every RPC call: the connected count oscillates between zero and one
+ * while an agent is working, and sampling it at the wrong instant reads a busy
+ * server as an empty one. The same timestamp covers the opposite failure — there
+ * is no heartbeat on these sockets, so a half-open one would otherwise pin the
+ * count at one for ever and the server would never exit.
+ */
+export function shouldExitWhenIdle(s: IdleSnapshot, policy: IdlePolicy): IdleVerdict {
+  const holding = whatHoldsItOpen(s, policy)
+  if (holding) return { exit: false, because: holding }
+  if (s.msSinceClientActivity < policy.windowMs) {
+    return {
+      exit: false,
+      because: `quiet for only ${Math.round(s.msSinceClientActivity / 1000)}s`
+    }
+  }
+  return { exit: true }
+}
+
+/**
+ * The countdown that acts on the decision above.
+ *
+ * Deliberately dumb: it polls the snapshot, and the only judgement it makes is
+ * the one `shouldExitWhenIdle` hands back. Two rules it does enforce, because
+ * both are about *when* rather than *whether*:
+ *
+ * The exit is explicit, never a matter of letting the event loop drain. The
+ * scheduler's inbox interval is not unref'd, so this process would sit there
+ * for ever regardless of how empty it is.
+ *
+ * And the snapshot is taken twice — once to decide, once immediately before
+ * acting. `shutdown()` calls `killAll()` on terminals and headless agents, so a
+ * countdown that expires in the same instant a session starts would destroy it.
+ * The second look costs nothing and closes that window.
+ */
+export class IdleWatch {
+  private timer: NodeJS.Timeout | null = null
+
+  constructor(
+    private readonly snapshot: () => IdleSnapshot,
+    private readonly policy: IdlePolicy,
+    private readonly onIdle: () => void,
+    checkEveryMs?: number
+  ) {
+    // Derived from the window rather than fixed, so the lateness is always a
+    // fraction of the wait instead of a flat minute: a half-hour window is
+    // checked every minute, and a short one — which is how tests watch a process
+    // actually leave — is checked often enough to be observable.
+    this.checkEveryMs =
+      checkEveryMs ?? Math.max(250, Math.min(60_000, Math.floor(policy.windowMs / 4)))
+  }
+
+  private readonly checkEveryMs: number
+
+  /** Idempotent, following the shape `scheduler.startInboxWorker` already uses. */
+  start(): void {
+    if (this.timer) return
+    this.timer = setInterval(() => this.tick(), this.checkEveryMs)
+    // Nothing should stay alive merely because this is watching.
+    this.timer.unref?.()
+  }
+
+  stop(): void {
+    if (!this.timer) return
+    clearInterval(this.timer)
+    this.timer = null
+  }
+
+  /** Exposed for tests and for a caller that wants to check without waiting. */
+  /** When the last thing holding this server open let go. Null while busy. */
+  private quietSince: number | null = null
+
+  tick(): IdleVerdict {
+    const snapshot = this.snapshot()
+    const holding = whatHoldsItOpen(snapshot, this.policy)
+    if (holding) {
+      // Busy again: the clock restarts from whenever this ends, not from
+      // whenever a client last spoke. Otherwise an agent working for three hours
+      // after the window closed would leave the server exiting on the very next
+      // tick, with none of the grace the setting implies.
+      this.quietSince = null
+      return { exit: false, because: holding }
+    }
+    this.quietSince ??= Date.now()
+
+    // Two clocks, and the later one wins. A client that spoke recently means
+    // somebody is out there even with nothing running; a session that ended
+    // recently means the work only just stopped.
+    const quietFor = Math.min(Date.now() - this.quietSince, snapshot.msSinceClientActivity)
+    if (quietFor < this.policy.windowMs) {
+      return { exit: false, because: `quiet for only ${Math.round(quietFor / 1000)}s` }
+    }
+
+    this.onIdle()
+    return { exit: true }
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -32,7 +32,7 @@ import { scheduler } from './scheduler'
 import { getTaskImagePath as resolveTaskImagePath } from './task-images'
 import { redeemCode, pollRequest, pendingRequests } from './pairing'
 import { getTailscaleStatus } from './tailscale'
-import { initRebind, checkAndRebind } from './server-rebind'
+import { initRebind, checkAndRebind, getCurrentHost } from './server-rebind'
 import { isAllowedUpgrade, logRefusedUpgrade, setTrustedOriginHosts } from './ws-origin'
 import { setEnvPassthrough, setLaunchDataDir } from './process-utils'
 import log from './logger'
@@ -71,6 +71,15 @@ async function refreshTrustedOrigins(): Promise<void> {
  * straight back. The environment variable exists for tests, which cannot wait
  * half an hour to watch a process leave.
  */
+/**
+ * How long a shutdown may take before this process leaves regardless.
+ *
+ * Generous, because the work it waits on is real -- persisting sessions, killing
+ * terminals, stopping connector subprocesses -- and cutting it short loses more
+ * than it saves. It exists only for the case where one of those never returns.
+ */
+const SHUTDOWN_DEADLINE_MS = 30_000
+
 function resolveIdleWindowMs(): number {
   const raw = process.env.VORN_IDLE_TIMEOUT_MS
   const parsed = raw ? Number(raw) : NaN
@@ -432,7 +441,22 @@ export async function startServer(
   const { hookStatusMapper } = await import('./hook-status-mapper')
   const { sessionManager } = await import('./session-persistence')
 
+  // Two failures, and they need different answers. A shutdown that *throws* is
+  // retried by the idle watch, which is why that watch keeps ticking. A shutdown
+  // that *hangs* -- `stopAllMcpClients()` awaits child processes that can -- must
+  // not be retried, because `killAll()` and `app.close()` would run a second
+  // time; but leaving it hung is the worst state of all, a live process holding
+  // the port with its credential already cleared and its port file already gone.
+  // So re-entry is refused and a deadline is armed instead. Unref'd: it is a
+  // backstop, not a reason to stay alive.
+  let shuttingDown = false
   const shutdown = async () => {
+    if (shuttingDown) return
+    shuttingDown = true
+    setTimeout(() => {
+      log.error('[server] shutdown did not finish; exiting anyway')
+      process.exit(1)
+    }, SHUTDOWN_DEADLINE_MS).unref?.()
     log.info('[server] shutting down...')
     // Stop the periodic timer first, then do one final synchronous save
     sessionManager.stopAutoSave()
@@ -470,33 +494,36 @@ export async function startServer(
       // seconds, and a finished agent is not a reason to stay up.
       headless: headlessManager.getActiveSessions().filter((h) => h.status === 'running').length,
       msSinceClientActivity: clientRegistry.msSinceActivity(),
+      msSinceHookActivity: hookServer.msSinceHookActivity(),
       bridgeAttached: browserBridge.isConnected,
       pendingPermissions: hookServer.getPendingPermissions().length,
       pendingPairings: pendingRequests().length,
       connectorLeases: dbCountActiveConnectorInboxLeases(new Date().toISOString()),
-      enabledSchedules: scheduler.serverSideScheduleCount()
+      enabledSchedules: scheduler.serverSideScheduleCount(),
+      servesOthers: getCurrentHost() === '0.0.0.0'
     }),
     { windowMs: resolveIdleWindowMs(), schedulesHoldOpen: true },
     () => {
       log.info('[server] nothing left to do; shutting down')
-      // Caught, and the watch is left running. A shutdown that throws part-way
-      // has already cleared the credential and removed the port file, so giving
-      // up here would leave a process still bound to the port that no app can
-      // use or discover -- the exact state this feature exists to prevent.
-      // Exiting hard is the floor.
+      // A shutdown that throws has already cleared the credential and removed
+      // the port file, so giving up here would leave a process bound to a port
+      // no app can use or discover -- the exact state this feature exists to
+      // prevent. Exiting hard is the floor. A shutdown that hangs instead is
+      // caught by the deadline armed inside it.
       void shutdown().catch((err) => {
         log.error({ err }, '[server] idle shutdown failed; exiting anyway')
         process.exit(1)
       })
     }
   )
-  // Off wherever the server is the thing being run rather than something an app
-  // started: a hand-run `vorn-server serve`, or a machine serving a phone over
-  // the network. Nothing would restart it, and "my phone could not reach my Mac
-  // this morning" is a worse failure than a process that outstays its welcome.
-  const servesOthers = host === '0.0.0.0'
-  if (options.idleShutdown ?? !servesOthers) idleWatch.start()
-  else log.info('[server] idle shutdown off: this server is here to be reached')
+  // Off entirely for a hand-run `vorn-server serve`: that process is the thing
+  // being run, and nothing would bring it back. Being bound wide is handled in
+  // the snapshot instead, because it can change while this runs.
+  if (options.idleShutdown === false) {
+    log.info('[server] idle shutdown off: this server was started to be run')
+  } else {
+    idleWatch.start()
+  }
 
   process.on('SIGTERM', shutdown)
   process.on('SIGINT', shutdown)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -460,7 +460,6 @@ export async function startServer(
       log.error('[server] shutdown did not finish; exiting anyway')
       process.exit(1)
     }, SHUTDOWN_DEADLINE_MS).unref?.()
-    log.info('[server] shutting down...')
     // Stop the periodic timer first, then do one final synchronous save
     sessionManager.stopAutoSave()
     sessionManager.persistNow()
@@ -487,6 +486,24 @@ export async function startServer(
     process.exit(0)
   }
 
+  /**
+   * Every way this process is asked to stop, so there is one of them.
+   *
+   * A rejected `shutdown()` reaches here rather than becoming an unhandled
+   * rejection. By the time one is visible the credential is cleared and the port
+   * file is gone, so there is nothing to salvage and nothing to retry -- what is
+   * left is a live process holding a port no app can discover, which is the state
+   * this whole feature exists to prevent. Exiting hard is the floor. A shutdown
+   * that hangs rather than rejects is caught by the deadline armed inside it.
+   */
+  const stopFor = (reason: string): void => {
+    log.info({ reason }, '[server] shutting down')
+    void shutdown().catch((err) => {
+      log.error({ err, reason }, '[server] shutdown failed; exiting anyway')
+      process.exit(1)
+    })
+  }
+
   // The server outlives the app now, so something has to decide when it is done.
   // Nothing here waits for the event loop to drain: the scheduler's inbox
   // interval is not unref'd, so this process would sit empty for ever.
@@ -506,18 +523,7 @@ export async function startServer(
       servesOthers: getCurrentHost() === '0.0.0.0'
     }),
     { windowMs: resolveIdleWindowMs(), schedulesHoldOpen: true },
-    () => {
-      log.info('[server] nothing left to do; shutting down')
-      // A shutdown that throws has already cleared the credential and removed
-      // the port file, so giving up here would leave a process bound to a port
-      // no app can use or discover -- the exact state this feature exists to
-      // prevent. Exiting hard is the floor. A shutdown that hangs instead is
-      // caught by the deadline armed inside it.
-      void shutdown().catch((err) => {
-        log.error({ err }, '[server] idle shutdown failed; exiting anyway')
-        process.exit(1)
-      })
-    }
+    () => stopFor('nothing left to do')
   )
   // Off entirely for a hand-run `vorn-server serve`: that process is the thing
   // being run, and nothing would bring it back. Being bound wide is handled in
@@ -528,8 +534,8 @@ export async function startServer(
     idleWatch.start()
   }
 
-  process.on('SIGTERM', shutdown)
-  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', () => stopFor('SIGTERM'))
+  process.on('SIGINT', () => stopFor('SIGINT'))
   // Why: this process outlives the app that started it, so a hangup on the
   // terminal or the departure of a parent must not take the sessions with it.
   // SIGTERM stays honoured — that is a request to stop, not an accident.
@@ -537,7 +543,7 @@ export async function startServer(
     log.info('[server] ignoring SIGHUP; sessions keep running')
   })
   process.on('message', (msg) => {
-    if (msg === 'shutdown') shutdown()
+    if (msg === 'shutdown') stopFor('the app asked')
   })
 
   return { app, port: actualPort, idleWatch }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -55,13 +55,14 @@ async function refreshTrustedOrigins(): Promise<void> {
 }
 
 /**
- * `dev` or `packaged`, preferring what the launcher told us.
+ * How long a shutdown may take before this process leaves regardless.
  *
- * The fallback reads the entry point rather than NODE_ENV: NODE_ENV is set to
- * 'production' by the packaged launcher AND left at whatever the shell had for a
- * CLI run, so it answers a different question than the one being asked. The entry
- * extension is the fact itself — `.ts` only runs under tsx from a checkout.
+ * Generous, because the work it waits on is real -- persisting sessions, killing
+ * terminals, stopping connector subprocesses -- and cutting it short loses more
+ * than it saves. It exists only for the case where one of those never returns.
  */
+const SHUTDOWN_DEADLINE_MS = 30_000
+
 /**
  * How long everything must stay empty before the server stops.
  *
@@ -71,21 +72,20 @@ async function refreshTrustedOrigins(): Promise<void> {
  * straight back. The environment variable exists for tests, which cannot wait
  * half an hour to watch a process leave.
  */
-/**
- * How long a shutdown may take before this process leaves regardless.
- *
- * Generous, because the work it waits on is real -- persisting sessions, killing
- * terminals, stopping connector subprocesses -- and cutting it short loses more
- * than it saves. It exists only for the case where one of those never returns.
- */
-const SHUTDOWN_DEADLINE_MS = 30_000
-
 function resolveIdleWindowMs(): number {
   const raw = process.env.VORN_IDLE_TIMEOUT_MS
   const parsed = raw ? Number(raw) : NaN
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_IDLE_WINDOW_MS
 }
 
+/**
+ * `dev` or `packaged`, preferring what the launcher told us.
+ *
+ * The fallback reads the entry point rather than NODE_ENV: NODE_ENV is set to
+ * 'production' by the packaged launcher AND left at whatever the shell had for a
+ * CLI run, so it answers a different question than the one being asked. The entry
+ * extension is the fact itself — `.ts` only runs under tsx from a checkout.
+ */
 function resolveBuildChannel(): 'dev' | 'packaged' {
   const declared = process.env.VORN_BUILD_CHANNEL
   if (declared === 'dev' || declared === 'packaged') return declared

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -441,14 +441,17 @@ export async function startServer(
   const { hookStatusMapper } = await import('./hook-status-mapper')
   const { sessionManager } = await import('./session-persistence')
 
-  // Two failures, and they need different answers. A shutdown that *throws* is
-  // retried by the idle watch, which is why that watch keeps ticking. A shutdown
-  // that *hangs* -- `stopAllMcpClients()` awaits child processes that can -- must
-  // not be retried, because `killAll()` and `app.close()` would run a second
-  // time; but leaving it hung is the worst state of all, a live process holding
-  // the port with its credential already cleared and its port file already gone.
-  // So re-entry is refused and a deadline is armed instead. Unref'd: it is a
-  // backstop, not a reason to stay alive.
+  // Two failures, and neither is retried -- by the time either is visible this
+  // has already cleared the credential and removed the port file, so a second
+  // attempt would be running `killAll()` and `app.close()` again over a server
+  // no app can discover anyway. The worst outcome is not a failed shutdown, it
+  // is a live process still holding the port with nothing able to reach it.
+  //
+  // So a throw takes the hard exit at the call site, and a hang -- which is
+  // reachable, `stopAllMcpClients()` awaits child processes -- takes the
+  // deadline armed here. Re-entry is refused because SIGTERM can arrive while
+  // one of those is already in flight. Unref'd: a backstop, not a reason to
+  // stay alive.
   let shuttingDown = false
   const shutdown = async () => {
     if (shuttingDown) return

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,13 +10,20 @@ import type { FastifyReply, FastifyRequest } from 'fastify'
 const _dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(process.argv[1])
 import websocket from '@fastify/websocket'
 import fastifyStatic from '@fastify/static'
-import { handleConnection, registerMethod, setServerIdentity } from './ws-handler'
+import {
+  handleConnection,
+  registerMethod,
+  setServerIdentity,
+  setLiveSessionCount
+} from './ws-handler'
+import { IdleWatch, DEFAULT_IDLE_WINDOW_MS } from './idle'
+import { browserBridge } from './browser-bridge'
 import { parseTopics, clientRegistry } from './broadcast'
 import { IPC } from '@vornrun/shared/types'
 import { registerAllMethods, setServerPort } from './register-methods'
 import { configManager } from './config-manager'
 import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
-import { getDataDir } from './database'
+import { getDataDir, dbCountActiveConnectorInboxLeases } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
 import { DEFAULT_SERVER_PORT, WS_PORT_FILENAME } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
@@ -55,6 +62,21 @@ async function refreshTrustedOrigins(): Promise<void> {
  * CLI run, so it answers a different question than the one being asked. The entry
  * extension is the fact itself — `.ts` only runs under tsx from a checkout.
  */
+/**
+ * How long everything must stay empty before the server stops.
+ *
+ * Not a setting. A number to tune is a knob nobody wants, and the honest range
+ * is narrow: with nothing running there is no work to lose by exiting, so the
+ * window is only there to avoid churning a process for somebody who is coming
+ * straight back. The environment variable exists for tests, which cannot wait
+ * half an hour to watch a process leave.
+ */
+function resolveIdleWindowMs(): number {
+  const raw = process.env.VORN_IDLE_TIMEOUT_MS
+  const parsed = raw ? Number(raw) : NaN
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_IDLE_WINDOW_MS
+}
+
 function resolveBuildChannel(): 'dev' | 'packaged' {
   const declared = process.env.VORN_BUILD_CHANNEL
   if (declared === 'dev' || declared === 'packaged') return declared
@@ -62,7 +84,7 @@ function resolveBuildChannel(): 'dev' | 'packaged' {
 }
 
 export async function startServer(
-  options: { host?: string; port?: number; dataDir?: string } = {}
+  options: { host?: string; port?: number; dataDir?: string; idleShutdown?: boolean } = {}
 ) {
   // Initialize database + config. This resolves the data directory for the whole
   // process; everything else reads it back with getDataDir() rather than
@@ -81,6 +103,9 @@ export async function startServer(
   // its own entry point, which is TypeScript in a checkout and bundled CJS in a
   // packaged app. Getting this wrong is not cosmetic: dev and packaged builds
   // deliberately share ~/.vorn, so a wrong answer lets one adopt the other's.
+  // What a launcher deciding whether to adopt this server gets to hear before it
+  // has authenticated — see `ServerIdentity.sessions`.
+  setLiveSessionCount(() => ptyManager.livePtyCount())
   setServerIdentity({
     // The launcher passes the app's version; a CLI server has none to report and
     // says so rather than omitting the field, since every field on this frame is
@@ -435,6 +460,44 @@ export async function startServer(
     process.exit(0)
   }
 
+  // The server outlives the app now, so something has to decide when it is done.
+  // Nothing here waits for the event loop to drain: the scheduler's inbox
+  // interval is not unref'd, so this process would sit empty for ever.
+  const idleWatch = new IdleWatch(
+    () => ({
+      sessions: ptyManager.livePtyCount(),
+      // Filtered to running: `headless-manager` keeps exited entries for thirty
+      // seconds, and a finished agent is not a reason to stay up.
+      headless: headlessManager.getActiveSessions().filter((h) => h.status === 'running').length,
+      msSinceClientActivity: clientRegistry.msSinceActivity(),
+      bridgeAttached: browserBridge.isConnected,
+      pendingPermissions: hookServer.getPendingPermissions().length,
+      pendingPairings: pendingRequests().length,
+      connectorLeases: dbCountActiveConnectorInboxLeases(new Date().toISOString()),
+      enabledSchedules: scheduler.serverSideScheduleCount()
+    }),
+    { windowMs: resolveIdleWindowMs(), schedulesHoldOpen: true },
+    () => {
+      log.info('[server] nothing left to do; shutting down')
+      // Caught, and the watch is left running. A shutdown that throws part-way
+      // has already cleared the credential and removed the port file, so giving
+      // up here would leave a process still bound to the port that no app can
+      // use or discover -- the exact state this feature exists to prevent.
+      // Exiting hard is the floor.
+      void shutdown().catch((err) => {
+        log.error({ err }, '[server] idle shutdown failed; exiting anyway')
+        process.exit(1)
+      })
+    }
+  )
+  // Off wherever the server is the thing being run rather than something an app
+  // started: a hand-run `vorn-server serve`, or a machine serving a phone over
+  // the network. Nothing would restart it, and "my phone could not reach my Mac
+  // this morning" is a worse failure than a process that outstays its welcome.
+  const servesOthers = host === '0.0.0.0'
+  if (options.idleShutdown ?? !servesOthers) idleWatch.start()
+  else log.info('[server] idle shutdown off: this server is here to be reached')
+
   process.on('SIGTERM', shutdown)
   process.on('SIGINT', shutdown)
   // Why: this process outlives the app that started it, so a hangup on the
@@ -447,7 +510,7 @@ export async function startServer(
     if (msg === 'shutdown') shutdown()
   })
 
-  return { app, port: actualPort }
+  return { app, port: actualPort, idleWatch }
 }
 
 // Run directly

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -745,6 +745,20 @@ class PtyManager extends EventEmitter {
     this.sessionOrder = []
   }
 
+  /**
+   * How many terminals still have a process behind them.
+   *
+   * Not `getActiveSessions().length`. That returns session *records*, and a
+   * record outlives its process: when a shell exits on its own, `onExit` drops
+   * the pty and marks the session `'idle'`, but the record stays so the card can
+   * keep showing its exit code until somebody closes it. Only `killPty` removes
+   * it. So a finished-but-still-open tab reads as a live session for ever, which
+   * is precisely the state the idle check must not treat as busy.
+   */
+  livePtyCount(): number {
+    return this.ptys.size
+  }
+
   getActiveSessions(): TerminalSession[] {
     if (this.sessionOrder.length === 0) {
       return Array.from(this.sessions.values())

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -84,7 +84,39 @@ function getTriggerConfig(wf: WorkflowDefinition): TriggerConfig | null {
 }
 
 class Scheduler extends EventEmitter {
+  /**
+   * How many schedules are armed right now.
+   *
+   * For the idle check, which treats one as a reason to stay alive. Weaker than
+   * it sounds: a run is executed by a renderer, so an armed schedule with no
+   * client attached cannot fire. Staying up means being there when a desktop
+   * returns, not doing the work.
+   */
+  armedScheduleCount(): number {
+    return this.cronJobs.size + this.timeouts.size
+  }
+
+  /**
+   * Armed schedules that this server can act on with nobody attached.
+   *
+   * Only connector polls. `dispatchConnectorPoll` really does the work here --
+   * it calls the connector and writes inbox rows without any client -- whereas a
+   * recurring or one-off trigger only broadcasts `SCHEDULER_EXECUTE` for a
+   * renderer to execute, so staying awake for one buys nothing: with no client
+   * the occurrence is emitted, the minute lock is written, and the run is lost.
+   * Holding the server open for that would be keeping a promise by dropping it.
+   *
+   * It matters which: connector polls are seeded enabled when a connector is
+   * installed, so counting every armed cron meant anyone with a connector had a
+   * server that never exited.
+   */
+  serverSideScheduleCount(): number {
+    return this.connectorPollWorkflowIds.size
+  }
+
   private cronJobs = new Map<string, ScheduledTask>()
+  /** Of those, the ones that do real work here rather than in a renderer. */
+  private connectorPollWorkflowIds = new Set<string>()
   private timeouts = new Map<string, NodeJS.Timeout>()
   private inboxTimer: NodeJS.Timeout | null = null
 
@@ -180,6 +212,7 @@ class Scheduler extends EventEmitter {
       if (!wf || !wf.enabled || (kind !== 'recurring' && kind !== 'connectorPoll')) {
         this.cronJobs.get(id)?.stop()
         this.cronJobs.delete(id)
+        this.connectorPollWorkflowIds.delete(id)
       }
     }
     for (const [id] of this.timeouts) {
@@ -222,6 +255,7 @@ class Scheduler extends EventEmitter {
             timezone: trigger.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
           })
           this.cronJobs.set(wf.id, task)
+          if (trigger.triggerType === 'connectorPoll') this.connectorPollWorkflowIds.add(wf.id)
         } catch (err) {
           log.error({ err }, `[scheduler] failed to schedule workflow "${wf.name}":`)
         }
@@ -451,6 +485,7 @@ class Scheduler extends EventEmitter {
     for (const [, job] of this.cronJobs) job.stop()
     for (const [, timer] of this.timeouts) clearTimeout(timer)
     this.cronJobs.clear()
+    this.connectorPollWorkflowIds.clear()
     this.timeouts.clear()
     if (this.inboxTimer) clearInterval(this.inboxTimer)
     this.inboxTimer = null

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -85,18 +85,6 @@ function getTriggerConfig(wf: WorkflowDefinition): TriggerConfig | null {
 
 class Scheduler extends EventEmitter {
   /**
-   * How many schedules are armed right now.
-   *
-   * For the idle check, which treats one as a reason to stay alive. Weaker than
-   * it sounds: a run is executed by a renderer, so an armed schedule with no
-   * client attached cannot fire. Staying up means being there when a desktop
-   * returns, not doing the work.
-   */
-  armedScheduleCount(): number {
-    return this.cronJobs.size + this.timeouts.size
-  }
-
-  /**
    * Armed schedules that this server can act on with nobody attached.
    *
    * Only connector polls. `dispatchConnectorPoll` really does the work here --
@@ -259,6 +247,18 @@ class Scheduler extends EventEmitter {
         } catch (err) {
           log.error({ err }, `[scheduler] failed to schedule workflow "${wf.name}":`)
         }
+      }
+
+      // Membership is derived from the trigger as it stands now, not from what
+      // it was when the job was created. Both loops above keep an existing cron
+      // job when the new kind is still cron-eligible, and the registration below
+      // is skipped for an id that already has one -- so an edit from `recurring`
+      // to `connectorPoll` would never add the id, and the reverse edit would
+      // leave it behind. Either way the count that decides whether this server
+      // may leave stops describing the schedules it actually holds.
+      if (this.cronJobs.has(wf.id)) {
+        if (trigger.triggerType === 'connectorPoll') this.connectorPollWorkflowIds.add(wf.id)
+        else this.connectorPollWorkflowIds.delete(wf.id)
       }
 
       if (trigger.triggerType === 'once' && !this.timeouts.has(wf.id)) {

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -46,11 +46,9 @@ let helloFrameCache: string | null = null
  * spawns its own rather than guessing.
  */
 let identity: ServerIdentity | null = null
-let identityFrameCache: string | null = null
 
 export function setServerIdentity(next: ServerIdentity): void {
   identity = next
-  identityFrameCache = null
 }
 
 function helloFrame(): string {
@@ -76,8 +74,26 @@ function helloFrame(): string {
  */
 function identityFrame(): string | null {
   if (!identity) return null
-  identityFrameCache ??= JSON.stringify(createNotification('server:identity', identity))
-  return identityFrameCache
+  // Built per connection rather than cached: the session count is the point of
+  // sending it, and a count fixed at boot would be a lie by the second socket.
+  // The frame goes only to loopback peers, so this is not a per-request cost on
+  // anything remote.
+  return JSON.stringify(
+    createNotification('server:identity', { ...identity, sessions: liveSessionCount?.() })
+  )
+}
+
+/**
+ * How many terminals are live, when somebody has told us how to ask.
+ *
+ * A function rather than a number because the count changes; injected rather
+ * than imported because `ws-handler` has no business knowing about PTYs, and a
+ * direct import would put the socket layer downstream of the terminal layer.
+ */
+let liveSessionCount: (() => number) | null = null
+
+export function setLiveSessionCount(fn: () => number): void {
+  liveSessionCount = fn
 }
 
 /**
@@ -284,6 +300,10 @@ export function handleConnection(
   }
 
   ws.on('message', async (raw: Buffer) => {
+    // Every inbound frame counts as a client doing something, including the ones
+    // that go on to be refused. What the idle check needs to know is whether
+    // anybody is out there, not whether they were allowed.
+    clientRegistry.touch()
     let msg: RpcRequest
     try {
       msg = JSON.parse(raw.toString())

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -309,13 +309,21 @@ export function handleConnection(
     }
 
     const { id, method, params } = msg
-    // A frame counts as somebody being out there -- including one that goes on to
-    // be refused, since what the idle check needs is whether anybody is there,
-    // not whether they were allowed. The exception is the frame every connection
-    // opens with: `ServerBridge` sends it from its `open` handler, so a Vorn
-    // merely asking this server whether it may adopt it would otherwise reset
-    // this server's idle clock on the way past, one blocked launch at a time.
-    if (method !== 'bridge:identify') clientRegistry.touch()
+    // A frame from a socket that has proved itself counts as somebody being out
+    // there, and the idle watch stays up for it. Two things do not count.
+    //
+    // An unauthenticated frame, because anything on this machine can open a
+    // socket to loopback: counting those would let arbitrary local traffic pin a
+    // server nobody is using, without ever proving it is a client. Same rule the
+    // hook endpoint follows, and for the same reason.
+    //
+    // And `bridge:identify`, even authenticated, because `ServerBridge` sends it
+    // from its own `open` handler -- so it arrives on every connection including
+    // the one another Vorn opens purely to ask whether it may adopt this server.
+    // Counting that would let a user blocked by a leftover reset its clock on
+    // every launch attempt, so the leftover never leaves and the launches never
+    // stop being blocked.
+    if (session && method !== 'bridge:identify') clientRegistry.touch()
 
     // Everything below this line requires an authenticated socket. The one
     // exception is the credential itself.

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -300,10 +300,6 @@ export function handleConnection(
   }
 
   ws.on('message', async (raw: Buffer) => {
-    // Every inbound frame counts as a client doing something, including the ones
-    // that go on to be refused. What the idle check needs to know is whether
-    // anybody is out there, not whether they were allowed.
-    clientRegistry.touch()
     let msg: RpcRequest
     try {
       msg = JSON.parse(raw.toString())
@@ -313,6 +309,13 @@ export function handleConnection(
     }
 
     const { id, method, params } = msg
+    // A frame counts as somebody being out there -- including one that goes on to
+    // be refused, since what the idle check needs is whether anybody is there,
+    // not whether they were allowed. The exception is the frame every connection
+    // opens with: `ServerBridge` sends it from its `open` handler, so a Vorn
+    // merely asking this server whether it may adopt it would otherwise reset
+    // this server's idle clock on the way past, one blocked launch at a time.
+    if (method !== 'bridge:identify') clientRegistry.touch()
 
     // Everything below this line requires an authenticated socket. The one
     // exception is the credential itself.

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -120,6 +120,19 @@ export interface ServerIdentity {
    * the packaged app's bundled server, or the reverse.
    */
   buildChannel: 'dev' | 'packaged'
+  /**
+   * How many terminals this server currently has a process behind.
+   *
+   * Optional, so a server that predates it still validates. It rides this frame
+   * rather than an RPC because a launcher decides whether to adopt *before* it
+   * authenticates and closes the socket the moment it refuses — so for five of
+   * the six refusal reasons there is no request it could make. This is the only
+   * thing it hears from a server it has just declined.
+   *
+   * Treat it as a number from an untrusted party: coerce and clamp it, never
+   * splice it into a sentence.
+   */
+  sessions?: number
 }
 
 // ─── Authentication ─────────────────────────────────────────────

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1086,6 +1086,9 @@ export interface AppConfig {
      * With this on, quitting closes a window and nothing else; the next launch
      * reconnects to the sessions that were already running.
      *
+     * The background server shuts itself down once nothing is left running,
+     * so this does not leave a process behind for ever.
+     *
      * Defaults to on. Turning it off restores the old behaviour exactly, and
      * "Stop Sessions and Server" in the File menu does it once without changing
      * the setting.

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -409,6 +409,9 @@ export function createApiShim(wsUrl: string) {
     // one, so there is no local server for it to be looking away from.
     onLocalServerStillRunning: (_callback: (notice: unknown) => void) => () => {},
     stopLocalServer: async () => ({ ok: false, error: 'Not available here.' }),
+    // Present so the surface test passes; the palette hides the command in web,
+    // so nothing should reach this.
+    stopSessionsAndServer: unsupportedInWeb('Stopping the server'),
 
     onMenuNewAgent: (_callback: () => void) => () => {},
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,7 +20,8 @@ import {
   detachFromServer,
   getServerBridge,
   getLastAdoptionRefusal,
-  AdoptionRefusedError
+  AdoptionRefusedError,
+  probeSessions
 } from './server/server-launcher'
 import { readHostSettings } from './server/host-store'
 import { registerConnectHandlers, showConnectWindow } from './server/connect-window'
@@ -530,7 +531,14 @@ app.whenReady().then(async () => {
     const local = readPortFile()
     if (local) {
       mainWindow.webContents.once('did-finish-load', () => {
-        mainWindow?.webContents.send(LOCAL_SERVER_RUNNING_CHANNEL, { sessions: null })
+        // Asked rather than assumed, and the window is not held waiting for the
+        // answer: a server that does not reply leaves the count null, which the
+        // toast already words as "Sessions are".
+        void probeSessions(local.port)
+          .catch(() => null)
+          .then((sessions) => {
+            mainWindow?.webContents.send(LOCAL_SERVER_RUNNING_CHANNEL, { sessions })
+          })
       })
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,10 @@ import { updateManager } from './update-manager'
 import { IPC, PermissionRequestInfo, type AppConfig } from '../shared/types'
 import { setArtifactNotify } from './artifact-watcher'
 import { SURFACE } from '../shared/surface'
-import { LOCAL_SERVER_RUNNING_CHANNEL } from '../shared/adoption-channels'
+import {
+  LOCAL_SERVER_RUNNING_CHANNEL,
+  STOP_SESSIONS_AND_SERVER_CHANNEL
+} from '../shared/adoption-channels'
 import {
   launchServer,
   stopServer,
@@ -440,7 +443,14 @@ app.whenReady().then(async () => {
     // refusing to open for no reason, so it gets a window that names the reason
     // and offers to end that server, which is the only thing that resolves it.
     if (err instanceof AdoptionRefusedError) {
-      showConnectWindow(explainRefusal(err.refusal.reason), 'local-server-refused')
+      // The count rides the recorded refusal rather than the thrown error: the
+      // error carries the verdict, the record carries what we learned about the
+      // incumbent while deciding.
+      showConnectWindow(
+        explainRefusal(err.refusal.reason),
+        'local-server-refused',
+        getLastAdoptionRefusal()?.incumbentSessions ?? null
+      )
       return
     }
     app.quit()
@@ -488,14 +498,19 @@ app.whenReady().then(async () => {
   ipcMain.on(IPC.WINDOW_CLOSE, () => mainWindow?.close())
   ipcMain.handle(IPC.WINDOW_IS_MAXIMIZED, () => mainWindow?.isMaximized() ?? false)
 
-  createMenu(toggleWidget, () => {
-    // Ends the sessions and the server on purpose. Expressed as "quit, but do
-    // not keep them" rather than as its own shutdown, so there is exactly one
-    // path that stops a server and exactly one place that holds the quit open
-    // until it has finished.
+  // Ends the sessions and the server on purpose. Expressed as "quit, but do not
+  // keep them" rather than as its own shutdown, so there is exactly one path
+  // that stops a server and exactly one place that holds the quit open until it
+  // has finished.
+  //
+  // Named once and shared, because the File menu and the command palette offer
+  // the same words and must not mean two different things.
+  const stopSessionsAndServer = (): void => {
     keepSessionsRunning = false
     app.quit()
-  })
+  }
+  createMenu(toggleWidget, stopSessionsAndServer)
+  ipcMain.handle(STOP_SESSIONS_AND_SERVER_CHANNEL, () => stopSessionsAndServer())
   createWindow()
 
   if (!mainWindow) {

--- a/src/main/server/connect-window.ts
+++ b/src/main/server/connect-window.ts
@@ -137,15 +137,18 @@ function connectMarkup(reason: string, cause: ConnectWindowCause, holding: numbe
   // directory, "run a server on this machine" is the thing that just failed.
   const refused = cause === 'local-server-refused'
   const heading = refused ? 'Another Vorn server is running' : 'Cannot reach that Vorn'
-  // Composed from a count, never from anything that server said in words. It
-  // may not have said anything at all, in which case "Sessions" is the honest
-  // form -- there certainly are some, or it would have shut itself down.
-  const held =
-    holding === null ? 'Sessions are' : holding === 1 ? '1 session is' : `${holding} sessions are`
-  const lede = refused
-    ? `${held} alive inside it. This app will not start a second server beside it, ` +
-      'because both would share one database.'
-    : 'The server this app is pointed at did not answer.'
+  // Composed from a count, never from anything that server said in words. Two
+  // cases carry no number to state: an older server that does not send one, and
+  // a server holding nothing at all -- which is reachable, since it is given a
+  // grace period before it leaves. Neither can claim sessions that are not there.
+  const refusedLede =
+    holding === null || holding === 0
+      ? "It holds this machine's data directory, and this app will not start a " +
+        'second server beside it, because both would share one database.'
+      : `${holding === 1 ? '1 session is' : `${holding} sessions are`} alive inside it. ` +
+        'This app will not start a second server beside it, because both would share ' +
+        'one database.'
+  const lede = refused ? refusedLede : 'The server this app is pointed at did not answer.'
   const localButton = refused
     ? '<button id="stop-local">Stop it and start fresh</button>'
     : '<button id="local" class="quiet">Run a server on this machine</button>'

--- a/src/main/server/connect-window.ts
+++ b/src/main/server/connect-window.ts
@@ -87,7 +87,8 @@ export type ConnectWindowCause = 'host-unreachable' | 'local-server-refused'
 
 export function showConnectWindow(
   reason: string,
-  cause: ConnectWindowCause = 'host-unreachable'
+  cause: ConnectWindowCause = 'host-unreachable',
+  holding: number | null = null
 ): void {
   if (connectWindow && !connectWindow.isDestroyed()) {
     connectWindow.focus()
@@ -118,7 +119,7 @@ export function showConnectWindow(
 
   log.info('[connect] showing the connect window')
   void connectWindow.loadURL(
-    `data:text/html;charset=utf-8,${encodeURIComponent(connectMarkup(reason, cause))}`
+    `data:text/html;charset=utf-8,${encodeURIComponent(connectMarkup(reason, cause, holding))}`
   )
 }
 
@@ -130,15 +131,20 @@ function escapeHtml(value: string): string {
     .replace(/"/g, '&quot;')
 }
 
-function connectMarkup(reason: string, cause: ConnectWindowCause): string {
+function connectMarkup(reason: string, cause: ConnectWindowCause, holding: number | null): string {
   // Two situations reach this window, and only one of them can be resolved by
   // running a server here: when another one already holds this machine's data
   // directory, "run a server on this machine" is the thing that just failed.
   const refused = cause === 'local-server-refused'
   const heading = refused ? 'Another Vorn server is running' : 'Cannot reach that Vorn'
+  // Composed from a count, never from anything that server said in words. It
+  // may not have said anything at all, in which case "Sessions" is the honest
+  // form -- there certainly are some, or it would have shut itself down.
+  const held =
+    holding === null ? 'Sessions are' : holding === 1 ? '1 session is' : `${holding} sessions are`
   const lede = refused
-    ? 'Your sessions are alive inside it. This app will not start a second server ' +
-      'beside it, because both would share one database.'
+    ? `${held} alive inside it. This app will not start a second server beside it, ` +
+      'because both would share one database.'
     : 'The server this app is pointed at did not answer.'
   const localButton = refused
     ? '<button id="stop-local">Stop it and start fresh</button>'

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -77,7 +77,11 @@ let adoptedPid: number | null = null
  * is empty. The pid is what lets them end it on purpose -- the one actor allowed
  * to, since this code never ends an incumbent on its own.
  */
-export type AdoptionRefusal = AdoptionVerdict & { kind: 'refuse' } & { incumbentPid: number | null }
+export type AdoptionRefusal = AdoptionVerdict & { kind: 'refuse' } & {
+  incumbentPid: number | null
+  /** Terminals the refused server said it holds, or null if it did not say. */
+  incumbentSessions: number | null
+}
 
 let lastRefusal: AdoptionRefusal | null = null
 
@@ -501,6 +505,19 @@ function onServerExit(detail: string): void {
 }
 
 /**
+ * A session count from a server we are not going to use.
+ *
+ * Anything that is not a plain, sane integer becomes null, which the window
+ * renders as "sessions" rather than a number. A stranger does not get to choose
+ * what Vorn's own warning says.
+ */
+export function sessionsFrom(identity: ServerIdentity | null): number | null {
+  const n = identity?.sessions
+  if (typeof n !== 'number' || !Number.isInteger(n) || n < 0 || n > 10_000) return null
+  return n
+}
+
+/**
  * Long enough for a busy event loop, short enough not to stall a cold launch.
  *
  * A server that sends no identity frame at all -- too old, or not on loopback --
@@ -522,10 +539,14 @@ async function tryAdopt(
   port: number,
   expectedPid: number | undefined,
   self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
-): Promise<{ bridge: ServerBridge } | { refusal: AdoptionVerdict & { kind: 'refuse' } }> {
+): Promise<
+  | { bridge: ServerBridge }
+  | { refusal: AdoptionVerdict & { kind: 'refuse' }; sessions: number | null }
+> {
   const token = readLocalToken(self.dataDir)
   if (!token) {
     return {
+      sessions: null,
       refusal: {
         kind: 'refuse',
         reason: 'unusable',
@@ -556,6 +577,7 @@ async function tryAdopt(
   if (verdict.kind === 'refuse' || !identity) {
     candidate.close()
     return {
+      sessions: sessionsFrom(identity),
       refusal:
         verdict.kind === 'refuse'
           ? verdict
@@ -579,6 +601,7 @@ async function tryAdopt(
   if (!accepted) {
     candidate.close()
     return {
+      sessions: null,
       refusal: {
         kind: 'refuse',
         reason: 'unusable',
@@ -643,7 +666,14 @@ export async function launchServer(): Promise<ServerBridge> {
       return bridge
     }
     const { refusal } = outcome
-    lastRefusal = { ...refusal, incumbentPid: published.pid ?? null }
+    lastRefusal = {
+      ...refusal,
+      incumbentPid: published.pid ?? null,
+      // Coerced, not trusted. This number comes from the party this app has just
+      // decided it cannot use, so it is clamped and rendered as a count — never
+      // as text spliced into a sentence.
+      incumbentSessions: 'sessions' in outcome ? outcome.sessions : null
+    }
     log.warn(
       `[launcher] declined to adopt the running server (${refusal.reason}): ` +
         `${refusal.detail}. It keeps running and keeps its sessions.`

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -528,6 +528,33 @@ const ADOPT_IDENTITY_TIMEOUT_MS = 3_000
 const ADOPT_AUTH_TIMEOUT_MS = 5_000
 
 /**
+ * Ask a running server, without joining it, how many terminals it holds.
+ *
+ * The greeting is the first frame on the socket and arrives before
+ * authentication, so this answers even for a server that would reject this app's
+ * credential -- which is the whole reason the count rides that frame. Used where
+ * the app is pointed elsewhere and merely wants to say what is still running
+ * here; null means "could not tell", never "nothing".
+ */
+export async function probeSessions(port: number): Promise<number | null> {
+  const token = readLocalToken()
+  if (!token) return null
+  const probe = new ServerBridge(`ws://127.0.0.1:${port}/ws`, token)
+  probe.connect()
+  try {
+    return await new Promise<number | null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), ADOPT_IDENTITY_TIMEOUT_MS)
+      probe.once('identity', (found: ServerIdentity) => {
+        clearTimeout(timer)
+        resolve(sessionsFrom(found))
+      })
+    })
+  } finally {
+    probe.close()
+  }
+}
+
+/**
  * Connect to a server that is already running and decide whether to keep it.
  *
  * Never kills the incumbent. The process holding the PTYs is the one with the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron'
-import { LOCAL_SERVER_RUNNING_CHANNEL, type LocalServerNotice } from '../shared/adoption-channels'
+import {
+  LOCAL_SERVER_RUNNING_CHANNEL,
+  STOP_SESSIONS_AND_SERVER_CHANNEL,
+  type LocalServerNotice
+} from '../shared/adoption-channels'
 import { captureViewerSettings, withViewerSettings } from '@vornrun/shared/viewer-settings-store'
 import {
   CreateTerminalPayload,
@@ -606,6 +610,9 @@ const api = {
    *  local server is still running. */
   stopLocalServer: (): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('connect:stopLocal'),
+
+  /** The File menu's "Stop Sessions and Server", offered from the palette too. */
+  stopSessionsAndServer: (): Promise<void> => ipcRenderer.invoke(STOP_SESSIONS_AND_SERVER_CHANNEL),
 
   // Pairing a phone by showing it a code
   startPairing: (): Promise<{ code: string; expiresAt: number }> =>

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -7,6 +7,7 @@ import { FileTypeIcon } from './file-icons'
 import { getProjectHostIds, getProjectRemoteHostId, type RecentSession } from '../../shared/types'
 import { SortMode, StatusFilter } from '../stores/types'
 import { AGENT_DEFINITIONS, AGENT_LIST } from '../lib/agent-definitions'
+import { isElectron } from '../lib/platform'
 import { AgentIcon } from './AgentIcon'
 import { getDisplayName } from '../lib/terminal-display'
 import {
@@ -36,6 +37,7 @@ import {
   Plug,
   HardDrive,
   LayoutDashboard,
+  Power,
   Globe
 } from 'lucide-react'
 
@@ -209,6 +211,24 @@ function useCommands(
       keywords: ['new task', 'add task', 'todo'],
       onExecute: () => setTaskDialogOpen(true)
     })
+    // Desktop only, and hidden rather than inert in the browser: a phone cannot
+    // end a server it did not start, and a command that appears and does nothing
+    // is worse than one that is not there.
+    if (isElectron) {
+      commands.push({
+        id: 'action:stop-sessions-and-server',
+        // The File menu's wording, exactly. Two places, one ending.
+        label: 'Stop Sessions and Server',
+        sublabel: terminals.size > 0 ? `${terminals.size} running` : undefined,
+        category: 'actions',
+        icon: <Power size={14} strokeWidth={1.5} />,
+        keywords: ['stop', 'quit', 'shutdown', 'server', 'end', 'kill'],
+        onExecute: () => {
+          void window.api.stopSessionsAndServer?.()
+        }
+      })
+    }
+
     commands.push({
       id: 'action:toggle-layout',
       label: 'Toggle Layout (Grid/Tabs)',

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -88,7 +88,7 @@ export function GeneralSettings() {
         {/* Keep sessions running */}
         <SettingRow
           label="Keep Sessions Running When Vorn Closes"
-          description="Agents keep working while Vorn is shut. Reopening reconnects to them instead of restarting them. A background server stays running until every session ends."
+          description="Agents keep working while Vorn is shut. Reopening reconnects to them instead of restarting them. A background server stays running until every session ends, then shuts down on its own."
         >
           <ToggleSwitch
             checked={config.defaults.keepSessionsRunning ?? true}

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -17,6 +17,30 @@ export function GeneralSettings() {
 
   if (!config) return null
 
+  // Two ordinary settings quietly override the sentence above, and a promise
+  // that is conditional should say so where it is made rather than leaving the
+  // user to notice a server that never leaves.
+  // Read the way `scheduler.getTriggerConfig` reads it -- first trigger node,
+  // its own config -- so this cannot describe a different set of workflows from
+  // the one the server actually stays awake for.
+  const polling = (config.workflows ?? []).some((w) => {
+    if (!w.enabled) return false
+    const trigger = w.nodes.find((n) => n.type === 'trigger')
+    return (
+      (trigger?.config as { triggerType?: string } | undefined)?.triggerType === 'connectorPoll'
+    )
+  })
+  const reasons = [
+    config.defaults.networkAccessEnabled
+      ? 'Network Access is on, so it stays up to be reached from your other devices'
+      : null,
+    polling ? 'a connector is polling on a schedule, which it services itself' : null
+  ].filter(Boolean)
+  const serverStaysUp =
+    reasons.length === 0
+      ? undefined
+      : `${reasons.join(', and ')}. This server will not shut down on its own.`
+
   const updateDefaults = (patch: Partial<typeof config.defaults>): void => {
     const updated = {
       ...config,
@@ -89,6 +113,7 @@ export function GeneralSettings() {
         <SettingRow
           label="Keep Sessions Running When Vorn Closes"
           description="Agents keep working while Vorn is shut. Reopening reconnects to them instead of restarting them. A background server stays running until every session ends, then shuts down on its own."
+          note={serverStaysUp}
         >
           <ToggleSwitch
             checked={config.defaults.keepSessionsRunning ?? true}

--- a/src/renderer/components/settings/SettingRow.tsx
+++ b/src/renderer/components/settings/SettingRow.tsx
@@ -3,11 +3,20 @@ import { ReactNode } from 'react'
 export function SettingRow({
   label,
   description,
+  note,
   children,
   disabled
 }: {
   label: string
   description: string
+  /**
+   * A condition that changes what the description promises, shown under it.
+   *
+   * For settings whose behaviour something else can quietly override. Plain
+   * muted text rather than a callout: this is a fact about the current state,
+   * not a warning, and colour here is reserved for status.
+   */
+  note?: ReactNode
   children: ReactNode
   disabled?: boolean
 }) {
@@ -18,6 +27,11 @@ export function SettingRow({
       <div>
         <div className="text-sm font-medium text-gray-200">{label}</div>
         <div className="text-xs text-gray-500 mt-0.5">{description}</div>
+        {note && (
+          <div className="text-xs text-gray-400 mt-1.5 pl-2 border-l border-white/[0.12]">
+            {note}
+          </div>
+        )}
       </div>
       {children}
     </div>

--- a/src/shared/adoption-channels.ts
+++ b/src/shared/adoption-channels.ts
@@ -20,3 +20,13 @@ export interface LocalServerNotice {
   /** How many sessions the local server was holding, when that could be read. */
   sessions: number | null
 }
+
+/**
+ * Ending the sessions and the server deliberately.
+ *
+ * The File menu and the command palette both offer this, under the same words,
+ * and both reach the one closure in `index.ts` — a label that ends the app from
+ * one place and not from another is the kind of difference people only find
+ * once.
+ */
+export const STOP_SESSIONS_AND_SERVER_CHANNEL = 'app:stop-sessions-and-server'

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -186,7 +186,9 @@ describe('serve', () => {
     expect(startServer).toHaveBeenCalledWith({
       host: undefined,
       port: undefined,
-      dataDir
+      dataDir,
+      // A server somebody ran on purpose does not get to decide it is done.
+      idleShutdown: false
     })
     expect(io.out()).toContain('Vorn server listening on port 4400')
     expect(io.out()).toContain('No device tokens existed')
@@ -212,7 +214,8 @@ describe('serve', () => {
     expect(startServer).toHaveBeenCalledWith({
       host: '0.0.0.0',
       port: 9999,
-      dataDir
+      dataDir,
+      idleShutdown: false
     })
     expect(io.out()).toContain('listening on port 9999')
   })

--- a/tests/hook-payload.test.ts
+++ b/tests/hook-payload.test.ts
@@ -277,3 +277,59 @@ describe('the utility underneath it', () => {
     expect(() => normalizePath(undefined as unknown as string)).toThrow(TypeError)
   })
 })
+
+describe('what the idle clock counts as an agent being alive', () => {
+  // `msSinceHookActivity` is the only trace an agent started outside Vorn leaves
+  // on this server, and the idle watch stays up for it. That makes advancing it
+  // a way to keep the server alive, so it must take the same proof every other
+  // hook request takes.
+  it('advances on an authenticated hook post', async () => {
+    const started = await startHookServer()
+    server = started
+    await new Promise((r) => setTimeout(r, 30))
+    const before = started.instance.msSinceHookActivity()
+    expect(before).toBeGreaterThan(0)
+
+    await post(
+      started.port,
+      started.token,
+      '{"hook_event_name":"Stop","session_id":"s","cwd":"/tmp"}'
+    )
+    expect(started.instance.msSinceHookActivity()).toBeLessThan(before)
+  })
+
+  it('does not advance for a request with no credential', async () => {
+    const started = await startHookServer()
+    server = started
+    await new Promise((r) => setTimeout(r, 30))
+    const before = started.instance.msSinceHookActivity()
+
+    const status = await post(started.port, 'not-the-token', '{"hook_event_name":"Stop"}')
+    expect(status).toBe(401)
+    // Anything on this machine can reach loopback. If a refused request counted,
+    // a port scan would be enough to keep a server nobody is using alive for
+    // ever -- a worse hole than the one this clock closes.
+    expect(started.instance.msSinceHookActivity()).toBeGreaterThanOrEqual(before)
+  })
+
+  it('does not advance for a request that is not a POST', async () => {
+    const started = await startHookServer()
+    server = started
+    await new Promise((r) => setTimeout(r, 30))
+    const before = started.instance.msSinceHookActivity()
+
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(
+        { hostname: '127.0.0.1', port: started.port, path: '/hooks', method: 'GET' },
+        (res) => {
+          res.resume()
+          expect(res.statusCode).toBe(404)
+          resolve()
+        }
+      )
+      req.on('error', reject)
+      req.end()
+    })
+    expect(started.instance.msSinceHookActivity()).toBeGreaterThanOrEqual(before)
+  })
+})

--- a/tests/idle-exit.process.test.ts
+++ b/tests/idle-exit.process.test.ts
@@ -34,14 +34,27 @@ beforeAll(() => {
 
 let child: ChildProcess | null = null
 let dir: string | null = null
+let output: string[] = []
+
+/** What the server said, for a failure message. Trimmed: it is chatty. */
+function saidSoFar(): string {
+  return output.join('').split('\n').slice(-25).join('\n')
+}
 
 function launch(idleMs: number): ChildProcess {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-idle-'))
   fs.mkdirSync(path.join(dir, '.vorn'), { recursive: true })
+  output = []
   const proc = spawn(
     process.execPath,
     [ENTRY, '--data-dir', path.join(dir, '.vorn'), '--port', '0'],
     {
+      // Piped and drained below, never piped and left. An unread pipe fills at
+      // 64KB and then blocks the writer, and this server logs a line per request
+      // through pino -- so the second case here, which sends frames for nine
+      // seconds, would stall the very process it is asking to stay alive. Kept
+      // rather than ignored because the output is the only diagnosis available
+      // when one of these fails.
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
       env: {
@@ -53,6 +66,8 @@ function launch(idleMs: number): ChildProcess {
     }
   )
   child = proc
+  proc.stdout?.on('data', (b: Buffer) => output.push(b.toString()))
+  proc.stderr?.on('data', (b: Buffer) => output.push(b.toString()))
   return proc
 }
 
@@ -87,7 +102,7 @@ describe('a server with nothing to do', () => {
     const proc = launch(2_000)
     const pid = proc.pid as number
     await new Promise((r) => setTimeout(r, 12_000))
-    expect(alive(pid)).toBe(false)
+    expect(alive(pid), `still running. server said:\n${saidSoFar()}`).toBe(false)
   }, 40_000)
 
   it('stays up while a websocket client keeps sending frames', async () => {
@@ -121,6 +136,6 @@ describe('a server with nothing to do', () => {
     const stillUp = alive(pid)
     ws.close()
 
-    expect(stillUp).toBe(true)
+    expect(stillUp, `left while a client was talking. server said:\n${saidSoFar()}`).toBe(true)
   }, 45_000)
 })

--- a/tests/idle-exit.process.test.ts
+++ b/tests/idle-exit.process.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { spawn, type ChildProcess } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * Does the process actually leave?
+ *
+ * The pure tests pin the decision; this pins the only thing they cannot — that a
+ * real server, told nothing is happening, exits. It is the claim the feature is
+ * named for, and it was untested until a review pointed out that every green
+ * test was asserting a snapshot rather than a process.
+ *
+ * HOME is redirected along with --data-dir, and that is not tidiness: `shutdown()`
+ * calls `uninstallHooks()`, which writes `~/.claude/settings.json` regardless of
+ * the data dir. A test that skipped this would uninstall the developer's own
+ * agent hooks on the way past.
+ */
+
+const ENTRY = path.join(__dirname, '..', 'packages', 'server', 'dist', 'index.cjs')
+const built = fs.existsSync(ENTRY)
+
+let child: ChildProcess | null = null
+let dir: string | null = null
+
+function launch(idleMs: number): ChildProcess {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-idle-'))
+  fs.mkdirSync(path.join(dir, '.vorn'), { recursive: true })
+  const proc = spawn(
+    process.execPath,
+    [ENTRY, '--data-dir', path.join(dir, '.vorn'), '--port', '0'],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: {
+        ...process.env,
+        HOME: dir,
+        USERPROFILE: dir,
+        VORN_IDLE_TIMEOUT_MS: String(idleMs)
+      }
+    }
+  )
+  child = proc
+  return proc
+}
+
+const alive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+afterEach(() => {
+  if (child?.pid && alive(child.pid)) {
+    try {
+      process.kill(-child.pid, 'SIGKILL')
+    } catch {
+      try {
+        process.kill(child.pid, 'SIGKILL')
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+  child = null
+  if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  dir = null
+})
+
+describe.skipIf(!built)('a server with nothing to do', () => {
+  it('exits on its own', async () => {
+    const proc = launch(2_000)
+    const pid = proc.pid as number
+    await new Promise((r) => setTimeout(r, 12_000))
+    expect(alive(pid)).toBe(false)
+  }, 40_000)
+
+  it('stays up while a websocket client keeps sending frames', async () => {
+    // The counterpart to the first test, and the one that proves the window
+    // measures traffic rather than elapsed time. These sockets have no
+    // heartbeat, so only real frames reset the clock.
+    const proc = launch(2_000)
+    const pid = proc.pid as number
+    const portFile = path.join(dir as string, '.vorn', 'ws-port')
+    const tokenFile = path.join(dir as string, '.vorn', 'local-token')
+    for (let i = 0; i < 60 && !(fs.existsSync(portFile) && fs.existsSync(tokenFile)); i++) {
+      await new Promise((r) => setTimeout(r, 250))
+    }
+    expect(fs.existsSync(portFile)).toBe(true)
+
+    const { port } = JSON.parse(fs.readFileSync(portFile, 'utf-8'))
+    const token = fs.readFileSync(tokenFile, 'utf-8').trim()
+    const { default: WebSocket } = await import('ws')
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    await new Promise((r) => ws.once('open', r))
+
+    // Well past the window, sending the whole time.
+    const deadline = Date.now() + 9_000
+    let n = 0
+    while (Date.now() < deadline) {
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id: ++n, method: 'config:load' }))
+      await new Promise((r) => setTimeout(r, 500))
+    }
+    const stillUp = alive(pid)
+    ws.close()
+
+    expect(stillUp).toBe(true)
+  }, 45_000)
+})

--- a/tests/idle-exit.process.test.ts
+++ b/tests/idle-exit.process.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { spawn, type ChildProcess } from 'node:child_process'
+import { describe, it, expect, afterEach, beforeAll } from 'vitest'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -18,8 +18,19 @@ import path from 'node:path'
  * agent hooks on the way past.
  */
 
-const ENTRY = path.join(__dirname, '..', 'packages', 'server', 'dist', 'index.cjs')
-const built = fs.existsSync(ENTRY)
+const SERVER = path.join(__dirname, '..', 'packages', 'server')
+const ENTRY = path.join(SERVER, 'dist', 'index.cjs')
+
+// Built here rather than skipped when missing. `dist/` is gitignored and
+// `yarn test` is a bare `vitest run`, so a skip-if-absent gate meant this file
+// never ran in CI -- green on the one claim the feature is named for, proving
+// nothing. The build is a few seconds and only happens when the bundle is not
+// already there.
+beforeAll(() => {
+  if (fs.existsSync(ENTRY)) return
+  const built = spawnSync('yarn', ['build'], { cwd: SERVER, stdio: 'inherit', shell: false })
+  if (built.status !== 0) throw new Error('could not build the server bundle for this test')
+}, 180_000)
 
 let child: ChildProcess | null = null
 let dir: string | null = null
@@ -71,7 +82,7 @@ afterEach(() => {
   dir = null
 })
 
-describe.skipIf(!built)('a server with nothing to do', () => {
+describe('a server with nothing to do', () => {
   it('exits on its own', async () => {
     const proc = launch(2_000)
     const pid = proc.pid as number

--- a/tests/idle.test.ts
+++ b/tests/idle.test.ts
@@ -343,3 +343,38 @@ describe('a desktop flag that outlived its desktop', () => {
     }
   })
 })
+
+describe('once the decision is made', () => {
+  const brief: IdlePolicy = { windowMs: 1_000, schedulesHoldOpen: true }
+
+  it('fires exactly once, however long the shutdown takes', () => {
+    // `shutdown()` may take up to its deadline, and this interval would
+    // otherwise keep firing throughout -- announcing "nothing left to do" once
+    // per tick against a shutdown already in flight, and re-entering a path that
+    // only refuses the re-entry.
+    vi.useFakeTimers()
+    try {
+      let exits = 0
+      const watch = new IdleWatch(quiet, brief, () => exits++, 100)
+      watch.tick() // starts the countdown
+      vi.advanceTimersByTime(brief.windowMs)
+      for (let i = 0; i < 10; i++) watch.tick()
+      expect(exits).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stops its own interval, so nothing is left ticking', () => {
+    vi.useFakeTimers()
+    try {
+      let exits = 0
+      const watch = new IdleWatch(quiet, brief, () => exits++, 100)
+      watch.start()
+      vi.advanceTimersByTime(brief.windowMs * 20)
+      expect(exits).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/tests/idle.test.ts
+++ b/tests/idle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import {
   IdleWatch,
   shouldExitWhenIdle,
@@ -24,6 +24,8 @@ const quiet = (over: Partial<IdleSnapshot> = {}): IdleSnapshot => ({
   sessions: 0,
   headless: 0,
   msSinceClientActivity: DEFAULT_IDLE_WINDOW_MS + 1,
+  msSinceHookActivity: DEFAULT_IDLE_WINDOW_MS + 1,
+  servesOthers: false,
   bridgeAttached: false,
   pendingPermissions: 0,
   pendingPairings: 0,
@@ -32,25 +34,50 @@ const quiet = (over: Partial<IdleSnapshot> = {}): IdleSnapshot => ({
   ...over
 })
 
+/**
+ * The window check, for a server that has been quiet the whole time nobody has
+ * been talking to it. `shouldExitWhenIdle` takes the quiet duration from its
+ * caller because the caller owns the later of two clocks; where the only clock
+ * is the client one, the two are the same number.
+ */
+function decide(s: IdleSnapshot, policy: IdlePolicy) {
+  return shouldExitWhenIdle(s, policy, Math.min(s.msSinceClientActivity, s.msSinceHookActivity))
+}
+
 describe('what keeps a server alive', () => {
   it('exits when everything really is empty', () => {
-    expect(shouldExitWhenIdle(quiet(), policy)).toEqual({ exit: true })
+    expect(decide(quiet(), policy)).toEqual({ exit: true })
   })
 
   it.each([
     ['a terminal session', { sessions: 1 }],
     ['a running headless agent', { headless: 1 }],
-    ['an attached desktop', { bridgeAttached: true }],
     ['an agent waiting on a permission', { pendingPermissions: 1 }],
     ['a pairing in progress', { pendingPairings: 1 }],
     ['outstanding connector work', { connectorLeases: 1 }],
     ['an enabled schedule', { enabledSchedules: 1 }]
   ])('stays up for %s', (_label, over) => {
-    expect(shouldExitWhenIdle(quiet(over), policy).exit).toBe(false)
+    expect(decide(quiet(over), policy).exit).toBe(false)
+  })
+
+  it('stays up for an attached desktop that is still talking', () => {
+    const attached = quiet({ bridgeAttached: true, msSinceClientActivity: 1_000 })
+    expect(decide(attached, policy)).toMatchObject({ exit: false, restartsCountdown: false })
+    expect(whatHoldsItOpen(attached, policy)).toBe('a desktop is attached')
+  })
+
+  it('does not stay up for a desktop that has said nothing for the whole window', () => {
+    // The flag is presence, and presence has no heartbeat behind it: a laptop
+    // that slept with Vorn open leaves `isConnected` true for ever. Without this,
+    // that is a server nothing can ever stop. A desktop that is genuinely there
+    // is sending frames, so it never reaches this.
+    const stale = quiet({ bridgeAttached: true, msSinceClientActivity: policy.windowMs })
+    expect(whatHoldsItOpen(stale, policy)).toBeNull()
+    expect(decide(stale, policy)).toEqual({ exit: true })
   })
 
   it('says what is holding it, so a log line can explain itself', () => {
-    const verdict = shouldExitWhenIdle(quiet({ sessions: 2 }), policy)
+    const verdict = decide(quiet({ sessions: 2 }), policy)
     expect(verdict).toMatchObject({ exit: false, because: '2 session(s)' })
   })
 })
@@ -69,7 +96,7 @@ describe('the three ways this could be wrongly true', () => {
     // 0↔1 while an agent is working. A client that acted a second ago is not an
     // absent client, however many sockets happen to be open this instant.
     const between = quiet({ msSinceClientActivity: 1_000 })
-    expect(shouldExitWhenIdle(between, policy)).toMatchObject({ exit: false })
+    expect(decide(between, policy)).toMatchObject({ exit: false })
   })
 
   it('still exits when a socket lingers but nothing has happened on it', () => {
@@ -78,32 +105,26 @@ describe('the three ways this could be wrongly true', () => {
     // flow leaves an entry in the client map for ever. An earlier version asked
     // whether anybody was connected and returned "yes" here — which made this
     // test pass against a snapshot the real registry could never produce.
-    expect(shouldExitWhenIdle(quiet({ msSinceClientActivity: 60 * 60_000 }), policy).exit).toBe(
-      true
-    )
+    expect(decide(quiet({ msSinceClientActivity: 60 * 60_000 }), policy).exit).toBe(true)
   })
 })
 
 describe('the window itself', () => {
   it('waits rather than exiting the moment the last thing goes', () => {
     const justQuiet = quiet({ msSinceClientActivity: 5_000 })
-    expect(shouldExitWhenIdle(justQuiet, policy)).toMatchObject({
+    expect(decide(justQuiet, policy)).toMatchObject({
       exit: false,
       because: 'quiet for only 5s'
     })
   })
 
   it('exits exactly at the window, not a tick before', () => {
-    expect(
-      shouldExitWhenIdle(quiet({ msSinceClientActivity: policy.windowMs - 1 }), policy).exit
-    ).toBe(false)
-    expect(shouldExitWhenIdle(quiet({ msSinceClientActivity: policy.windowMs }), policy).exit).toBe(
-      true
-    )
+    expect(decide(quiet({ msSinceClientActivity: policy.windowMs - 1 }), policy).exit).toBe(false)
+    expect(decide(quiet({ msSinceClientActivity: policy.windowMs }), policy).exit).toBe(true)
   })
 
   it('is quiet only by the clock, never by who is connected', () => {
-    expect(shouldExitWhenIdle(quiet({ msSinceClientActivity: 0 }), policy)).toMatchObject({
+    expect(decide(quiet({ msSinceClientActivity: 0 }), policy)).toMatchObject({
       exit: false,
       because: 'quiet for only 0s'
     })
@@ -116,8 +137,8 @@ describe('the schedule carve-out', () => {
     // connector polls. A renderer-executed trigger is not in it, because
     // staying awake for one would keep a promise by dropping the run.
     const off: IdlePolicy = { ...policy, schedulesHoldOpen: false }
-    expect(shouldExitWhenIdle(quiet({ enabledSchedules: 3 }), off).exit).toBe(true)
-    expect(shouldExitWhenIdle(quiet({ enabledSchedules: 3 }), policy).exit).toBe(false)
+    expect(decide(quiet({ enabledSchedules: 3 }), off).exit).toBe(true)
+    expect(decide(quiet({ enabledSchedules: 3 }), policy).exit).toBe(false)
   })
 })
 
@@ -228,5 +249,97 @@ describe('what a refused server is allowed to tell us', () => {
   it('treats no identity at all as no count', async () => {
     const { sessionsFrom } = await import('../src/main/server/server-launcher')
     expect(sessionsFrom(null)).toBeNull()
+  })
+})
+
+describe('what the promise in Settings does not cover', () => {
+  it('never exits while bound wide, because nothing would bring it back', () => {
+    // A phone is the only client, and "my phone could not reach my Mac this
+    // morning" is worse than a leftover process. Said out loud in Settings
+    // rather than left as a silent exception to the sentence there.
+    const wide = quiet({ servesOthers: true })
+    expect(whatHoldsItOpen(wide, policy)).toBe(
+      'this server is bound to be reached from the network'
+    )
+    expect(decide(wide, policy).exit).toBe(false)
+  })
+
+  it('reads that per snapshot, so rebinding mid-life is not missed', () => {
+    // `checkAndRebind` moves this socket between loopback and 0.0.0.0 while the
+    // process runs. A watch that captured the boot host would arm itself on a
+    // server that has since become a phone's only way in -- and, the other way
+    // round, never release one that is now local-only.
+    vi.useFakeTimers()
+    try {
+      let snapshot = quiet({ servesOthers: true })
+      let exits = 0
+      const watch = new IdleWatch(
+        () => snapshot,
+        policy,
+        () => exits++,
+        1
+      )
+
+      watch.tick()
+      vi.advanceTimersByTime(policy.windowMs * 2)
+      expect(watch.tick().exit).toBe(false)
+      expect(exits).toBe(0)
+
+      // Network Access turned off; the socket is rebound to loopback.
+      snapshot = quiet({ servesOthers: false })
+      watch.tick()
+      vi.advanceTimersByTime(policy.windowMs)
+      expect(watch.tick()).toEqual({ exit: true })
+      expect(exits).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('an agent running outside Vorn', () => {
+  it('holds the server open through the hook endpoint alone', () => {
+    // Hooks are installed into the user's agent settings globally, so a `claude`
+    // run the user started in their own terminal has no session record, no
+    // headless entry and no socket here. `shutdown()` uninstalls those hooks, so
+    // exiting under it breaks that run's permission routing for the rest of it.
+    const outside = quiet({ msSinceHookActivity: 1_000 })
+    expect(decide(outside, policy)).toMatchObject({ exit: false })
+  })
+
+  it('stops holding it once the hooks go quiet too', () => {
+    expect(decide(quiet(), policy)).toEqual({ exit: true })
+  })
+})
+
+describe('a desktop flag that outlived its desktop', () => {
+  it('releases after one window, not two', () => {
+    // The flag has no heartbeat behind it, so a slept laptop leaves it true for
+    // ever. The escape is the client clock -- and the countdown must not be
+    // restarted by this veto, or crossing the window would start a second one.
+    vi.useFakeTimers()
+    try {
+      let ms = 0
+      const snapshot = (): IdleSnapshot =>
+        quiet({ bridgeAttached: true, msSinceClientActivity: ms, msSinceHookActivity: ms })
+      let exits = 0
+      const watch = new IdleWatch(snapshot, policy, () => exits++, 1)
+
+      watch.tick()
+      ms = policy.windowMs - 1
+      vi.advanceTimersByTime(ms)
+      expect(watch.tick()).toMatchObject({ exit: false, because: 'a desktop is attached' })
+      expect(exits).toBe(0)
+
+      // One millisecond later the veto lapses -- and the countdown it never
+      // restarted has been running the whole time, so the server goes now
+      // rather than at the end of a second window.
+      ms = policy.windowMs
+      vi.advanceTimersByTime(1)
+      expect(watch.tick()).toEqual({ exit: true })
+      expect(exits).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/tests/idle.test.ts
+++ b/tests/idle.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IdleWatch,
+  shouldExitWhenIdle,
+  whatHoldsItOpen,
+  DEFAULT_IDLE_WINDOW_MS,
+  type IdleSnapshot,
+  type IdlePolicy
+} from '../packages/server/src/idle'
+
+/**
+ * Deciding whether a server with nobody using it should stop.
+ *
+ * The two wrong answers cost differently, and these tests are written around
+ * that. Exiting while something is live runs `killAll()` on terminals and
+ * headless agents, so a wrong yes destroys work. Never exiting only leaves a
+ * leftover server in the way. So the bar for "yes" is high and every one of
+ * these checks that a live thing vetoes.
+ */
+
+const policy: IdlePolicy = { windowMs: DEFAULT_IDLE_WINDOW_MS, schedulesHoldOpen: true }
+
+const quiet = (over: Partial<IdleSnapshot> = {}): IdleSnapshot => ({
+  sessions: 0,
+  headless: 0,
+  msSinceClientActivity: DEFAULT_IDLE_WINDOW_MS + 1,
+  bridgeAttached: false,
+  pendingPermissions: 0,
+  pendingPairings: 0,
+  connectorLeases: 0,
+  enabledSchedules: 0,
+  ...over
+})
+
+describe('what keeps a server alive', () => {
+  it('exits when everything really is empty', () => {
+    expect(shouldExitWhenIdle(quiet(), policy)).toEqual({ exit: true })
+  })
+
+  it.each([
+    ['a terminal session', { sessions: 1 }],
+    ['a running headless agent', { headless: 1 }],
+    ['an attached desktop', { bridgeAttached: true }],
+    ['an agent waiting on a permission', { pendingPermissions: 1 }],
+    ['a pairing in progress', { pendingPairings: 1 }],
+    ['outstanding connector work', { connectorLeases: 1 }],
+    ['an enabled schedule', { enabledSchedules: 1 }]
+  ])('stays up for %s', (_label, over) => {
+    expect(shouldExitWhenIdle(quiet(over), policy).exit).toBe(false)
+  })
+
+  it('says what is holding it, so a log line can explain itself', () => {
+    const verdict = shouldExitWhenIdle(quiet({ sessions: 2 }), policy)
+    expect(verdict).toMatchObject({ exit: false, because: '2 session(s)' })
+  })
+})
+
+describe('the three ways this could be wrongly true', () => {
+  it('counts a session whose status is idle', () => {
+    // `pty-manager` marks a session idle five seconds after its agent stops
+    // typing. That is a live terminal with a shell in it. The snapshot carries a
+    // count precisely so no caller can be tempted to filter by status the way
+    // `getActiveSessionsForWorktree` does for a different question.
+    expect(whatHoldsItOpen(quiet({ sessions: 1 }), policy)).toBe('1 session(s)')
+  })
+
+  it('does not read a gap between MCP calls as idleness', () => {
+    // MCP opens a fresh socket per RPC call, so a connected *count* oscillates
+    // 0↔1 while an agent is working. A client that acted a second ago is not an
+    // absent client, however many sockets happen to be open this instant.
+    const between = quiet({ msSinceClientActivity: 1_000 })
+    expect(shouldExitWhenIdle(between, policy)).toMatchObject({ exit: false })
+  })
+
+  it('still exits when a socket lingers but nothing has happened on it', () => {
+    // The opposite failure, and the reason this is a duration and not a
+    // presence test: there is no heartbeat, so a slept laptop or a dropped NAT
+    // flow leaves an entry in the client map for ever. An earlier version asked
+    // whether anybody was connected and returned "yes" here — which made this
+    // test pass against a snapshot the real registry could never produce.
+    expect(shouldExitWhenIdle(quiet({ msSinceClientActivity: 60 * 60_000 }), policy).exit).toBe(
+      true
+    )
+  })
+})
+
+describe('the window itself', () => {
+  it('waits rather than exiting the moment the last thing goes', () => {
+    const justQuiet = quiet({ msSinceClientActivity: 5_000 })
+    expect(shouldExitWhenIdle(justQuiet, policy)).toMatchObject({
+      exit: false,
+      because: 'quiet for only 5s'
+    })
+  })
+
+  it('exits exactly at the window, not a tick before', () => {
+    expect(
+      shouldExitWhenIdle(quiet({ msSinceClientActivity: policy.windowMs - 1 }), policy).exit
+    ).toBe(false)
+    expect(shouldExitWhenIdle(quiet({ msSinceClientActivity: policy.windowMs }), policy).exit).toBe(
+      true
+    )
+  })
+
+  it('is quiet only by the clock, never by who is connected', () => {
+    expect(shouldExitWhenIdle(quiet({ msSinceClientActivity: 0 }), policy)).toMatchObject({
+      exit: false,
+      because: 'quiet for only 0s'
+    })
+  })
+})
+
+describe('the schedule carve-out', () => {
+  it('can be turned off, and then a schedule stops vetoing', () => {
+    // The count fed in is only the schedules this server can service alone —
+    // connector polls. A renderer-executed trigger is not in it, because
+    // staying awake for one would keep a promise by dropping the run.
+    const off: IdlePolicy = { ...policy, schedulesHoldOpen: false }
+    expect(shouldExitWhenIdle(quiet({ enabledSchedules: 3 }), off).exit).toBe(true)
+    expect(shouldExitWhenIdle(quiet({ enabledSchedules: 3 }), policy).exit).toBe(false)
+  })
+})
+
+describe('the watch that acts on the decision', () => {
+  const busy = (): IdleSnapshot => quiet({ sessions: 1 })
+
+  it('does not exit while something is running, however long it waits', () => {
+    let exits = 0
+    const watch = new IdleWatch(busy, policy, () => exits++, 1)
+    for (let i = 0; i < 5; i++) watch.tick()
+    expect(exits).toBe(0)
+  })
+
+  it('starts the clock when the last thing lets go, not when a client last spoke', () => {
+    // The bug this pins: the window used to be measured purely from client
+    // activity. Close the app at 09:00, leave an agent running until 12:00, and
+    // the moment it finished the elapsed time was already three hours — so the
+    // very next tick exited, with none of the grace the setting implies.
+    let snapshot: IdleSnapshot = quiet({ sessions: 1, msSinceClientActivity: 3 * 60 * 60_000 })
+    let exits = 0
+    const watch = new IdleWatch(
+      () => snapshot,
+      policy,
+      () => exits++,
+      1
+    )
+
+    expect(watch.tick()).toMatchObject({ exit: false, because: '1 session(s)' })
+
+    // The session ends. A client has not spoken for three hours, but the work
+    // only just stopped, so the wait starts now.
+    snapshot = quiet({ sessions: 0, msSinceClientActivity: 3 * 60 * 60_000 })
+    expect(watch.tick()).toMatchObject({ exit: false })
+    expect(exits).toBe(0)
+  })
+
+  it('restarts the clock if something starts again mid-wait', () => {
+    let snapshot = quiet({ msSinceClientActivity: 0 })
+    let exits = 0
+    const short: IdlePolicy = { windowMs: 50, schedulesHoldOpen: true }
+    const watch = new IdleWatch(
+      () => snapshot,
+      short,
+      () => exits++,
+      1
+    )
+
+    watch.tick() // quiet, clock starts
+    snapshot = quiet({ sessions: 1, msSinceClientActivity: 0 })
+    watch.tick() // busy again, clock cleared
+    snapshot = quiet({ msSinceClientActivity: 0 })
+    expect(watch.tick()).toMatchObject({ exit: false }) // waiting afresh
+    expect(exits).toBe(0)
+  })
+
+  it('exits once both clocks have run out', async () => {
+    let exits = 0
+    const short: IdlePolicy = { windowMs: 30, schedulesHoldOpen: true }
+    const watch = new IdleWatch(
+      () => quiet({ msSinceClientActivity: 10_000 }),
+      short,
+      () => exits++,
+      1
+    )
+
+    watch.tick()
+    await new Promise((r) => setTimeout(r, 60))
+    watch.tick()
+
+    expect(exits).toBe(1)
+  })
+
+  it('start is idempotent, matching the scheduler it borrows the shape from', () => {
+    const watch = new IdleWatch(busy, policy, () => {}, 10_000)
+    watch.start()
+    watch.start()
+    watch.stop()
+    expect(() => watch.stop()).not.toThrow()
+  })
+})
+
+describe('what a refused server is allowed to tell us', () => {
+  it.each([
+    ['a plain count', 3, 3],
+    ['zero', 0, 0],
+    ['a negative', -1, null],
+    ['a fraction', 1.5, null],
+    ['nonsense', Number.NaN, null],
+    ['absurdly large', 999_999, null],
+    ['a string', '5', null],
+    ['nothing at all', undefined, null]
+  ])('coerces %s', async (_label, sessions, expected) => {
+    // The number rides the pre-auth identity frame from a server this app has
+    // just decided it cannot use, and it ends up in Vorn's own warning. So it is
+    // coerced rather than trusted: anything odd becomes null and the window says
+    // "Sessions" instead of a figure.
+    const { sessionsFrom } = await import('../src/main/server/server-launcher')
+    const identity = {
+      dataDir: '/x',
+      appVersion: '1',
+      buildChannel: 'packaged' as const,
+      pid: 1,
+      ...(sessions === undefined ? {} : { sessions })
+    }
+    expect(sessionsFrom(identity as never)).toBe(expected)
+  })
+
+  it('treats no identity at all as no count', async () => {
+    const { sessionsFrom } = await import('../src/main/server/server-launcher')
+    expect(sessionsFrom(null)).toBeNull()
+  })
+})

--- a/tests/scheduler-connector-poll.test.ts
+++ b/tests/scheduler-connector-poll.test.ts
@@ -556,3 +556,53 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
     expect(dbRecordConnectorPollPageMock).not.toHaveBeenCalled()
   })
 })
+
+describe('the count that decides whether this server may leave', () => {
+  // `serverSideScheduleCount` is the only schedule kind that vetoes an idle
+  // shutdown, because a connector poll is the only one this server performs
+  // itself. A recurring or one-off trigger is executed by a renderer, so waiting
+  // for one would keep a promise by dropping the run.
+  const recurring = (id: string): WorkflowDefinition => {
+    const wf = makePollWorkflow(id)
+    wf.nodes[0].config = {
+      triggerType: 'recurring',
+      cron: '*/5 * * * *'
+    } as unknown as ConnectorPollTriggerConfig
+    return wf
+  }
+
+  beforeEach(() => {
+    scheduler.stopAll()
+  })
+
+  it('counts an armed connector poll and not a recurring trigger', () => {
+    scheduler.syncSchedules([makePollWorkflow('poll-a'), recurring('cron-a')])
+    expect(scheduler.serverSideScheduleCount()).toBe(1)
+  })
+
+  it('follows a trigger that changes kind in either direction', () => {
+    // Both sync loops keep an existing cron job when the new kind is still
+    // cron-eligible, and registration is skipped for an id that already has one.
+    // So membership taken at creation time never moved again: flipping to
+    // `connectorPoll` left the server free to exit and silently stop polling,
+    // and flipping away from it left the server pinned open for ever.
+    scheduler.syncSchedules([recurring('wf-x')])
+    expect(scheduler.serverSideScheduleCount()).toBe(0)
+
+    scheduler.syncSchedules([makePollWorkflow('wf-x')])
+    expect(scheduler.serverSideScheduleCount()).toBe(1)
+
+    scheduler.syncSchedules([recurring('wf-x')])
+    expect(scheduler.serverSideScheduleCount()).toBe(0)
+  })
+
+  it('drops the count when the workflow is disabled', () => {
+    scheduler.syncSchedules([makePollWorkflow('wf-y')])
+    expect(scheduler.serverSideScheduleCount()).toBe(1)
+
+    const disabled = makePollWorkflow('wf-y')
+    disabled.enabled = false
+    scheduler.syncSchedules([disabled])
+    expect(scheduler.serverSideScheduleCount()).toBe(0)
+  })
+})

--- a/tests/ws-handler.test.ts
+++ b/tests/ws-handler.test.ts
@@ -10,7 +10,7 @@ const CLOSE_UNAUTHENTICATED = 4001
 const CLOSE_CREDENTIAL_REJECTED = 4002
 
 vi.mock('../packages/server/src/broadcast', () => ({
-  clientRegistry: { add: vi.fn(), remove: vi.fn(), setTopics: vi.fn() }
+  clientRegistry: { add: vi.fn(), remove: vi.fn(), setTopics: vi.fn(), touch: vi.fn() }
 }))
 vi.mock('../packages/server/src/logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }

--- a/tests/ws-handler.test.ts
+++ b/tests/ws-handler.test.ts
@@ -657,6 +657,18 @@ describe('what counts as somebody being out there', () => {
     expect(clientRegistry.touch).toHaveBeenCalled()
   })
 
+  it('does not count a frame from a socket that has not proved itself', () => {
+    // Anything on this machine can open a socket to loopback. If an
+    // unauthenticated frame counted, arbitrary local traffic could pin a server
+    // nobody is using without ever proving it is a client -- the same hole the
+    // hook endpoint closes by advancing its clock only past authentication.
+    const ws = createMockWs()
+    ;(clientRegistry.touch as ReturnType<typeof vi.fn>).mockClear()
+    handleConnection(ws as never, { socket: { remoteAddress: '127.0.0.1' } } as never)
+    sendMessage(ws, { jsonrpc: '2.0', id: 1, method: 'config:load' })
+    expect(clientRegistry.touch).not.toHaveBeenCalled()
+  })
+
   it('does not count the frame every connection opens with', () => {
     // `ServerBridge` sends `bridge:identify` from its own `open` handler, so it
     // arrives on every socket -- including the one another Vorn opens purely to

--- a/tests/ws-handler.test.ts
+++ b/tests/ws-handler.test.ts
@@ -647,3 +647,27 @@ describe('narrowing what a socket receives', () => {
     expect(clientRegistry.setTopics).not.toHaveBeenCalled()
   })
 })
+
+describe('what counts as somebody being out there', () => {
+  it('counts an ordinary call', () => {
+    const ws = createMockWs()
+    connectAuthed(ws)
+    ;(clientRegistry.touch as ReturnType<typeof vi.fn>).mockClear()
+    sendMessage(ws, { jsonrpc: '2.0', id: 1, method: 'config:load' })
+    expect(clientRegistry.touch).toHaveBeenCalled()
+  })
+
+  it('does not count the frame every connection opens with', () => {
+    // `ServerBridge` sends `bridge:identify` from its own `open` handler, so it
+    // arrives on every socket -- including the one another Vorn opens purely to
+    // ask this server whether it may adopt it, and the one behind
+    // `probeSessions`. Counting it would let a user blocked by a leftover server
+    // reset that server's idle clock on every launch attempt, so the leftover
+    // never leaves and the launches never stop being blocked.
+    const ws = createMockWs()
+    connectAuthed(ws)
+    ;(clientRegistry.touch as ReturnType<typeof vi.fn>).mockClear()
+    sendMessage(ws, { jsonrpc: '2.0', id: 1, method: 'bridge:identify' })
+    expect(clientRegistry.touch).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
#494 let the server outlive the app. Nothing made it stop.

The setting that shipped with it says, in Settings → General: *"A background
server stays running until every session ends."* It did not — it ran until
something killed it. And because #494 also made a server this app cannot use
**refused** rather than replaced, a leftover one could stop Vorn opening at all.
Correct, since two writers on one SQLite file erase each other's sessions, but a
leftover was permanent. This bounds it, and makes the sentence true.

## What it does

The decision lives in `packages/server/src/idle.ts` as a pure module, apart from
the timer that acts on it — the same split `server-relaunch.ts` argues for about
its own: the wiring cannot be unit tested, the decision can, and the decision is
where the ways to be wrong are.

Holding it open: a live PTY, a running headless agent, an attached desktop that
is still talking, an agent waiting on a permission, a pairing mid-flow,
outstanding connector work, an armed connector poll, or a socket bound wide.
Once none of those apply, a 30-minute quiet window, then the process leaves.

## The traps this had to avoid

**Session records outlive their PTYs.** A shell that exits on its own keeps its
record so the card can show an exit code. Counting records pinned the server for
ever — "quit Vorn, agent finishes, tab left open" is exactly the case this
exists for. It counts live PTYs.

**There is no websocket heartbeat.** Sockets are removed on close or error only,
so presence is not a usable signal: one half-open connection from a slept laptop
would pin any count at one for ever. Every client test is a duration. That same
duration is the only escape for the attached-desktop flag, which any
authenticated socket may set.

**MCP opens a fresh socket per RPC call**, so a connected *count* oscillates
between zero and one while an agent is working. Sampling it at the wrong instant
reads a busy server as an empty one.

**The window starts when the last thing let go**, not when a client last spoke.
An agent that worked for three hours after the app closed would otherwise get
none of the grace the setting implies.

**Connecting is not activity.** Another Vorn asking whether it may adopt this
server sends a frame on open, so counting that would let a user blocked by a
leftover keep it alive one launch attempt at a time — the exact loop this ends.

**An agent run outside Vorn is otherwise invisible.** Hooks are installed
globally, so such a run has no session, no headless entry and no socket here —
and shutting down uninstalls those hooks, breaking its permission routing
mid-run. The hook endpoint is a clock.

## Where the promise does not hold, and now says so

Two ordinary settings override it, both on purpose:

- **Network Access on.** The socket binds `0.0.0.0` to serve a phone. Nothing
  would restart it, and "my phone could not reach my Mac this morning" is worse
  than a process that outstays its welcome. Read per tick, not at boot —
  `checkAndRebind` moves this socket while the process runs.
- **A connector poll armed.** This server performs those itself. Recurring and
  one-off triggers are executed by a renderer, so waiting for one would keep a
  promise by dropping the run; they do not hold it.

Rather than leave either as a silent exception, the Settings row names whichever
applies. A conditional promise should say so where it is made.

Also off for a hand-run `vorn-server serve`: that process is the thing being run.

## Tested on a real process

The pure tests pin the decision. A process-level test pins the only thing they
cannot — that a server, told nothing is happening, actually exits. It builds the
bundle it needs rather than skipping when absent: `dist/` is gitignored and
`yarn test` builds nothing, so a skip-if-missing gate meant it never ran in CI,
green on the one claim the feature is named for.

Ten scenarios were also run by hand against the bundled server in throwaway
sandboxes — empty, live terminal, killed terminal, talking client, silent
client, bound wide, repeated adoption probes, a shell that exited with its tab
still open, and an agent posting only to the hook endpoint. All ten behaved.

## Also here

- The palette gains the File menu's *Stop Sessions and Server*, sharing one
  closure so the same words cannot mean two endings. Hidden on web.
- A refused server reports how many terminals it holds, on the one frame that
  arrives before a launcher decides — coerced to a number, never spliced as
  text, because it comes from the party this app has just decided not to trust.
  The count that already had a slot in the running-here notice is filled too.
- A shutdown that throws takes the hard exit; one that hangs is caught by a
  deadline armed when it starts. Those need different answers.
- Changing a workflow's trigger between recurring and connector poll now moves
  it in and out of the count that pins this server. Membership was taken when
  the cron job was created, and both sync loops keep an existing job.

## Not in this PR

Saying *when* an idle server will leave. The storyboard draws "will exit on its
own at 14:32"; the watch keeps that clock privately and nothing publishes it —
and in the scene drawn, an incumbent holding two sessions, there is no deadline
to state at all, because a live session vetoes rather than starting a countdown.
Filed as its own task, since it needs a decision before it needs code.
