### PR TITLE
chore(release): 0.7.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only — root plus the six workspace packages, via `scripts/sync-versions.sh`.

Since `0.7.0-beta.4`:

- Give this machine's server a name it can own (#497)
- Let a focused session's header act like the titlebar it replaced (#503)
- Find the run history button by its name, not by its icon (#504)
- `@tiptap/extension-placeholder` 3.29.2 → 3.30.3 (#498)
- `@tiptap/extension-link` 3.29.2 → 3.30.3 (#501)
- `lucide-react` 1.16.0 → 1.34.0 (#502)