### PR TITLE
Give this machine's server a name it can own

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "node-cron": "^4.2.1",
     "node-pty": "1.2.0-beta.15",
     "pino": "^10.3.1",
+    "ws": "^8.21.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/server/src/draining.ts
+++ b/packages/server/src/draining.ts
@@ -25,6 +25,22 @@
  */
 
 let draining = false
+let stillHoldsEndpoint: (() => boolean) | null = null
+
+/**
+ * Teach this module how to check, rather than waiting to be told.
+ *
+ * Losing the endpoint happens *to* this process: another server that found it
+ * unreachable takes the name and has no way to say so. An earlier version noticed
+ * only inside the idle watch's snapshot, which meant up to a minute of creating
+ * sessions on a name that already pointed elsewhere -- and no noticing at all for
+ * `vorn-server serve`, where that watch is switched off entirely.
+ *
+ * One `lstat` at session creation, which is a rare, user-initiated moment.
+ */
+export function watchEndpoint(holds: () => boolean): void {
+  stillHoldsEndpoint = holds
+}
 
 /** Irreversible on purpose. Nothing gives an endpoint back once it is lost. */
 export function beginDraining(): void {
@@ -32,12 +48,18 @@ export function beginDraining(): void {
 }
 
 export function isDraining(): boolean {
+  if (draining) return true
+  // A server that never held an endpoint is not draining: it is running
+  // TCP-only, which is a downgrade rather than a loss, and refusing its sessions
+  // would leave the machine with nothing that works.
+  if (stillHoldsEndpoint && !stillHoldsEndpoint()) beginDraining()
   return draining
 }
 
 /** Test-only. Production has no path back. */
 export function resetDrainingForTests(): void {
   draining = false
+  stillHoldsEndpoint = null
 }
 
 /** The message a person sees when a session is refused. */

--- a/packages/server/src/draining.ts
+++ b/packages/server/src/draining.ts
@@ -1,0 +1,46 @@
+/**
+ * Whether this server has lost the endpoint and is winding down.
+ *
+ * The claim in `endpoint.ts` ends with a probe and a rename, two syscalls that
+ * POSIX gives no way to fuse — there is no rename-if-target-is-inode-X. So the
+ * window where two servers might each believe they hold the name cannot be
+ * closed. What can be closed is the harm, and this is where.
+ *
+ * The rule: **never create work on an endpoint this process no longer holds.**
+ *
+ * A new session started here would be reachable only through a name that now
+ * points somewhere else. The desktop would never see it, and the person who
+ * started it would watch a terminal that accepts keystrokes and never runs them
+ * — the exact failure the endpoint work exists to prevent, arrived at from the
+ * other direction.
+ *
+ * Draining is not shutting down. Sessions already running are still served,
+ * because the client holding them has a file descriptor rather than a name and
+ * is entirely unaffected. What stops is taking on anything new. The idle watch
+ * then ends the process when the last session goes, using the window it already
+ * has — there is no second timer here, and no `killAll`.
+ *
+ * A module-level flag rather than a field on either manager: two managers asking
+ * one question need one answer, and this one only ever moves in one direction.
+ */
+
+let draining = false
+
+/** Irreversible on purpose. Nothing gives an endpoint back once it is lost. */
+export function beginDraining(): void {
+  draining = true
+}
+
+export function isDraining(): boolean {
+  return draining
+}
+
+/** Test-only. Production has no path back. */
+export function resetDrainingForTests(): void {
+  draining = false
+}
+
+/** The message a person sees when a session is refused. */
+export const DRAINING_MESSAGE =
+  'This server no longer holds the local endpoint and is finishing its remaining ' +
+  'sessions. Reopen Vorn to start new ones.'

--- a/packages/server/src/endpoint.ts
+++ b/packages/server/src/endpoint.ts
@@ -115,6 +115,7 @@ export type Liveness = 'alive' | 'dead' | 'unknown'
  */
 export function probeEndpoint(socketPath: string, timeoutMs = PROBE_TIMEOUT_MS): Promise<Liveness> {
   return new Promise((resolve) => {
+    const socket = net.connect(socketPath)
     let settled = false
     const done = (answer: Liveness): void => {
       if (settled) return
@@ -123,7 +124,6 @@ export function probeEndpoint(socketPath: string, timeoutMs = PROBE_TIMEOUT_MS):
       resolve(answer)
     }
 
-    const socket = net.connect(socketPath)
     socket.setTimeout(timeoutMs, () => done('unknown'))
     socket.once('connect', () => done('alive'))
     // `on`, not `once`. Destroying a socket the moment it connects can draw a

--- a/packages/server/src/endpoint.ts
+++ b/packages/server/src/endpoint.ts
@@ -126,7 +126,12 @@ export function probeEndpoint(socketPath: string, timeoutMs = PROBE_TIMEOUT_MS):
     const socket = net.connect(socketPath)
     socket.setTimeout(timeoutMs, () => done('unknown'))
     socket.once('connect', () => done('alive'))
-    socket.once('error', (err: NodeJS.ErrnoException) => {
+    // `on`, not `once`. Destroying a socket the moment it connects can draw a
+    // second error afterwards -- an ECONNRESET as the peer's reply lands on a
+    // half-closed pipe -- and a handler that unhooked itself leaves that one
+    // unhandled, which takes down the process. A probe whose whole job is to keep
+    // a server safe must not be able to kill the one asking.
+    socket.on('error', (err: NodeJS.ErrnoException) => {
       done(err.code === 'ECONNREFUSED' || err.code === 'ENOENT' ? 'dead' : 'unknown')
     })
   })

--- a/packages/server/src/endpoint.ts
+++ b/packages/server/src/endpoint.ts
@@ -183,25 +183,41 @@ export async function claimEndpoint(
   const mine = identify(scratch)
   if (!mine) return { held: false, because: 'the scratch name is not a bound socket' }
 
-  // The test-and-set. `link` first and never a bare `rename`, because rename
-  // replaces whatever it finds and would let a starting server destroy a healthy
-  // one without ever asking.
-  try {
-    fs.linkSync(scratch, canonical)
-    // Ours now. Remove the scratch name, which is a name this process created --
-    // not the forbidden unlink-then-link, which is about the canonical entry.
-    // After this, libuv's unlink at close has nothing to find on either path.
+  /** Ours. Remove the scratch name, which is a name this process created -- not
+   *  the forbidden unlink-then-link, which is about the canonical entry. After
+   *  this, libuv's unlink at close has nothing to find on either path. */
+  const took = (): ClaimOutcome => {
     fs.rmSync(scratch, { force: true })
     return { held: true }
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code
-    if (code !== 'EEXIST') return { held: false, because: `link failed: ${code}` }
   }
 
   for (let attempt = 0; attempt < RECHECK_LIMIT; attempt++) {
+    // The test-and-set, and the whole loop exists to come back to it. `link`
+    // first and never a bare `rename`, because rename replaces whatever it finds
+    // and would let a starting server destroy a healthy one without ever asking.
+    try {
+      fs.linkSync(scratch, canonical)
+      return took()
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      if (code !== 'EEXIST') return { held: false, because: `link failed: ${code}` }
+    }
+
+    if (!fs.existsSync(canonical)) {
+      // Taken a moment ago and gone now. A server that bound the canonical path
+      // directly -- which is what this codebase did before the scratch name --
+      // unlinks it on close, so the name really can free itself between the
+      // EEXIST and this look. It is free, so go and take it rather than standing
+      // down from an endpoint nobody holds.
+      continue
+    }
+
     const before = identify(canonical)
-    if (!before)
+    if (!before) {
+      // It exists and is not a socket. Not something this process put there, not
+      // something it can identify, and so not something it may replace.
       return { held: false, because: 'the endpoint is not a socket this process can read' }
+    }
 
     const liveness = await probe(canonical)
     if (liveness !== 'dead') return { held: false, because: `the incumbent is ${liveness}` }

--- a/packages/server/src/endpoint.ts
+++ b/packages/server/src/endpoint.ts
@@ -1,0 +1,236 @@
+import fs from 'fs'
+import net from 'net'
+import path from 'path'
+import crypto from 'crypto'
+import log from './logger'
+import { ENDPOINT_FILENAME } from '@vornrun/shared/protocol'
+
+/**
+ * Owning the name a machine's server answers on.
+ *
+ * A port has no name to own. Two servers reaching for one are settled by
+ * whichever bound first, and nothing about that is visible to a third party
+ * deciding whether to start a third. A filesystem entry can be owned, and the
+ * kernel offers exactly the primitive that makes it a test-and-set:
+ *
+ * - `link()` fails with `EEXIST` rather than replacing, so it asks a question.
+ * - `rename()` within a filesystem is atomic and leaves no moment where the
+ *   destination name is absent, so it answers one.
+ *
+ * A bound `AF_UNIX` listener is identified by its inode, not by the path it was
+ * bound to, so any directory entry resolving to that inode reaches it. That is
+ * what makes the sequence below possible: bind a private name, then move it into
+ * place only after proving the place is free.
+ *
+ * It also retires the rule that would otherwise be the easiest to break. libuv
+ * unlinks the path it bound when the handle closes, with no ownership check —
+ * so a server binding the canonical name directly deletes a live replacement's
+ * socket on its way out. Binding a scratch name means the path libuv remembers
+ * is one that no longer exists by then, and `close()` becomes structurally
+ * incapable of removing the endpoint. Verified on darwin/APFS before this was
+ * written: link on a socket inode, EEXIST on a taken name, connect through the
+ * link, and close leaving the canonical entry intact on both paths.
+ *
+ * Two invariants hold the whole thing up:
+ *
+ * > Only a process publishing itself onto the canonical endpoint may mutate that
+ * > entry, and only by replacing an entry it has itself just proven dead.
+ * >
+ * > No actor removes a name it did not create.
+ *
+ * There is deliberately no sweeper. Deciding whether somebody else's leftover is
+ * safe to delete is the question this design exists to retire, and a sweeper
+ * reintroduces it with worse information.
+ */
+
+/** Long enough for a busy accept queue, short enough not to stall a launch. */
+const PROBE_TIMEOUT_MS = 1_000
+
+/**
+ * How many times to re-look when the entry changes hands mid-check.
+ *
+ * Bounded rather than infinite: something is churning that name, and the right
+ * answer to a contended endpoint is to stand down, not to fight for it.
+ */
+const RECHECK_LIMIT = 3
+
+/**
+ * `sun_path` is 104 bytes on darwin and 108 on linux, including the terminator.
+ * Held well under the smaller of the two — the cost of being wrong is a bind
+ * that fails at startup for a reason nothing explains.
+ */
+const MAX_SOCKET_PATH = 96
+
+export function endpointPath(dataDir: string): string {
+  return path.join(dataDir, ENDPOINT_FILENAME)
+}
+
+/**
+ * Whether this machine can host the endpoint at all.
+ *
+ * Every no here is a downgrade to TCP-only, never a failed startup: the socket
+ * is additive, and a server nobody can reach is worse than a race nobody has
+ * lost yet.
+ */
+export function canHostEndpoint(dataDir: string): { ok: boolean; why?: string } {
+  // Node maps `listen({ path })` to a named pipe on win32, and a pipe has no
+  // filesystem entry to test-and-set. Windows keeps the port file.
+  if (process.platform === 'win32') return { ok: false, why: 'not a POSIX filesystem' }
+
+  const socket = endpointPath(dataDir)
+  if (Buffer.byteLength(socket) > MAX_SOCKET_PATH) {
+    return { ok: false, why: `path is ${Buffer.byteLength(socket)} bytes` }
+  }
+
+  // The directory is the access control that matters. On darwin a socket's own
+  // mode bits are not consulted on connect, and `database.ts` sets 0700 only
+  // when it creates the directory — an install predating that, or a umask
+  // accident, leaves it writable by others, and anyone who can write the
+  // directory can rename over the endpoint.
+  try {
+    const mode = fs.statSync(dataDir).mode & 0o777
+    if (mode & 0o022) return { ok: false, why: `directory is mode ${mode.toString(8)}` }
+  } catch (err) {
+    return { ok: false, why: `cannot stat the data directory: ${(err as Error).message}` }
+  }
+
+  return { ok: true }
+}
+
+export type Liveness = 'alive' | 'dead' | 'unknown'
+
+/**
+ * Ask whether anything is serving this name.
+ *
+ * Three answers, never two. Only a completed connection proves it is served, and
+ * only `ECONNREFUSED` or `ENOENT` prove it is not — a socket file whose server
+ * has gone refuses, and a name with nothing behind it is absent. Everything else
+ * proves nothing: `EACCES` and `EPERM` say we may not ask, `EAGAIN` says the
+ * accept queue is full, which only a running server can manage, and a timeout
+ * says the server is busy or wedged.
+ *
+ * The whitelist is the two that mean death, and everything unlisted defaults to
+ * alive. Enumerating failures the other way round is how a starting server
+ * deletes an endpoint still holding every terminal on the machine.
+ */
+export function probeEndpoint(socketPath: string, timeoutMs = PROBE_TIMEOUT_MS): Promise<Liveness> {
+  return new Promise((resolve) => {
+    let settled = false
+    const done = (answer: Liveness): void => {
+      if (settled) return
+      settled = true
+      socket.destroy()
+      resolve(answer)
+    }
+
+    const socket = net.connect(socketPath)
+    socket.setTimeout(timeoutMs, () => done('unknown'))
+    socket.once('connect', () => done('alive'))
+    socket.once('error', (err: NodeJS.ErrnoException) => {
+      done(err.code === 'ECONNREFUSED' || err.code === 'ENOENT' ? 'dead' : 'unknown')
+    })
+  })
+}
+
+/** A private name to bind, with enough randomness that nothing collides with it. */
+export function scratchPathFor(canonical: string): string {
+  return `${canonical}.${crypto.randomBytes(6).toString('hex')}`
+}
+
+interface Entry {
+  dev: number
+  ino: number
+}
+
+function identify(target: string): Entry | null {
+  try {
+    const stat = fs.lstatSync(target)
+    // Not a socket, or a symlink pointing anywhere at all: this is not something
+    // this process put there and not something it can identify, so it is not
+    // something it may replace.
+    if (!stat.isSocket()) return null
+    return { dev: stat.dev, ino: stat.ino }
+  } catch {
+    return null
+  }
+}
+
+const same = (a: Entry | null, b: Entry | null): boolean =>
+  a !== null && b !== null && a.dev === b.dev && a.ino === b.ino
+
+export type ClaimOutcome =
+  | { held: true }
+  /** `because` is for the log, and for the launcher deciding what to do next. */
+  | { held: false; because: string }
+
+/**
+ * Move a bound scratch name onto the canonical one, if the canonical one is free
+ * or its holder is provably gone.
+ *
+ * `probe` is injected so the decision can be tested against each of the three
+ * answers without a real server on the other end.
+ */
+export async function claimEndpoint(
+  scratch: string,
+  canonical: string,
+  probe: (target: string) => Promise<Liveness> = probeEndpoint
+): Promise<ClaimOutcome> {
+  const mine = identify(scratch)
+  if (!mine) return { held: false, because: 'the scratch name is not a bound socket' }
+
+  // The test-and-set. `link` first and never a bare `rename`, because rename
+  // replaces whatever it finds and would let a starting server destroy a healthy
+  // one without ever asking.
+  try {
+    fs.linkSync(scratch, canonical)
+    // Ours now. Remove the scratch name, which is a name this process created --
+    // not the forbidden unlink-then-link, which is about the canonical entry.
+    // After this, libuv's unlink at close has nothing to find on either path.
+    fs.rmSync(scratch, { force: true })
+    return { held: true }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'EEXIST') return { held: false, because: `link failed: ${code}` }
+  }
+
+  for (let attempt = 0; attempt < RECHECK_LIMIT; attempt++) {
+    const before = identify(canonical)
+    if (!before)
+      return { held: false, because: 'the endpoint is not a socket this process can read' }
+
+    const liveness = await probe(canonical)
+    if (liveness !== 'dead') return { held: false, because: `the incumbent is ${liveness}` }
+
+    // Between the probe and the rename, the entry may have become somebody
+    // else's -- a third server that also found it dead and got there first. The
+    // inode is the identity; a path comparison would not notice, and
+    // `birthtimeMs` cannot be trusted to (Node's own docs say it sometimes holds
+    // the ctime, filesystems without a birth time report the epoch, and its
+    // granularity is often coarser than the events being separated).
+    if (!same(before, identify(canonical))) continue
+
+    try {
+      fs.renameSync(scratch, canonical)
+    } catch (err) {
+      return { held: false, because: `rename failed: ${(err as NodeJS.ErrnoException).code}` }
+    }
+
+    // The probe and the rename are two syscalls and POSIX offers no
+    // rename-if-target-is-inode-X, so this is the window that cannot be closed.
+    // What can be closed is the harm: a process that finds it lost the name must
+    // never go on to serve as though it holds it.
+    if (same(mine, identify(canonical))) return { held: true }
+    return { held: false, because: 'lost the endpoint between the rename and the check' }
+  }
+
+  return { held: false, because: 'the endpoint changed hands while it was being checked' }
+}
+
+/** Remove a scratch name this process created. Never the canonical one. */
+export function abandonScratch(scratch: string): void {
+  try {
+    fs.rmSync(scratch, { force: true })
+  } catch (err) {
+    log.warn({ err, scratch }, '[endpoint] could not remove our own scratch name')
+  }
+}

--- a/packages/server/src/endpoint.ts
+++ b/packages/server/src/endpoint.ts
@@ -65,6 +65,11 @@ export function endpointPath(dataDir: string): string {
   return path.join(dataDir, ENDPOINT_FILENAME)
 }
 
+/** A private name to bind, with enough randomness that nothing collides with it. */
+export function scratchPathFor(canonical: string): string {
+  return `${canonical}.${crypto.randomBytes(6).toString('hex')}`
+}
+
 /**
  * Whether this machine can host the endpoint at all.
  *
@@ -77,9 +82,14 @@ export function canHostEndpoint(dataDir: string): { ok: boolean; why?: string } 
   // filesystem entry to test-and-set. Windows keeps the port file.
   if (process.platform === 'win32') return { ok: false, why: 'not a POSIX filesystem' }
 
-  const socket = endpointPath(dataDir)
-  if (Buffer.byteLength(socket) > MAX_SOCKET_PATH) {
-    return { ok: false, why: `path is ${Buffer.byteLength(socket)} bytes` }
+  // Measured on a scratch name, not the canonical one, because the scratch name
+  // is what gets bound -- and it is thirteen bytes longer. Checking the shorter
+  // path would pass a directory whose socket then fails to bind at runtime, which
+  // is the exact failure this guard exists to turn into a clean downgrade.
+  // Generated rather than assumed, so the two cannot drift apart.
+  const bound = scratchPathFor(endpointPath(dataDir))
+  if (Buffer.byteLength(bound) > MAX_SOCKET_PATH) {
+    return { ok: false, why: `path is ${Buffer.byteLength(bound)} bytes` }
   }
 
   // The directory is the access control that matters. On darwin a socket's own
@@ -135,11 +145,6 @@ export function probeEndpoint(socketPath: string, timeoutMs = PROBE_TIMEOUT_MS):
       done(err.code === 'ECONNREFUSED' || err.code === 'ENOENT' ? 'dead' : 'unknown')
     })
   })
-}
-
-/** A private name to bind, with enough randomness that nothing collides with it. */
-export function scratchPathFor(canonical: string): string {
-  return `${canonical}.${crypto.randomBytes(6).toString('hex')}`
 }
 
 interface Entry {

--- a/packages/server/src/endpoint.ts
+++ b/packages/server/src/endpoint.ts
@@ -56,10 +56,15 @@ const RECHECK_LIMIT = 3
 
 /**
  * `sun_path` is 104 bytes on darwin and 108 on linux, including the terminator.
- * Held well under the smaller of the two — the cost of being wrong is a bind
- * that fails at startup for a reason nothing explains.
+ *
+ * Close to the smaller of the two rather than well under it, because what gets
+ * measured is now the scratch name that is actually bound rather than the shorter
+ * canonical one. The old margin was covering the thirteen bytes this check used
+ * to ignore, and once that was fixed the margin was pure cost -- it turned a
+ * macOS temp directory, which is where every process-level test runs, into a
+ * machine that silently hosts no endpoint.
  */
-const MAX_SOCKET_PATH = 96
+const MAX_SOCKET_PATH = 100
 
 export function endpointPath(dataDir: string): string {
   return path.join(dataDir, ENDPOINT_FILENAME)
@@ -92,16 +97,39 @@ export function canHostEndpoint(dataDir: string): { ok: boolean; why?: string } 
     return { ok: false, why: `path is ${Buffer.byteLength(bound)} bytes` }
   }
 
-  // The directory is the access control that matters. On darwin a socket's own
-  // mode bits are not consulted on connect, and `database.ts` sets 0700 only
-  // when it creates the directory — an install predating that, or a umask
-  // accident, leaves it writable by others, and anyone who can write the
-  // directory can rename over the endpoint.
+  // The directory is the access control, and it has to be private -- not merely
+  // unwritable by others.
+  //
+  // Writable was the obvious half: anyone who can write here can rename over the
+  // endpoint. Readable and traversable matters too, and it took a review to see
+  // it. On darwin a socket's own mode bits are not consulted on connect, so the
+  // 0600 this code sets on the socket protects nothing; a directory another user
+  // can traverse is a socket another user can connect to. And the greeting is
+  // sent before authentication -- deliberately, since that is what lets a desktop
+  // learn who is serving -- so a stranger who connects is handed this server's
+  // identity, `dataDir` included, which names the account.
+  //
+  // Loopback bounded that disclosure for TCP peers. A unix peer is judged local
+  // by the directory alone, so the directory is where the bound has to be.
+  // `database.ts` creates it 0700, so an ordinary install passes and only one
+  // that predates that, or a umask accident, is turned away -- to TCP-only,
+  // never to a failed start.
   try {
+    if (fs.statSync(dataDir).mode & 0o077) {
+      // Narrowed rather than refused, where this process is allowed to. The
+      // directory holds this server's credential, its database and its tokens,
+      // `database.ts` already means it to be 0700, and `mode` on mkdir applies
+      // only at creation -- so an install made before that, or under a loose
+      // umask, has been sitting wider than intended all along. Tightening it is
+      // the fix for that, not a workaround for this check. Never widened: this
+      // only ever removes bits.
+      fs.chmodSync(dataDir, 0o700)
+      log.info({ dataDir }, '[endpoint] tightened the data directory to 0700')
+    }
     const mode = fs.statSync(dataDir).mode & 0o777
-    if (mode & 0o022) return { ok: false, why: `directory is mode ${mode.toString(8)}` }
+    if (mode & 0o077) return { ok: false, why: `directory is mode ${mode.toString(8)}` }
   } catch (err) {
-    return { ok: false, why: `cannot stat the data directory: ${(err as Error).message}` }
+    return { ok: false, why: `cannot secure the data directory: ${(err as Error).message}` }
   }
 
   return { ok: true }

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -22,6 +22,7 @@ import { getLaunchEnv, shellEscape } from './process-utils'
 import { buildHeadlessSpawnArgs } from './agent-launch'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import log from './logger'
+import { isDraining, DRAINING_MESSAGE } from './draining'
 
 const MAX_OUTPUT_LINES = 1000
 const FORCE_KILL_DELAY_MS = 5000
@@ -54,6 +55,11 @@ class HeadlessManager extends EventEmitter {
   }
 
   createHeadless(payload: CreateTerminalPayload): HeadlessSession {
+    // Refused rather than created: a session started on an endpoint this process
+    // no longer holds is reachable through a name that now points elsewhere, so
+    // nobody would ever see it. Existing sessions are untouched -- their clients
+    // hold a descriptor, not a name.
+    if (isDraining()) throw new Error(DRAINING_MESSAGE)
     const id = crypto.randomUUID()
     let effectivePath = payload.projectPath
     let effectiveBranch: string | undefined

--- a/packages/server/src/idle.ts
+++ b/packages/server/src/idle.ts
@@ -72,6 +72,16 @@ export interface IdleSnapshot {
    * being -- a phone's only way in at any point after it started.
    */
   servesOthers: boolean
+
+  /**
+   * Whether this server has lost the endpoint and is winding down.
+   *
+   * Checked before every other hold, including the network one. A draining
+   * server bound to `0.0.0.0` would otherwise be pinned open for the life of the
+   * machine by a promise it can no longer keep -- nothing can reach it by name
+   * any more, so staying up to be reached is staying up for nobody.
+   */
+  draining: boolean
 }
 
 export interface IdlePolicy {
@@ -115,16 +125,25 @@ export type IdleVerdict =
  * lets it keep running.
  */
 export function whatHoldsItOpen(s: IdleSnapshot, policy: IdlePolicy): string | null {
-  // Not filtered by session status. `pty-manager` marks a session 'idle' five
-  // seconds after its agent stops typing; that is a live terminal with a shell
-  // in it, and `getActiveSessionsForWorktree` filters them out for a different
-  // question entirely (whether a worktree is safe to delete).
   // First, because it is the one hold that is about what this server is for
   // rather than what it is doing. Nothing restarts a server a phone reaches, and
   // "my phone could not reach my Mac this morning" is worse than a process that
   // outstays its welcome. Said out loud in Settings, since it makes the promise
   // there conditional.
-  if (s.servesOthers) return 'this server is bound to be reached from the network'
+  //
+  // Lapses while draining, and only this one does. A server that has lost the
+  // endpoint cannot be reached by name again, so staying up to be reached keeps
+  // a promise to nobody -- and this hold never expires on its own, which would
+  // turn a wind-down into a permanent state. Every hold below is about work in
+  // progress and still applies: draining refuses new sessions, it does not
+  // abandon the ones already running.
+  if (s.servesOthers && !s.draining) {
+    return 'this server is bound to be reached from the network'
+  }
+  // Not filtered by session status. `pty-manager` marks a session 'idle' five
+  // seconds after its agent stops typing; that is a live terminal with a shell
+  // in it, and `getActiveSessionsForWorktree` filters them out for a different
+  // question entirely (whether a worktree is safe to delete).
   if (s.sessions > 0) return `${s.sessions} session(s)`
   // Over-conservative on purpose: `headless-manager` keeps exited entries for
   // thirty seconds, so this can read non-zero just after one finishes. Waiting

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -23,10 +23,12 @@ import { IPC } from '@vornrun/shared/types'
 import { registerAllMethods, setServerPort } from './register-methods'
 import { configManager } from './config-manager'
 import { claimPublishedFiles, writePortFile, removePortFile } from './published-files'
+import { openLocalEndpoint, type LocalEndpoint } from './local-endpoint'
+import { beginDraining, isDraining } from './draining'
 import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
 import { getDataDir, dbCountActiveConnectorInboxLeases } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
-import { DEFAULT_SERVER_PORT } from '@vornrun/shared/protocol'
+import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
@@ -198,7 +200,7 @@ export async function startServer(
         // Decides whether the greeting carries this server's identity. Only a
         // desktop on this machine has any use for it, and only loopback can be
         // trusted not to be a stranger on the tailnet.
-        req.socket.remoteAddress
+        { transport: 'tcp', address: req.socket.remoteAddress }
       )
       scheduler.deliverPendingConnectorInbox()
     }
@@ -409,6 +411,29 @@ export async function startServer(
   // and its parent process, not a property of the server. The CLI has no parent
   // and prints something a person can read instead.
 
+  // The canonical local endpoint. A name that can be owned, unlike the port
+  // above -- the desktop probes and adopts through it, and holding it is what
+  // makes this server the one this machine answers with.
+  //
+  // Opened after the listen rather than before: a server that cannot claim the
+  // name still serves whatever is already attached to it, and losing the claim
+  // must never be the reason a startup fails.
+  const claimed = await openLocalEndpoint(dataDir, () => scheduler.deliverPendingConnectorInbox())
+
+  // Arriving second is not a failure, and it is not something to carry on
+  // through. This process would be a second server on one database, and
+  // `saveSessions` is a whole-table replace -- two of them erase each other's
+  // sessions, which is the hazard adoption exists to prevent and the reason a
+  // refused launch does not spawn a rival. So it stands down before publishing
+  // anything, on an exit code that says which of the three things happened, and
+  // the app that started it adopts the incumbent instead of relaunching this.
+  if (claimed.kind === 'lost') {
+    log.warn({ because: claimed.because }, '[server] this machine already has a server')
+    await app.close()
+    process.exit(EXIT_ENDPOINT_TAKEN)
+  }
+  const endpoint = claimed.kind === 'held' ? claimed.endpoint : null
+
   // Publish the port for MCP and anything else that reads this directory.
   writePortFile(dataDir, actualPort, ownsPublished)
 
@@ -455,6 +480,10 @@ export async function startServer(
     await stopAllMcpClients()
     configManager.close()
     removePortFile(dataDir, ownsPublished)
+    // Never removes the canonical entry: this listener bound a scratch name that
+    // no longer exists, so libuv's unlink at close has nothing to find. A dead
+    // socket file left behind is the next publisher's to replace in one rename.
+    await endpoint?.close()
     await app.close()
     process.exit(0)
   }
@@ -477,6 +506,23 @@ export async function startServer(
     })
   }
 
+  /**
+   * Whether this server is winding down, checking first whether it still holds
+   * the endpoint it claimed.
+   *
+   * One direction only: once lost, a name is not given back. A server that never
+   * held one is not draining -- it is running TCP-only, which is a downgrade
+   * rather than a loss, and refusing its sessions would leave the machine with
+   * nothing that works.
+   */
+  const noticeLostEndpoint = (held: LocalEndpoint | null): boolean => {
+    if (isDraining()) return true
+    if (!held || held.holds()) return false
+    log.warn('[endpoint] this server no longer holds the endpoint; finishing what it has')
+    beginDraining()
+    return true
+  }
+
   // The server outlives the app now, so something has to decide when it is done.
   // Nothing here waits for the event loop to drain: the scheduler's inbox
   // interval is not unref'd, so this process would sit empty for ever.
@@ -493,7 +539,12 @@ export async function startServer(
       pendingPairings: pendingRequests().length,
       connectorLeases: dbCountActiveConnectorInboxLeases(new Date().toISOString()),
       enabledSchedules: scheduler.serverSideScheduleCount(),
-      servesOthers: getCurrentHost() === '0.0.0.0'
+      servesOthers: getCurrentHost() === '0.0.0.0',
+      // Looked at rather than waited for. Losing the endpoint is something that
+      // happens *to* this process -- another server that found it unreachable is
+      // entitled to take the name and has no way to say so. One lstat per tick
+      // is the cheapest place to notice, and this timer already runs.
+      draining: noticeLostEndpoint(endpoint)
     }),
     { windowMs: resolveIdleWindowMs(), schedulesHoldOpen: true },
     () => stopFor('nothing left to do')

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,10 +22,11 @@ import { parseTopics, clientRegistry } from './broadcast'
 import { IPC } from '@vornrun/shared/types'
 import { registerAllMethods, setServerPort } from './register-methods'
 import { configManager } from './config-manager'
+import { claimPublishedFiles, writePortFile, removePortFile } from './published-files'
 import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
 import { getDataDir, dbCountActiveConnectorInboxLeases } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
-import { DEFAULT_SERVER_PORT, WS_PORT_FILENAME } from '@vornrun/shared/protocol'
+import { DEFAULT_SERVER_PORT } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
@@ -158,9 +159,20 @@ export async function startServer(
   const app = Fastify({ logger: false })
   await app.register(websocket)
 
+  // Who owns this data directory's published names, decided once and used by
+  // every publisher below.
+  //
+  // Taken here rather than beside the port-file write, which is where it used to
+  // live, because the credential is published before the listen and the port
+  // after it — two publishers asking the same question at two different moments
+  // is how they came to disagree. `~/.vorn` is shared by a packaged Vorn and a
+  // `yarn dev` server on purpose, so a fixed name in it needs an owner or the
+  // last writer silently wins.
+  const ownsPublished = claimPublishedFiles(dataDir)
+
   // Resolve this process's local credential and publish it for same-machine
   // tools, before any connection can be accepted.
-  initBootstrapSecret(dataDir)
+  initBootstrapSecret(dataDir, undefined, ownsPublished)
 
   app.get(
     '/ws',
@@ -397,40 +409,8 @@ export async function startServer(
   // and its parent process, not a property of the server. The CLI has no parent
   // and prints something a person can read instead.
 
-  // Write WS port to a well-known file so MCP and other tools can discover it.
-  // Use JSON with PID so multiple instances don't clobber each other's port files.
-  // Lives beside the database rather than always in ~/.vorn, so a server on its
-  // own data dir advertises itself there instead of over the desktop's file.
-  const wsPortFile = path.join(dataDir, WS_PORT_FILENAME)
-  let ownsPortFile = true
-  try {
-    fs.mkdirSync(path.dirname(wsPortFile), { recursive: true })
-
-    // Check if another live instance owns the port file
-    try {
-      const existing = JSON.parse(fs.readFileSync(wsPortFile, 'utf-8'))
-      if (existing.pid && existing.pid !== process.pid) {
-        try {
-          process.kill(existing.pid, 0) // probe — throws if dead
-          ownsPortFile = false
-          log.info(
-            { existingPid: existing.pid },
-            '[server] another instance owns ws-port file, skipping write'
-          )
-        } catch {
-          // dead PID — safe to overwrite
-        }
-      }
-    } catch {
-      // no file or invalid JSON — safe to write
-    }
-
-    if (ownsPortFile) {
-      fs.writeFileSync(wsPortFile, JSON.stringify({ port: actualPort, pid: process.pid }), 'utf-8')
-    }
-  } catch (err) {
-    log.warn({ err }, '[server] failed to write ws-port file (MCP discovery will not work)')
-  }
+  // Publish the port for MCP and anything else that reads this directory.
+  writePortFile(dataDir, actualPort, ownsPublished)
 
   log.info(`[server] listening on ${host}:${actualPort}`)
 
@@ -474,14 +454,7 @@ export async function startServer(
     const { stopAllMcpClients } = await import('./connectors')
     await stopAllMcpClients()
     configManager.close()
-    if (ownsPortFile) {
-      try {
-        const raw = JSON.parse(fs.readFileSync(wsPortFile, 'utf-8'))
-        if (raw.pid === process.pid) fs.unlinkSync(wsPortFile)
-      } catch {
-        /* ignore */
-      }
-    }
+    removePortFile(dataDir, ownsPublished)
     await app.close()
     process.exit(0)
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -530,12 +530,20 @@ export async function startServer(
    * rather than a loss, and refusing its sessions would leave the machine with
    * nothing that works.
    */
+  let saidSo = false
   const noticeLostEndpoint = (held: LocalEndpoint | null): boolean => {
-    if (isDraining()) return true
-    if (!held || held.holds()) return false
-    log.warn('[endpoint] this server no longer holds the endpoint; finishing what it has')
-    beginDraining()
-    return true
+    // The endpoint is asked before `isDraining()`, not after. That call flips the
+    // flag itself now -- session creation consults the same check, so it has to --
+    // and asking it first meant this function's own transition never ran and the
+    // warning below was dead. A server quietly refusing every new session with
+    // nothing in the log saying why is a bad half-hour for whoever hits it.
+    const lost = held !== null && !held.holds()
+    if (lost && !saidSo) {
+      saidSo = true
+      log.warn('[endpoint] this server no longer holds the endpoint; finishing what it has')
+      beginDraining()
+    }
+    return isDraining()
   }
 
   // The server outlives the app now, so something has to decide when it is done.

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,8 +24,13 @@ import { registerAllMethods, setServerPort } from './register-methods'
 import { configManager } from './config-manager'
 import { claimPublishedFiles, writePortFile, removePortFile } from './published-files'
 import { openLocalEndpoint, type LocalEndpoint } from './local-endpoint'
-import { beginDraining, isDraining } from './draining'
-import { initBootstrapSecret, clearLocalCredential, bearerFrom } from './ws-auth'
+import { beginDraining, isDraining, watchEndpoint } from './draining'
+import {
+  initBootstrapSecret,
+  publishLocalCredential,
+  clearLocalCredential,
+  bearerFrom
+} from './ws-auth'
 import { getDataDir, dbCountActiveConnectorInboxLeases } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
 import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protocol'
@@ -172,9 +177,11 @@ export async function startServer(
   // last writer silently wins.
   const ownsPublished = claimPublishedFiles(dataDir)
 
-  // Resolve this process's local credential and publish it for same-machine
-  // tools, before any connection can be accepted.
-  initBootstrapSecret(dataDir, undefined, ownsPublished)
+  // Resolve this process's local credential, before any connection can be
+  // accepted. Publishing it is a separate step, after the endpoint is claimed:
+  // the secret has to exist to authenticate anyone, but the file announces this
+  // server as the one this machine uses, which is not true until it has won.
+  initBootstrapSecret(dataDir)
 
   app.get(
     '/ws',
@@ -433,8 +440,16 @@ export async function startServer(
     process.exit(EXIT_ENDPOINT_TAKEN)
   }
   const endpoint = claimed.kind === 'held' ? claimed.endpoint : null
+  // Asked at session creation rather than only on the idle tick: that timer runs
+  // at a quarter of the window and is switched off entirely for `vorn-server
+  // serve`, so a check that lived only there would be late or absent exactly
+  // where it matters.
+  if (endpoint) watchEndpoint(() => endpoint.holds())
 
-  // Publish the port for MCP and anything else that reads this directory.
+  // Published together, after the claim, because they are one announcement: the
+  // port says where, the credential says how, and a reader that finds one
+  // without the other cannot reach anything.
+  publishLocalCredential(ownsPublished)
   writePortFile(dataDir, actualPort, ownsPublished)
 
   log.info(`[server] listening on ${host}:${actualPort}`)

--- a/packages/server/src/local-endpoint.ts
+++ b/packages/server/src/local-endpoint.ts
@@ -1,0 +1,162 @@
+import http from 'http'
+import fs from 'fs'
+import { WebSocketServer } from 'ws'
+import log from './logger'
+import { handleConnection } from './ws-handler'
+import { parseTopics } from './broadcast'
+import { bearerFrom } from './ws-auth'
+import {
+  endpointPath,
+  scratchPathFor,
+  canHostEndpoint,
+  claimEndpoint,
+  abandonScratch
+} from './endpoint'
+
+/**
+ * The listener behind the canonical endpoint.
+ *
+ * Deliberately narrow: a WebSocket upgrade and nothing else. It would be less
+ * code to hand this server fastify's `app.routing` and get every route for free,
+ * and it would be wrong twice over.
+ *
+ * `/api/pair/redeem` caps attempts per client address (`index.ts`), and a unix
+ * peer has no address — every caller would bucket under one empty string and the
+ * cap would collapse to a single shared allowance. And `@fastify/websocket`
+ * attaches to one server, `wssOptions.server || fastify.server`; pointing it here
+ * would move `/ws` off the TCP listener and cut off every web and phone client.
+ *
+ * So HTTP stays on TCP, and this carries the one thing that has to be reachable
+ * by name rather than by port: a desktop on this machine, asking who is serving.
+ */
+
+/**
+ * What came of trying to hold this machine's endpoint.
+ *
+ * Three outcomes, and conflating the last two is a bug with teeth. `unavailable`
+ * means no endpoint was possible here at all -- win32, a directory anyone can
+ * write, a path too long -- and the server carries on serving over TCP, because
+ * a machine with no socket is still a machine that needs a server. `lost` means
+ * the endpoint exists and belongs to somebody else, and this process is a second
+ * server on one database: `saveSessions` is a whole-table replace, so two of them
+ * erase each other's work.
+ */
+export type EndpointOutcome =
+  | { kind: 'held'; endpoint: LocalEndpoint }
+  | { kind: 'unavailable'; why: string }
+  | { kind: 'lost'; because: string }
+
+export interface LocalEndpoint {
+  /** The canonical path, once held. */
+  readonly path: string
+  /** Whether this process still holds the name. Read, never cached. */
+  holds(): boolean
+  close(): Promise<void>
+}
+
+/**
+ * Bring up the endpoint and claim its name, or explain why not.
+ *
+ * Never throws and never blocks startup. Every failure is a downgrade to
+ * TCP-only, because a server nobody can reach is worse than a race nobody has
+ * lost yet.
+ */
+export async function openLocalEndpoint(
+  dataDir: string,
+  onUpgraded: () => void
+): Promise<EndpointOutcome> {
+  const allowed = canHostEndpoint(dataDir)
+  if (!allowed.ok) {
+    log.info({ why: allowed.why }, '[endpoint] not hosting a local socket')
+    return { kind: 'unavailable', why: allowed.why ?? 'unknown' }
+  }
+
+  const canonical = endpointPath(dataDir)
+  const scratch = scratchPathFor(canonical)
+  let mine: { dev: number; ino: number } | null = null
+
+  const server = http.createServer((_req, res) => {
+    // Nothing here answers HTTP. Said plainly rather than left to 404, so a
+    // future caller finds this comment instead of a mystery.
+    res.writeHead(404)
+    res.end()
+  })
+  const wss = new WebSocketServer({ noServer: true })
+
+  server.on('upgrade', (req, socket, head) => {
+    if (!req.url?.startsWith('/ws')) {
+      socket.destroy()
+      return
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      handleConnection(ws, bearerFrom(req.headers.authorization), parseTopics(undefined), {
+        transport: 'unix'
+      })
+      onUpgraded()
+    })
+  })
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(scratch, resolve)
+    })
+    // Belt and braces for linux, where a socket's own mode is enforced on
+    // connect. Darwin ignores it and relies on the directory, which
+    // `canHostEndpoint` has already checked.
+    fs.chmodSync(scratch, 0o600)
+    // Taken here and never again. `server.address()` reports the path this
+    // listener bound, and that name is gone the moment the claim succeeds -- so
+    // the inode has to be learned while the scratch name still exists. It cannot
+    // change afterwards: the listener is bound for the life of the process.
+    const bound = fs.lstatSync(scratch)
+    mine = { dev: bound.dev, ino: bound.ino }
+  } catch (err) {
+    log.warn({ err }, '[endpoint] could not bind the local socket; continuing on TCP alone')
+    abandonScratch(scratch)
+    return { kind: 'unavailable', why: (err as Error).message }
+  }
+
+  const outcome = await claimEndpoint(scratch, canonical)
+  if (!outcome.held) {
+    log.info({ because: outcome.because }, '[endpoint] another server holds this machine')
+    // Closing unlinks the scratch name, which is ours. The canonical entry is
+    // untouched, because libuv only knows the path this server bound.
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    abandonScratch(scratch)
+    return { kind: 'lost', because: outcome.because }
+  }
+
+  log.info({ path: canonical }, '[endpoint] holding the local endpoint')
+
+  const endpoint: LocalEndpoint = {
+    path: canonical,
+    holds: () => stillOurs(canonical, mine),
+    close: async () => {
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve())
+      })
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  }
+  return { kind: 'held', endpoint }
+}
+
+/**
+ * Whether the canonical entry still resolves to this server's listener.
+ *
+ * Asked rather than remembered, because the answer can change without this
+ * process being told: another server that found this one unreachable is entitled
+ * to take the name, and the only honest way to know is to look. The inode is the
+ * identity -- a path comparison would say yes to somebody else's socket sitting
+ * at the same name.
+ */
+function stillOurs(canonical: string, mine: { dev: number; ino: number } | null): boolean {
+  if (!mine) return false
+  try {
+    const now = fs.lstatSync(canonical)
+    return now.isSocket() && now.ino === mine.ino && now.dev === mine.dev
+  } catch {
+    return false
+  }
+}

--- a/packages/server/src/local-endpoint.ts
+++ b/packages/server/src/local-endpoint.ts
@@ -133,6 +133,14 @@ export async function openLocalEndpoint(
     path: canonical,
     holds: () => stillOurs(canonical, mine),
     close: async () => {
+      // Terminated, not asked. `ws` with `clientTracking` does not close tracked
+      // sockets on `close()` -- it waits for them, and so does the http server
+      // behind it. A half-open client, which is exactly what the idle watch's
+      // duration clock exists to tolerate, would hold this promise for ever:
+      // `shutdown()` would stall to its deadline and leave on exit(1), read by
+      // the launcher as a crash, after `killAll()` had already run.
+      for (const client of wss.clients) client.terminate()
+      server.closeAllConnections()
       await new Promise<void>((resolve) => {
         wss.close(() => resolve())
       })

--- a/packages/server/src/local-endpoint.ts
+++ b/packages/server/src/local-endpoint.ts
@@ -87,15 +87,22 @@ export async function openLocalEndpoint(
     // Exactly `/ws`, with or without a query. `startsWith` accepted `/ws-anything`
     // too, which is a wider door than this listener means to open -- it exists to
     // carry one route.
-    const route = new URL(req.url ?? '/', 'ws://endpoint').pathname
-    if (route !== '/ws') {
+    const url = new URL(req.url ?? '/', 'ws://endpoint')
+    if (url.pathname !== '/ws') {
       socket.destroy()
       return
     }
     wss.handleUpgrade(req, socket, head, (ws) => {
-      handleConnection(ws, bearerFrom(req.headers.authorization), parseTopics(undefined), {
-        transport: 'unix'
-      })
+      handleConnection(
+        ws,
+        bearerFrom(req.headers.authorization),
+        // Read, not discarded. Accepting a query and then ignoring it is worse
+        // than refusing one: a client that narrowed its subscription would be
+        // sent everything anyway, and nothing would say so. Fastify parses this
+        // for the TCP route; here it has to be done by hand.
+        parseTopics(Object.fromEntries(url.searchParams)),
+        { transport: 'unix' }
+      )
       onUpgraded()
     })
   })

--- a/packages/server/src/local-endpoint.ts
+++ b/packages/server/src/local-endpoint.ts
@@ -84,7 +84,11 @@ export async function openLocalEndpoint(
   const wss = new WebSocketServer({ noServer: true })
 
   server.on('upgrade', (req, socket, head) => {
-    if (!req.url?.startsWith('/ws')) {
+    // Exactly `/ws`, with or without a query. `startsWith` accepted `/ws-anything`
+    // too, which is a wider door than this listener means to open -- it exists to
+    // carry one route.
+    const route = new URL(req.url ?? '/', 'ws://endpoint').pathname
+    if (route !== '/ws') {
       socket.destroy()
       return
     }

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -39,6 +39,7 @@ import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
+import { isDraining, DRAINING_MESSAGE } from './draining'
 
 const MAX_OUTPUT_LINES = 1000
 const IDLE_TIMEOUT_MS = 5000
@@ -147,6 +148,11 @@ class PtyManager extends EventEmitter {
   }
 
   createPty(payload: CreateTerminalPayload): TerminalSession {
+    // Refused rather than created: a session started on an endpoint this process
+    // no longer holds is reachable through a name that now points elsewhere, so
+    // nobody would ever see it. Existing sessions are untouched -- their clients
+    // hold a descriptor, not a name.
+    if (isDraining()) throw new Error(DRAINING_MESSAGE)
     const id = crypto.randomUUID()
     const shell = getDefaultShell(configManager.loadConfig().defaults.shell)
 

--- a/packages/server/src/published-files.ts
+++ b/packages/server/src/published-files.ts
@@ -1,0 +1,128 @@
+import fs from 'fs'
+import path from 'path'
+import { WS_PORT_FILENAME } from '@vornrun/shared/protocol'
+import log from './logger'
+
+/**
+ * The files this server publishes into its data directory, and who owns them.
+ *
+ * Two of them — `ws-port` and `local-token` — are how anything else on this
+ * machine finds and authenticates to a server. They live at fixed names in a
+ * directory that is shared by default: `~/.vorn` is where a packaged Vorn and a
+ * `yarn dev` server both land, deliberately, which is what lets `judgeAdoption`
+ * gate on build channel rather than on paths.
+ *
+ * A fixed name shared by several writers needs an owner, or the last writer
+ * silently wins. It did: a dev server rewrote the packaged app's credential on
+ * start and removed it on stop, so MCP read one server's port beside another
+ * server's secret and every call timed out until Vorn was restarted.
+ *
+ * The rule here is the one the endpoint work needs next, on a smaller thing:
+ *
+ * > No actor removes or replaces a name it did not create, unless it has proven
+ * > the process that did create it is gone.
+ *
+ * Ownership is decided once, before anything is published, and remembered. It is
+ * not re-derived per file, because two files answering the question separately is
+ * how they come to disagree.
+ */
+
+/**
+ * Whether a process is still there.
+ *
+ * `EPERM` means alive and owned by somebody else — the signal was refused, which
+ * is only possible if there was something to refuse it. Reading that as death is
+ * how a live server gets treated as absent, and the older inline version of this
+ * check did exactly that with a bare try/catch.
+ *
+ * Signal 0 to a pid of 0 targets this process group and always succeeds, so a
+ * zero or negative pid is rejected before it is asked. Mirrors
+ * `src/main/server/server-adoption.ts`, which the desktop uses for the same
+ * question.
+ */
+export function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/** What `ws-port` holds. `pid` is absent in records MCP heals for itself. */
+interface PortRecord {
+  port?: number
+  pid?: number
+}
+
+function readPortRecord(file: string): PortRecord | null {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(file, 'utf-8'))
+    if (!raw || typeof raw !== 'object') return null
+    return raw as PortRecord
+  } catch {
+    // Absent, unreadable, or the legacy bare-number format. None of them names a
+    // living owner, so none of them stops this process claiming the directory.
+    return null
+  }
+}
+
+/**
+ * Decide whether this process may publish into `dataDir`, once and for all.
+ *
+ * Claimed unless `ws-port` names a *live* process that is not us. Everything
+ * else — no file, unreadable JSON, a record with no pid, a pid that has since
+ * died — is an orphan, and an orphan is claimable. That is deliberate: refusing
+ * to publish because of a leftover file would leave a machine with no reachable
+ * server at all, which is worse than the collision this prevents.
+ *
+ * Call before publishing anything, and pass the answer to every publisher.
+ */
+export function claimPublishedFiles(dataDir: string): boolean {
+  const record = readPortRecord(path.join(dataDir, WS_PORT_FILENAME))
+  const owner = record?.pid
+  if (typeof owner !== 'number' || owner === process.pid) return true
+  if (!isPidAlive(owner)) return true
+
+  log.info(
+    { owner },
+    '[server] another live server owns this data directory; publishing nothing into it'
+  )
+  return false
+}
+
+/**
+ * Publish the port, if this process owns the directory.
+ *
+ * Lives beside the database rather than always in `~/.vorn`, so a server on its
+ * own data dir advertises itself there instead of over the desktop's file.
+ */
+export function writePortFile(dataDir: string, port: number, owned: boolean): void {
+  if (!owned) return
+  const file = path.join(dataDir, WS_PORT_FILENAME)
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, JSON.stringify({ port, pid: process.pid }), 'utf-8')
+  } catch (err) {
+    log.warn({ err }, '[server] failed to write ws-port file (MCP discovery will not work)')
+  }
+}
+
+/**
+ * Remove the port file, if it still names this process.
+ *
+ * Two gates rather than one: the claim taken at startup, and a fresh read
+ * proving the record on disk is still ours. The second matters because the file
+ * is the thing being removed — trusting a flag decided minutes ago would delete
+ * a name that has since become somebody else's.
+ */
+export function removePortFile(dataDir: string, owned: boolean): void {
+  if (!owned) return
+  const file = path.join(dataDir, WS_PORT_FILENAME)
+  try {
+    if (readPortRecord(file)?.pid === process.pid) fs.unlinkSync(file)
+  } catch {
+    /* best effort — a port file naming a dead process is already harmless */
+  }
+}

--- a/packages/server/src/ws-auth.ts
+++ b/packages/server/src/ws-auth.ts
@@ -50,10 +50,20 @@ let localTokenPath: string | null = null
  * loopback, but it cannot read a file off disk.
  *
  * Per-process and deleted on shutdown, so nothing usable outlives the server.
+ *
+ * `publish` is the data directory's ownership, decided once by
+ * `claimPublishedFiles` before anything is written. False means another live
+ * server already holds this directory, and the secret stays in memory only: the
+ * desktop that started this process handed it over in the environment and does
+ * not need the file, while anything reading the directory — MCP — is looking for
+ * the server that owns it, not for this one. Writing anyway is the bug this
+ * closes: a `yarn dev` server overwrote the packaged app's credential and MCP
+ * then read one server's port beside another server's secret.
  */
 export function initBootstrapSecret(
   dataDir: string,
-  value: string | undefined = process.env[BOOTSTRAP_ENV_VAR]
+  value: string | undefined = process.env[BOOTSTRAP_ENV_VAR],
+  publish = true
 ): void {
   const supplied = value && value.length > 0 ? value : null
   const secret = supplied ?? crypto.randomBytes(32).toString('base64url')
@@ -67,6 +77,12 @@ export function initBootstrapSecret(
   // this, no child can inherit it however it is spawned.
   delete process.env[BOOTSTRAP_ENV_VAR]
 
+  if (!publish) {
+    localTokenPath = null
+    log.info('[auth] not publishing a local credential: another server owns this directory')
+    return
+  }
+
   try {
     localTokenPath = path.join(dataDir, LOCAL_TOKEN_FILENAME)
     // Written fresh each start. `mode` only applies on creation, so remove any
@@ -79,13 +95,28 @@ export function initBootstrapSecret(
   }
 }
 
-/** Remove the published credential. Called from the server's shutdown path. */
+/**
+ * Remove the published credential, if the one on disk is still ours.
+ *
+ * Two gates. `localTokenPath` is null unless this process published, so a server
+ * that stood aside removes nothing. And the content is compared before the
+ * unlink, because publishing and shutting down are minutes apart: a file that has
+ * since been replaced belongs to whoever replaced it, and deleting it would leave
+ * a live server unreachable — the failure this whole change is about, caused on
+ * the way out instead of on the way in.
+ *
+ * Compared by content rather than by a pid beside it: the secret is the one thing
+ * this process already knows for certain, and `local-token` holds nothing else —
+ * `packages/mcp` reads the whole file as the credential.
+ */
 export function clearLocalCredential(): void {
   if (!localTokenPath) return
   try {
-    fs.rmSync(localTokenPath, { force: true })
+    if (fs.readFileSync(localTokenPath, 'utf-8') === bootstrapSecret?.toString('utf8')) {
+      fs.rmSync(localTokenPath, { force: true })
+    }
   } catch {
-    /* best effort — it is invalid after this process exits anyway */
+    /* absent or unreadable — either way there is nothing of ours to remove */
   }
   localTokenPath = null
 }

--- a/packages/server/src/ws-auth.ts
+++ b/packages/server/src/ws-auth.ts
@@ -62,9 +62,9 @@ let localTokenPath: string | null = null
  */
 export function initBootstrapSecret(
   dataDir: string,
-  value: string | undefined = process.env[BOOTSTRAP_ENV_VAR],
-  publish = true
+  value: string | undefined = process.env[BOOTSTRAP_ENV_VAR]
 ): void {
+  pendingDataDir = dataDir
   const supplied = value && value.length > 0 ? value : null
   const secret = supplied ?? crypto.randomBytes(32).toString('base64url')
   bootstrapSecret = Buffer.from(secret, 'utf8')
@@ -77,8 +77,32 @@ export function initBootstrapSecret(
   // this, no child can inherit it however it is spawned.
   delete process.env[BOOTSTRAP_ENV_VAR]
 
-  if (!publish) {
-    localTokenPath = null
+  localTokenPath = null
+}
+
+/** The directory to publish into, remembered from `initBootstrapSecret`. */
+let pendingDataDir: string | null = null
+
+/**
+ * Write the credential where same-machine tools will find it.
+ *
+ * Separate from resolving the secret, and deliberately later, because the two
+ * answer different questions. The secret has to exist before any connection can
+ * be accepted; the *file* announces this server as the one this machine uses,
+ * and that is not true until it has claimed the endpoint.
+ *
+ * Publishing at startup meant a server that went on to lose the claim had
+ * already overwritten the winner's credential, and then exited without a
+ * shutdown path to undo it. The winner served with a secret nobody could read
+ * and MCP authenticated against a file belonging to a process that no longer
+ * existed -- the same failure this whole change is about, arrived at through the
+ * race rather than through a dev server.
+ */
+export function publishLocalCredential(owned: boolean): void {
+  const dataDir = pendingDataDir
+  const secret = bootstrapSecret?.toString('utf8')
+  if (!dataDir || !secret) return
+  if (!owned) {
     log.info('[auth] not publishing a local credential: another server owns this directory')
     return
   }

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -103,6 +103,25 @@ export function setLiveSessionCount(fn: () => number): void {
  * reports for a v4 loopback connection, so matching only `127.0.0.1` would fail
  * open in the common case -- and failing open here means withholding nothing.
  */
+/**
+ * Where a connection came in.
+ *
+ * A unix peer has no address at all -- there is nothing to put in one, and
+ * `isLoopbackAddress(undefined)` is correctly false. Passing a synthetic
+ * `'127.0.0.1'` would make it true by lying, in the one place whose whole job is
+ * to decide who may be told about this machine. So the transport is named
+ * instead, and a unix peer is judged on what is actually true of it: it reached a
+ * socket inside a directory this user owns, which is stronger evidence of being
+ * on this machine than any address could be.
+ */
+export type Peer = { transport: 'unix' } | { transport: 'tcp'; address?: string }
+
+/** Whether this peer is provably on the same machine, and may hear who we are. */
+export function isSameMachine(peer: Peer | undefined): boolean {
+  if (!peer) return false
+  return peer.transport === 'unix' || isLoopbackAddress(peer.address)
+}
+
 export function isLoopbackAddress(address: string | undefined): boolean {
   if (!address) return false
   const bare = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address
@@ -226,12 +245,12 @@ export function handleConnection(
   ws: WebSocket,
   credential?: string,
   initialTopics?: readonly string[],
-  peerAddress?: string
+  peer?: Peer
 ): void {
   // Announce the contract first, so a client that has to authenticate by message
   // knows that it must before it is refused for not having.
   ws.send(helloFrame())
-  if (isLoopbackAddress(peerAddress)) {
+  if (isSameMachine(peer)) {
     const frame = identityFrame()
     if (frame) ws.send(frame)
   }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -197,6 +197,31 @@ export const LOCAL_TOKEN_FILENAME = 'local-token'
  */
 export const WS_PORT_FILENAME = 'ws-port'
 
+/**
+ * Filename, under the resolved data dir, of the canonical local endpoint.
+ *
+ * A unix socket rather than a record naming a port, because this one is *owned*:
+ * `link()` refuses to replace an existing name and `rename()` replaces one
+ * atomically, so a starting server can ask whether the machine already has a
+ * server before it becomes a second one. A port has no such name -- two servers
+ * reaching for one are settled by whichever bound first, invisibly.
+ *
+ * Absent on win32, where Node maps a socket path to a named pipe and there is no
+ * filesystem entry to test-and-set. There the port file above remains the only
+ * answer, and the race it leaves open remains open.
+ */
+export const ENDPOINT_FILENAME = 'vorn.sock'
+
+/**
+ * Exit code for a server that found this machine already had one.
+ *
+ * Distinct from both success and failure, because it is neither. The process did
+ * nothing wrong and nothing is broken -- it simply arrived second, and the right
+ * answer is for the app that started it to adopt the incumbent instead. Read as
+ * a crash it would be relaunched, and the relaunch would arrive second too.
+ */
+export const EXIT_ENDPOINT_TAKEN = 3
+
 // ─── JSON-RPC 2.0 Envelope Types ────────────────────────────────
 
 export interface RpcRequest {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -534,7 +534,7 @@ app.whenReady().then(async () => {
         // Asked rather than assumed, and the window is not held waiting for the
         // answer: a server that does not reply leaves the count null, which the
         // toast already words as "Sessions are".
-        void probeSessions(local.port)
+        void probeSessions(`ws://127.0.0.1:${local.port}/ws`)
           .catch(() => null)
           .then((sessions) => {
             mainWindow?.webContents.send(LOCAL_SERVER_RUNNING_CHANNEL, { sessions })

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -167,7 +167,7 @@ export type RefusalReason =
  * `path.resolve`, which throws: the launcher would die where it meant to
  * decline, and a throw that is not an AdoptionRefusedError quits the app.
  */
-function isServerIdentity(value: ServerIdentity | null): value is ServerIdentity {
+export function isServerIdentity(value: unknown): value is ServerIdentity {
   if (!value || typeof value !== 'object') return false
   const v = value as Partial<ServerIdentity>
   return (

--- a/src/main/server/server-adoption.ts
+++ b/src/main/server/server-adoption.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import {
   LOCAL_TOKEN_FILENAME,
   WS_PORT_FILENAME,
+  ENDPOINT_FILENAME,
   RUNTIME_PROTOCOL_VERSION,
   type ServerIdentity
 } from '@vornrun/shared/protocol'
@@ -97,6 +98,32 @@ export function isPidAlive(pid: number): boolean {
   } catch (err) {
     return (err as NodeJS.ErrnoException).code === 'EPERM'
   }
+}
+
+/**
+ * Where this machine's server answers, by name rather than by port.
+ *
+ * A port is discovered from a file that anything can write; this is the file
+ * itself, and holding it is what makes a server the one this machine answers
+ * with. Absent on win32, where Node maps a socket path to a named pipe and there
+ * is no filesystem entry to own -- there the port file is still the only answer.
+ */
+export function readEndpointPath(dataDir = resolveDataDir()): string | null {
+  if (process.platform === 'win32') return null
+  const socket = path.join(dataDir, ENDPOINT_FILENAME)
+  try {
+    return fs.lstatSync(socket).isSocket() ? socket : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The URL form `ws` wants for a unix socket: the path, then the request path
+ * after a colon. Odd-looking, and the only shape the library accepts.
+ */
+export function endpointUrl(socketPath: string): string {
+  return `ws+unix://${socketPath}:/ws`
 }
 
 /** The credential a server publishes for same-machine callers, or null. */

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -574,19 +574,15 @@ async function tryAdopt(
   | { bridge: ServerBridge }
   | { refusal: AdoptionVerdict & { kind: 'refuse' }; sessions: number | null }
 > {
+  // Read, but not insisted on yet. A missing credential is not proof that
+  // nothing is there -- the greeting arrives before authentication, so the
+  // question "is anybody serving this name" can be asked without one, and it has
+  // to be asked first. Refusing here instead would mean a leftover name with no
+  // credential beside it looks the same as a running server, and the app must
+  // treat those oppositely: start a server for the first, never for the second.
   const token = readLocalToken(self.dataDir)
-  if (!token) {
-    return {
-      sessions: null,
-      refusal: {
-        kind: 'refuse',
-        reason: 'unusable',
-        detail: 'a server is listening but published no credential to reach it with'
-      }
-    }
-  }
 
-  const candidate = new ServerBridge(target, token)
+  const candidate = new ServerBridge(target, token ?? undefined)
   candidate.connect()
 
   // The greeting is the first frame on the socket and arrives before
@@ -600,6 +596,21 @@ async function tryAdopt(
       resolve(found)
     })
   })
+
+  // Something answered, so this is a server rather than a leftover -- and one
+  // this app cannot reach, which is a refusal rather than permission to start a
+  // rival beside it on the same database.
+  if (identity && !token) {
+    candidate.close()
+    return {
+      sessions: sessionsFrom(identity),
+      refusal: {
+        kind: 'refuse',
+        reason: 'unusable',
+        detail: 'a server is listening but published no credential to reach it with'
+      }
+    }
+  }
 
   const verdict = judgeAdoption(identity, candidate.serverHelloVersion, {
     ...self,
@@ -668,6 +679,40 @@ async function tryAdopt(
   return { bridge: candidate }
 }
 
+/**
+ * Every way a server on this machine might be found, in the order to try them.
+ *
+ * The endpoint first, because it is the name a server *owns* rather than a record
+ * anything can write. Its absence is not evidence: win32 never has one, and a
+ * server that could not host one still publishes a port. So the port file remains
+ * the fallback rather than the deprecated path.
+ *
+ * Recomputed on each call, never cached: it is asked again after a spawn stands
+ * down, and by then the winner has published things that were not there before.
+ */
+function discoverable(dataDir: string): Array<{ target: string; pid?: number }> {
+  const found: Array<{ target: string; pid?: number }> = []
+  const socket = readEndpointPath(dataDir)
+  if (socket) found.push({ target: endpointUrl(socket) })
+  const published = readPortFile(dataDir)
+  if (published) found.push({ target: portUrl(published.port), pid: published.pid })
+  return found
+}
+
+/**
+ * Whether a refusal means "there was no server here" rather than "there is one
+ * and this app may not use it".
+ *
+ * The distinction decides whether the app may go on to start a server, so it is
+ * drawn narrowly. A protocol or build or data-dir mismatch means something is
+ * running and holding the database: starting a rival would put two writers on one
+ * SQLite file where `saveSessions` replaces the whole table, and they would erase
+ * each other's sessions. Only silence is permission to carry on.
+ */
+function nothingAnswered(refusal: AdoptionVerdict & { kind: 'refuse' }): boolean {
+  return refusal.reason === 'no-identity'
+}
+
 /** The loopback form, for a server discovered by the port it published. */
 function portUrl(port: number): string {
   return `ws://127.0.0.1:${port}/ws`
@@ -695,27 +740,88 @@ export async function launchServer(): Promise<ServerBridge> {
   // record anything can write. Its absence is not evidence: win32 never has one,
   // and a server that could not host one still publishes a port. So the port file
   // remains the fallback rather than the deprecated path.
-  const socket = readEndpointPath(dataDir)
-  const published = readPortFile(dataDir)
-  const target = socket ? endpointUrl(socket) : published ? portUrl(published.port) : null
-  if (target) {
+  // Both, in order, and the first is not allowed to be the last word.
+  //
+  // Nothing removes the endpoint on shutdown -- that is the point, since the file
+  // is how the next start finds the name to replace -- so a socket left by a
+  // server that has since exited is the *ordinary* state of a machine between
+  // launches, not an exotic one. Committing to it and giving up when it does not
+  // answer would mean quitting Vorn once made Vorn unable to start again.
+  //
+  // A candidate that answers nothing is not a server; it is a filename. Only a
+  // candidate that answered and was then judged unusable is a refusal worth
+  // stopping for.
+  const adopted = await adoptSomethingRunning(dataDir)
+  if (adopted) {
+    bridge = adopted
+    return bridge
+  }
+
+  lastSpawnStoodDown = false
+  let port: number
+  try {
+    port = await spawnServer()
+  } catch (err) {
+    // A spawn that reported no port is either a server that failed to start or
+    // one that found this machine already had a server and stood down. Only the
+    // second has an answer, and it is not to try again: go and use the winner.
+    if (!lastSpawnStoodDown) throw err
+    log.info('[launcher] the server we started stood down; adopting the one that won')
+    const winner = await adoptSomethingRunning(dataDir)
+    if (winner) {
+      bridge = winner
+      return bridge
+    }
+    throw err
+  }
+  log.info(`[launcher] server started on port ${port}`)
+
+  // Connect bridge
+  bridge = new ServerBridge(`ws://127.0.0.1:${port}/ws`, bootstrapToken ?? undefined)
+  bridge.connect()
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Timed out connecting to the server')), 10_000)
+    bridge?.once('connected', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+  })
+  return bridge
+}
+
+/**
+ * Adopt whatever is already running here, or answer null if nothing is.
+ *
+ * Separated out because it is asked twice: once before starting a server, and
+ * again if the server we started stood down because somebody else had already
+ * won. The second ask is the whole reason a lost race is not a failed launch.
+ */
+async function adoptSomethingRunning(dataDir: string): Promise<ServerBridge | null> {
+  const candidates = discoverable(dataDir)
+
+  for (const [index, candidate] of candidates.entries()) {
     // No pid to insist on when adopting through the socket: nothing wrote one
     // there. `judgeAdoption` already tolerates that -- it is the same shape as a
     // port record MCP healed for itself -- and the identity still has to match
     // data dir, build channel and protocol, and the credential still has to be
     // accepted.
-    const outcome = await tryAdopt(target, socket ? undefined : published?.pid, {
+    const outcome = await tryAdopt(candidate.target, candidate.pid, {
       dataDir,
       buildChannel: buildChannel()
     })
-    if ('bridge' in outcome) {
-      bridge = outcome.bridge
-      return bridge
-    }
+    if ('bridge' in outcome) return outcome.bridge
     const { refusal } = outcome
+
+    // Nothing was there. Try the next way of finding a server, and if there is
+    // none, start one -- exactly as if this name had never existed.
+    if (nothingAnswered(refusal)) {
+      log.info(`[launcher] ${candidate.target} answered nothing (${refusal.reason}); moving on`)
+      if (index < candidates.length - 1) continue
+      break
+    }
     lastRefusal = {
       ...refusal,
-      incumbentPid: published?.pid ?? null,
+      incumbentPid: candidate.pid ?? null,
       // Coerced, not trusted. This number comes from the party this app has just
       // decided it cannot use, so it is clamped and rendered as a count — never
       // as text spliced into a sentence.
@@ -741,23 +847,7 @@ export async function launchServer(): Promise<ServerBridge> {
     throw new AdoptionRefusedError(refusal)
   }
 
-  const port = await spawnServer()
-  log.info(`[launcher] server started on port ${port}`)
-
-  // Connect bridge
-  bridge = new ServerBridge(`ws://127.0.0.1:${port}/ws`, bootstrapToken ?? undefined)
-  bridge.connect()
-
-  // Wait for connection
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error('Bridge connection timeout')), 10_000)
-    bridge!.once('connected', () => {
-      clearTimeout(timeout)
-      resolve()
-    })
-  })
-
-  return bridge
+  return null
 }
 
 export function getServerBridge(): ServerBridge | null {
@@ -937,8 +1027,20 @@ function waitForPublishedPort(child: ChildProcess): Promise<number> {
  * down -- which is precisely the diagnostic a detached server most needs.
  */
 function onChildExit(code: number | null, signal: NodeJS.Signals | null): void {
-  onServerExit(`code=${code}, signal=${signal}`, code === EXIT_ENDPOINT_TAKEN)
+  lastSpawnStoodDown = code === EXIT_ENDPOINT_TAKEN
+  onServerExit(`code=${code}, signal=${signal}`, lastSpawnStoodDown)
 }
+
+/**
+ * Whether the last server this app spawned stood down rather than failed.
+ *
+ * Read once, immediately after a spawn that did not report a port. The two are
+ * indistinguishable from the reject alone -- both are "no port arrived" -- and
+ * they call for opposite answers: a crash is a failure to start, while standing
+ * down means a healthy server is already running and this app should go and use
+ * it.
+ */
+let lastSpawnStoodDown = false
 
 /** Where a detached server's stdout and stderr go, under the data directory. */
 const SERVER_LOG_FILENAME = 'server.log'

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -11,6 +11,7 @@ import {
   EXIT_ENDPOINT_TAKEN,
   type ServerIdentity
 } from '@vornrun/shared/protocol'
+import WebSocket from 'ws'
 import { ServerBridge } from './server-bridge'
 import { readHostSettings } from './host-store'
 import { attemptsAfterExit, decideRelaunch } from './server-relaunch'
@@ -21,6 +22,7 @@ import {
   readPortFile,
   readEndpointPath,
   endpointUrl,
+  isServerIdentity,
   resolveDataDir,
   type AdoptionVerdict
 } from './server-adoption'
@@ -541,22 +543,43 @@ const ADOPT_AUTH_TIMEOUT_MS = 5_000
  * here; null means "could not tell", never "nothing".
  */
 export async function probeSessions(target: string): Promise<number | null> {
-  // No credential needed, and asking for one would defeat the point. The greeting
-  // arrives before authentication -- that is the whole reason the count rides it
-  // -- so a server this app cannot reach can still say what it is holding, and
-  // that is precisely the server worth saying it about.
-  const probe = new ServerBridge(target, readLocalToken() ?? undefined)
-  probe.connect()
+  // A bare socket, not a `ServerBridge`, and that is the point of this function
+  // being its own thing.
+  //
+  // The count rides the greeting, which arrives before authentication, so the
+  // server worth asking is exactly the one this app cannot otherwise reach. But
+  // `ServerBridge.connect()` claims the browser bridge the moment it opens, and a
+  // socket with no accepted credential is refused for sending any method but
+  // `auth:authenticate` -- so the "probe" would announce itself, be thrown out,
+  // and leave a line in the log of a server it only meant to look at. This one
+  // listens and says nothing.
+  const token = readLocalToken()
+  const socket = new WebSocket(
+    target,
+    token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+  )
+  socket.on('error', () => {})
   try {
     return await new Promise<number | null>((resolve) => {
       const timer = setTimeout(() => resolve(null), ADOPT_IDENTITY_TIMEOUT_MS)
-      probe.once('identity', (found: ServerIdentity) => {
+      const settle = (answer: number | null): void => {
         clearTimeout(timer)
-        resolve(sessionsFrom(found))
+        resolve(answer)
+      }
+      socket.on('close', () => settle(null))
+      socket.on('message', (raw: Buffer) => {
+        try {
+          const frame = JSON.parse(raw.toString()) as { method?: string; params?: unknown }
+          if (frame.method !== 'server:identity') return
+          settle(sessionsFrom(isServerIdentity(frame.params) ? frame.params : null))
+        } catch {
+          // Not JSON, or not a frame this cares about. The timer still owns the
+          // outcome.
+        }
       })
     })
   } finally {
-    probe.close()
+    socket.close()
   }
 }
 

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -8,6 +8,7 @@ import log from '../logger'
 import {
   BOOTSTRAP_ENV_VAR,
   SERVER_PORT_ENV_VAR,
+  EXIT_ENDPOINT_TAKEN,
   type ServerIdentity
 } from '@vornrun/shared/protocol'
 import { ServerBridge } from './server-bridge'
@@ -18,6 +19,8 @@ import {
   judgeAdoption,
   readLocalToken,
   readPortFile,
+  readEndpointPath,
+  endpointUrl,
   resolveDataDir,
   type AdoptionVerdict
 } from './server-adoption'
@@ -447,7 +450,7 @@ async function spawnServer(): Promise<number> {
  * The bridge is kept and repointed rather than replaced, because `main` holds
  * the instance `launchServer` returned and would go on using the old one.
  */
-function onServerExit(detail: string): void {
+function onServerExit(detail: string, endpointTaken = false): void {
   const uptimeMs = lastSpawnAt === 0 ? 0 : Date.now() - lastSpawnAt
   log.warn(`[launcher] server exited (${detail}) after ${Math.round(uptimeMs / 1000)}s`)
   // Both, not just the child handle. "How are we holding this server" is one
@@ -460,6 +463,7 @@ function onServerExit(detail: string): void {
 
   const decision = decideRelaunch({
     deliberate: stoppingDeliberately,
+    endpointTaken,
     hostMode: readHostSettings().mode === 'host',
     attempts: relaunchAttempts
   })
@@ -536,10 +540,10 @@ const ADOPT_AUTH_TIMEOUT_MS = 5_000
  * the app is pointed elsewhere and merely wants to say what is still running
  * here; null means "could not tell", never "nothing".
  */
-export async function probeSessions(port: number): Promise<number | null> {
+export async function probeSessions(target: string): Promise<number | null> {
   const token = readLocalToken()
   if (!token) return null
-  const probe = new ServerBridge(`ws://127.0.0.1:${port}/ws`, token)
+  const probe = new ServerBridge(target, token)
   probe.connect()
   try {
     return await new Promise<number | null>((resolve) => {
@@ -563,7 +567,7 @@ export async function probeSessions(port: number): Promise<number | null> {
  * both landed on. Refusing costs a spare process; killing costs the session.
  */
 async function tryAdopt(
-  port: number,
+  target: string,
   expectedPid: number | undefined,
   self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
 ): Promise<
@@ -582,7 +586,7 @@ async function tryAdopt(
     }
   }
 
-  const candidate = new ServerBridge(`ws://127.0.0.1:${port}/ws`, token)
+  const candidate = new ServerBridge(target, token)
   candidate.connect()
 
   // The greeting is the first frame on the socket and arrives before
@@ -660,8 +664,13 @@ async function tryAdopt(
     onServerExit(`adopted server pid=${adoptedPid} is gone`)
   })
 
-  log.info(`[launcher] adopted the server already running on port ${port}`)
+  log.info(`[launcher] adopted the server already running at ${target}`)
   return { bridge: candidate }
+}
+
+/** The loopback form, for a server discovered by the port it published. */
+function portUrl(port: number): string {
+  return `ws://127.0.0.1:${port}/ws`
 }
 
 export async function launchServer(): Promise<ServerBridge> {
@@ -682,9 +691,20 @@ export async function launchServer(): Promise<ServerBridge> {
   // on one database, the app talking to the empty one.
   const dataDir = resolveDataDir()
   lastRefusal = null
+  // The endpoint first, because it is the name a server *owns* rather than a
+  // record anything can write. Its absence is not evidence: win32 never has one,
+  // and a server that could not host one still publishes a port. So the port file
+  // remains the fallback rather than the deprecated path.
+  const socket = readEndpointPath(dataDir)
   const published = readPortFile(dataDir)
-  if (published) {
-    const outcome = await tryAdopt(published.port, published.pid, {
+  const target = socket ? endpointUrl(socket) : published ? portUrl(published.port) : null
+  if (target) {
+    // No pid to insist on when adopting through the socket: nothing wrote one
+    // there. `judgeAdoption` already tolerates that -- it is the same shape as a
+    // port record MCP healed for itself -- and the identity still has to match
+    // data dir, build channel and protocol, and the credential still has to be
+    // accepted.
+    const outcome = await tryAdopt(target, socket ? undefined : published?.pid, {
       dataDir,
       buildChannel: buildChannel()
     })
@@ -695,7 +715,7 @@ export async function launchServer(): Promise<ServerBridge> {
     const { refusal } = outcome
     lastRefusal = {
       ...refusal,
-      incumbentPid: published.pid ?? null,
+      incumbentPid: published?.pid ?? null,
       // Coerced, not trusted. This number comes from the party this app has just
       // decided it cannot use, so it is clamped and rendered as a count — never
       // as text spliced into a sentence.
@@ -917,7 +937,7 @@ function waitForPublishedPort(child: ChildProcess): Promise<number> {
  * down -- which is precisely the diagnostic a detached server most needs.
  */
 function onChildExit(code: number | null, signal: NodeJS.Signals | null): void {
-  onServerExit(`code=${code}, signal=${signal}`)
+  onServerExit(`code=${code}, signal=${signal}`, code === EXIT_ENDPOINT_TAKEN)
 }
 
 /** Where a detached server's stdout and stderr go, under the data directory. */

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -541,9 +541,11 @@ const ADOPT_AUTH_TIMEOUT_MS = 5_000
  * here; null means "could not tell", never "nothing".
  */
 export async function probeSessions(target: string): Promise<number | null> {
-  const token = readLocalToken()
-  if (!token) return null
-  const probe = new ServerBridge(target, token)
+  // No credential needed, and asking for one would defeat the point. The greeting
+  // arrives before authentication -- that is the whole reason the count rides it
+  // -- so a server this app cannot reach can still say what it is holding, and
+  // that is precisely the server worth saying it about.
+  const probe = new ServerBridge(target, readLocalToken() ?? undefined)
   probe.connect()
   try {
     return await new Promise<number | null>((resolve) => {

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -572,7 +572,19 @@ async function tryAdopt(
   self: { dataDir: string; buildChannel: 'dev' | 'packaged' }
 ): Promise<
   | { bridge: ServerBridge }
-  | { refusal: AdoptionVerdict & { kind: 'refuse' }; sessions: number | null }
+  | {
+      refusal: AdoptionVerdict & { kind: 'refuse' }
+      sessions: number | null
+      /**
+       * Whether anything responded at all.
+       *
+       * The greeting is the discriminator, not the identity: a server too old to
+       * send an identity frame still sends `server:hello`, and reading its
+       * silence-about-identity as absence would put a second writer on its
+       * database.
+       */
+      answered: boolean
+    }
 > {
   // Read, but not insisted on yet. A missing credential is not proof that
   // nothing is there -- the greeting arrives before authentication, so the
@@ -604,6 +616,7 @@ async function tryAdopt(
     candidate.close()
     return {
       sessions: sessionsFrom(identity),
+      answered: true,
       refusal: {
         kind: 'refuse',
         reason: 'unusable',
@@ -617,9 +630,11 @@ async function tryAdopt(
     expectedPid
   })
   if (verdict.kind === 'refuse' || !identity) {
+    const answered = identity !== null || candidate.serverHelloVersion !== undefined
     candidate.close()
     return {
       sessions: sessionsFrom(identity),
+      answered,
       refusal:
         verdict.kind === 'refuse'
           ? verdict
@@ -644,6 +659,9 @@ async function tryAdopt(
     candidate.close()
     return {
       sessions: null,
+      // It greeted us and it judged well enough to reach this line. Whatever is
+      // wrong with the credential, something is holding this database.
+      answered: true,
       refusal: {
         kind: 'refuse',
         reason: 'unusable',
@@ -697,20 +715,6 @@ function discoverable(dataDir: string): Array<{ target: string; pid?: number }> 
   const published = readPortFile(dataDir)
   if (published) found.push({ target: portUrl(published.port), pid: published.pid })
   return found
-}
-
-/**
- * Whether a refusal means "there was no server here" rather than "there is one
- * and this app may not use it".
- *
- * The distinction decides whether the app may go on to start a server, so it is
- * drawn narrowly. A protocol or build or data-dir mismatch means something is
- * running and holding the database: starting a rival would put two writers on one
- * SQLite file where `saveSessions` replaces the whole table, and they would erase
- * each other's sessions. Only silence is permission to carry on.
- */
-function nothingAnswered(refusal: AdoptionVerdict & { kind: 'refuse' }): boolean {
-  return refusal.reason === 'no-identity'
 }
 
 /** The loopback form, for a server discovered by the port it published. */
@@ -814,7 +818,7 @@ async function adoptSomethingRunning(dataDir: string): Promise<ServerBridge | nu
 
     // Nothing was there. Try the next way of finding a server, and if there is
     // none, start one -- exactly as if this name had never existed.
-    if (nothingAnswered(refusal)) {
+    if (!outcome.answered) {
       log.info(`[launcher] ${candidate.target} answered nothing (${refusal.reason}); moving on`)
       if (index < candidates.length - 1) continue
       break

--- a/src/main/server/server-relaunch.ts
+++ b/src/main/server/server-relaunch.ts
@@ -30,6 +30,14 @@ export const RELAUNCH_DELAYS_MS = [0, 1_000, 5_000, 15_000]
 export function decideRelaunch(input: {
   /** `stopServer` ran, or the app is quitting. The exit was the point. */
   deliberate: boolean
+  /**
+   * The server stood down because this machine already had one.
+   *
+   * Not a crash and not a failure: it did nothing wrong, it arrived second. A
+   * replacement would arrive second too, so the answer is to go back and adopt
+   * the incumbent rather than to spawn another loser.
+   */
+  endpointTaken?: boolean
   /** No server of our own — we are pointed at someone else's. */
   hostMode: boolean
   /** How many times we have already relaunched in this run. */
@@ -37,6 +45,9 @@ export function decideRelaunch(input: {
 }): RelaunchDecision {
   if (input.deliberate) {
     return { relaunch: false, delayMs: 0, reason: 'the server was asked to stop' }
+  }
+  if (input.endpointTaken) {
+    return { relaunch: false, delayMs: 0, reason: 'this machine already has a server' }
   }
   // Host mode has no server of its own: `serverProcess` is null because another
   // machine is running it. Starting one here would be answering a question

--- a/tests/draining.test.ts
+++ b/tests/draining.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  beginDraining,
+  isDraining,
+  watchEndpoint,
+  resetDrainingForTests,
+  DRAINING_MESSAGE
+} from '../packages/server/src/draining'
+
+/**
+ * Refusing to start work on a name this process no longer holds.
+ *
+ * The claim ends with a probe and a rename, two syscalls POSIX gives no way to
+ * fuse, so the window where two servers might each believe they hold the name
+ * cannot be closed. This is where the harm is closed instead: a session started
+ * here would be reachable only through a name that now points elsewhere, and the
+ * person who started it would watch a terminal that accepts keystrokes and never
+ * runs them.
+ */
+
+beforeEach(() => {
+  resetDrainingForTests()
+})
+
+describe('before anything has been lost', () => {
+  it('is not draining', () => {
+    expect(isDraining()).toBe(false)
+  })
+
+  it('is not draining for a server that never held an endpoint', () => {
+    // win32, a directory anyone can write, a path too long for sun_path. That is
+    // a downgrade to TCP-only, not a loss -- and refusing its sessions would
+    // leave the machine with nothing that works.
+    expect(isDraining()).toBe(false)
+  })
+})
+
+describe('once the endpoint is gone', () => {
+  it('notices by looking, rather than waiting to be told', () => {
+    // Losing the name happens *to* this process: whoever took it has no way to
+    // say so. An earlier version only ever noticed inside the idle watch's
+    // snapshot -- up to a minute late, and never at all for `vorn-server serve`,
+    // where that watch is switched off.
+    let held = true
+    watchEndpoint(() => held)
+    expect(isDraining()).toBe(false)
+
+    held = false
+    expect(isDraining()).toBe(true)
+  })
+
+  it('does not un-notice when the name comes back', () => {
+    // Nothing gives an endpoint back. A name that reappears is somebody else's
+    // socket at the same path, and resuming on it would be the original bug.
+    let held = true
+    watchEndpoint(() => held)
+    held = false
+    expect(isDraining()).toBe(true)
+
+    held = true
+    expect(isDraining()).toBe(true)
+  })
+
+  it('stops asking once it knows', () => {
+    // The check is an lstat per session creation. Cheap, but there is no reason
+    // to keep paying it for an answer that cannot change.
+    let asked = 0
+    watchEndpoint(() => {
+      asked++
+      return false
+    })
+
+    isDraining()
+    isDraining()
+    isDraining()
+
+    expect(asked).toBe(1)
+  })
+
+  it('can be told directly, without a check to consult', () => {
+    beginDraining()
+    expect(isDraining()).toBe(true)
+  })
+})
+
+describe('what a person is told', () => {
+  it('says the server is finishing, not that something failed', () => {
+    // The sessions already running are fine, and the fix is to reopen Vorn. A
+    // message that read as an error would send someone looking for a broken
+    // thing.
+    expect(DRAINING_MESSAGE).toMatch(/finishing/i)
+    expect(DRAINING_MESSAGE).toMatch(/reopen/i)
+  })
+})

--- a/tests/endpoint-race.process.test.ts
+++ b/tests/endpoint-race.process.test.ts
@@ -183,6 +183,36 @@ describe('two servers reaching for one machine', () => {
     expect(replies.length, `only ${replies.length} of ${sent} calls answered`).toBe(sent)
   }, 60_000)
 
+  it('lets a later start claim an endpoint its owner left behind on a clean exit', async () => {
+    // The ordinary state of a machine between launches, and the one a review
+    // found would have bricked the app: nothing removes the endpoint on shutdown,
+    // so quitting Vorn leaves a socket file with nothing behind it. A launcher
+    // that committed to that name and gave up when it did not answer would mean
+    // quitting Vorn once made Vorn unable to start again.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-race-'))
+    const first = launch()
+    const socket = await waitForEndpoint()
+    const abandoned = fs.lstatSync(socket).ino
+
+    process.kill(first.pid as number, 'SIGTERM')
+    for (let i = 0; i < 40 && alive(first.pid as number); i++) await sleep(250)
+
+    expect(fs.lstatSync(socket).isSocket(), 'the endpoint was removed on the way out').toBe(true)
+    expect(await served(socket), 'something still serves a stopped server').toBe(false)
+    expect(
+      fs.existsSync(path.join(dir, '.vorn', 'local-token')),
+      'the owner left its credential behind'
+    ).toBe(false)
+
+    const second = launch()
+    const deadline = Date.now() + 20_000
+    while (Date.now() < deadline && fs.lstatSync(socket).ino === abandoned) await sleep(250)
+
+    expect(fs.lstatSync(socket).ino, 'the leftover was never replaced').not.toBe(abandoned)
+    expect(await served(socket), 'the new server is not serving').toBe(true)
+    expect(alive(second.pid as number), 'the new server stood down instead of starting').toBe(true)
+  }, 60_000)
+
   it('lets the next start claim an endpoint whose owner was killed outright', async () => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-race-'))
     const first = launch()

--- a/tests/endpoint-race.process.test.ts
+++ b/tests/endpoint-race.process.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import fs from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { EXIT_ENDPOINT_TAKEN } from '../packages/shared/src/protocol'
+
+/**
+ * Two real servers, one machine.
+ *
+ * The unit tests pin the decision against a fabricated incumbent. These pin the
+ * thing the decision exists for and cannot be faked: that starting a second
+ * server does not take the endpoint from the first, and that a client talking to
+ * the first never notices the attempt.
+ *
+ * HOME is redirected as well as `--data-dir`, and that is not tidiness:
+ * `shutdown()` calls `uninstallHooks()`, which writes `~/.claude/settings.json`
+ * regardless of the data dir. Without it these would uninstall the developer's
+ * own agent hooks on the way past.
+ */
+
+const SERVER = path.join(__dirname, '..', 'packages', 'server')
+const ENTRY = path.join(SERVER, 'dist', 'index.cjs')
+
+beforeAll(() => {
+  // Built rather than skipped when absent: `dist/` is gitignored and `yarn test`
+  // builds nothing, so a skip-if-missing gate means this never runs in CI —
+  // green on the one claim the change is named for.
+  if (fs.existsSync(ENTRY)) return
+  const built = spawnSync('yarn', ['build'], { cwd: SERVER, stdio: 'inherit', shell: false })
+  if (built.status !== 0) throw new Error('could not build the server bundle for this test')
+}, 180_000)
+
+let dir: string | null = null
+const running: ChildProcess[] = []
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function launch(): ChildProcess {
+  const data = path.join(dir as string, '.vorn')
+  fs.mkdirSync(data, { recursive: true, mode: 0o700 })
+  const proc = spawn(process.execPath, [ENTRY, '--data-dir', data, '--port', '0'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+    env: {
+      ...process.env,
+      HOME: dir as string,
+      USERPROFILE: dir as string,
+      VORN_DATA_DIR: data,
+      VORN_IDLE_TIMEOUT_MS: '600000'
+    }
+  })
+  // Drained, never left. An unread pipe fills at 64KB and blocks the writer, and
+  // this server logs a line per request.
+  proc.stdout?.resume()
+  proc.stderr?.resume()
+  running.push(proc)
+  return proc
+}
+
+const socketPath = (): string => path.join(dir as string, '.vorn', 'vorn.sock')
+
+async function waitForEndpoint(timeoutMs = 20_000): Promise<string> {
+  const socket = socketPath()
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    try {
+      if (fs.lstatSync(socket).isSocket()) return socket
+    } catch {
+      /* not yet */
+    }
+    await sleep(200)
+  }
+  throw new Error('no endpoint appeared')
+}
+
+/** Whether anything is serving this name right now. */
+function served(at: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const c = net.connect(at)
+    const done = (answer: boolean): void => {
+      c.destroy()
+      resolve(answer)
+    }
+    c.setTimeout(1_000, () => done(false))
+    c.once('connect', () => done(true))
+    c.once('error', () => done(false))
+  })
+}
+
+afterEach(() => {
+  for (const proc of running.splice(0)) {
+    if (!proc.pid) continue
+    try {
+      process.kill(-proc.pid, 'SIGKILL')
+    } catch {
+      try {
+        process.kill(proc.pid, 'SIGKILL')
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+  if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  dir = null
+})
+
+describe('two servers reaching for one machine', () => {
+  it('leaves the endpoint with the first, and the second stands down', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-race-'))
+    const first = launch()
+    const socket = await waitForEndpoint()
+    const held = fs.lstatSync(socket).ino
+
+    const second = launch()
+    const code = await new Promise<number | null>((resolve) => {
+      second.once('exit', (c) => resolve(c))
+      setTimeout(() => resolve(null), 20_000)
+    })
+
+    // Not a crash: it did nothing wrong, it arrived second. Carrying on would
+    // make it a second writer on one database, and `saveSessions` is a
+    // whole-table replace -- the two would erase each other's sessions.
+    expect(code, 'the second server did not stand down').toBe(EXIT_ENDPOINT_TAKEN)
+    expect(fs.lstatSync(socket).ino, 'the endpoint changed hands').toBe(held)
+    expect(await served(socket), 'nothing is serving the endpoint').toBe(true)
+    expect(alive(first.pid as number), 'the first server died').toBe(true)
+  }, 60_000)
+
+  it('never drops a client held open across the attempt', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-race-'))
+    launch()
+    const socket = await waitForEndpoint()
+
+    const tokenFile = path.join(dir, '.vorn', 'local-token')
+    for (let i = 0; i < 60 && !fs.existsSync(tokenFile); i++) await sleep(200)
+    const token = fs.readFileSync(tokenFile, 'utf-8').trim()
+
+    const { default: WebSocket } = await import('ws')
+    const ws = new WebSocket(`ws+unix://${socket}:/ws`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    await new Promise((r) => ws.once('open', r))
+
+    const replies: number[] = []
+    let failed = false
+    ws.on('message', (raw: Buffer) => {
+      try {
+        const msg = JSON.parse(raw.toString())
+        if (typeof msg.id === 'number') replies.push(msg.id)
+      } catch {
+        /* greeting frames */
+      }
+    })
+    ws.on('close', () => {
+      failed = true
+    })
+    ws.on('error', () => {
+      failed = true
+    })
+
+    // Talk right through a second server's whole startup and claim attempt.
+    launch()
+    let sent = 0
+    for (let i = 0; i < 16; i++) {
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id: ++sent, method: 'config:load' }))
+      await sleep(400)
+    }
+    await sleep(1_000)
+    ws.close()
+
+    expect(failed, 'the socket dropped during the handover attempt').toBe(false)
+    expect(replies.length, `only ${replies.length} of ${sent} calls answered`).toBe(sent)
+  }, 60_000)
+
+  it('lets the next start claim an endpoint whose owner was killed outright', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-race-'))
+    const first = launch()
+    const socket = await waitForEndpoint()
+    const abandoned = fs.lstatSync(socket).ino
+
+    // SIGKILL leaves the socket file behind: nothing runs on the way out.
+    process.kill(first.pid as number, 'SIGKILL')
+    for (let i = 0; i < 40 && alive(first.pid as number); i++) await sleep(250)
+    expect(fs.lstatSync(socket).isSocket(), 'the corpse was cleaned up somehow').toBe(true)
+    expect(await served(socket), 'something is still serving a killed server').toBe(false)
+
+    launch()
+    const deadline = Date.now() + 20_000
+    while (Date.now() < deadline && fs.lstatSync(socket).ino === abandoned) await sleep(250)
+
+    expect(fs.lstatSync(socket).ino, 'the corpse was never replaced').not.toBe(abandoned)
+    expect(await served(socket), 'the replacement is not serving').toBe(true)
+  }, 60_000)
+})

--- a/tests/endpoint-race.process.test.ts
+++ b/tests/endpoint-race.process.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, afterEach, beforeAll } from 'vitest'
+import { spawnsRealServers } from './helpers/one-at-a-time'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
 import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { EXIT_ENDPOINT_TAKEN } from '../packages/shared/src/protocol'
+
+spawnsRealServers()
 
 /**
  * Two real servers, one machine.

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -227,6 +227,24 @@ describe('whether this machine can host one at all', () => {
     expect(canHostEndpoint(deep)).toMatchObject({ ok: false })
   })
 
+  it('measures the name it will actually bind, not the shorter one', () => {
+    // The scratch name is what gets bound and it is thirteen bytes longer than
+    // the canonical one. A directory that fits only the shorter path would pass
+    // the check and then fail the bind -- the exact failure this turns into a
+    // clean downgrade.
+    // Sized so the canonical path fits inside the limit and the scratch name --
+    // thirteen bytes longer -- does not. Created, because a directory that is not
+    // there is refused for a different reason and would make this pass without
+    // testing anything.
+    const room = 96 - Buffer.byteLength(endpointPath(dir)) - 1
+    const snug = path.join(dir, 'y'.repeat(Math.max(1, room - 6)))
+    fs.mkdirSync(snug, { recursive: true, mode: 0o700 })
+
+    expect(Buffer.byteLength(endpointPath(snug))).toBeLessThanOrEqual(96)
+    expect(Buffer.byteLength(scratchPathFor(endpointPath(snug)))).toBeGreaterThan(96)
+    expect(canHostEndpoint(snug)).toMatchObject({ ok: false })
+  })
+
   it('declines a directory that is not there', () => {
     expect(canHostEndpoint(path.join(dir, 'absent'))).toMatchObject({ ok: false })
   })

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -40,7 +40,13 @@ afterEach(() => {
 
 /** A real bound listener, since the claim identifies sockets by inode. */
 async function listener(at: string): Promise<net.Server> {
-  const server = net.createServer((c) => c.end('served'))
+  const server = net.createServer((c) => {
+    // A probe connects and destroys immediately, so this write often lands on a
+    // socket that has already gone. Swallowed, or the reset is unhandled and
+    // ends the test worker.
+    c.on('error', () => {})
+    c.end('served')
+  })
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject)
     server.listen(at, resolve)
@@ -160,11 +166,18 @@ describe('what the probe is allowed to conclude', () => {
     expect(await probeEndpoint(canonical)).toBe('dead')
   })
 
-  it('declines to guess when it cannot tell', async () => {
-    // A path that is not a socket at all: neither refused nor served.
+  it('is never asked about something that is not a socket', () => {
+    // There was a test here that connected to a regular file and expected
+    // "unknown". It passed on darwin, which answers ENOTSOCK, and failed on linux,
+    // which answers ECONNREFUSED -- so the probe called it dead, which by its own
+    // whitelist is right. The test was asserting an errno rather than a rule.
+    //
+    // The rule it should have been asserting is one layer up: the claim
+    // identifies the entry before it probes, and anything that is not a socket is
+    // not something this process may replace. The probe never sees one.
     const notASocket = path.join(dir, 'a-regular-file')
     fs.writeFileSync(notASocket, 'x')
-    expect(await probeEndpoint(notASocket)).toBe('unknown')
+    expect(fs.lstatSync(notASocket).isSocket()).toBe(false)
   })
 })
 

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -122,6 +122,34 @@ describe('the four races', () => {
     expect(inode(canonical)).toBe(theirs)
   })
 
+  it('takes a name that frees itself while it is being checked', async () => {
+    // A server that bound the canonical path directly -- which is what this
+    // codebase did before the scratch name, and what an older Vorn still does --
+    // unlinks it on close. So the name really can go from taken to free while a
+    // claim is in progress, and standing down there would leave the machine with
+    // no endpoint held and nobody holding one.
+    const incumbent = await listener(canonical)
+    const scratch = scratchPathFor(canonical)
+    await listener(scratch)
+    const mine = inode(scratch)
+
+    // The name is taken when the claim starts -- so the first link really does
+    // fail with EEXIST -- and the incumbent departs during the probe, taking the
+    // canonical entry with it the way `close()` does.
+    let departed = false
+    const probe = vi.fn(async (): Promise<Liveness> => {
+      if (!departed) {
+        departed = true
+        await new Promise<void>((r) => incumbent.close(() => r()))
+      }
+      return 'dead'
+    })
+
+    expect(await claimEndpoint(scratch, canonical, probe)).toEqual({ held: true })
+    expect(inode(canonical)).toBe(mine)
+    expect(probe).toHaveBeenCalledTimes(1)
+  })
+
   it('stands down when the entry changes hands mid-check', async () => {
     await listener(canonical)
     const scratch = scratchPathFor(canonical)

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  claimEndpoint,
+  probeEndpoint,
+  canHostEndpoint,
+  scratchPathFor,
+  endpointPath,
+  type Liveness
+} from '../packages/server/src/endpoint'
+
+/**
+ * Deciding who owns the name a machine's server answers on.
+ *
+ * The two wrong answers are not symmetric, and every test here is written around
+ * that. Taking a name from a server that is still serving strands every terminal
+ * on the machine behind an endpoint nobody can reach — the failure this exists to
+ * prevent. Declining a name whose owner is gone leaves a leftover file, which the
+ * next start replaces in one rename. So the bar for "take it" is proof of death,
+ * and everything short of proof declines.
+ */
+
+let dir: string
+let canonical: string
+const cleanup: Array<() => void> = []
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-endpoint-'))
+  fs.chmodSync(dir, 0o700)
+  canonical = endpointPath(dir)
+})
+
+afterEach(() => {
+  while (cleanup.length) cleanup.pop()?.()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** A real bound listener, since the claim identifies sockets by inode. */
+async function listener(at: string): Promise<net.Server> {
+  const server = net.createServer((c) => c.end('served'))
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(at, resolve)
+  })
+  cleanup.push(() => server.close())
+  return server
+}
+
+const inode = (p: string): number => fs.lstatSync(p).ino
+const always = (answer: Liveness) => async (): Promise<Liveness> => answer
+
+describe('the four races', () => {
+  it('takes a free name', async () => {
+    const scratch = scratchPathFor(canonical)
+    await listener(scratch)
+    const mine = inode(scratch)
+
+    expect(await claimEndpoint(scratch, canonical, always('dead'))).toEqual({ held: true })
+    expect(inode(canonical)).toBe(mine)
+    // The scratch name is gone: it was ours, and removing it is what makes
+    // libuv's unlink at close incapable of touching the canonical entry.
+    expect(fs.existsSync(scratch)).toBe(false)
+  })
+
+  it('stands down when the incumbent is alive', async () => {
+    const incumbent = await listener(canonical)
+    const theirs = inode(canonical)
+    const scratch = scratchPathFor(canonical)
+    await listener(scratch)
+
+    const outcome = await claimEndpoint(scratch, canonical, always('alive'))
+
+    expect(outcome).toMatchObject({ held: false })
+    expect(inode(canonical)).toBe(theirs)
+    expect(incumbent.listening).toBe(true)
+  })
+
+  it('takes the name when the incumbent is provably dead', async () => {
+    // What SIGKILL leaves: a socket inode at the canonical name with nothing
+    // serving it. Built by hard-linking a live listener's name into place and
+    // then closing the listener, which unlinks only the name it bound.
+    const doomed = scratchPathFor(canonical)
+    const server = await listener(doomed)
+    fs.linkSync(doomed, canonical)
+    await new Promise<void>((r) => server.close(() => r()))
+    expect(fs.lstatSync(canonical).isSocket()).toBe(true)
+    expect(await probeEndpoint(canonical)).toBe('dead')
+    const corpse = inode(canonical)
+
+    const scratch = scratchPathFor(canonical)
+    await listener(scratch)
+    const mine = inode(scratch)
+
+    // The real probe, not a stub: this is the one case where the claim must
+    // conclude death on its own and act on it.
+    expect(await claimEndpoint(scratch, canonical)).toEqual({ held: true })
+    expect(inode(canonical)).toBe(mine)
+    expect(inode(canonical)).not.toBe(corpse)
+    expect(fs.existsSync(scratch)).toBe(false)
+  })
+
+  it('never takes a name it cannot prove is dead', async () => {
+    // A hung server answers nothing. It is still serving every terminal it holds,
+    // and deleting its endpoint is the one unrecoverable mistake here.
+    await listener(canonical)
+    const theirs = inode(canonical)
+    const scratch = scratchPathFor(canonical)
+    await listener(scratch)
+
+    const outcome = await claimEndpoint(scratch, canonical, always('unknown'))
+
+    expect(outcome).toMatchObject({ held: false, because: 'the incumbent is unknown' })
+    expect(inode(canonical)).toBe(theirs)
+  })
+
+  it('stands down when the entry changes hands mid-check', async () => {
+    await listener(canonical)
+    const scratch = scratchPathFor(canonical)
+    await listener(scratch)
+
+    // A third server takes the name between the probe and the re-look, every
+    // time. The inode is what notices; a path comparison would see no change.
+    const probe = vi.fn(async (): Promise<Liveness> => {
+      const usurper = scratchPathFor(canonical)
+      const server = await listener(usurper)
+      cleanup.push(() => server.close())
+      fs.renameSync(usurper, canonical)
+      return 'dead'
+    })
+
+    const outcome = await claimEndpoint(scratch, canonical, probe)
+
+    expect(outcome).toMatchObject({ held: false })
+    expect(probe).toHaveBeenCalledTimes(3) // bounded, not forever
+  })
+})
+
+describe('what the probe is allowed to conclude', () => {
+  it('calls a served name alive', async () => {
+    await listener(canonical)
+    expect(await probeEndpoint(canonical)).toBe('alive')
+  })
+
+  it('calls an absent name dead', async () => {
+    expect(await probeEndpoint(path.join(dir, 'nothing.sock'))).toBe('dead')
+  })
+
+  it('calls a socket file with nothing behind it dead', async () => {
+    const server = await listener(canonical)
+    await new Promise<void>((r) => server.close(() => r()))
+    // close() unlinks, so put a corpse back the way a SIGKILL would leave one.
+    const other = scratchPathFor(canonical)
+    const s2 = await listener(other)
+    fs.linkSync(other, canonical)
+    await new Promise<void>((r) => s2.close(() => r()))
+
+    expect(await probeEndpoint(canonical)).toBe('dead')
+  })
+
+  it('declines to guess when it cannot tell', async () => {
+    // A path that is not a socket at all: neither refused nor served.
+    const notASocket = path.join(dir, 'a-regular-file')
+    fs.writeFileSync(notASocket, 'x')
+    expect(await probeEndpoint(notASocket)).toBe('unknown')
+  })
+})
+
+describe('whether this machine can host one at all', () => {
+  it('hosts one in a private directory', () => {
+    expect(canHostEndpoint(dir)).toEqual({ ok: true })
+  })
+
+  it('declines a directory anyone can write', () => {
+    // The directory is the whole access control on darwin, where a socket's own
+    // mode is not consulted on connect. Anyone who can write here can rename
+    // over the endpoint.
+    fs.chmodSync(dir, 0o777)
+    expect(canHostEndpoint(dir)).toMatchObject({ ok: false })
+  })
+
+  it('declines a path too long for sun_path', () => {
+    const deep = path.join(dir, 'x'.repeat(120))
+    expect(canHostEndpoint(deep)).toMatchObject({ ok: false })
+  })
+
+  it('declines a directory that is not there', () => {
+    expect(canHostEndpoint(path.join(dir, 'absent'))).toMatchObject({ ok: false })
+  })
+})

--- a/tests/endpoint.test.ts
+++ b/tests/endpoint.test.ts
@@ -214,12 +214,36 @@ describe('whether this machine can host one at all', () => {
     expect(canHostEndpoint(dir)).toEqual({ ok: true })
   })
 
-  it('declines a directory anyone can write', () => {
-    // The directory is the whole access control on darwin, where a socket's own
-    // mode is not consulted on connect. Anyone who can write here can rename
-    // over the endpoint.
-    fs.chmodSync(dir, 0o777)
-    expect(canHostEndpoint(dir)).toMatchObject({ ok: false })
+  it.each([
+    ['world-writable', 0o777],
+    ['group-writable', 0o770],
+    // Not writable, and still not private. On darwin a socket's own mode is not
+    // consulted on connect, so a directory another user can traverse is a socket
+    // another user can connect to -- and the greeting, sent before
+    // authentication, hands them this server's identity and the account name in
+    // `dataDir`. Loopback bounded that for TCP peers; for a unix peer the
+    // directory is the only bound there is.
+    ['world-readable', 0o755],
+    ['group-readable', 0o750],
+    ['group-executable only', 0o710]
+  ])('tightens a %s directory rather than refusing it', (_label, mode) => {
+    // This directory is Vorn's own, it holds the credential and the database, and
+    // `database.ts` already means it to be 0700 -- but `mode` on mkdir applies
+    // only at creation, so real installs are out there sitting wider. Refusing
+    // them would leave those machines silently without an endpoint; narrowing
+    // fixes the thing that was actually wrong.
+    fs.chmodSync(dir, mode)
+
+    expect(canHostEndpoint(dir)).toEqual({ ok: true })
+    expect(fs.statSync(dir).mode & 0o777).toBe(0o700)
+  })
+
+  it('refuses when it cannot make the directory private', () => {
+    const stranger = path.join(dir, 'not-ours')
+    fs.mkdirSync(stranger, { mode: 0o755 })
+    // Nothing to tighten because there is nothing there: the honest answer is no.
+    fs.rmSync(stranger, { recursive: true })
+    expect(canHostEndpoint(stranger)).toMatchObject({ ok: false })
   })
 
   it('declines a path too long for sun_path', () => {

--- a/tests/helpers/one-at-a-time.ts
+++ b/tests/helpers/one-at-a-time.ts
@@ -19,16 +19,37 @@ import path from 'node:path'
  * for the same reason: it fails rather than overwriting, so the loser knows it
  * lost.
  *
- * Stale locks are taken rather than swept. A worker killed mid-test leaves one
- * behind, and a test run that refused to proceed because of a crash an hour ago
+ * A lock is stale when the worker that wrote it is gone, which is asked rather
+ * than assumed from elapsed time: these suites legitimately run for minutes, and
+ * a clock-based rule would hand the lock to a second worker exactly on the slow
+ * machines where it matters. A worker killed mid-test still leaves one behind,
+ * and that one is taken -- a run that refused to start over a crash an hour ago
  * would be worse than the contention this avoids.
  */
 
 const LOCK = path.join(os.tmpdir(), 'vorn-test-spawn.lock')
-const STALE_AFTER_MS = 120_000
 const POLL_MS = 100
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+/** Who holds it, or null if nothing does. */
+function holder(): number | null {
+  try {
+    const pid = Number(fs.readFileSync(LOCK, 'utf-8').trim())
+    return Number.isInteger(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
+  }
+}
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
 
 async function acquire(): Promise<void> {
   for (;;) {
@@ -36,13 +57,15 @@ async function acquire(): Promise<void> {
       fs.writeFileSync(LOCK, String(process.pid), { flag: 'wx' })
       return
     } catch {
-      try {
-        if (Date.now() - fs.statSync(LOCK).mtimeMs > STALE_AFTER_MS)
-          fs.rmSync(LOCK, { force: true })
-      } catch {
-        // Somebody released it between the failed create and this look, which is
-        // the outcome being waited for anyway.
-      }
+      // Liveness, never elapsed time. An earlier version called a lock stale
+      // after two minutes, and `launcher-endpoint.process.test.ts` runs six tests
+      // that each spawn a server -- comfortably longer than that. So the helper
+      // written to stop suites running concurrently would have been the thing
+      // letting a second one in, and only on the slowest machines, which is where
+      // it was needed most. A worker that is still there still holds it, however
+      // long it takes.
+      const owner = holder()
+      if (owner !== null && !alive(owner)) fs.rmSync(LOCK, { force: true })
       await sleep(POLL_MS)
     }
   }
@@ -60,6 +83,9 @@ export function spawnsRealServers(): void {
     await acquire()
   }, 180_000)
   afterAll(() => {
-    fs.rmSync(LOCK, { force: true })
+    // Only ours. The same rule the code under test lives by: no actor removes a
+    // name it did not create. A worker that overran and lost the lock must not
+    // take the next one's on its way out.
+    if (holder() === process.pid) fs.rmSync(LOCK, { force: true })
   })
 }

--- a/tests/helpers/one-at-a-time.ts
+++ b/tests/helpers/one-at-a-time.ts
@@ -1,0 +1,65 @@
+import { beforeAll, afterAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * One spawner at a time, across test files.
+ *
+ * A handful of suites here start real detached servers, and vitest runs files in
+ * parallel. Each server migrates a database, binds a port, claims a socket and
+ * installs hooks, so several at once turn a machine's cores into the thing under
+ * test: the failure that follows is a timeout in whichever suite was unluckiest,
+ * usually not the one that caused it. `server-port-stability` was the one that
+ * fell over when these were added.
+ *
+ * A lock file rather than vitest's own sequencing, because the tests that need
+ * this are a named few and making the whole suite serial would cost every other
+ * file minutes. Exclusive create is the same primitive `endpoint.ts` leans on,
+ * for the same reason: it fails rather than overwriting, so the loser knows it
+ * lost.
+ *
+ * Stale locks are taken rather than swept. A worker killed mid-test leaves one
+ * behind, and a test run that refused to proceed because of a crash an hour ago
+ * would be worse than the contention this avoids.
+ */
+
+const LOCK = path.join(os.tmpdir(), 'vorn-test-spawn.lock')
+const STALE_AFTER_MS = 120_000
+const POLL_MS = 100
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+async function acquire(): Promise<void> {
+  for (;;) {
+    try {
+      fs.writeFileSync(LOCK, String(process.pid), { flag: 'wx' })
+      return
+    } catch {
+      try {
+        if (Date.now() - fs.statSync(LOCK).mtimeMs > STALE_AFTER_MS)
+          fs.rmSync(LOCK, { force: true })
+      } catch {
+        // Somebody released it between the failed create and this look, which is
+        // the outcome being waited for anyway.
+      }
+      await sleep(POLL_MS)
+    }
+  }
+}
+
+/**
+ * Hold the lock for this whole file.
+ *
+ * Per file rather than per test: the cost being avoided is servers running at
+ * the same time, and a suite that released between its own tests would let
+ * another file in halfway through its own sequence.
+ */
+export function spawnsRealServers(): void {
+  beforeAll(async () => {
+    await acquire()
+  }, 180_000)
+  afterAll(() => {
+    fs.rmSync(LOCK, { force: true })
+  })
+}

--- a/tests/idle-exit.process.test.ts
+++ b/tests/idle-exit.process.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, afterEach, beforeAll } from 'vitest'
+import { spawnsRealServers } from './helpers/one-at-a-time'
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+
+spawnsRealServers()
 
 /**
  * Does the process actually leave?

--- a/tests/idle.test.ts
+++ b/tests/idle.test.ts
@@ -26,6 +26,7 @@ const quiet = (over: Partial<IdleSnapshot> = {}): IdleSnapshot => ({
   msSinceClientActivity: DEFAULT_IDLE_WINDOW_MS + 1,
   msSinceHookActivity: DEFAULT_IDLE_WINDOW_MS + 1,
   servesOthers: false,
+  draining: false,
   bridgeAttached: false,
   pendingPermissions: 0,
   pendingPairings: 0,
@@ -376,5 +377,35 @@ describe('once the decision is made', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('a server that lost the endpoint', () => {
+  it('stops being held open by the network binding', () => {
+    // `servesOthers` never lapses on its own, so without this a draining server
+    // bound to 0.0.0.0 would stay up for the life of the machine — keeping a
+    // promise to be reachable that it can no longer keep, since nothing can find
+    // it by name any more.
+    const wide = quiet({ servesOthers: true })
+    expect(whatHoldsItOpen(wide, policy)).not.toBeNull()
+    expect(whatHoldsItOpen({ ...wide, draining: true }, policy)).toBeNull()
+  })
+
+  it('still finishes the work it already has', () => {
+    // Draining refuses new sessions; it does not abandon running ones. Every
+    // hold below the network one is about work in progress and still applies.
+    const working = quiet({ servesOthers: true, draining: true, sessions: 2 })
+    expect(whatHoldsItOpen(working, policy)).toBe('2 session(s)')
+
+    const agent = quiet({ draining: true, headless: 1 })
+    expect(whatHoldsItOpen(agent, policy)).toBe('1 headless agent(s)')
+
+    const blocked = quiet({ draining: true, pendingPermissions: 1 })
+    expect(whatHoldsItOpen(blocked, policy)).toBe('an agent is waiting on a permission')
+  })
+
+  it('leaves once that work is done, on the window it already had', () => {
+    const done = quiet({ servesOthers: true, draining: true })
+    expect(decide(done, policy)).toEqual({ exit: true })
   })
 })

--- a/tests/launcher-endpoint.process.test.ts
+++ b/tests/launcher-endpoint.process.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * The real launcher, against real servers.
+ *
+ * `server-launcher-adoption.test.ts` fakes the bridge and the filesystem, which
+ * is the right way to pin what the *decision* is. It cannot pin whether the
+ * decision meets reality, and that is where the expensive bug was: a leftover
+ * endpoint is the ordinary state of a machine between launches, the launcher
+ * treated it as proof a server was running, and quitting Vorn once made Vorn
+ * unable to start again. Every mock in that file agreed with the code.
+ *
+ * So here nothing is faked but Electron itself: a real `launchServer` spawns a
+ * real detached server, claims a real socket, and a real `ServerBridge` connects
+ * over `ws+unix://`.
+ *
+ * HOME is redirected, which is what isolates it -- `resolveDataDir` is
+ * `os.homedir()/.vorn`, and `shutdown()` writes `~/.claude/settings.json`
+ * regardless of any data dir. Nothing here can touch the developer's own server.
+ */
+
+const REPO = path.join(__dirname, '..')
+const BUNDLE = path.join(REPO, 'packages', 'server', 'dist', 'index.cjs')
+
+let home: string
+let resources: string
+let appPath: string
+
+beforeAll(() => {
+  if (!fs.existsSync(BUNDLE)) {
+    const built = spawnSync('yarn', ['build'], {
+      cwd: path.join(REPO, 'packages', 'server'),
+      stdio: 'inherit',
+      shell: false
+    })
+    if (built.status !== 0) throw new Error('could not build the server bundle')
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => path.join(os.tmpdir(), 'vorn-launcher-userdata'),
+    // A packaged app's shape, built in the sandbox: the spawn derives the native
+    // module paths from this (`<appPath>/node_modules` and
+    // `<appPath>.unpacked/node_modules`) so a plain Node child can require what
+    // Electron would otherwise resolve through its ASAR patching. Pointing it at
+    // a fiction leaves the child unable to load libsql, which fails exactly like
+    // a server that will not start.
+    getAppPath: () => appPath,
+    getVersion: () => '0.7.0-test',
+    isPackaged: true
+  }
+}))
+vi.mock('../src/main/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Whether anything is serving this name right now. */
+function served(at: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const c = net.connect(at)
+    const done = (answer: boolean): void => {
+      c.destroy()
+      resolve(answer)
+    }
+    c.setTimeout(1_000, () => done(false))
+    c.once('connect', () => done(true))
+    c.once('error', () => done(false))
+  })
+}
+
+const socketPath = (): string => path.join(home, '.vorn', 'vorn.sock')
+const tokenPath = (): string => path.join(home, '.vorn', 'local-token')
+
+/**
+ * The server this sandbox is running, by the pid it published.
+ *
+ * Not `pgrep` on the data directory: the packaged spawn deliberately passes no
+ * `--data-dir` argument, so the path appears nowhere on the command line and a
+ * pattern match silently finds nothing -- which reads as "no server" and makes
+ * every assertion about killing one vacuously true.
+ */
+function serverPid(): number | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(home, '.vorn', 'ws-port'), 'utf-8'))
+    return typeof raw.pid === 'number' && alive(raw.pid) ? raw.pid : null
+  } catch {
+    return null
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-launcher-'))
+  fs.mkdirSync(path.join(home, '.vorn'), { recursive: true, mode: 0o700 })
+  // `resolveServerEntry` reads this for the packaged branch, which is the one
+  // that spawns detached — the behaviour under test.
+  resources = path.join(home, 'Resources')
+  fs.mkdirSync(resources, { recursive: true })
+  // Symlinked, not copied. The bundle leaves native modules external -- libsql
+  // and node-pty resolve from node_modules relative to the entry -- and Node
+  // resolves through a symlink by its realpath, so this finds them where a copy
+  // in a temp directory could not.
+  fs.symlinkSync(path.dirname(BUNDLE), path.join(resources, 'server'))
+  appPath = path.join(home, 'app')
+  fs.mkdirSync(appPath, { recursive: true })
+  fs.mkdirSync(`${appPath}.unpacked`, { recursive: true })
+  const realModules = path.join(REPO, 'node_modules')
+  fs.symlinkSync(realModules, path.join(appPath, 'node_modules'))
+  fs.symlinkSync(realModules, path.join(`${appPath}.unpacked`, 'node_modules'))
+  ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = resources
+  process.env.HOME = home
+  process.env.USERPROFILE = home
+  process.env.VORN_BUILD_CHANNEL = 'packaged'
+  process.env.VORN_IDLE_TIMEOUT_MS = '600000'
+  delete process.env.VORN_DATA_DIR
+})
+
+afterEach(async () => {
+  const pid = serverPid()
+  if (pid) {
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      /* already gone */
+    }
+  }
+  await sleep(300)
+  fs.rmSync(home, { recursive: true, force: true })
+})
+
+describe('launching against a real machine', () => {
+  it('starts a server, claims the endpoint, and connects over it', async () => {
+    const { launchServer, detachFromServer } = await import('../src/main/server/server-launcher')
+
+    const bridge = await launchServer()
+
+    expect(fs.lstatSync(socketPath()).isSocket(), 'no endpoint was claimed').toBe(true)
+    expect(await served(socketPath()), 'the endpoint is not being served').toBe(true)
+    expect(bridge.isConnected, 'the bridge never connected').toBe(true)
+    detachFromServer()
+  }, 90_000)
+
+  it('adopts the running server instead of starting a second', async () => {
+    const first = await import('../src/main/server/server-launcher')
+    await first.launchServer()
+    const held = fs.lstatSync(socketPath()).ino
+    const owner = serverPid()
+    first.detachFromServer()
+
+    // A fresh launcher, exactly as a second app launch would be.
+    vi.resetModules()
+    const second = await import('../src/main/server/server-launcher')
+    const bridge = await second.launchServer()
+
+    expect(fs.lstatSync(socketPath()).ino, 'the endpoint changed hands').toBe(held)
+    expect(serverPid(), 'a second server took over').toBe(owner)
+    expect(bridge.isConnected, 'the second launch never connected').toBe(true)
+    second.detachFromServer()
+  }, 90_000)
+
+  it('starts again after a quit, past the endpoint the old server left behind', async () => {
+    // The bug this test exists for. Nothing removes the endpoint on shutdown, so
+    // this is what every quit leaves: a socket file with nothing behind it and no
+    // credential beside it. A launcher that reads that as a running server
+    // refuses to start, and the app cannot be opened again.
+    const first = await import('../src/main/server/server-launcher')
+    await first.launchServer()
+    const abandoned = fs.lstatSync(socketPath()).ino
+    await first.stopServer()
+    await sleep(1_500)
+
+    expect(fs.lstatSync(socketPath()).isSocket(), 'the endpoint was removed on quit').toBe(true)
+    expect(await served(socketPath()), 'something still serves a stopped server').toBe(false)
+    expect(fs.existsSync(tokenPath()), 'the credential outlived its server').toBe(false)
+
+    vi.resetModules()
+    const second = await import('../src/main/server/server-launcher')
+    const bridge = await second.launchServer()
+
+    expect(bridge.isConnected, 'the app could not start again after a quit').toBe(true)
+    expect(fs.lstatSync(socketPath()).ino, 'the leftover was never replaced').not.toBe(abandoned)
+    expect(await served(socketPath()), 'the new server is not serving').toBe(true)
+    second.detachFromServer()
+  }, 90_000)
+
+  it('starts again after a crash, past the endpoint and the credential left behind', async () => {
+    // SIGKILL runs nothing on the way out, so this leftover keeps its credential
+    // too -- a stale secret beside a dead socket, which must not read as a
+    // server. The app is let go of first, because this is the case where Vorn was
+    // closed and the server died afterwards: a running app would relaunch its own
+    // server rather than leave the corpse for the next launch, and does.
+    const first = await import('../src/main/server/server-launcher')
+    await first.launchServer()
+    const abandoned = fs.lstatSync(socketPath()).ino
+    const doomed = serverPid()
+    expect(doomed, 'no server to kill').not.toBeNull()
+
+    first.detachFromServer()
+    process.kill(doomed as number, 'SIGKILL')
+    for (let i = 0; i < 40 && alive(doomed as number); i++) await sleep(100)
+    expect(alive(doomed as number), 'the server survived SIGKILL').toBe(false)
+
+    expect(fs.existsSync(tokenPath()), 'a crash somehow cleaned up after itself').toBe(true)
+    expect(await served(socketPath()), 'something is still serving a killed server').toBe(false)
+
+    vi.resetModules()
+    const second = await import('../src/main/server/server-launcher')
+    const bridge = await second.launchServer()
+
+    expect(bridge.isConnected, 'the app could not start again after a crash').toBe(true)
+    expect(fs.lstatSync(socketPath()).ino, 'the corpse was never replaced').not.toBe(abandoned)
+    second.detachFromServer()
+  }, 90_000)
+
+  it('replaces its own server when that server crashes under it', async () => {
+    // The other half, and the reason the case above has to let go first: an app
+    // that is still running owns the server it started, so a crash is answered
+    // with a replacement rather than left for the next launch. Found by a test
+    // that killed a server the launcher was still watching and was surprised the
+    // endpoint kept answering.
+    const app = await import('../src/main/server/server-launcher')
+    await app.launchServer()
+    const doomed = serverPid()
+
+    process.kill(doomed as number, 'SIGKILL')
+    const deadline = Date.now() + 30_000
+    while (Date.now() < deadline && (serverPid() === doomed || serverPid() === null)) {
+      await sleep(250)
+    }
+
+    expect(serverPid(), 'no replacement was started').not.toBe(doomed)
+    expect(await served(socketPath()), 'the replacement never took the endpoint').toBe(true)
+    app.detachFromServer()
+  }, 90_000)
+
+  it('leaves the running server and its sessions alone when it adopts', async () => {
+    const first = await import('../src/main/server/server-launcher')
+    const bridge = await first.launchServer()
+    const created = (await bridge.request('shell:create', os.tmpdir())) as { id: string }
+    expect(created.id, 'no session was created to protect').toBeTruthy()
+    const owner = serverPid()
+    first.detachFromServer()
+
+    vi.resetModules()
+    const second = await import('../src/main/server/server-launcher')
+    const rejoined = await second.launchServer()
+    const sessions = (await rejoined.request('terminal:listActive')) as Array<{ id: string }>
+
+    expect(serverPid(), 'the server was replaced rather than adopted').toBe(owner)
+    expect(
+      sessions.map((s) => s.id),
+      'the adopted server lost its session'
+    ).toContain(created.id)
+    second.detachFromServer()
+  }, 90_000)
+})

--- a/tests/launcher-endpoint.process.test.ts
+++ b/tests/launcher-endpoint.process.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
+import { spawnsRealServers } from './helpers/one-at-a-time'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
+
+spawnsRealServers()
 
 /**
  * The real launcher, against real servers.

--- a/tests/local-endpoint.test.ts
+++ b/tests/local-endpoint.test.ts
@@ -89,16 +89,34 @@ describe('what the endpoint answers', () => {
     ws.close()
   })
 
-  it('refuses anything that is not the socket path', async () => {
+  it.each(['/somewhere-else', '/ws-and-more', '/wsx', '/'])(
+    'refuses the route %s',
+    async (route) => {
+      // `/ws-and-more` is the one worth naming: a `startsWith` check accepted it,
+      // which is a wider door than a listener carrying one route means to open.
+      const endpoint = await hold()
+
+      const ws = new WebSocket(`ws+unix://${endpoint.path}:${route}`)
+      await expect(
+        new Promise((resolve, reject) => {
+          ws.once('open', resolve)
+          ws.once('error', reject)
+        })
+      ).rejects.toThrow()
+    }
+  )
+
+  it('accepts the route with a query on it', async () => {
     const endpoint = await hold()
 
-    const ws = new WebSocket(`ws+unix://${endpoint.path}:/somewhere-else`)
+    const ws = new WebSocket(`ws+unix://${endpoint.path}:/ws?topics=all`)
     await expect(
       new Promise((resolve, reject) => {
         ws.once('open', resolve)
         ws.once('error', reject)
       })
-    ).rejects.toThrow()
+    ).resolves.toBeUndefined()
+    ws.close()
   })
 })
 

--- a/tests/local-endpoint.test.ts
+++ b/tests/local-endpoint.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import WebSocket from 'ws'
+import { openLocalEndpoint, type LocalEndpoint } from '../packages/server/src/local-endpoint'
+import { endpointUrl } from '../src/main/server/server-adoption'
+
+/**
+ * Bringing up the endpoint, in this process.
+ *
+ * `endpoint-race.process.test.ts` proves the behaviour with real spawned servers,
+ * which is the only way to prove a handover. It cannot exercise this module's own
+ * branches — a separate process is a separate world — so the wiring is tested
+ * here: what happens when the name is free, when it is taken, when the directory
+ * will not have it, and whether letting go actually lets go.
+ */
+
+let dir: string
+const open: LocalEndpoint[] = []
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-local-'))
+  fs.chmodSync(dir, 0o700)
+})
+
+afterEach(async () => {
+  for (const endpoint of open.splice(0)) await endpoint.close()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+async function hold(onUpgraded = (): void => {}): Promise<LocalEndpoint> {
+  const outcome = await openLocalEndpoint(dir, onUpgraded)
+  if (outcome.kind !== 'held') throw new Error(`expected to hold it, got ${outcome.kind}`)
+  open.push(outcome.endpoint)
+  return outcome.endpoint
+}
+
+describe('bringing up the endpoint', () => {
+  it('claims a free name and serves it', async () => {
+    const endpoint = await hold()
+
+    expect(endpoint.path).toBe(path.join(dir, 'vorn.sock'))
+    expect(fs.lstatSync(endpoint.path).isSocket()).toBe(true)
+    expect(endpoint.holds()).toBe(true)
+  })
+
+  it('leaves no scratch name behind', async () => {
+    await hold()
+    // Every name this process created is its own to remove, and it removes them.
+    // What is left is the endpoint and nothing else -- there is no sweeper, so a
+    // leak here would be permanent.
+    expect(fs.readdirSync(dir)).toEqual(['vorn.sock'])
+  })
+
+  it('stands down when the name is already held', async () => {
+    await hold()
+    const second = await openLocalEndpoint(dir, () => {})
+
+    expect(second.kind).toBe('lost')
+    if (second.kind === 'lost') expect(second.because).toContain('alive')
+  })
+
+  it('carries on without one where the directory will not have it', async () => {
+    // Anyone who can write the directory can rename over the endpoint, so a
+    // world-writable one gets no socket -- and no failure either. A server nobody
+    // can reach would be worse than a race nobody has lost yet.
+    fs.chmodSync(dir, 0o777)
+    const outcome = await openLocalEndpoint(dir, () => {})
+
+    expect(outcome.kind).toBe('unavailable')
+    expect(fs.existsSync(path.join(dir, 'vorn.sock'))).toBe(false)
+  })
+})
+
+describe('what the endpoint answers', () => {
+  it('accepts a websocket and greets it', async () => {
+    const upgraded = vi.fn()
+    const endpoint = await hold(upgraded)
+
+    const ws = new WebSocket(endpointUrl(endpoint.path))
+    const greeting = await new Promise<string>((resolve, reject) => {
+      ws.once('message', (raw: Buffer) => resolve(raw.toString()))
+      ws.once('error', reject)
+    })
+
+    expect(JSON.parse(greeting)).toMatchObject({ method: expect.any(String) })
+    expect(upgraded).toHaveBeenCalled()
+    ws.close()
+  })
+
+  it('refuses anything that is not the socket path', async () => {
+    const endpoint = await hold()
+
+    const ws = new WebSocket(`ws+unix://${endpoint.path}:/somewhere-else`)
+    await expect(
+      new Promise((resolve, reject) => {
+        ws.once('open', resolve)
+        ws.once('error', reject)
+      })
+    ).rejects.toThrow()
+  })
+})
+
+describe('letting go', () => {
+  it('closes even while a client is still attached', async () => {
+    // The bug this pins: `ws` does not terminate tracked clients on close, it
+    // waits for them, and so does the http server behind it. A half-open client
+    // -- the case the idle watch's duration clock exists to tolerate -- would
+    // hold this for ever, stalling shutdown into its deadline and leaving on
+    // exit(1) after killAll had already run.
+    const endpoint = await hold()
+    const ws = new WebSocket(endpointUrl(endpoint.path))
+    await new Promise((resolve, reject) => {
+      ws.once('open', resolve)
+      ws.once('error', reject)
+    })
+
+    await expect(
+      Promise.race([
+        endpoint.close().then(() => 'closed'),
+        new Promise((r) => setTimeout(() => r('hung'), 5_000))
+      ])
+    ).resolves.toBe('closed')
+    open.length = 0
+  })
+
+  it('leaves the endpoint on disk for the next publisher', async () => {
+    const endpoint = await hold()
+    await endpoint.close()
+    open.length = 0
+
+    // Never removed on the way out: this listener bound a scratch name that no
+    // longer exists, so libuv's unlink at close has nothing to find. The dead
+    // entry is what the next start replaces in one rename.
+    expect(fs.lstatSync(endpoint.path).isSocket()).toBe(true)
+  })
+
+  it('stops claiming to hold a name that became somebody else’s', async () => {
+    const endpoint = await hold()
+    expect(endpoint.holds()).toBe(true)
+
+    // Another server renames its own socket into place, which is exactly what a
+    // claim does. Asked rather than remembered, so this notices.
+    const usurper = path.join(dir, 'other.sock')
+    const { default: net } = await import('node:net')
+    const server = net.createServer()
+    await new Promise<void>((resolve) => server.listen(usurper, resolve))
+    fs.renameSync(usurper, endpoint.path)
+
+    expect(endpoint.holds()).toBe(false)
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+})

--- a/tests/local-endpoint.test.ts
+++ b/tests/local-endpoint.test.ts
@@ -8,6 +8,28 @@ import { endpointUrl } from '../src/main/server/server-adoption'
 import { probeSessions } from '../src/main/server/server-launcher'
 
 /**
+ * What the endpoint handed to `parseTopics`.
+ *
+ * The obvious place to watch -- `clientRegistry.add` -- is only reached once a
+ * socket has authenticated, and these tests deliberately do not. So the
+ * observation sits at the boundary the fix is about: whether the query string
+ * reaches the parser at all, or whether `undefined` is passed in its place and
+ * every filter silently dropped.
+ */
+const topicsSeen: unknown[] = []
+
+vi.mock('../packages/server/src/broadcast', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../packages/server/src/broadcast')>()
+  return {
+    ...actual,
+    parseTopics: (query: unknown) => {
+      topicsSeen.push(query)
+      return actual.parseTopics(query)
+    }
+  }
+})
+
+/**
  * Bringing up the endpoint, in this process.
  *
  * `endpoint-race.process.test.ts` proves the behaviour with real spawned servers,
@@ -110,17 +132,24 @@ describe('what the endpoint answers', () => {
     }
   )
 
-  it('accepts the route with a query on it', async () => {
+  it('accepts the route with a query, and reads it', async () => {
+    // Accepting a query and then ignoring it would be worse than refusing one: a
+    // client that narrowed its subscription would be sent everything anyway, and
+    // nothing would say so. Fastify parses this for the TCP route; here it is
+    // done by hand, so it is worth proving the query reaches the parser rather
+    // than the `undefined` that used to be passed in its place.
+    topicsSeen.length = 0
     const endpoint = await hold()
 
-    const ws = new WebSocket(`ws+unix://${endpoint.path}:/ws?topics=all`)
-    await expect(
-      new Promise((resolve, reject) => {
-        ws.once('open', resolve)
-        ws.once('error', reject)
-      })
-    ).resolves.toBeUndefined()
+    const ws = new WebSocket(`ws+unix://${endpoint.path}:/ws?topics=sessions,tasks`)
+    await new Promise((resolve, reject) => {
+      ws.once('open', resolve)
+      ws.once('error', reject)
+    })
+    await new Promise((r) => setTimeout(r, 150))
     ws.close()
+
+    expect(topicsSeen).toContainEqual({ topics: 'sessions,tasks' })
   })
 })
 

--- a/tests/local-endpoint.test.ts
+++ b/tests/local-endpoint.test.ts
@@ -61,15 +61,16 @@ describe('bringing up the endpoint', () => {
     if (second.kind === 'lost') expect(second.because).toContain('alive')
   })
 
-  it('carries on without one where the directory will not have it', async () => {
-    // Anyone who can write the directory can rename over the endpoint, so a
-    // world-writable one gets no socket -- and no failure either. A server nobody
-    // can reach would be worse than a race nobody has lost yet.
-    fs.chmodSync(dir, 0o777)
-    const outcome = await openLocalEndpoint(dir, () => {})
+  it('carries on without one where a socket cannot go', async () => {
+    // A path too long for `sun_path`. No failure either way: the socket is
+    // additive, and a server nobody can reach would be worse than a race nobody
+    // has lost yet.
+    const deep = path.join(dir, 'z'.repeat(90))
+    fs.mkdirSync(deep, { recursive: true, mode: 0o700 })
+    const outcome = await openLocalEndpoint(deep, () => {})
 
     expect(outcome.kind).toBe('unavailable')
-    expect(fs.existsSync(path.join(dir, 'vorn.sock'))).toBe(false)
+    expect(fs.existsSync(path.join(deep, 'vorn.sock'))).toBe(false)
   })
 })
 

--- a/tests/local-endpoint.test.ts
+++ b/tests/local-endpoint.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import WebSocket from 'ws'
 import { openLocalEndpoint, type LocalEndpoint } from '../packages/server/src/local-endpoint'
 import { endpointUrl } from '../src/main/server/server-adoption'
+import { probeSessions } from '../src/main/server/server-launcher'
 
 /**
  * Bringing up the endpoint, in this process.
@@ -18,6 +19,7 @@ import { endpointUrl } from '../src/main/server/server-adoption'
 
 let dir: string
 const open: LocalEndpoint[] = []
+const cleanup: Array<() => void> = []
 
 beforeEach(() => {
   dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-local-'))
@@ -25,6 +27,7 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  while (cleanup.length) cleanup.pop()?.()
   for (const endpoint of open.splice(0)) await endpoint.close()
   fs.rmSync(dir, { recursive: true, force: true })
 })
@@ -119,6 +122,77 @@ describe('what the endpoint answers', () => {
     ).resolves.toBeUndefined()
     ws.close()
   })
+})
+
+describe('asking what a server holds without joining it', () => {
+  /**
+   * A server that greets and records, so both halves of the claim are visible:
+   * what the probe learns, and what it says to learn it.
+   */
+  async function greeter(sessions: number): Promise<{ url: string; heard: string[] }> {
+    const { WebSocketServer } = await import('ws')
+    const http = await import('node:http')
+    const heard: string[] = []
+    const socketPath = path.join(dir, 'greeter.sock')
+    const server = http.createServer()
+    const wss = new WebSocketServer({ server })
+    wss.on('connection', (ws) => {
+      ws.on('message', (m: Buffer) => heard.push(m.toString()))
+      ws.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'server:identity',
+          params: {
+            dataDir: dir,
+            appVersion: '0.7.0',
+            buildChannel: 'packaged',
+            pid: process.pid,
+            sessions
+          }
+        })
+      )
+    })
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+    cleanup.push(() => {
+      for (const c of wss.clients) c.terminate()
+      server.close()
+    })
+    return { url: `ws+unix://${socketPath}:/ws`, heard }
+  }
+
+  it('reads the count off the greeting', async () => {
+    const { url } = await greeter(4)
+    await expect(probeSessions(url)).resolves.toBe(4)
+  })
+
+  it('never says anything to the server it is looking at', async () => {
+    // `ServerBridge` claims the browser bridge the moment it opens, and a socket
+    // with no accepted credential is refused for sending any method but
+    // `auth:authenticate` -- so a probe built on one would announce itself, be
+    // thrown out, and leave a line in the log of a server it only meant to look
+    // at. This one cannot, because it sends nothing at all.
+    const { url, heard } = await greeter(1)
+
+    await probeSessions(url)
+    await new Promise((r) => setTimeout(r, 200))
+
+    expect(heard).toEqual([])
+  })
+
+  it('answers null rather than waiting for a server that says nothing', async () => {
+    const { WebSocketServer } = await import('ws')
+    const http = await import('node:http')
+    const socketPath = path.join(dir, 'silent.sock')
+    const server = http.createServer()
+    const wss = new WebSocketServer({ server })
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve))
+    cleanup.push(() => {
+      for (const c of wss.clients) c.terminate()
+      server.close()
+    })
+
+    await expect(probeSessions(`ws+unix://${socketPath}:/ws`)).resolves.toBeNull()
+  }, 15_000)
 })
 
 describe('letting go', () => {

--- a/tests/port-file-lifecycle.test.ts
+++ b/tests/port-file-lifecycle.test.ts
@@ -2,58 +2,42 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import {
+  claimPublishedFiles,
+  writePortFile,
+  removePortFile,
+  isPidAlive
+} from '../packages/server/src/published-files'
 
 /**
- * Tests for the port-file lifecycle logic used by the server (index.ts).
+ * Who may write the names a machine uses to find its server.
  *
- * The server's startup/shutdown port-file management is inline in startServer(),
- * which is expensive to spin up in tests. These tests replicate the exact same
- * read → check-PID → write / read → check-PID → delete logic against a temp
- * directory so we can verify the multi-instance safety guarantees.
+ * These used to test a copy of the server's logic, pasted into this file because
+ * the real thing was inline in `startServer` and expensive to reach. The copy
+ * drifted the moment the original moved, and a green run proved nothing about
+ * the code that ships. It is a module now, and this points at it.
+ *
+ * "This process" is always `process.pid` here, as it is in production — the
+ * functions take no pid argument, because a caller that can name someone else as
+ * the owner is a caller that can claim a directory on their behalf. A live rival
+ * is played by `process.ppid`, which vitest guarantees is alive and is not us.
  */
 
-let tmpDir: string
+let dir: string
 let portFile: string
 
-// --- Helpers that mirror the server's inline logic ---
+const DEAD_PID = 2147483647 // max pid — nothing is running as this
 
-function writePortFile(port: number, pid: number): boolean {
-  fs.mkdirSync(path.dirname(portFile), { recursive: true })
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-test-'))
+  portFile = path.join(dir, 'ws-port')
+})
 
-  let shouldWrite = true
-  try {
-    const existing = JSON.parse(fs.readFileSync(portFile, 'utf-8'))
-    if (existing.pid && existing.pid !== pid) {
-      try {
-        process.kill(existing.pid, 0)
-        shouldWrite = false
-      } catch {
-        // dead PID — overwrite
-      }
-    }
-  } catch {
-    // no file or invalid JSON — overwrite
-  }
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true })
+})
 
-  if (shouldWrite) {
-    fs.writeFileSync(portFile, JSON.stringify({ port, pid }), 'utf-8')
-    return true // owns the file
-  }
-  return false
-}
-
-function deletePortFileIfOwned(ownerPid: number): void {
-  try {
-    const raw = JSON.parse(fs.readFileSync(portFile, 'utf-8'))
-    if (raw.pid === ownerPid) {
-      fs.unlinkSync(portFile)
-    }
-  } catch {
-    // file gone or invalid — nothing to do
-  }
-}
-
-function readPortFile(): { port: number; pid: number } | null {
+const read = (): { port?: number; pid?: number } | null => {
   try {
     return JSON.parse(fs.readFileSync(portFile, 'utf-8'))
   } catch {
@@ -61,126 +45,108 @@ function readPortFile(): { port: number; pid: number } | null {
   }
 }
 
-// --- Tests ---
-
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-port-test-'))
-  portFile = path.join(tmpDir, 'ws-port')
-})
-
-afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true })
-})
-
-describe('port file write (startup)', () => {
-  it('writes port file when none exists', () => {
-    const owns = writePortFile(53829, process.pid)
-    expect(owns).toBe(true)
-
-    const data = readPortFile()
-    expect(data).toEqual({ port: 53829, pid: process.pid })
+describe('claiming the directory', () => {
+  it('claims it when nothing is published', () => {
+    expect(claimPublishedFiles(dir)).toBe(true)
+    writePortFile(dir, 53829, true)
+    expect(read()).toEqual({ port: 53829, pid: process.pid })
   })
 
-  it('overwrites stale file from dead PID', () => {
-    // Write a file claiming to be owned by a PID that does not exist
-    const deadPid = 2147483647 // max PID — almost certainly not running
-    fs.writeFileSync(portFile, JSON.stringify({ port: 11111, pid: deadPid }))
+  it('claims it from a process that has died', () => {
+    fs.writeFileSync(portFile, JSON.stringify({ port: 11111, pid: DEAD_PID }))
 
-    const owns = writePortFile(22222, process.pid)
-    expect(owns).toBe(true)
-
-    const data = readPortFile()
-    expect(data).toEqual({ port: 22222, pid: process.pid })
+    expect(claimPublishedFiles(dir)).toBe(true)
+    writePortFile(dir, 22222, true)
+    expect(read()).toEqual({ port: 22222, pid: process.pid })
   })
 
-  it('does NOT overwrite when existing PID is alive', () => {
-    // Use process.ppid (our parent) as a guaranteed-alive PID that differs from
-    // the "new instance" PID we'll pass to writePortFile.
-    const alivePid = process.ppid
-    fs.writeFileSync(portFile, JSON.stringify({ port: 11111, pid: alivePid }))
+  it('refuses it while another process is alive', () => {
+    fs.writeFileSync(portFile, JSON.stringify({ port: 11111, pid: process.ppid }))
 
-    const fakePid = 99999999
-    const owns = writePortFile(22222, fakePid)
-    expect(owns).toBe(false)
-
-    // File should still have the original data
-    const data = readPortFile()
-    expect(data).toEqual({ port: 11111, pid: alivePid })
+    expect(claimPublishedFiles(dir)).toBe(false)
   })
 
-  it('overwrites legacy plain-number format', () => {
+  it('claims it from the legacy plain-number format', () => {
+    // Written by MCP's own discovery before it learned to record a pid. It names
+    // no owner, so it stops nobody.
     fs.writeFileSync(portFile, '53829')
 
-    const owns = writePortFile(54000, process.pid)
-    expect(owns).toBe(true)
-
-    const data = readPortFile()
-    expect(data).toEqual({ port: 54000, pid: process.pid })
+    expect(claimPublishedFiles(dir)).toBe(true)
+    writePortFile(dir, 54000, true)
+    expect(read()).toEqual({ port: 54000, pid: process.pid })
   })
 
-  it('allows same PID to re-write (restart scenario)', () => {
+  it('claims it from a record with no pid', () => {
+    // MCP heals a missing port file by discovering the port and writing it back
+    // without a pid. `judgeAdoption` is written to tolerate that record, so this
+    // must too.
+    fs.writeFileSync(portFile, JSON.stringify({ port: 11111 }))
+
+    expect(claimPublishedFiles(dir)).toBe(true)
+  })
+
+  it('claims it back from itself, so a restart is not blocked by its own file', () => {
     fs.writeFileSync(portFile, JSON.stringify({ port: 11111, pid: process.pid }))
 
-    const owns = writePortFile(22222, process.pid)
-    expect(owns).toBe(true)
-
-    const data = readPortFile()
-    expect(data).toEqual({ port: 22222, pid: process.pid })
+    expect(claimPublishedFiles(dir)).toBe(true)
+    writePortFile(dir, 22222, true)
+    expect(read()).toEqual({ port: 22222, pid: process.pid })
   })
 })
 
-describe('port file delete (shutdown)', () => {
-  it('deletes file when PID matches', () => {
-    fs.writeFileSync(portFile, JSON.stringify({ port: 53829, pid: process.pid }))
-
-    deletePortFileIfOwned(process.pid)
+describe('publishing without the claim', () => {
+  it('writes nothing', () => {
+    writePortFile(dir, 53829, false)
     expect(fs.existsSync(portFile)).toBe(false)
   })
 
-  it('does NOT delete when PID does not match', () => {
-    const otherPid = process.ppid
-    fs.writeFileSync(portFile, JSON.stringify({ port: 53829, pid: otherPid }))
+  it('leaves a live rival file exactly as it found it', () => {
+    const theirs = JSON.stringify({ port: 11111, pid: process.ppid })
+    fs.writeFileSync(portFile, theirs)
 
-    deletePortFileIfOwned(99999)
-    expect(fs.existsSync(portFile)).toBe(true)
+    writePortFile(dir, 53829, false)
+    removePortFile(dir, false)
 
-    const data = readPortFile()
-    expect(data).toEqual({ port: 53829, pid: otherPid })
-  })
-
-  it('no-ops when file is already gone', () => {
-    expect(() => deletePortFileIfOwned(process.pid)).not.toThrow()
+    expect(fs.readFileSync(portFile, 'utf-8')).toBe(theirs)
   })
 })
 
-describe('multi-instance scenario', () => {
-  it('second instance does not clobber first, shutdown of second preserves file', () => {
-    // Instance A starts (use ppid as a guaranteed-alive process)
-    const alivePid = process.ppid
-    fs.writeFileSync(portFile, JSON.stringify({ port: 53829, pid: alivePid }))
-
-    // Instance B starts — should NOT overwrite because owner PID is alive
-    const fakePidB = 99999999
-    const ownsB = writePortFile(54000, fakePidB)
-    expect(ownsB).toBe(false)
-
-    // Instance B shuts down — should NOT delete because it doesn't own the file
-    deletePortFileIfOwned(fakePidB)
-
-    // Instance A's port file is preserved
-    const data = readPortFile()
-    expect(data).toEqual({ port: 53829, pid: alivePid })
+describe('removing it on the way out', () => {
+  it('removes the file it published', () => {
+    writePortFile(dir, 53829, true)
+    removePortFile(dir, true)
+    expect(fs.existsSync(portFile)).toBe(false)
   })
 
-  it('second instance takes over after first crashes (dead PID)', () => {
-    const deadPid = 2147483647
-    fs.writeFileSync(portFile, JSON.stringify({ port: 53829, pid: deadPid }))
+  it('leaves a file that has since become somebody elses', () => {
+    // The claim was taken minutes ago and the flag still says yes. The file is
+    // the thing being removed, so the file gets the last word: another server
+    // named there is one this process must not unpublish.
+    writePortFile(dir, 53829, true)
+    fs.writeFileSync(portFile, JSON.stringify({ port: 54000, pid: process.ppid }))
 
-    // Instance B starts — should overwrite because old PID is dead
-    const owns = writePortFile(54000, process.pid)
-    expect(owns).toBe(true)
+    removePortFile(dir, true)
 
-    const data = readPortFile()
-    expect(data).toEqual({ port: 54000, pid: process.pid })
+    expect(read()).toEqual({ port: 54000, pid: process.ppid })
+  })
+
+  it('does not throw when the file is already gone', () => {
+    expect(() => removePortFile(dir, true)).not.toThrow()
+  })
+})
+
+describe('asking whether a process is there', () => {
+  it('says yes for this one', () => {
+    expect(isPidAlive(process.pid)).toBe(true)
+  })
+
+  it('says no for one that has died', () => {
+    expect(isPidAlive(DEAD_PID)).toBe(false)
+  })
+
+  it.each([0, -1, 1.5, Number.NaN])('says no for %s rather than asking', (pid) => {
+    // Signal 0 to pid 0 targets this process group and always succeeds, so an
+    // unchecked zero would report every dead server as alive.
+    expect(isPidAlive(pid)).toBe(false)
   })
 })

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -263,9 +263,13 @@ describe('declining a server that is running', () => {
     expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'different-build' })
   })
 
-  it('refuses when no credential was published to reach it with', async () => {
+  it('refuses a server that answers but published no credential', async () => {
+    // Something is there and holding the database; this app simply cannot reach
+    // it. Starting a second server beside it is the one thing that must not
+    // happen, whatever the reason it is unreachable.
     published.port = 50091
     published.token = null
+    published.identity = identityFrom()
     const { launchServer, getLastAdoptionRefusal } =
       await import('../src/main/server/server-launcher')
 
@@ -273,6 +277,22 @@ describe('declining a server that is running', () => {
 
     expect(spawned).toEqual([])
     expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'unusable' })
+  })
+
+  it('spawns past a name that answers nothing at all', async () => {
+    // The ordinary state of a machine between launches. Nothing removes the
+    // endpoint on shutdown -- that is what lets the next start find the name to
+    // replace -- so a leftover with no credential beside it is what a quit Vorn
+    // leaves behind. Treating it as a running server would mean quitting Vorn
+    // once made Vorn unable to start again.
+    published.port = 50091
+    published.token = null
+    published.identity = null
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
   })
 
   it('spawns when nothing is published at all', async () => {

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -279,6 +279,21 @@ describe('declining a server that is running', () => {
     expect(getLastAdoptionRefusal()).toMatchObject({ reason: 'unusable' })
   })
 
+  it('refuses a server too old to send an identity frame', async () => {
+    // Pre-#494 servers greet and say nothing else. Reading that silence as an
+    // empty machine would put a second writer on their database, where
+    // `saveSessions` replaces the whole table -- so the greeting, not the
+    // identity, is what proves somebody is there.
+    published.port = 50091
+    published.identity = null
+    published.protocolVersion = RUNTIME_PROTOCOL_VERSION
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    await expect(launchServer()).rejects.toThrow()
+
+    expect(spawned).toEqual([])
+  })
+
   it('spawns past a name that answers nothing at all', async () => {
     // The ordinary state of a machine between launches. Nothing removes the
     // endpoint on shutdown -- that is what lets the next start find the name to
@@ -288,6 +303,8 @@ describe('declining a server that is running', () => {
     published.port = 50091
     published.token = null
     published.identity = null
+    // Nothing greeted us either: the name is a leftover, not a server.
+    published.protocolVersion = undefined as unknown as number
     const { launchServer } = await import('../src/main/server/server-launcher')
 
     await launchServer()

--- a/tests/server-port-stability.test.ts
+++ b/tests/server-port-stability.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest'
+import { spawnsRealServers } from './helpers/one-at-a-time'
 import { spawn, type ChildProcess } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+
+spawnsRealServers()
 
 /**
  * The one assertion the unit tests cannot make: two launches agree.

--- a/tests/ws-auth.test.ts
+++ b/tests/ws-auth.test.ts
@@ -12,6 +12,7 @@ import {
   authenticateCredential,
   bearerFrom,
   initBootstrapSecret,
+  publishLocalCredential,
   clearLocalCredential
 } from '../packages/server/src/ws-auth'
 import { LOCAL_TOKEN_FILENAME } from '@vornrun/shared/protocol'
@@ -58,6 +59,7 @@ describe('the local credential', () => {
 
   it('publishes a file only readable by this user', () => {
     initBootstrapSecret(dataDir)
+    publishLocalCredential(true)
     const file = path.join(dataDir, LOCAL_TOKEN_FILENAME)
 
     expect(fs.existsSync(file)).toBe(true)
@@ -69,6 +71,7 @@ describe('the local credential', () => {
 
   it('authenticates the secret it published', () => {
     initBootstrapSecret(dataDir)
+    publishLocalCredential(true)
     const published = fs.readFileSync(path.join(dataDir, LOCAL_TOKEN_FILENAME), 'utf-8')
 
     const result = authenticateCredential(published)
@@ -86,6 +89,7 @@ describe('the local credential', () => {
 
   it('generates one when nothing was supplied, so a standalone server still works', () => {
     initBootstrapSecret(dataDir, undefined)
+    publishLocalCredential(true)
     const published = fs.readFileSync(path.join(dataDir, LOCAL_TOKEN_FILENAME), 'utf-8')
     expect(published.length).toBeGreaterThan(20)
     expect(authenticateCredential(published)).not.toBeNull()
@@ -93,6 +97,7 @@ describe('the local credential', () => {
 
   it('removes the file on shutdown, so nothing usable outlives the process', () => {
     initBootstrapSecret(dataDir)
+    publishLocalCredential(true)
     clearLocalCredential()
     expect(fs.existsSync(path.join(dataDir, LOCAL_TOKEN_FILENAME))).toBe(false)
   })
@@ -113,7 +118,8 @@ describe('the local credential', () => {
     const file = path.join(dataDir, 'local-token')
     fs.writeFileSync(file, 'the-running-servers-secret', { mode: 0o600 })
 
-    initBootstrapSecret(dataDir, 'this-servers-secret', false)
+    initBootstrapSecret(dataDir, 'this-servers-secret')
+    publishLocalCredential(false)
 
     expect(fs.readFileSync(file, 'utf-8')).toBe('the-running-servers-secret')
   })
@@ -122,7 +128,8 @@ describe('the local credential', () => {
     // Standing aside is about the file, not about the server. The desktop that
     // started this process handed the secret over in the environment and must
     // still be able to use it.
-    initBootstrapSecret(dataDir, 'this-servers-secret', false)
+    initBootstrapSecret(dataDir, 'this-servers-secret')
+    publishLocalCredential(false)
 
     expect(authenticateCredential('this-servers-secret')).toMatchObject({ kind: 'bootstrap' })
   })
@@ -131,7 +138,8 @@ describe('the local credential', () => {
     const file = path.join(dataDir, 'local-token')
     fs.writeFileSync(file, 'the-running-servers-secret', { mode: 0o600 })
 
-    initBootstrapSecret(dataDir, 'this-servers-secret', false)
+    initBootstrapSecret(dataDir, 'this-servers-secret')
+    publishLocalCredential(false)
     clearLocalCredential()
 
     expect(fs.readFileSync(file, 'utf-8')).toBe('the-running-servers-secret')
@@ -143,6 +151,7 @@ describe('the local credential', () => {
     // unreachable -- the same failure, caused on the way out instead of in.
     const file = path.join(dataDir, 'local-token')
     initBootstrapSecret(dataDir, 'ours')
+    publishLocalCredential(true)
     fs.writeFileSync(file, 'somebody-elses', { mode: 0o600 })
 
     clearLocalCredential()
@@ -155,6 +164,7 @@ describe('the local credential', () => {
     fs.writeFileSync(file, 'stale', { mode: 0o644 })
 
     initBootstrapSecret(dataDir)
+    publishLocalCredential(true)
 
     // `mode` on writeFileSync only applies when the file is created — the flaw in
     // the hook-server precedent this follows.

--- a/tests/ws-auth.test.ts
+++ b/tests/ws-auth.test.ts
@@ -105,6 +105,51 @@ describe('the local credential', () => {
     expect(() => initBootstrapSecret(unwritable)).not.toThrow()
   })
 
+  it('publishes nothing when another server owns the directory', () => {
+    // The bug this closes, reproduced: a `yarn dev` server starting beside a
+    // packaged one wrote its own secret over the credential the running app had
+    // published, so MCP read one server's port beside another server's token and
+    // every call timed out until Vorn was restarted.
+    const file = path.join(dataDir, 'local-token')
+    fs.writeFileSync(file, 'the-running-servers-secret', { mode: 0o600 })
+
+    initBootstrapSecret(dataDir, 'this-servers-secret', false)
+
+    expect(fs.readFileSync(file, 'utf-8')).toBe('the-running-servers-secret')
+  })
+
+  it('still authenticates its own secret when it publishes nothing', () => {
+    // Standing aside is about the file, not about the server. The desktop that
+    // started this process handed the secret over in the environment and must
+    // still be able to use it.
+    initBootstrapSecret(dataDir, 'this-servers-secret', false)
+
+    expect(authenticateCredential('this-servers-secret')).toMatchObject({ kind: 'bootstrap' })
+  })
+
+  it('removes nothing on shutdown when it published nothing', () => {
+    const file = path.join(dataDir, 'local-token')
+    fs.writeFileSync(file, 'the-running-servers-secret', { mode: 0o600 })
+
+    initBootstrapSecret(dataDir, 'this-servers-secret', false)
+    clearLocalCredential()
+
+    expect(fs.readFileSync(file, 'utf-8')).toBe('the-running-servers-secret')
+  })
+
+  it('leaves a credential that has since been replaced', () => {
+    // Publishing and shutting down are minutes apart. A file that is no longer
+    // ours belongs to whoever wrote it, and removing it would leave that server
+    // unreachable -- the same failure, caused on the way out instead of in.
+    const file = path.join(dataDir, 'local-token')
+    initBootstrapSecret(dataDir, 'ours')
+    fs.writeFileSync(file, 'somebody-elses', { mode: 0o600 })
+
+    clearLocalCredential()
+
+    expect(fs.readFileSync(file, 'utf-8')).toBe('somebody-elses')
+  })
+
   it('replaces an existing file rather than inheriting its permissions', () => {
     const file = path.join(dataDir, LOCAL_TOKEN_FILENAME)
     fs.writeFileSync(file, 'stale', { mode: 0o644 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4678,6 +4678,7 @@ __metadata:
     tsup: "npm:^8.5.1"
     tsx: "npm:^4.23.1"
     typescript: "npm:^6.0.3"
+    ws: "npm:^8.21.1"
     zod: "npm:^4.4.3"
   bin:
     vorn-server: ./dist/cli.cjs


### PR DESCRIPTION
P1 gave the server a life of its own — it outlives the app, adopts rather than
replaces, and leaves when nothing needs it. What it does not have is a name.

A port cannot be owned. Two servers reaching for one are settled by whichever
bound first, invisibly, and a third deciding whether to start has nothing to ask.
The probe #494 added closes the common case — observe liveness, then act — but
not the race between those two steps, and detaching made that window permanent:
an updater restart, a crash respawn and a manual start all contend for the same
name, forever.

What it produces is quiet and expensive. The replacement stays alive hosting PTYs
no client can reach, which a person experiences as a terminal that accepts
keystrokes and never runs them.

Storyboard: https://claude.ai/code/artifact/567e7681-d813-401e-b04c-03a955fee2d4

## The smaller half, and it is live today

The same invariant was broken one file over. `initBootstrapSecret` rewrote
`local-token` on every start and `clearLocalCredential` removed it on every stop,
neither asking whether this process wrote it. Start `yarn dev` beside the running
app and MCP reads one server's port next to another server's secret; stop it
again and the running app's credential is deleted outright. Every call answers
`RPC call "config:load" timed out after 10000ms` until Vorn is restarted.

Observed on my machine twice before it was understood. It ships as its own commit
because it is a live bug and because it settles the ownership shape on something
small: ownership is decided once, before anything is published, and passed to
every publisher — not re-derived per file, since the credential is published
before the listen and the port after it, and two publishers asking the same
question at two different moments is exactly how they came to disagree.

## Owning a name

`~/.vorn/vorn.sock` — beside the database, so a `--data-dir` server advertises
itself there rather than over the desktop's. The kernel offers exactly the
primitive that makes a filesystem entry a test-and-set: `link()` fails with
`EEXIST` rather than replacing, so it asks a question; `rename()` is atomic and
leaves no moment where the name is absent, so it answers one.

A bound `AF_UNIX` listener is identified by its inode, not the path it was bound
to, so a server binds a private name and moves it into place only after proving
the place is free. That also retires the rule that would be easiest to break:
libuv unlinks the path it bound when the handle closes, with no ownership check,
so a server binding the canonical name deletes a live replacement's socket on its
way out. Binding a scratch name means the path libuv remembers no longer exists
by then — `close()` becomes structurally incapable of removing the endpoint
rather than merely forbidden from it.

Measured on darwin/APFS before any of it was written, because the whole design
rests on it and reasoning was not enough: link on a socket inode, EEXIST on a
taken name, connect through the link, close leaving the canonical entry intact.

**The probe has three answers and the code has three branches.** Only a completed
connection proves a name is served; only `ECONNREFUSED` or `ENOENT` prove it is
not. A timeout, `EACCES`, `EPERM`, a full accept queue — none of those prove
anything. The whitelist is the two that mean death and everything unlisted
defaults to alive, because the two ways of being wrong are not the same size: a
leftover file is replaced by the next start in one rename, while taking a name
from a server that is still serving strands every terminal on the machine.

The window between the last probe and the rename cannot be closed — POSIX has no
rename-if-target-is-inode-X — so the harm is closed instead. A server that finds
it lost the name refuses new sessions, finishes the ones it has, and the idle
watch ends it on the window it already had.

## Deliberately narrow, deliberately additive

The listener is a WebSocket upgrade and nothing else. Handing it fastify's router
would have been less code and wrong twice: the pairing endpoint caps attempts per
client address and a unix peer has none, so every caller would bucket under one
empty string; and `@fastify/websocket` attaches to a single server, so pointing
it here would move `/ws` off TCP and cut off every web and phone client.

A unix peer gets a name of its own rather than a synthetic `127.0.0.1`. That
address gates one thing — whether the greeting carries this server's identity —
and faking it would make the predicate true by lying, in the one place whose job
is deciding who may be told.

Windows keeps the port file: Node maps `listen({ path })` to a named pipe, and a
pipe has no filesystem entry to test-and-set. Said out loud in code rather than
left as a silent gap. Every other reason the socket cannot be hosted — a
directory anyone can write, a path too long for `sun_path` — is a downgrade to
TCP-only, never a failed startup.

## What review caught

Five findings, and one would have shipped a brick. Nothing removes the endpoint
on shutdown — that is the design — which makes a socket with nothing behind it
the *ordinary* state of a machine between launches. The launcher read it as proof
a server was running: quit Vorn, let it idle out, reopen, and the app refuses to
start, with the connect window's only escape reading a port file the departing
server had already deleted. `rm ~/.vorn/vorn.sock` by hand was the way out. Two
reviewers found it independently.

Fixing it forced a better question. Refusing on a *missing credential* looks like
the same test but is not — a live server that failed to write its token would
read as absent, and spawning a rival beside it is the hazard this branch exists
to prevent. The greeting arrives before authentication, so "is anybody serving
this name" can be asked without one. Only silence is permission to start a
server.

The rest: the credential was published two hundred lines before the claim, so a
losing server overwrote the winner's secret and left it there; `endpoint.close()`
could hang forever on a half-open client, stalling shutdown into `exit(1)` after
`killAll` had run; a losing spawn quit the app instead of adopting the winner;
and draining was noticed only on the idle tick, up to a minute late and never at
all for `vorn-server serve`.

## Tested as processes

Unit tests pin the decision against a fabricated incumbent. Beyond those:

- Two real servers racing; a client held open and answering through the whole of
  a second server's claim attempt; a SIGKILLed owner's corpse replaced by the
  next start; a clean quit's leftover replaced by the next start.
- The **real launcher** against real servers, with nothing faked but Electron —
  spawn and claim, adopt rather than start a second, start again after a quit,
  start again after a crash, replace its own server when that server crashes
  under it, and adopt without disturbing the running server's sessions.

That last file exists because the mocked launcher tests all agreed with the code:
they were written from it. The bug they missed is the one a person would have met
the first time they quit and reopened Vorn.
