### PR TITLE
Let a focused session's header act like the titlebar it replaced

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -32,8 +32,8 @@ import { SessionRestoredBanner } from './components/SessionRestoredBanner'
 import { GridToolbar } from './components/GridToolbar'
 import { ToolbarBreadcrumb } from './components/ToolbarBreadcrumb'
 import { SettingsPage } from './components/SettingsPage'
-import { SidebarToggleButton } from './components/SidebarToggleButton'
-import { MainViewPills } from './components/MainViewPills'
+import { AppNavCluster } from './components/AppNavCluster'
+import { useFocusedTitlebar } from './hooks/useFocusedTitlebar'
 import { SessionDock } from './components/SessionDock'
 import { HeadlessBadge } from './components/HeadlessBadge'
 import { RecentSessionsButton } from './components/RecentSessionsButton'
@@ -120,8 +120,9 @@ export function App() {
   const isTabToolbarMerged =
     layoutMode === 'tabs' && mainViewMode === 'sessions' && !isMobile && !focusedId && !previewId
 
-  // Only hide toolbar on macOS focused view — Windows/Linux need it for window controls
-  const isFocusedFullScreen = isMac && !isMobile && (!!focusedId || !!previewId)
+  // Hidden only on macOS, where a focused session's own header takes the bar
+  // over. Windows and Linux keep theirs — it holds their window controls.
+  const { ownsTitlebar: isFocusedFullScreen } = useFocusedTitlebar()
 
   // On mobile, auto-close sidebar on initial load
   useEffect(() => {
@@ -606,13 +607,7 @@ export function App() {
                   <Menu size={20} strokeWidth={2} />
                 </button>
               )}
-              {!isMobile && !isSidebarOpen && (
-                <>
-                  <SidebarToggleButton />
-                  <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-                  <MainViewPills />
-                </>
-              )}
+              {!isMobile && !isSidebarOpen && <AppNavCluster />}
               {!isMobile && mainViewMode === 'sessions' && (
                 <>
                   <SessionDock includeMinimized={layoutMode === 'grid'} />

--- a/src/renderer/components/AppNavCluster.tsx
+++ b/src/renderer/components/AppNavCluster.tsx
@@ -1,0 +1,23 @@
+import { SidebarToggleButton } from './SidebarToggleButton'
+import { MainViewPills } from './MainViewPills'
+
+/**
+ * The way back to the sidebar and to the other two views, for whichever bar is
+ * standing in for the titlebar.
+ *
+ * Three bars can be that bar — the app toolbar, the merged tab strip, and a
+ * focused session's own header — and each of them was spelling this pair out
+ * for itself. The focused header spelled out neither, which is how expanding a
+ * session with the sidebar closed left no route to tasks or workflows at all.
+ *
+ * Shown only while the sidebar is hidden; open, it carries both itself.
+ */
+export function AppNavCluster() {
+  return (
+    <div className="shrink-0 flex items-center gap-1 titlebar-no-drag">
+      <SidebarToggleButton />
+      <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
+      <MainViewPills />
+    </div>
+  )
+}

--- a/src/renderer/components/FocusedCard.tsx
+++ b/src/renderer/components/FocusedCard.tsx
@@ -2,7 +2,9 @@ import { Minimize2 } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useAppStore } from '../stores'
 import { useShallow } from 'zustand/react/shallow'
-import { isMac } from '../lib/platform'
+import { isMac, TRAFFIC_LIGHT_PAD_PX } from '../lib/platform'
+import { AppNavCluster } from './AppNavCluster'
+import { useFocusedTitlebar } from '../hooks/useFocusedTitlebar'
 import { useIsMobile } from '../hooks/useIsMobile'
 import { CardSubjectIcon } from './CardSubjectIcon'
 import { usePromotedCardSubject } from '../hooks/usePromotedCards'
@@ -35,6 +37,9 @@ export function FocusedCard({ cardId }: { cardId: string }) {
     }))
   )
   const isMobile = useIsMobile()
