### PR TITLE
chore(release): 0.7.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.3",
+  "version": "0.7.0-beta.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Two changes since beta.3. One of them is the reason to update.

**A hook payload can no longer end the session.** Vorn froze mid-session, and the
Network screen saying it could not read the device list was true and forty
seconds beside the point -- the server had died at 18:46:10 and nothing brought
it back, so `token:list` had nothing to talk to. The app went on running, with
live terminals and no server, until it was quit and reopened.

The throw was the boring half: `hook-server` cast a body posted by another
process straight to `HookEvent`, which declares `session_id` and `cwd` as
required, so `normalizePath(undefined)` threw. The fatal half was the error
handling. `handleEvent` answers and ends the response *before* it emits, so by
the time a listener throws there is nothing left to reply with -- and the catch
above replied anyway, with `res.writeHead(400)` on a finished response. That
throws `ERR_HTTP_HEADERS_SENT` from inside the request handler with nothing
above it to catch. **The process died of its own error handler rather than of the
original error.**

Now the boundary validates, a sent response is not written to twice, and a
listener throw is contained where it happens.

And a crash became a freeze because nothing restarted the server: `child.on('exit')`
logged the code and stopped, in both branches. `ServerBridge` had always
reconnected every two seconds and never given up, so that wall of ECONNREFUSED in
the log was the client half working perfectly against a server nobody was
replacing. The launcher relaunches now -- not after a deliberate stop, never in
host mode, with a growing delay and a cap, and the attempt budget refilled once a
server has run a minute.

**The socket can hand over a workflow.** `workflow:get` took an id and nothing
produced one, so a client that had not already been told about a workflow could
not reach it. `workflow:list` returns the definitions and `workflow:setEnabled`
switches a schedule in one call, where the desktop goes through a whole-config
save. Both are what the phone's workflows view is built on.

For anyone updating: restarting Vorn is what reinstalls the hook registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLLkda79pJdwLQb6TpsEhB