### PR TITLE
Find the run history button by its name, not by its icon

### DIFF
--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
@@ -79,6 +79,15 @@ vi.mock('../src/renderer/stores', () => {
 const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
 
 describe('WorkflowEditor', () => {
+  // The editing id decides whether half this toolbar renders at all, and the
+  // store mock is a plain object rather than a store — nothing resets it
+  // between tests. It was on each test that set it to put it back, which holds
+  // right up until one of them forgets and the next test inherits an editor it
+  // never asked for.
+  afterEach(() => {
+    mockState.editingWorkflowId = null
+  })
+
   it('renders the canvas and properties panel when open with no node selected', () => {
     const { getByTestId } = render(<WorkflowEditor />)
     expect(getByTestId('canvas')).toBeInTheDocument()

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -188,15 +188,6 @@ describe('WorkflowEditor', () => {
     expect(mockState.setWorkflowEditorOpen).toHaveBeenCalledWith(false)
   })
 
-  it('clicking Run history toggles the run history panel', () => {
-    const { container, getByTestId } = render(<WorkflowEditor />)
-    mockState.editingWorkflowId = 'w1'
-    const historyButton = container.querySelector('svg.lucide-history')?.closest('button')
-    if (historyButton) fireEvent.click(historyButton)
-    expect(getByTestId('properties-panel')).toBeInTheDocument()
-    mockState.editingWorkflowId = null
-  })
-
   it('clicks Delete workflow in the overflow menu when editing', () => {
     mockState.editingWorkflowId = 'w1'
     const { container, getByText } = render(<WorkflowEditor />)
@@ -216,15 +207,19 @@ describe('WorkflowEditor', () => {
 
   it('toggles the run history panel via the history toolbar button when editing', () => {
     mockState.editingWorkflowId = 'w1'
-    const { container, getByTestId, queryByTestId } = render(<WorkflowEditor />)
-    const historyButton = container.querySelector('svg.lucide-history')?.closest('button')
-    expect(historyButton).toBeDefined()
-    if (historyButton) fireEvent.click(historyButton)
+    const { getByRole, getByTestId, queryByTestId } = render(<WorkflowEditor />)
+    // By the name the button carries, not by the icon inside it. lucide renames
+    // icons between releases -- History became an alias for RotateCcwClock in
+    // 1.33, so the old class selector matched nothing and the chained
+    // `?.closest()` handed back undefined. `toBeDefined()` was the only guard,
+    // and undefined is exactly what it fails on, so a renamed icon surfaced as a
+    // puzzle instead.
+    const historyButton = getByRole('button', { name: /Run history/ })
+    fireEvent.click(historyButton)
     expect(getByTestId('run-history')).toBeInTheDocument()
     expect(queryByTestId('properties-panel')).not.toBeInTheDocument()
-    if (historyButton) fireEvent.click(historyButton)
+    fireEvent.click(historyButton)
     expect(queryByTestId('run-history')).not.toBeInTheDocument()
-    mockState.editingWorkflowId = null
   })
 
   it('clicks Workflow settings menu item to open properties', () => {


### PR DESCRIPTION
Unblocks #502 (`lucide-react` 1.16.0 → 1.33.0), which fails CI on one test.

## Why it failed

lucide 1.33 makes the `History` export an alias for `RotateCcwClock`, so the rendered SVG carries `lucide-rotate-ccw-clock` instead of `lucide-history`. The test reached the button through `container.querySelector('svg.lucide-history')?.closest('button')`, which became `undefined` — and the assertion standing behind it was `toBeDefined()`, which is exactly what `undefined` fails. So a renamed icon surfaced as a puzzle rather than as a rename.

The class-generation scheme is unchanged between the two versions, and of the eight icon classes the suite selects on, `History` is the only one that moved. That is why exactly one test failed.

## The change

The button already carries `aria-label={`Run history (${executionHistory.length})`}`, so the test now asks for it by name. No release of lucide can move that.

Two things came out with it:

- **Dropped the test above it.** It set `mockState.editingWorkflowId` *after* rendering, and the button is gated on that id — so the button was never in the tree, the click it described never happened, and what it asserted was the properties panel that was already open. The test below it covers what its name promised, with the id set before the render.
- **Added an `afterEach` that resets the editing id.** Each test that set it was expected to unset it on the way out; rewriting the run history test dropped that line and left `'w1'` set for everything after. Nothing downstream reads it today, so the suite stayed green and the next test to depend on it would have been the one that looked broken. The reset is now a property of the file rather than of each author's memory.

## Verification

Ran against the real 1.33.0 package swapped into `node_modules`, not just the installed 1.16.0:

- old test + 1.33 → fails, reproducing the CI failure exactly
- new test + 1.33 → passes
- new test + 1.16 → passes
- all eight test files that select on lucide classes → 96 passing under 1.33
- the file passes under `--sequence.shuffle`, so the reset holds regardless of order

Tests only. After this lands, #502 should go green on a rebase.