+  // A card on the stage empties the window of its titlebar exactly as a session
+  // does, so its header owes the window the same things.
+  const { needsTrafficLightPad, showsAppNav } = useFocusedTitlebar()
 
   // Closed while focused. The stage empties on the next pass; bailing here
   // keeps it from drawing a header for a card that is gone.
@@ -63,12 +68,19 @@ export function FocusedCard({ cardId }: { cardId: string }) {
       <div
         className={`shrink-0 flex items-center gap-2 px-3 py-2 border-b border-white/[0.06]
                    ${isMac && !isMobile ? 'titlebar-drag' : 'titlebar-no-drag'}`}
+        style={needsTrafficLightPad ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : undefined}
         onDoubleClick={(e) => {
           if ((e.target as HTMLElement).closest('button, input, [role="button"]')) return
           contract()
         }}
         data-testid={`focused-card-${cardId}`}
       >
+        {showsAppNav && (
+          <>
+            <AppNavCluster />
+            <div className="w-px h-4 bg-white/[0.06]" />
+          </>
+        )}
         <span className="titlebar-no-drag flex items-center">
           <CardSubjectIcon card={subject} size={16} />
         </span>

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -36,10 +36,9 @@ import {
 import { toggleTerminalsPanel } from '../lib/session-utils'
 import { shouldOfferPane } from '../lib/pane-affordance'
 import { GridContextMenu } from './GridContextMenu'
+import { AppNavCluster } from './AppNavCluster'
 import { GridToolbar } from './GridToolbar'
 import { WindowControls } from './WindowControls'
-import { SidebarToggleButton } from './SidebarToggleButton'
-import { MainViewPills } from './MainViewPills'
 import { RecentSessionsButton } from './RecentSessionsButton'
 import { SessionDock } from './SessionDock'
 import { HeadlessBadge } from './HeadlessBadge'
@@ -326,10 +325,8 @@ export function TabView() {
         onPointerCancel={handlePointerCancel}
       >
         {!isSidebarOpen && (
-          <div className="shrink-0 flex items-center gap-1 pl-2 titlebar-no-drag">
-            <SidebarToggleButton />
-            <div className="w-px h-4 bg-white/[0.06] mx-0.5" />
-            <MainViewPills />
+          <div className="pl-2 flex items-center">
+            <AppNavCluster />
           </div>
         )}
 

--- a/src/renderer/components/card/CardHeader.tsx
+++ b/src/renderer/components/card/CardHeader.tsx
@@ -4,9 +4,11 @@ import { AgentStatusIcon } from '../AgentStatusIcon'
 import { InlineRename } from '../InlineRename'
 import { CardActionCluster, type CardVariant } from './CardActionCluster'
 import { FocusedNavHint } from './FocusedNavHint'
+import { AppNavCluster } from '../AppNavCluster'
+import { useFocusedTitlebar } from '../../hooks/useFocusedTitlebar'
 import { getDisplayName } from '../../lib/terminal-display'
 import { Pencil } from 'lucide-react'
-import { MOD } from '../../lib/platform'
+import { MOD, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { toast } from '../Toast'
 
 interface Props {
@@ -40,6 +42,10 @@ export function CardHeader({
       renameTerminal: s.renameTerminal
     }))
   )
+  // Only the focused variant is ever the window's titlebar; the grid's mini
+  // headers sit inside a window that still has one of its own.
+  const { needsTrafficLightPad, showsAppNav } = useFocusedTitlebar()
+  const isTitlebar = variant === 'focused'
 
   if (!terminal) return null
 
@@ -60,8 +66,21 @@ export function CardHeader({
       className={`flex items-center gap-2 px-3 py-2.5 border-b border-white/[0.04] shrink-0
                   transition-opacity duration-200 ease-out
                   ${dimmed ? 'opacity-60 group-hover/card:opacity-100' : 'opacity-100'}`}
-      style={{ background: 'var(--color-surface-raised)' }}
+      data-testid={isTitlebar ? 'focused-session-header' : undefined}
+      style={{
+        background: 'var(--color-surface-raised)',
+        // Standing in for the titlebar means clearing the traffic lights, which
+        // otherwise sit straight on top of the session's name.
+        ...(isTitlebar && needsTrafficLightPad ? { paddingLeft: `${TRAFFIC_LIGHT_PAD_PX}px` } : {})
+      }}
     >
+      {isTitlebar && showsAppNav && (
+        <>
+          <AppNavCluster />
+          <div className="w-px h-4 bg-white/[0.06]" />
+        </>
+      )}
+
       <div
         className={`flex-1 min-w-0 flex items-center gap-2 ${dragHandleClass}`}
         onDoubleClick={onDoubleClick}

--- a/src/renderer/hooks/useFocusedTitlebar.ts
+++ b/src/renderer/hooks/useFocusedTitlebar.ts
@@ -1,0 +1,47 @@
+import { useAppStore } from '../stores'
+import { useIsMobile } from './useIsMobile'
+import { isMac, isWeb } from '../lib/platform'
+
+/**
+ * Who is drawing the window's titlebar right now.
+ *
+ * On macOS the app drops its own bar whenever the focus stage fills the window,
+ * which promotes that stage's card header to the window's drag region — and to
+ * the rest of a titlebar's job with it: the inset the traffic lights sit in, and
+ * the controls the bar it replaced was carrying. Both were missing, so the
+ * lights landed on the session name and there was no way to reach tasks or
+ * workflows without collapsing the session first.
+ *
+ * It lives here rather than in each header so `App` and the headers cannot
+ * disagree about which of them owns the bar — the same reason `TabView` reads
+ * the pane column's own answer instead of re-deriving it.
+ */
+export interface FocusedTitlebar {
+  /** The app hides its own bar; the focused header stands in for it. */
+  ownsTitlebar: boolean
+  /** Leave room for the traffic lights — nothing else on screen is holding them. */
+  needsTrafficLightPad: boolean
+  /** Carry the sidebar toggle and the view pills, because the sidebar is not. */
+  showsAppNav: boolean
+}
+
+export function useFocusedTitlebar(): FocusedTitlebar {
+  const focusedId = useAppStore((s) => s.focusedTerminalId)
+  const previewId = useAppStore((s) => s.previewTerminalId)
+  const isSidebarOpen = useAppStore((s) => s.isSidebarOpen)
+  const isMobile = useIsMobile()
+
+  // Windows and Linux keep their own titlebar in this state — it holds their
+  // window controls — so nothing is handed over there.
+  const ownsTitlebar = isMac && !isMobile && (!!focusedId || !!previewId)
+
+  return {
+    ownsTitlebar,
+    // An open sidebar already holds both: SidebarHeader insets for the lights
+    // and lists the three views. Repeating them here would draw each twice.
+    // The web app has no traffic lights to clear, but it does lose the same
+    // controls, hence the split.
+    needsTrafficLightPad: ownsTitlebar && !isWeb && !isSidebarOpen,
+    showsAppNav: ownsTitlebar && !isSidebarOpen
+  }
+}

--- a/tests/card-header.test.tsx
+++ b/tests/card-header.test.tsx
@@ -21,6 +21,14 @@ vi.mock('../src/renderer/components/Toast', () => ({
   toast: { success: vi.fn(), error: vi.fn() }
 }))
 
+// The header asks whether it is standing in for the window's titlebar, and that
+// answer starts with whether this is a phone.
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  writable: true,
+  configurable: true
+})
+
 Object.defineProperty(window, 'api', {
   value: {
     killTerminal: vi.fn(),

--- a/tests/focused-titlebar.test.tsx
+++ b/tests/focused-titlebar.test.tsx
@@ -101,11 +101,26 @@ function focusCard(overrides: Record<string, unknown> = {}): string {
   return cardId
 }
 
-const appNavIsPresent = (): boolean =>
-  screen.queryByRole('button', { name: 'Toggle sidebar' }) !== null &&
-  screen.queryByRole('button', { name: 'Sessions' }) !== null &&
-  screen.queryByRole('button', { name: 'Tasks' }) !== null &&
-  screen.queryByRole('button', { name: 'Workflows' }) !== null
+/**
+ * Every control the hidden titlebar was carrying, asserted one by one.
+ *
+ * An `&&` of the four collapsed to a single boolean, and `expect(that).toBe(
+ * false)` is satisfied by any one of them going missing -- so a header that
+ * drew three of the four would have passed as "draws none".
+ */
+const NAV_CONTROLS = ['Toggle sidebar', 'Sessions', 'Tasks', 'Workflows']
+
+const expectAppNav = (): void => {
+  for (const name of NAV_CONTROLS) {
+    expect(screen.queryByRole('button', { name })).toBeInTheDocument()
+  }
+}
+
+const expectNoAppNav = (): void => {
+  for (const name of NAV_CONTROLS) {
+    expect(screen.queryByRole('button', { name })).not.toBeInTheDocument()
+  }
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -128,7 +143,7 @@ describe('the focused session header, standing in for the titlebar', () => {
     render(<CardHeader terminalId="t1" variant="focused" />)
 
     expect(screen.getByTestId('focused-session-header')).toHaveStyle({ paddingLeft: '80px' })
-    expect(appNavIsPresent()).toBe(true)
+    expectAppNav()
   })
 
   it('draws neither while the sidebar is open, which is already holding both', () => {
@@ -136,7 +151,7 @@ describe('the focused session header, standing in for the titlebar', () => {
     render(<CardHeader terminalId="t1" variant="focused" />)
 
     expect(screen.getByTestId('focused-session-header')).not.toHaveStyle({ paddingLeft: '80px' })
-    expect(appNavIsPresent()).toBe(false)
+    expectNoAppNav()
   })
 
   it('draws neither off macOS, where the app keeps its own titlebar', () => {
@@ -145,7 +160,7 @@ describe('the focused session header, standing in for the titlebar', () => {
     render(<CardHeader terminalId="t1" variant="focused" />)
 
     expect(screen.getByTestId('focused-session-header')).not.toHaveStyle({ paddingLeft: '80px' })
-    expect(appNavIsPresent()).toBe(false)
+    expectNoAppNav()
   })
 
   it('keeps the nav but drops the inset on the web, which has no traffic lights', () => {
@@ -154,7 +169,7 @@ describe('the focused session header, standing in for the titlebar', () => {
     render(<CardHeader terminalId="t1" variant="focused" />)
 
     expect(screen.getByTestId('focused-session-header')).not.toHaveStyle({ paddingLeft: '80px' })
-    expect(appNavIsPresent()).toBe(true)
+    expectAppNav()
   })
 
   it('leaves the grid’s own card headers alone', () => {
@@ -162,7 +177,7 @@ describe('the focused session header, standing in for the titlebar', () => {
     render(<CardHeader terminalId="t1" variant="mini" />)
 
     expect(screen.queryByTestId('focused-session-header')).not.toBeInTheDocument()
-    expect(appNavIsPresent()).toBe(false)
+    expectNoAppNav()
   })
 })
 
@@ -177,7 +192,7 @@ describe('a promoted card, standing in for the titlebar', () => {
     render(<FocusedStage />)
 
     expect(screen.getByTestId(`focused-card-${cardId}`)).toHaveStyle({ paddingLeft: '80px' })
-    expect(appNavIsPresent()).toBe(true)
+    expectAppNav()
   })
 
   it('draws neither while the sidebar is open', () => {
@@ -185,6 +200,6 @@ describe('a promoted card, standing in for the titlebar', () => {
     render(<FocusedStage />)
 
     expect(screen.getByTestId(`focused-card-${cardId}`)).not.toHaveStyle({ paddingLeft: '80px' })
-    expect(appNavIsPresent()).toBe(false)
+    expectNoAppNav()
   })
 })

--- a/tests/focused-titlebar.test.tsx
+++ b/tests/focused-titlebar.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+Object.defineProperty(window, 'matchMedia', {
+  value: () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+  writable: true,
+  configurable: true
+})
+Object.defineProperty(window, 'api', {
+  value: {
+    notifyWidgetStatus: vi.fn(),
+    listDir: vi.fn().mockResolvedValue([]),
+    killTerminal: vi.fn(),
+    listBranches: vi.fn().mockResolvedValue({ local: [], remote: [] })
+  },
+  writable: true,
+  configurable: true
+})
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('../src/renderer/components/ConfirmPopover', () => ({
+  ConfirmPopover: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('../src/renderer/components/GitChangesIndicator', () => ({
+  GitChangesIndicator: () => <div data-testid="git-changes" />,
+  BrowseFilesButton: () => <div data-testid="browse-files" />
+}))
+vi.mock('../src/renderer/components/PromotedPaneCard', () => ({
+  PromotedPaneCard: ({ cardId }: { cardId: string }) => <div data-testid={`body-${cardId}`} />
+}))
+vi.mock('../src/renderer/lib/terminal-close', () => ({
+  closeTerminalSession: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+// jsdom reports no platform, so the real `isMac` is false and the window never
+// hands its titlebar over — which would make every assertion here vacuous.
+// Getters rather than fixed values so one file can walk all four platforms.
+const platform = { isMac: true, isWeb: false }
+vi.mock('../src/renderer/lib/platform', async (orig) => {
+  const actual = await orig<typeof import('../src/renderer/lib/platform')>()
+  return {
+    ...actual,
+    get isMac() {
+      return platform.isMac
+    },
+    get isWeb() {
+      return platform.isWeb
+    }
+  }
+})
+
+const { useAppStore } = await import('../src/renderer/stores')
+const { CardHeader } = await import('../src/renderer/components/card/CardHeader')
+const { FocusedStage } = await import('../src/renderer/components/FocusedStage')
+
+const session = {
+  id: 't1',
+  agentType: 'claude',
+  projectName: 'vorn',
+  projectPath: '/repo',
+  status: 'running',
+  createdAt: 0,
+  displayName: 'Improve loading',
+  branch: 'main',
+  isWorktree: false
+}
+
+const initialState = useAppStore.getState()
+
+/** The stage as it looks with one session expanded and the sidebar hidden. */
+function focusSession(overrides: Record<string, unknown> = {}): void {
+  act(() => {
+    useAppStore.setState({
+      terminals: new Map([
+        ['t1', { id: 't1', session, status: 'running', lastOutputTimestamp: 1 }]
+      ]),
+      focusedTerminalId: 't1',
+      previewTerminalId: null,
+      isSidebarOpen: false,
+      ...overrides
+    } as never)
+  })
+}
+
+/** The same, with a popped-out file on the stage instead of the session. */
+function focusCard(overrides: Record<string, unknown> = {}): string {
+  focusSession(overrides)
+  let cardId = ''
+  act(() => {
+    cardId = useAppStore.getState().promoteFile('t1', '/repo/src/server.ts')
+  })
+  act(() => useAppStore.setState({ focusedTerminalId: cardId } as never))
+  return cardId
+}
+
+const appNavIsPresent = (): boolean =>
+  screen.queryByRole('button', { name: 'Toggle sidebar' }) !== null &&
+  screen.queryByRole('button', { name: 'Sessions' }) !== null &&
+  screen.queryByRole('button', { name: 'Tasks' }) !== null &&
+  screen.queryByRole('button', { name: 'Workflows' }) !== null
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  platform.isMac = true
+  platform.isWeb = false
+  act(() => useAppStore.setState(initialState))
+})
+
+/**
+ * On macOS the app drops its own titlebar while the focus stage fills the
+ * window, which leaves the stage's header as the only bar the window has. It
+ * was drawing neither the traffic-light inset nor the controls the hidden bar
+ * carried, so the lights landed on the session's name and there was no way to
+ * reach tasks or workflows without collapsing the session first.
+ */
+describe('the focused session header, standing in for the titlebar', () => {
+  it('clears the traffic lights and carries the app nav when the sidebar is hidden', () => {
+    focusSession()
+    render(<CardHeader terminalId="t1" variant="focused" />)
+
+    expect(screen.getByTestId('focused-session-header')).toHaveStyle({ paddingLeft: '80px' })
+    expect(appNavIsPresent()).toBe(true)
+  })
+
+  it('draws neither while the sidebar is open, which is already holding both', () => {
+    focusSession({ isSidebarOpen: true })
+    render(<CardHeader terminalId="t1" variant="focused" />)
+
+    expect(screen.getByTestId('focused-session-header')).not.toHaveStyle({ paddingLeft: '80px' })
+    expect(appNavIsPresent()).toBe(false)
+  })
+
+  it('draws neither off macOS, where the app keeps its own titlebar', () => {
+    platform.isMac = false
+    focusSession()
+    render(<CardHeader terminalId="t1" variant="focused" />)
+
+    expect(screen.getByTestId('focused-session-header')).not.toHaveStyle({ paddingLeft: '80px' })
+    expect(appNavIsPresent()).toBe(false)
+  })
+
+  it('keeps the nav but drops the inset on the web, which has no traffic lights', () => {
+    platform.isWeb = true
+    focusSession()
+    render(<CardHeader terminalId="t1" variant="focused" />)
+
+    expect(screen.getByTestId('focused-session-header')).not.toHaveStyle({ paddingLeft: '80px' })
+    expect(appNavIsPresent()).toBe(true)
+  })
+
+  it('leaves the grid’s own card headers alone', () => {
+    focusSession()
+    render(<CardHeader terminalId="t1" variant="mini" />)
+
+    expect(screen.queryByTestId('focused-session-header')).not.toBeInTheDocument()
+    expect(appNavIsPresent()).toBe(false)
+  })
+})
+
+/**
+ * A promoted card empties the window of its titlebar exactly as a session does,
+ * and draws its own header rather than CardHeader's — so it owes the window the
+ * same things, and had the same two gaps.
+ */
+describe('a promoted card, standing in for the titlebar', () => {
+  it('clears the traffic lights and carries the app nav when the sidebar is hidden', () => {
+    const cardId = focusCard()
+    render(<FocusedStage />)
+
+    expect(screen.getByTestId(`focused-card-${cardId}`)).toHaveStyle({ paddingLeft: '80px' })
+    expect(appNavIsPresent()).toBe(true)
+  })
+
+  it('draws neither while the sidebar is open', () => {
+    const cardId = focusCard({ isSidebarOpen: true })
+    render(<FocusedStage />)
+
+    expect(screen.getByTestId(`focused-card-${cardId}`)).not.toHaveStyle({ paddingLeft: '80px' })
+    expect(appNavIsPresent()).toBe(false)
+  })
+})


### PR DESCRIPTION
## The problem

On macOS the app drops its own titlebar whenever the focus stage fills the window, which leaves that stage's card header as the only bar the window has. It was never given the rest of the job:

- No traffic-light inset, so with the sidebar closed the macOS lights drew straight on top of the session's name.
- None of the controls the hidden bar was carrying came with it — no sidebar toggle, and no way to reach tasks or workflows without collapsing the session first.

With the sidebar open neither gap shows, because the sidebar header holds the inset and the three views itself. Closed, there was nothing.

## The fix

The tab strip already solves this for its own merged bar. Two pieces make the focused headers do the same:

- `useFocusedTitlebar` — one answer to who owns the titlebar, so `App` and the headers cannot disagree about it. It reports `ownsTitlebar` (the predicate `App` already used to hide its bar, unchanged), plus whether the header owes the window the inset and the nav.
- `AppNavCluster` — the sidebar toggle and the view pills, which were written out inline in the app toolbar and the tab strip and would have been copied twice more. Now one component with three call sites.

`CardHeader` honours both for its `focused` variant only, so the grid's mini headers are untouched. `FocusedCard` draws its own header rather than `CardHeader`'s and had both gaps too, so it gets the same treatment.

The inset is skipped on the web — a browser tab has no traffic lights — while the nav is not, since the web app loses the same controls.

## Tests

`tests/focused-titlebar.test.tsx` walks the states for both headers: sidebar closed gets the 80px inset and the nav, sidebar open gets neither, off macOS gets neither because the app keeps its own bar, and the web gets the nav without the inset. Checked against the unfixed code first — five of the seven fail there.

`tests/card-header.test.tsx` needed a `matchMedia` stub: the header now asks whether it is standing in for the titlebar, and that answer starts with whether this is a phone.

Renderer only. No server or main-process changes.