### PR TITLE
Let a session outlive the window, the server, and a crash

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,8 @@
     "@fastify/websocket": "^11.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@vornrun/shared": "workspace:*",
+    "@xterm/addon-serialize": "0.13.0",
+    "@xterm/headless": "5.5.0",
     "fastify": "^5.11.0",
     "libsql": "^0.5.29",
     "node-cron": "^4.2.1",

--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -10,6 +10,7 @@ import {
 } from '@vornrun/shared/types'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { shellEscape } from './process-utils'
+import { stripSessionSelectors } from './launch-tokens'
 
 function commandExists(cmd: string, env: Record<string, string>): boolean {
   try {
@@ -65,6 +66,26 @@ export function buildAgentLaunchLine(
   const effectiveArgs = payload.args !== undefined ? payload.args : cmd.args
   let launchLine = [cmd.command, ...effectiveArgs.map((a) => shellEscape(a))].join(' ')
 
+  // Where the configured command ends and its arguments begin. Known exactly
+  // rather than guessed, because this line was just composed here -- which is
+  // what lets `npx -y @anthropic-ai/claude-code` be a command and an argument
+  // that merely ends in `/claude` be left alone.
+  const argsFrom = cmd.command.length
+
+  const selecting = Boolean(
+    (payload.resumeSessionId && supportsExactSessionResume(payload.agentType)) ||
+    (!payload.resumeSessionId && payload.sessionId && supportsSessionIdPinning(payload.agentType))
+  )
+
+  // A configured command may already carry a selector -- somebody who always
+  // resumes the same session, or who pinned an id by hand. Two of them compete
+  // and one wins silently, which is the wrong session with nothing to say a
+  // choice was made. Removed only where it can be proven; a line this cannot
+  // read is handed back untouched and ours is appended beside theirs.
+  if (selecting) {
+    launchLine = stripSessionSelectors(launchLine, payload.agentType, argsFrom)
+  }
+
   if (payload.resumeSessionId && supportsExactSessionResume(payload.agentType)) {
     const escapedResumeId = shellEscape(payload.resumeSessionId)
     switch (payload.agentType) {
@@ -74,9 +95,16 @@ export function buildAgentLaunchLine(
       case 'copilot':
         launchLine += ` --resume ${escapedResumeId}`
         break
-      case 'codex':
-        launchLine = `${cmd.command} resume ${escapedResumeId}`
+      case 'codex': {
+        // Spliced in as the first argument rather than replacing the line.
+        // Rebuilding it as `${cmd.command} resume ${id}` threw away every
+        // argument the person had configured -- a model, a sandbox setting, an
+        // approval policy -- and only ever on the resume path, so a session came
+        // back configured differently from the one it continues.
+        const rest = launchLine.slice(argsFrom)
+        launchLine = `${launchLine.slice(0, argsFrom)} resume ${escapedResumeId}${rest}`
         break
+      }
       case 'opencode':
         launchLine += ` --session ${escapedResumeId}`
         break

--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -72,9 +72,11 @@ export function buildAgentLaunchLine(
   // that merely ends in `/claude` be left alone.
   const argsFrom = cmd.command.length
 
-  const selecting = Boolean(
-    (payload.resumeSessionId && supportsExactSessionResume(payload.agentType)) ||
-    (!payload.resumeSessionId && payload.sessionId && supportsSessionIdPinning(payload.agentType))
+  const exactResume = Boolean(
+    payload.resumeSessionId && supportsExactSessionResume(payload.agentType)
+  )
+  const pinning = Boolean(
+    !payload.resumeSessionId && payload.sessionId && supportsSessionIdPinning(payload.agentType)
   )
 
   // A configured command may already carry a selector -- somebody who always
@@ -82,11 +84,11 @@ export function buildAgentLaunchLine(
   // and one wins silently, which is the wrong session with nothing to say a
   // choice was made. Removed only where it can be proven; a line this cannot
   // read is handed back untouched and ours is appended beside theirs.
-  if (selecting) {
+  if (exactResume || pinning) {
     launchLine = stripSessionSelectors(launchLine, payload.agentType, argsFrom)
   }
 
-  if (payload.resumeSessionId && supportsExactSessionResume(payload.agentType)) {
+  if (exactResume && payload.resumeSessionId) {
     const escapedResumeId = shellEscape(payload.resumeSessionId)
     switch (payload.agentType) {
       case 'claude':

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1209,7 +1209,13 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
     ...(map.hasSeenOnboarding !== undefined && {
       hasSeenOnboarding: map.hasSeenOnboarding as boolean | number
     }),
-    ...(map.reopenSessions !== undefined && { reopenSessions: map.reopenSessions as boolean }),
+    // Default on, and that changed meaning rather than merely flipping. It used
+    // to decide whether every saved session was relaunched at start-up, which
+    // spends tokens and starts processes -- worth asking about, so it was off.
+    // Bringing a pane back no longer does either: it shows the last screen its
+    // terminal drew and waits. There is nothing to ask, and leaving it off made
+    // the whole thing invisible unless somebody went looking for a toggle.
+    reopenSessions: (map.reopenSessions as boolean) ?? true,
     // Saving iterates over every key in defaults, but loading is this explicit
     // list — so a key missing here round-trips to nothing and its feature is
     // silently inert.

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -968,6 +968,23 @@ function migrateSchema(d: Database.Database): void {
     })()
     log.info('[database] migrated schema to version 15 (config row revisions)')
   }
+
+  if (version < 16) {
+    // Where a shell actually is, rather than where it was started. The column
+    // never existed, so `shellCwd` round-tripped to nothing and a restored shell
+    // always fell back to its project directory -- which for anybody who had
+    // navigated somewhere, which is most shell use, was the wrong place.
+    d.transaction(() => {
+      const cols = d.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
+      if (!cols.some((c) => c.name === 'shell_cwd')) {
+        d.exec('ALTER TABLE sessions ADD COLUMN shell_cwd TEXT')
+      }
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '16')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 16 (shell working directory)')
+  }
 }
 
 /** The config-blob tables `saveConfig` rewrites, and so the ones that need stamping. */
@@ -1025,7 +1042,8 @@ function verifySchema(d: Database.Database): void {
         ddl: 'ALTER TABLE sessions ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0'
       },
       { column: 'worktree_name', ddl: 'ALTER TABLE sessions ADD COLUMN worktree_name TEXT' },
-      { column: 'agent_session_id', ddl: 'ALTER TABLE sessions ADD COLUMN agent_session_id TEXT' }
+      { column: 'agent_session_id', ddl: 'ALTER TABLE sessions ADD COLUMN agent_session_id TEXT' },
+      { column: 'shell_cwd', ddl: 'ALTER TABLE sessions ADD COLUMN shell_cwd TEXT' }
     ],
     agent_commands: [
       {
@@ -3008,8 +3026,8 @@ export function saveSessions(sessions: TerminalSession[]): void {
   const run = d.transaction(() => {
     d.prepare('DELETE FROM sessions').run()
     const insert = d.prepare(
-      `INSERT INTO sessions (id, agent_type, project_name, project_path, status, created_at, pid, display_name, branch, worktree_path, is_worktree, remote_host_id, remote_host_label, hook_session_id, status_source, saved_at, sort_order, worktree_name, agent_session_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO sessions (id, agent_type, project_name, project_path, status, created_at, pid, display_name, branch, worktree_path, is_worktree, remote_host_id, remote_host_label, hook_session_id, status_source, saved_at, sort_order, worktree_name, agent_session_id, shell_cwd)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (let i = 0; i < sessions.length; i++) {
       const s = sessions[i]
@@ -3032,7 +3050,8 @@ export function saveSessions(sessions: TerminalSession[]): void {
         savedAt,
         i,
         s.worktreeName ?? null,
-        s.agentSessionId ?? null
+        s.agentSessionId ?? null,
+        s.shellCwd ?? null
       )
     }
   })
@@ -3058,6 +3077,7 @@ export function getPreviousSessions(): TerminalSession[] {
     hook_session_id: string | null
     status_source: string | null
     saved_at: number | null
+    shell_cwd: string | null
     worktree_name: string | null
     agent_session_id: string | null
   }>
@@ -3083,7 +3103,8 @@ export function getPreviousSessions(): TerminalSession[] {
     ...(r.agent_session_id != null && { agentSessionId: r.agent_session_id }),
     // Selected since this table was written and dropped on the floor until now.
     // It is the only record of when a run ended.
-    ...(r.saved_at != null && { savedAt: r.saved_at })
+    ...(r.saved_at != null && { savedAt: r.saved_at }),
+    ...(r.shell_cwd != null && { shellCwd: r.shell_cwd })
   }))
 }
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -3080,7 +3080,10 @@ export function getPreviousSessions(): TerminalSession[] {
       statusSource: r.status_source as TerminalSession['statusSource']
     }),
     ...(r.worktree_name != null && { worktreeName: r.worktree_name }),
-    ...(r.agent_session_id != null && { agentSessionId: r.agent_session_id })
+    ...(r.agent_session_id != null && { agentSessionId: r.agent_session_id }),
+    // Selected since this table was written and dropped on the floor until now.
+    // It is the only record of when a run ended.
+    ...(r.saved_at != null && { savedAt: r.saved_at })
   }))
 }
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -3047,7 +3047,12 @@ export function saveSessions(sessions: TerminalSession[]): void {
         s.remoteHostLabel ?? null,
         s.hookSessionId ?? null,
         s.statusSource ?? null,
-        savedAt,
+        // A record's own stamp wins. Held sessions from a previous run are
+        // persisted beside the live ones, and re-stamping them with now made
+        // their age reset on every save -- so the window they are supposed to
+        // age out of never elapsed, and the pane reported them as having ended
+        // moments ago however long they had really been gone.
+        s.savedAt ?? savedAt,
         i,
         s.worktreeName ?? null,
         s.agentSessionId ?? null,

--- a/packages/server/src/history/checkpoint.ts
+++ b/packages/server/src/history/checkpoint.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import fsp from 'fs/promises'
 import path from 'path'
 import crypto from 'crypto'
 import log from '../logger'
@@ -22,7 +23,19 @@ import log from '../logger'
  * Nothing else in this repo has fsynced anything, so step three is new ground
  * and is the reason this module exists rather than a `writeFileSync` at the call
  * site. The rename shape follows `endpoint.ts`, which uses the same
- * scratch-then-rename idiom for a socket.
+ * scratch-then-rename idiom for a socket. The scratch *name* is spelled out here
+ * rather than calling that module's `scratchPathFor`: it would couple the
+ * history modules to the endpoint, which pulls in `net`, for two lines.
+ *
+ * The write is asynchronous throughout, and that is not a style preference. A
+ * synchronous version measured 5.8 ms of blocked event loop per checkpoint on a
+ * 460 KB screen -- fifty sessions in a row is a third of a second in which no
+ * terminal output moves, no socket frame is read and no request is answered.
+ * That would also have quietly undone the reason `writer.ts` gives a queue to
+ * each session rather than one to the server: a slow disk under one terminal
+ * would have held up every other terminal on the machine. Awaiting each step in
+ * turn preserves the write-sync-rename-sync order exactly, and the per-session
+ * queue is what guarantees no two writers meet in one directory.
  */
 
 export interface Checkpoint {
@@ -69,42 +82,40 @@ export function historyDir(dataDir: string, sessionId: string): string {
 }
 
 /**
- * Make a directory's contents durable.
+ * Make what a handle refers to durable.
  *
  * A rename is atomic but not durable: the entry can still be lost to power
  * failure until the directory itself is synced. Best-effort, because some
  * filesystems refuse to open a directory for this and failing to sync is not a
  * reason to fail the write -- but it is a reason to say so once.
  */
-function trySync(fd: number, what: string): void {
+async function trySync(handle: fsp.FileHandle, what: string): Promise<void> {
   try {
-    fs.fsyncSync(fd)
+    await handle.sync()
   } catch (err) {
     log.warn({ err, what }, '[history] could not fsync; this write may not survive power loss')
   }
 }
 
-function syncDir(dir: string): void {
-  let fd: number
+async function syncDir(dir: string): Promise<void> {
+  let handle: fsp.FileHandle
   try {
-    fd = fs.openSync(dir, 'r')
+    handle = await fsp.open(dir, 'r')
   } catch (err) {
     log.warn({ err, dir }, '[history] could not open the directory to fsync it')
     return
   }
   try {
-    trySync(fd, 'the history directory')
+    await trySync(handle, 'the history directory')
   } finally {
-    try {
-      fs.closeSync(fd)
-    } catch {
+    await handle.close().catch(() => {
       /* already closed */
-    }
+    })
   }
 }
 
-/** Written, renamed, and synced. Returns whether it landed. */
-export function writeCheckpoint(dir: string, checkpoint: Checkpoint): boolean {
+/** Written, renamed, and synced. Answers whether it landed. */
+export async function writeCheckpoint(dir: string, checkpoint: Checkpoint): Promise<boolean> {
   const body = JSON.stringify(checkpoint)
   if (Buffer.byteLength(body) > MAX_CHECKPOINT_BYTES) {
     log.warn(
@@ -121,28 +132,26 @@ export function writeCheckpoint(dir: string, checkpoint: Checkpoint): boolean {
   const target = path.join(dir, CHECKPOINT_FILE)
 
   try {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
-    const fd = fs.openSync(scratch, 'w', 0o600)
+    await fsp.mkdir(dir, { recursive: true, mode: 0o700 })
+    const handle = await fsp.open(scratch, 'w', 0o600)
     try {
-      fs.writeFileSync(fd, body, 'utf-8')
+      await handle.writeFile(body, 'utf-8')
       // The file's own contents, before the rename makes them reachable.
       // Best-effort, like the directory below: a filesystem that refuses to sync
       // still gives an atomic rename against other readers, and a checkpoint
       // that is merely not power-loss-durable beats no checkpoint at all.
-      trySync(fd, 'the checkpoint file')
+      await trySync(handle, 'the checkpoint file')
     } finally {
-      fs.closeSync(fd)
+      await handle.close()
     }
-    fs.renameSync(scratch, target)
-    syncDir(dir)
+    await fsp.rename(scratch, target)
+    await syncDir(dir)
     return true
   } catch (err) {
     log.warn({ err, dir }, '[history] could not write a checkpoint')
-    try {
-      fs.rmSync(scratch, { force: true })
-    } catch {
+    await fsp.rm(scratch, { force: true }).catch(() => {
       /* a scratch file this process created and could not remove */
-    }
+    })
     return false
   }
 }
@@ -158,6 +167,16 @@ export function writeCheckpoint(dir: string, checkpoint: Checkpoint): boolean {
 export function readCheckpoint(dir: string): Checkpoint | null {
   try {
     const raw: unknown = JSON.parse(fs.readFileSync(path.join(dir, CHECKPOINT_FILE), 'utf-8'))
+    return isCheckpoint(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+/** The same, off the event loop, for the recovery sweep that reads many. */
+export async function readCheckpointAsync(dir: string): Promise<Checkpoint | null> {
+  try {
+    const raw: unknown = JSON.parse(await fsp.readFile(path.join(dir, CHECKPOINT_FILE), 'utf-8'))
     return isCheckpoint(raw) ? raw : null
   } catch {
     return null

--- a/packages/server/src/history/checkpoint.ts
+++ b/packages/server/src/history/checkpoint.ts
@@ -59,6 +59,16 @@ export interface Checkpoint {
    * the difference between a file somebody can diagnose and one they cannot.
    */
   seq: number
+  /**
+   * Whether this was written by a shutdown rather than by the clock.
+   *
+   * It is the difference between "you closed Vorn" and "something stopped it",
+   * and a pane has no other way to tell: a crash runs nothing, so the last
+   * checkpoint it leaves is an ordinary periodic one. Only the flush on the way
+   * out sets this, which makes its absence the honest answer for every other
+   * ending -- a kill, an OOM, a machine losing power.
+   */
+  closedCleanly?: boolean
 }
 
 export const CHECKPOINT_FILE = 'checkpoint.json'
@@ -212,6 +222,7 @@ function isCheckpoint(value: unknown): value is Checkpoint {
     typeof v.title === 'string' &&
     typeof v.cwd === 'string' &&
     Number.isInteger(v.generation) &&
-    Number.isInteger(v.seq)
+    Number.isInteger(v.seq) &&
+    (v.closedCleanly === undefined || typeof v.closedCleanly === 'boolean')
   )
 }

--- a/packages/server/src/history/checkpoint.ts
+++ b/packages/server/src/history/checkpoint.ts
@@ -1,0 +1,180 @@
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import log from '../logger'
+
+/**
+ * The state a terminal can be restored to, written so a crash cannot half-write
+ * it.
+ *
+ * A checkpoint is the expensive half of the pair: the log is appended to
+ * constantly and this is written rarely, so this is where the durability
+ * discipline goes. Three steps, and the third is the one implementations forget:
+ *
+ *   1. Write a scratch file beside the target.
+ *   2. `rename` it into place — atomic, so a reader sees the old file or the new
+ *      one and never a half of either.
+ *   3. **fsync the parent directory.** The rename is atomic with respect to
+ *      other processes; it is not durable with respect to power loss until the
+ *      directory entry itself has been synced. Skip it and the atomic rename
+ *      buys nothing against the failure it was chosen for.
+ *
+ * Nothing else in this repo has fsynced anything, so step three is new ground
+ * and is the reason this module exists rather than a `writeFileSync` at the call
+ * site. The rename shape follows `endpoint.ts`, which uses the same
+ * scratch-then-rename idiom for a socket.
+ */
+
+export interface Checkpoint {
+  /** Escape sequences that reproduce the screen. */
+  screen: string
+  /** The bytes behind it, which carry scrollback the screen model does not. */
+  scrollback: string
+  cols: number
+  rows: number
+  title: string
+  cwd: string
+  /** Ties the log beside it to this checkpoint. */
+  generation: number
+  /** The last batch this includes. Replay starts after it. */
+  seq: number
+}
+
+export const CHECKPOINT_FILE = 'checkpoint.json'
+export const LOG_FILE = 'output.log'
+
+/**
+ * How large a checkpoint may be before it is skipped.
+ *
+ * Skipped whole rather than truncated: half a JSON document is not a smaller
+ * checkpoint, it is an unparseable one, and a session whose screen will not fit
+ * is better off restoring from an older checkpoint plus a longer log than from
+ * something that cannot be read at all.
+ */
+export const MAX_CHECKPOINT_BYTES = 2 * 1024 * 1024
+
+/**
+ * Where a session's history lives.
+ *
+ * Under a subdirectory of the data dir, never in it: `config-manager` puts an
+ * `fs.watch` on the data directory itself, and although it filters by filename
+ * the callback still fires per event -- an append-only log written beside the
+ * database would wake that watcher on every chunk of terminal output.
+ *
+ * The id is encoded because it ends up as a path segment, and a session id is
+ * not guaranteed to be one.
+ */
+export function historyDir(dataDir: string, sessionId: string): string {
+  return path.join(dataDir, 'history', encodeURIComponent(sessionId))
+}
+
+/**
+ * Make a directory's contents durable.
+ *
+ * A rename is atomic but not durable: the entry can still be lost to power
+ * failure until the directory itself is synced. Best-effort, because some
+ * filesystems refuse to open a directory for this and failing to sync is not a
+ * reason to fail the write -- but it is a reason to say so once.
+ */
+function trySync(fd: number, what: string): void {
+  try {
+    fs.fsyncSync(fd)
+  } catch (err) {
+    log.warn({ err, what }, '[history] could not fsync; this write may not survive power loss')
+  }
+}
+
+function syncDir(dir: string): void {
+  let fd: number
+  try {
+    fd = fs.openSync(dir, 'r')
+  } catch (err) {
+    log.warn({ err, dir }, '[history] could not open the directory to fsync it')
+    return
+  }
+  try {
+    trySync(fd, 'the history directory')
+  } finally {
+    try {
+      fs.closeSync(fd)
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
+/** Written, renamed, and synced. Returns whether it landed. */
+export function writeCheckpoint(dir: string, checkpoint: Checkpoint): boolean {
+  const body = JSON.stringify(checkpoint)
+  if (Buffer.byteLength(body) > MAX_CHECKPOINT_BYTES) {
+    log.warn(
+      { dir, bytes: Buffer.byteLength(body) },
+      '[history] screen too large to checkpoint; skipping this one whole'
+    )
+    return false
+  }
+
+  // Random rather than a fixed `.tmp`, so two writers -- which should not exist,
+  // but a second server on one data dir is a thing this codebase has had to
+  // reason about before -- cannot land on each other's scratch file.
+  const scratch = path.join(dir, `.${CHECKPOINT_FILE}.${crypto.randomBytes(6).toString('hex')}`)
+  const target = path.join(dir, CHECKPOINT_FILE)
+
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const fd = fs.openSync(scratch, 'w', 0o600)
+    try {
+      fs.writeFileSync(fd, body, 'utf-8')
+      // The file's own contents, before the rename makes them reachable.
+      // Best-effort, like the directory below: a filesystem that refuses to sync
+      // still gives an atomic rename against other readers, and a checkpoint
+      // that is merely not power-loss-durable beats no checkpoint at all.
+      trySync(fd, 'the checkpoint file')
+    } finally {
+      fs.closeSync(fd)
+    }
+    fs.renameSync(scratch, target)
+    syncDir(dir)
+    return true
+  } catch (err) {
+    log.warn({ err, dir }, '[history] could not write a checkpoint')
+    try {
+      fs.rmSync(scratch, { force: true })
+    } catch {
+      /* a scratch file this process created and could not remove */
+    }
+    return false
+  }
+}
+
+/**
+ * Read a checkpoint, or answer null.
+ *
+ * Null for absent, unreadable, unparseable and wrong-shaped alike, because the
+ * caller's response to all of them is identical: there is nothing to restore
+ * from, so start clean. A checkpoint that fails to parse is not worth a throw --
+ * it is the ordinary residue of a crash.
+ */
+export function readCheckpoint(dir: string): Checkpoint | null {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(path.join(dir, CHECKPOINT_FILE), 'utf-8'))
+    return isCheckpoint(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+function isCheckpoint(value: unknown): value is Checkpoint {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Partial<Checkpoint>
+  return (
+    typeof v.screen === 'string' &&
+    typeof v.scrollback === 'string' &&
+    Number.isInteger(v.cols) &&
+    Number.isInteger(v.rows) &&
+    typeof v.title === 'string' &&
+    typeof v.cwd === 'string' &&
+    Number.isInteger(v.generation) &&
+    Number.isInteger(v.seq)
+  )
+}

--- a/packages/server/src/history/checkpoint.ts
+++ b/packages/server/src/history/checkpoint.ts
@@ -49,7 +49,15 @@ export interface Checkpoint {
   cwd: string
   /** Ties the log beside it to this checkpoint. */
   generation: number
-  /** The last batch this includes. Replay starts after it. */
+  /**
+   * The last batch on disk that this supersedes.
+   *
+   * Recovery does not read it, and that is not an oversight: a checkpoint
+   * replaces the log rather than being written past it, so there is never a
+   * prefix to skip. It is here because the generation says *which* log belongs
+   * to this checkpoint and this says *how much* of one it stood in for, which is
+   * the difference between a file somebody can diagnose and one they cannot.
+   */
   seq: number
 }
 
@@ -75,10 +83,20 @@ export const MAX_CHECKPOINT_BYTES = 2 * 1024 * 1024
  * database would wake that watcher on every chunk of terminal output.
  *
  * The id is encoded because it ends up as a path segment, and a session id is
- * not guaranteed to be one.
+ * not guaranteed to be one. Encoding is not on its own a guarantee, which is
+ * worth saying because it reads like one: `encodeURIComponent('..')` is `'..'`,
+ * so an id of two dots would name the data directory itself -- and `reset()`
+ * begins by removing the directory it is given. Every id today is a
+ * `crypto.randomUUID()`, so nothing reaches that; the check below is what makes
+ * that a fact about this function rather than about its callers.
  */
 export function historyDir(dataDir: string, sessionId: string): string {
-  return path.join(dataDir, 'history', encodeURIComponent(sessionId))
+  const root = path.join(dataDir, 'history')
+  const at = path.join(root, encodeURIComponent(sessionId))
+  if (path.dirname(at) !== root) {
+    throw new Error(`a session id that does not name a directory under history: ${sessionId}`)
+  }
+  return at
 }
 
 /**

--- a/packages/server/src/history/log.ts
+++ b/packages/server/src/history/log.ts
@@ -1,0 +1,215 @@
+/**
+ * The on-disk shape of a terminal's history, and nothing else.
+ *
+ * Pure functions over buffers: no files, no sessions, no timers. Everything that
+ * can go wrong with this format can go wrong in a unit test, which matters more
+ * here than usual because every failure mode is a *crash* — the input this reader
+ * is designed for is a file that was being written when the process died.
+ *
+ * ## Why frames rather than raw bytes
+ *
+ * A crash tears the final append. Raw output would leave a reader no way to know
+ * where the good part ends, and feeding an emulator half an escape sequence is
+ * worse than feeding it nothing: it either swallows the text that follows or
+ * prints it as characters. A length prefix makes the tear detectable, so replay
+ * stops at the last whole frame. It is the same rule the in-memory byte buffer
+ * already trims by — a boundary, never an arbitrary cut.
+ *
+ * ## Why a checksum as well as a length
+ *
+ * A length catches a torn tail. It does not catch a byte that changed in the
+ * middle of a file that is otherwise the right size, and a wrong byte inside an
+ * escape sequence is exactly the input that makes a terminal do something
+ * inexplicable three screens later. SQLite's WAL and etcd's log both checksum
+ * per record for this reason, and it costs a table lookup per byte.
+ *
+ * ## Layout
+ *
+ *     header = 'VRNL'  u8 formatVersion  u32le generation
+ *     frame  = u8 kind  u32le payloadLength  u32le crc32  payload
+ *                0x01 batch   u32le seq
+ *                0x02 output  utf8 bytes
+ *                0x03 resize  u16le cols  u16le rows
+ *                0x04 clear   -
+ *
+ * The generation ties a log to the checkpoint it was written for. A log found
+ * beside a newer checkpoint is not a log of what happened after it, and replaying
+ * one over the other would produce a screen that never existed.
+ */
+
+export const MAGIC = 'VRNL'
+export const FORMAT_VERSION = 1
+
+const HEADER_BYTES = 4 + 1 + 4
+const FRAME_PREFIX_BYTES = 1 + 4 + 4
+
+export const FrameKind = {
+  Batch: 0x01,
+  Output: 0x02,
+  Resize: 0x03,
+  Clear: 0x04
+} as const
+
+export type Frame =
+  | { kind: 'batch'; seq: number }
+  | { kind: 'output'; data: string }
+  | { kind: 'resize'; cols: number; rows: number }
+  | { kind: 'clear' }
+
+/**
+ * CRC-32, the IEEE polynomial every other implementation of this uses.
+ *
+ * Written out because the repo has no checksum of any kind and this is fifteen
+ * lines against a dependency. The table is built once on first use rather than
+ * at import, so a server that never writes history never pays for it.
+ */
+let table: Uint32Array | null = null
+
+function crcTable(): Uint32Array {
+  if (table) return table
+  const built = new Uint32Array(256)
+  for (let i = 0; i < 256; i++) {
+    let c = i
+    for (let bit = 0; bit < 8; bit++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+    built[i] = c >>> 0
+  }
+  table = built
+  return table
+}
+
+export function crc32(bytes: Buffer): number {
+  const t = crcTable()
+  let c = 0xffffffff
+  for (let i = 0; i < bytes.length; i++) c = t[(c ^ bytes[i]) & 0xff]! ^ (c >>> 8)
+  return (c ^ 0xffffffff) >>> 0
+}
+
+export function writeHeader(generation: number): Buffer {
+  const buf = Buffer.alloc(HEADER_BYTES)
+  buf.write(MAGIC, 0, 'ascii')
+  buf.writeUInt8(FORMAT_VERSION, 4)
+  buf.writeUInt32LE(generation >>> 0, 5)
+  return buf
+}
+
+export interface Header {
+  formatVersion: number
+  generation: number
+}
+
+/**
+ * Read the header, or say why not.
+ *
+ * Null rather than a throw: a file that is absent, empty, truncated to nothing
+ * or written by a different version is an ordinary thing to find on disk after a
+ * crash, and the caller's answer to all of them is the same — start again.
+ */
+export function readHeader(buf: Buffer): Header | null {
+  if (buf.length < HEADER_BYTES) return null
+  if (buf.subarray(0, 4).toString('ascii') !== MAGIC) return null
+  return { formatVersion: buf.readUInt8(4), generation: buf.readUInt32LE(5) }
+}
+
+function frame(kind: number, payload: Buffer): Buffer {
+  const buf = Buffer.alloc(FRAME_PREFIX_BYTES + payload.length)
+  buf.writeUInt8(kind, 0)
+  buf.writeUInt32LE(payload.length, 1)
+  buf.writeUInt32LE(crc32(payload), 5)
+  payload.copy(buf, FRAME_PREFIX_BYTES)
+  return buf
+}
+
+export function frameBatch(seq: number): Buffer {
+  const payload = Buffer.alloc(4)
+  payload.writeUInt32LE(seq >>> 0, 0)
+  return frame(FrameKind.Batch, payload)
+}
+
+export function frameOutput(data: string): Buffer {
+  return frame(FrameKind.Output, Buffer.from(data, 'utf-8'))
+}
+
+export function frameResize(cols: number, rows: number): Buffer {
+  const payload = Buffer.alloc(4)
+  payload.writeUInt16LE(cols & 0xffff, 0)
+  payload.writeUInt16LE(rows & 0xffff, 2)
+  return frame(FrameKind.Resize, payload)
+}
+
+export function frameClear(): Buffer {
+  return frame(FrameKind.Clear, Buffer.alloc(0))
+}
+
+/** Why a read stopped where it did. `end` is the only one that is not damage. */
+export type StopReason = 'end' | 'torn' | 'checksum' | 'unknown-kind' | 'malformed'
+
+export interface ReadResult {
+  frames: Frame[]
+  /** Bytes consumed, so a caller can truncate the file to what was whole. */
+  consumed: number
+  reason: StopReason
+}
+
+/**
+ * Read frames until one is not whole.
+ *
+ * Never throws, and never skips. A frame that fails its checksum ends the read
+ * rather than being stepped over, because a file with one bad frame is a file
+ * whose remaining bytes have no established meaning — the prefix is trustworthy
+ * and the rest is a guess. A slightly stale screen is a small wrong; a screen
+ * assembled from bytes nobody can vouch for is an unbounded one.
+ */
+export function readFrames(buf: Buffer, from = HEADER_BYTES): ReadResult {
+  const frames: Frame[] = []
+  let at = from
+
+  for (;;) {
+    if (at === buf.length) return { frames, consumed: at, reason: 'end' }
+    if (at + FRAME_PREFIX_BYTES > buf.length) return { frames, consumed: at, reason: 'torn' }
+
+    const kind = buf.readUInt8(at)
+    const length = buf.readUInt32LE(at + 1)
+    const expected = buf.readUInt32LE(at + 5)
+    const start = at + FRAME_PREFIX_BYTES
+
+    // Checked before it is used as a slice bound: a torn length field can read
+    // as an enormous number, and `subarray` would answer with a short buffer
+    // whose checksum then fails for the wrong reason.
+    if (start + length > buf.length) return { frames, consumed: at, reason: 'torn' }
+
+    const payload = buf.subarray(start, start + length)
+    if (crc32(payload) !== expected) return { frames, consumed: at, reason: 'checksum' }
+
+    const decoded = decode(kind, payload)
+    if (!decoded) {
+      return { frames, consumed: at, reason: kind in KNOWN ? 'malformed' : 'unknown-kind' }
+    }
+
+    frames.push(decoded)
+    at = start + length
+  }
+}
+
+const KNOWN: Record<number, true> = {
+  [FrameKind.Batch]: true,
+  [FrameKind.Output]: true,
+  [FrameKind.Resize]: true,
+  [FrameKind.Clear]: true
+}
+
+function decode(kind: number, payload: Buffer): Frame | null {
+  switch (kind) {
+    case FrameKind.Batch:
+      return payload.length === 4 ? { kind: 'batch', seq: payload.readUInt32LE(0) } : null
+    case FrameKind.Output:
+      return { kind: 'output', data: payload.toString('utf-8') }
+    case FrameKind.Resize:
+      return payload.length === 4
+        ? { kind: 'resize', cols: payload.readUInt16LE(0), rows: payload.readUInt16LE(2) }
+        : null
+    case FrameKind.Clear:
+      return payload.length === 0 ? { kind: 'clear' } : null
+    default:
+      return null
+  }
+}

--- a/packages/server/src/history/log.ts
+++ b/packages/server/src/history/log.ts
@@ -30,12 +30,19 @@
  *                0x01 batch   u32le seq
  *                0x02 output  utf8 bytes
  *                0x03 resize  u16le cols  u16le rows
- *                0x04 clear   -
+ *
+ * There is no reset kind. One was drafted and removed: nothing in the server
+ * clears a live terminal's history -- the only path that empties it is a PTY
+ * exit, which deletes the files outright -- so it would have been a kind with a
+ * reader and no writer, and an unreachable branch in replay. `formatVersion`
+ * exists to add one the day something needs it.
  *
  * The generation ties a log to the checkpoint it was written for. A log found
  * beside a newer checkpoint is not a log of what happened after it, and replaying
  * one over the other would produce a screen that never existed.
  */
+
+import zlib from 'zlib'
 
 export const MAGIC = 'VRNL'
 export const FORMAT_VERSION = 1
@@ -46,42 +53,30 @@ const FRAME_PREFIX_BYTES = 1 + 4 + 4
 export const FrameKind = {
   Batch: 0x01,
   Output: 0x02,
-  Resize: 0x03,
-  Clear: 0x04
+  Resize: 0x03
 } as const
 
 export type Frame =
   | { kind: 'batch'; seq: number }
   | { kind: 'output'; data: string }
   | { kind: 'resize'; cols: number; rows: number }
-  | { kind: 'clear' }
 
 /**
  * CRC-32, the IEEE polynomial every other implementation of this uses.
  *
- * Written out because the repo has no checksum of any kind and this is fifteen
- * lines against a dependency. The table is built once on first use rather than
- * at import, so a server that never writes history never pays for it.
+ * Node's own, which has been in the standard library since 22.2 and is native.
+ * An earlier version of this file wrote the table out by hand on the grounds
+ * that the repo has no checksum anywhere and fifteen lines beats a dependency --
+ * true, and it missed that this needs neither. Measured at about a hundred times
+ * the throughput of the table-driven loop, on a function that runs once per
+ * frame written and once per frame replayed.
+ *
+ * Wrapped rather than re-exported so the name stays this module's, and so the
+ * tests that pin the published check value keep testing what the format
+ * actually uses.
  */
-let table: Uint32Array | null = null
-
-function crcTable(): Uint32Array {
-  if (table) return table
-  const built = new Uint32Array(256)
-  for (let i = 0; i < 256; i++) {
-    let c = i
-    for (let bit = 0; bit < 8; bit++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
-    built[i] = c >>> 0
-  }
-  table = built
-  return table
-}
-
 export function crc32(bytes: Buffer): number {
-  const t = crcTable()
-  let c = 0xffffffff
-  for (let i = 0; i < bytes.length; i++) c = t[(c ^ bytes[i]) & 0xff]! ^ (c >>> 8)
-  return (c ^ 0xffffffff) >>> 0
+  return zlib.crc32(bytes)
 }
 
 export function writeHeader(generation: number): Buffer {
@@ -107,7 +102,13 @@ export interface Header {
 export function readHeader(buf: Buffer): Header | null {
   if (buf.length < HEADER_BYTES) return null
   if (buf.subarray(0, 4).toString('ascii') !== MAGIC) return null
-  return { formatVersion: buf.readUInt8(4), generation: buf.readUInt32LE(5) }
+  // The version was written, returned, and never consulted, while the comment
+  // above claimed a file from a different version was one of the cases this
+  // covers. Refusing it is the conservative half of that promise: a reader that
+  // does not know a layout should start again rather than guess at it.
+  const formatVersion = buf.readUInt8(4)
+  if (formatVersion !== FORMAT_VERSION) return null
+  return { formatVersion, generation: buf.readUInt32LE(5) }
 }
 
 function frame(kind: number, payload: Buffer): Buffer {
@@ -134,10 +135,6 @@ export function frameResize(cols: number, rows: number): Buffer {
   payload.writeUInt16LE(cols & 0xffff, 0)
   payload.writeUInt16LE(rows & 0xffff, 2)
   return frame(FrameKind.Resize, payload)
-}
-
-export function frameClear(): Buffer {
-  return frame(FrameKind.Clear, Buffer.alloc(0))
 }
 
 /** Why a read stopped where it did. `end` is the only one that is not damage. */
@@ -182,7 +179,7 @@ export function readFrames(buf: Buffer, from = HEADER_BYTES): ReadResult {
 
     const decoded = decode(kind, payload)
     if (!decoded) {
-      return { frames, consumed: at, reason: kind in KNOWN ? 'malformed' : 'unknown-kind' }
+      return { frames, consumed: at, reason: KNOWN.has(kind) ? 'malformed' : 'unknown-kind' }
     }
 
     frames.push(decoded)
@@ -190,12 +187,12 @@ export function readFrames(buf: Buffer, from = HEADER_BYTES): ReadResult {
   }
 }
 
-const KNOWN: Record<number, true> = {
-  [FrameKind.Batch]: true,
-  [FrameKind.Output]: true,
-  [FrameKind.Resize]: true,
-  [FrameKind.Clear]: true
-}
+/**
+ * Derived rather than written out again. A kind added above and forgotten here
+ * would be reported as `unknown-kind` -- the right answer by accident before it
+ * is implemented, and the wrong one afterwards.
+ */
+const KNOWN = new Set<number>(Object.values(FrameKind))
 
 function decode(kind: number, payload: Buffer): Frame | null {
   switch (kind) {
@@ -207,8 +204,6 @@ function decode(kind: number, payload: Buffer): Frame | null {
       return payload.length === 4
         ? { kind: 'resize', cols: payload.readUInt16LE(0), rows: payload.readUInt16LE(2) }
         : null
-    case FrameKind.Clear:
-      return payload.length === 0 ? { kind: 'clear' } : null
     default:
       return null
   }

--- a/packages/server/src/history/recovery.ts
+++ b/packages/server/src/history/recovery.ts
@@ -4,7 +4,7 @@ import log from '../logger'
 import { createScreen, feedScreen, resizeScreen } from '../terminal-screen'
 import { seedScrollback } from '../terminal-scrollback'
 import { readHeader, readFrames, type Frame, type StopReason } from './log'
-import { readCheckpointAsync, LOG_FILE } from './checkpoint'
+import { readCheckpointAsync, LOG_FILE, CHECKPOINT_FILE } from './checkpoint'
 
 /**
  * Putting back what a crash interrupted.
@@ -55,18 +55,35 @@ export interface Recovered {
 
 export interface RecoverableSession {
   id: string
-  /** What the session record remembers, which for an older row is nothing. */
-  cols?: number
-  rows?: number
 }
 
 /**
- * The geometry to rebuild at when neither the checkpoint nor the session record
- * says. The same numbers a PTY is spawned at, so a screen restored without one
- * wraps where the program was writing.
+ * The geometry to rebuild at when there is no checkpoint to take one from.
+ *
+ * Not a guess. A log with no checkpoint beside it begins where `startHistory`
+ * opened it, which is the spawn -- and a PTY is spawned at exactly these
+ * numbers. Any resize the terminal saw afterwards is a frame further down that
+ * same log, so the replay arrives at the right size by the same route the
+ * original did.
+ *
+ * The session record is not consulted: the `sessions` table carries no geometry,
+ * so a term reading `session.cols` would look like a source of truth and always
+ * be undefined.
  */
 const FALLBACK_COLS = 80
 const FALLBACK_ROWS = 24
+
+/**
+ * How many terminals are rebuilt.
+ *
+ * Each one is a headless emulator with its buffers, held for the life of the
+ * process -- nothing disposes a recovered model, because nothing has attached to
+ * it yet. Fifty was measured at about eight megabytes, which is the same ceiling
+ * fifty live sessions carry, so this bounds the recovered set at no more than
+ * the running one. What is skipped keeps its files: it is not restored, it is
+ * not read yet, and a later start can have it.
+ */
+const MAX_RESTORED = 50
 
 export interface RecoveryReport {
   recovered: Recovered[]
@@ -87,10 +104,17 @@ const AT_ONCE = 8
  * with no session behind it is not history somebody might want, it is history
  * nobody can ask for -- ordinary residue from a crash that ran none of the
  * teardown that normally removes it.
+ *
+ * That reasoning holds only while the list is known to be complete, which is why
+ * `sessions` may be null. `getPreviousSessions` answers `[]` both when there are
+ * none and when it could not read them, and those two are the difference between
+ * removing nothing and removing every terminal's history on the strength of one
+ * transient database error. Null means "could not read": restore nothing, sweep
+ * nothing, leave it all for a start that can.
  */
 export async function recoverHistory(
   dataDir: string,
-  sessions: RecoverableSession[]
+  sessions: RecoverableSession[] | null
 ): Promise<RecoveryReport> {
   const root = path.join(dataDir, 'history')
   let entries: string[]
@@ -98,6 +122,11 @@ export async function recoverHistory(
     entries = await fs.readdir(root)
   } catch {
     // No history directory is the ordinary first run, not a failure.
+    return { recovered: [], swept: 0 }
+  }
+
+  if (sessions === null) {
+    log.warn('[history] the session list could not be read; leaving every terminal alone')
     return { recovered: [], swept: 0 }
   }
 
@@ -122,6 +151,16 @@ export async function recoverHistory(
     } catch (err) {
       log.warn({ err, entry }, '[history] could not remove history for a session that is gone')
     }
+  }
+
+  if (restorable.length > MAX_RESTORED) {
+    // Said rather than done quietly. A cap that nobody is told about reads as
+    // "everything was restored" on the one start where it was not.
+    log.warn(
+      { found: restorable.length, restoring: MAX_RESTORED },
+      '[history] more terminals on disk than are rebuilt at once; the rest keep their files'
+    )
+    restorable.length = MAX_RESTORED
   }
 
   for (let from = 0; from < restorable.length; from += AT_ONCE) {
@@ -161,6 +200,27 @@ export async function recoverHistory(
 }
 
 /**
+ * Remove scratch files a crash left behind.
+ *
+ * `writeCheckpoint` names its scratch file randomly and removes it only when the
+ * write fails; a process that dies mid-write removes nothing, and up to two
+ * megabytes of it sits there under a name nothing will ever reuse. Cleared here
+ * because this is the one moment it is certainly safe -- no writer for this
+ * session exists yet.
+ */
+async function sweepScratch(dir: string): Promise<void> {
+  try {
+    for (const entry of await fs.readdir(dir)) {
+      if (entry.startsWith(`.${CHECKPOINT_FILE}.`)) {
+        await fs.rm(path.join(dir, entry), { force: true })
+      }
+    }
+  } catch {
+    /* nothing there, or nothing removable; neither stops a restore */
+  }
+}
+
+/**
  * A directory name back into a session id.
  *
  * Null rather than a throw for something that is not one: `decodeURIComponent`
@@ -175,6 +235,7 @@ function decode(entry: string): string | null {
 }
 
 async function restore(dir: string, session: RecoverableSession): Promise<Recovered | null> {
+  await sweepScratch(dir)
   const checkpoint = await readCheckpointAsync(dir)
   const { frames, stopped } = await readLog(dir, checkpoint?.generation)
   if (!checkpoint && !frames.length) return null
@@ -184,8 +245,8 @@ async function restore(dir: string, session: RecoverableSession): Promise<Recove
   // columns, and rebuilding it at any other width moves every line after the
   // first wrap. A resize frame further down the log moves it afterwards, which
   // is what the client did at the time too.
-  const cols = checkpoint?.cols ?? session.cols ?? FALLBACK_COLS
-  const rows = checkpoint?.rows ?? session.rows ?? FALLBACK_ROWS
+  const cols = checkpoint?.cols ?? FALLBACK_COLS
+  const rows = checkpoint?.rows ?? FALLBACK_ROWS
 
   createScreen(session.id, cols, rows)
   let scrollback = checkpoint?.scrollback ?? ''

--- a/packages/server/src/history/recovery.ts
+++ b/packages/server/src/history/recovery.ts
@@ -1,10 +1,10 @@
-import fs from 'fs'
+import fs from 'fs/promises'
 import path from 'path'
 import log from '../logger'
 import { createScreen, feedScreen, resizeScreen } from '../terminal-screen'
 import { seedScrollback } from '../terminal-scrollback'
 import { readHeader, readFrames, type Frame, type StopReason } from './log'
-import { readCheckpoint, historyDir, LOG_FILE } from './checkpoint'
+import { readCheckpointAsync, LOG_FILE } from './checkpoint'
 
 /**
  * Putting back what a crash interrupted.
@@ -27,6 +27,13 @@ import { readCheckpoint, historyDir, LOG_FILE } from './checkpoint'
  * writes a fresh header and appends from the beginning, so a session that
  * crashed before its first checkpoint has a complete log -- which is exactly the
  * short-lived session a checkpoint interval was never going to cover.
+ *
+ * Sessions are restored a few at a time rather than one after another. Each
+ * touches only its own directory, its own screen model and its own scrollback
+ * key, so there is nothing to serialize them for -- and reading them one at a
+ * time meant up to a hundred and fifty megabytes of file reads that the thread
+ * pool could have overlapped. Bounded rather than unbounded: fifty terminals
+ * built at once is fifty emulators and every checkpoint resident together.
  *
  * ## What this does not do
  *
@@ -67,6 +74,10 @@ export interface RecoveryReport {
   swept: number
 }
 
+/** How many sessions are rebuilt at once. Enough to overlap the reads, few
+ * enough that peak memory stays near one terminal's worth times this. */
+const AT_ONCE = 8
+
 /**
  * Restore every session the database still knows about, and sweep the rest.
  *
@@ -84,7 +95,7 @@ export async function recoverHistory(
   const root = path.join(dataDir, 'history')
   let entries: string[]
   try {
-    entries = fs.readdirSync(root)
+    entries = await fs.readdir(root)
   } catch {
     // No history directory is the ordinary first run, not a failure.
     return { recovered: [], swept: 0 }
@@ -92,32 +103,53 @@ export async function recoverHistory(
 
   const known = new Map(sessions.map((s) => [s.id, s]))
   const report: RecoveryReport = { recovered: [], swept: 0 }
+  const restorable: Array<{ at: string; session: RecoverableSession }> = []
 
   for (const entry of entries) {
+    // Named once. Rebuilding the path from the decoded id would re-encode what
+    // was just decoded, and `encodeURIComponent(decodeURIComponent(x)) === x`
+    // does not hold for every string a directory listing can produce.
+    const at = path.join(root, entry)
     const id = decode(entry)
     const session = id === null ? undefined : known.get(id)
-    if (!session) {
-      try {
-        fs.rmSync(path.join(root, entry), { recursive: true, force: true })
-        report.swept += 1
-      } catch (err) {
-        log.warn({ err, entry }, '[history] could not remove history for a session that is gone')
-      }
+    if (session) {
+      restorable.push({ at, session })
       continue
     }
-
     try {
-      const one = await restore(historyDir(dataDir, session.id), session)
-      if (one) report.recovered.push(one)
+      await fs.rm(at, { recursive: true, force: true })
+      report.swept += 1
     } catch (err) {
-      log.warn({ err, id: session.id }, '[history] could not restore this terminal')
+      log.warn({ err, entry }, '[history] could not remove history for a session that is gone')
     }
+  }
+
+  for (let from = 0; from < restorable.length; from += AT_ONCE) {
+    const batch = restorable.slice(from, from + AT_ONCE)
+    const done = await Promise.all(
+      batch.map(async ({ at, session }) => {
+        try {
+          return await restore(at, session)
+        } catch (err) {
+          log.warn({ err, id: session.id }, '[history] could not restore this terminal')
+          return null
+        }
+      })
+    )
+    for (const one of done) if (one) report.recovered.push(one)
   }
 
   if (report.recovered.length || report.swept) {
     const damaged = report.recovered.filter((r) => r.stopped !== 'end')
     log.info(
-      { restored: report.recovered.length, swept: report.swept, damaged: damaged.length },
+      {
+        restored: report.recovered.length,
+        swept: report.swept,
+        damaged: damaged.length,
+        // A session restored without one crashed before its first checkpoint,
+        // so its whole history came from the log. Worth being able to see.
+        fromLogAlone: report.recovered.filter((r) => !r.fromCheckpoint).length
+      },
       '[history] restored terminals from the last run'
     )
     for (const one of damaged) {
@@ -143,8 +175,8 @@ function decode(entry: string): string | null {
 }
 
 async function restore(dir: string, session: RecoverableSession): Promise<Recovered | null> {
-  const checkpoint = readCheckpoint(dir)
-  const { frames, stopped } = readLog(dir, checkpoint?.generation)
+  const checkpoint = await readCheckpointAsync(dir)
+  const { frames, stopped } = await readLog(dir, checkpoint?.generation)
   if (!checkpoint && !frames.length) return null
 
   // The geometry the checkpoint was taken at, not the one the session record
@@ -160,9 +192,8 @@ async function restore(dir: string, session: RecoverableSession): Promise<Recove
   if (checkpoint?.screen) feedScreen(session.id, checkpoint.screen)
 
   for (const frame of frames) {
-    await apply(session.id, frame, cols, rows)
+    await apply(session.id, frame)
     if (frame.kind === 'output') scrollback += frame.data
-    if (frame.kind === 'clear') scrollback = ''
   }
 
   seedScrollback(session.id, scrollback)
@@ -174,13 +205,13 @@ async function restore(dir: string, session: RecoverableSession): Promise<Recove
   }
 }
 
-function readLog(
+async function readLog(
   dir: string,
   generation: number | undefined
-): { frames: Frame[]; stopped: StopReason } {
+): Promise<{ frames: Frame[]; stopped: StopReason }> {
   let buf: Buffer
   try {
-    buf = fs.readFileSync(path.join(dir, LOG_FILE))
+    buf = await fs.readFile(path.join(dir, LOG_FILE))
   } catch {
     return { frames: [], stopped: 'end' }
   }
@@ -202,16 +233,13 @@ function readLog(
   return { frames: read.frames, stopped: read.reason }
 }
 
-async function apply(id: string, frame: Frame, cols: number, rows: number): Promise<void> {
+async function apply(id: string, frame: Frame): Promise<void> {
   switch (frame.kind) {
     case 'output':
       feedScreen(id, frame.data)
       return
     case 'resize':
       await resizeScreen(id, frame.cols, frame.rows)
-      return
-    case 'clear':
-      createScreen(id, cols, rows)
       return
     case 'batch':
       // A boundary, not a thing that happened. It marks where one flush ended so

--- a/packages/server/src/history/recovery.ts
+++ b/packages/server/src/history/recovery.ts
@@ -51,6 +51,8 @@ export interface Recovered {
   stopped: StopReason
   /** Whether a checkpoint was found to replay onto. */
   fromCheckpoint: boolean
+  /** The last run shut down rather than being stopped under it. */
+  closedCleanly: boolean
 }
 
 export interface RecoverableSession {
@@ -265,7 +267,8 @@ async function restore(dir: string, session: RecoverableSession): Promise<Recove
     id: session.id,
     replayed: frames.length,
     stopped,
-    fromCheckpoint: checkpoint !== null
+    fromCheckpoint: checkpoint !== null,
+    closedCleanly: checkpoint?.closedCleanly === true
   }
 }
 

--- a/packages/server/src/history/recovery.ts
+++ b/packages/server/src/history/recovery.ts
@@ -248,7 +248,10 @@ async function restore(dir: string, session: RecoverableSession): Promise<Recove
   const cols = checkpoint?.cols ?? FALLBACK_COLS
   const rows = checkpoint?.rows ?? FALLBACK_ROWS
 
-  createScreen(session.id, cols, rows)
+  createScreen(session.id, cols, rows, {
+    ...(checkpoint?.title !== undefined && { title: checkpoint.title }),
+    ...(checkpoint?.cwd !== undefined && { cwd: checkpoint.cwd })
+  })
   let scrollback = checkpoint?.scrollback ?? ''
   if (checkpoint?.screen) feedScreen(session.id, checkpoint.screen)
 

--- a/packages/server/src/history/recovery.ts
+++ b/packages/server/src/history/recovery.ts
@@ -1,0 +1,221 @@
+import fs from 'fs'
+import path from 'path'
+import log from '../logger'
+import { createScreen, feedScreen, resizeScreen } from '../terminal-screen'
+import { seedScrollback } from '../terminal-scrollback'
+import { readHeader, readFrames, type Frame, type StopReason } from './log'
+import { readCheckpoint, historyDir, LOG_FILE } from './checkpoint'
+
+/**
+ * Putting back what a crash interrupted.
+ *
+ * The checkpoint is the screen as of the moment it was written and the log is
+ * everything that happened after. Replaying one over the other is the whole
+ * mechanism, and the two rules that keep it honest are both refusals:
+ *
+ *   - **A log whose generation does not match the checkpoint is ignored.** It
+ *     describes what happened before a checkpoint that already includes it, and
+ *     replaying it would print every byte twice. This is the case a crash
+ *     between the checkpoint landing and the log being replaced produces, which
+ *     is a window the writer cannot close.
+ *   - **A frame that fails its length or its checksum ends the replay.** Not
+ *     skipped: the bytes after a frame nobody can vouch for have no established
+ *     meaning, and a screen assembled from them is wrong in ways nobody can
+ *     bound. `readFrames` already stops; this just does not argue with it.
+ *
+ * A log with no checkpoint beside it is still worth replaying. `startHistory`
+ * writes a fresh header and appends from the beginning, so a session that
+ * crashed before its first checkpoint has a complete log -- which is exactly the
+ * short-lived session a checkpoint interval was never going to cover.
+ *
+ * ## What this does not do
+ *
+ * It does not hand anything to a client. Nothing asks: `terminal:readScrollback`
+ * exists and no caller uses it, and replaying into a live pane needs a sequence
+ * number the live path does not carry. This restores the server's own two models
+ * so that the pane, when something is built to ask, has something to be given.
+ */
+
+export interface Recovered {
+  id: string
+  /** Frames replayed from the log on top of the checkpoint. */
+  replayed: number
+  /** Why the replay stopped. Anything but `end` is damage worth knowing about. */
+  stopped: StopReason
+  /** Whether a checkpoint was found to replay onto. */
+  fromCheckpoint: boolean
+}
+
+export interface RecoverableSession {
+  id: string
+  /** What the session record remembers, which for an older row is nothing. */
+  cols?: number
+  rows?: number
+}
+
+/**
+ * The geometry to rebuild at when neither the checkpoint nor the session record
+ * says. The same numbers a PTY is spawned at, so a screen restored without one
+ * wraps where the program was writing.
+ */
+const FALLBACK_COLS = 80
+const FALLBACK_ROWS = 24
+
+export interface RecoveryReport {
+  recovered: Recovered[]
+  /** Directories removed because nothing can name them any more. */
+  swept: number
+}
+
+/**
+ * Restore every session the database still knows about, and sweep the rest.
+ *
+ * The sweep is safe for one reason: history is keyed by session id, and an id
+ * the database has no record of cannot be reached by anything in the product.
+ * `getPreviousSessions` is the only way a pane ever names one. So a directory
+ * with no session behind it is not history somebody might want, it is history
+ * nobody can ask for -- ordinary residue from a crash that ran none of the
+ * teardown that normally removes it.
+ */
+export async function recoverHistory(
+  dataDir: string,
+  sessions: RecoverableSession[]
+): Promise<RecoveryReport> {
+  const root = path.join(dataDir, 'history')
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(root)
+  } catch {
+    // No history directory is the ordinary first run, not a failure.
+    return { recovered: [], swept: 0 }
+  }
+
+  const known = new Map(sessions.map((s) => [s.id, s]))
+  const report: RecoveryReport = { recovered: [], swept: 0 }
+
+  for (const entry of entries) {
+    const id = decode(entry)
+    const session = id === null ? undefined : known.get(id)
+    if (!session) {
+      try {
+        fs.rmSync(path.join(root, entry), { recursive: true, force: true })
+        report.swept += 1
+      } catch (err) {
+        log.warn({ err, entry }, '[history] could not remove history for a session that is gone')
+      }
+      continue
+    }
+
+    try {
+      const one = await restore(historyDir(dataDir, session.id), session)
+      if (one) report.recovered.push(one)
+    } catch (err) {
+      log.warn({ err, id: session.id }, '[history] could not restore this terminal')
+    }
+  }
+
+  if (report.recovered.length || report.swept) {
+    const damaged = report.recovered.filter((r) => r.stopped !== 'end')
+    log.info(
+      { restored: report.recovered.length, swept: report.swept, damaged: damaged.length },
+      '[history] restored terminals from the last run'
+    )
+    for (const one of damaged) {
+      log.warn({ id: one.id, stopped: one.stopped }, '[history] this log did not read to the end')
+    }
+  }
+
+  return report
+}
+
+/**
+ * A directory name back into a session id.
+ *
+ * Null rather than a throw for something that is not one: `decodeURIComponent`
+ * rejects a lone percent, and a directory nobody wrote could be anything.
+ */
+function decode(entry: string): string | null {
+  try {
+    return decodeURIComponent(entry)
+  } catch {
+    return null
+  }
+}
+
+async function restore(dir: string, session: RecoverableSession): Promise<Recovered | null> {
+  const checkpoint = readCheckpoint(dir)
+  const { frames, stopped } = readLog(dir, checkpoint?.generation)
+  if (!checkpoint && !frames.length) return null
+
+  // The geometry the checkpoint was taken at, not the one the session record
+  // remembers: the screen is being rebuilt from bytes that wrapped at those
+  // columns, and rebuilding it at any other width moves every line after the
+  // first wrap. A resize frame further down the log moves it afterwards, which
+  // is what the client did at the time too.
+  const cols = checkpoint?.cols ?? session.cols ?? FALLBACK_COLS
+  const rows = checkpoint?.rows ?? session.rows ?? FALLBACK_ROWS
+
+  createScreen(session.id, cols, rows)
+  let scrollback = checkpoint?.scrollback ?? ''
+  if (checkpoint?.screen) feedScreen(session.id, checkpoint.screen)
+
+  for (const frame of frames) {
+    await apply(session.id, frame, cols, rows)
+    if (frame.kind === 'output') scrollback += frame.data
+    if (frame.kind === 'clear') scrollback = ''
+  }
+
+  seedScrollback(session.id, scrollback)
+  return {
+    id: session.id,
+    replayed: frames.length,
+    stopped,
+    fromCheckpoint: checkpoint !== null
+  }
+}
+
+function readLog(
+  dir: string,
+  generation: number | undefined
+): { frames: Frame[]; stopped: StopReason } {
+  let buf: Buffer
+  try {
+    buf = fs.readFileSync(path.join(dir, LOG_FILE))
+  } catch {
+    return { frames: [], stopped: 'end' }
+  }
+
+  const header = readHeader(buf)
+  if (!header) return { frames: [], stopped: 'malformed' }
+  // The refusal this whole scheme rests on. Not a warning and a replay anyway:
+  // a log from before the checkpoint beside it is not a shorter history, it is a
+  // second copy of one already restored.
+  if (generation !== undefined && header.generation !== generation) {
+    log.warn(
+      { dir, log: header.generation, checkpoint: generation },
+      '[history] this log belongs to an earlier checkpoint; ignoring it'
+    )
+    return { frames: [], stopped: 'end' }
+  }
+
+  const read = readFrames(buf)
+  return { frames: read.frames, stopped: read.reason }
+}
+
+async function apply(id: string, frame: Frame, cols: number, rows: number): Promise<void> {
+  switch (frame.kind) {
+    case 'output':
+      feedScreen(id, frame.data)
+      return
+    case 'resize':
+      await resizeScreen(id, frame.cols, frame.rows)
+      return
+    case 'clear':
+      createScreen(id, cols, rows)
+      return
+    case 'batch':
+      // A boundary, not a thing that happened. It marks where one flush ended so
+      // a torn tail can be found; there is nothing to apply.
+      return
+  }
+}

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -105,6 +105,8 @@ const MAX_PENDING_BYTES = 4 * 1024 * 1024
 interface Recorded {
   id: string
   dir: string
+  /** Joined once. It cannot change, and it was being rebuilt four times a second. */
+  logPath: string
   generation: number
   /** The last batch written to the log. A batch is one flush, not one write. */
   seq: number
@@ -157,14 +159,29 @@ export function configureHistory(dir: string, over: Partial<HistoryTiming> = {})
   sealed = false
 }
 
-/** Begin recording a terminal, replacing any history left under its id. */
+/**
+ * Begin recording a terminal, replacing any history left under its id.
+ *
+ * Not `stopHistory` first, which is what this used to do and which raced itself.
+ * That enqueues a removal on the *old* record's queue and then this builds a new
+ * record with a queue of its own -- two queues over one directory, so the old
+ * removal could land after the new log had been written and take it away. The
+ * symptom was a respawned session whose history quietly stopped until the next
+ * checkpoint rebuilt the directory.
+ *
+ * The new record inherits the old one's tail instead. That keeps every operation
+ * on this directory in one order, including any append still in flight from the
+ * PTY that just went, and `reset` below removes what was there anyway.
+ */
 export function startHistory(id: string): void {
   if (!dataDir || sealed) return
-  stopHistory(id)
+  const previous = recorded.get(id)
+  recorded.delete(id)
 
   const held: Recorded = {
     id,
     dir: historyDir(dataDir, id),
+    logPath: path.join(historyDir(dataDir, id), LOG_FILE),
     generation: 1,
     seq: 0,
     pending: [],
@@ -174,7 +191,7 @@ export function startHistory(id: string): void {
     broken: false,
     lastRecordAt: Date.now(),
     lastCheckpointAt: Date.now(),
-    tail: Promise.resolve(),
+    tail: previous ? previous.tail.catch(() => undefined) : Promise.resolve(),
     queued: 0
   }
   recorded.set(id, held)
@@ -190,18 +207,21 @@ export function startHistory(id: string): void {
  */
 export function recordOutput(id: string, data: string): void {
   if (!data) return
-  push(id, frameOutput(data))
+  // Looked up before the frame is built, not after. Encoding the chunk and
+  // running a checksum over it only to find that nothing is recording this
+  // session is a full pass over every byte, thrown away -- and that is the
+  // ordinary case in every process that never called `configureHistory`.
+  const held = recorded.get(id)
+  if (held) push(held, frameOutput(data))
 }
 
 /** Record a resize, with the numbers node-pty was given. */
 export function recordResize(id: string, cols: number, rows: number): void {
-  push(id, frameResize(cols, rows))
+  const held = recorded.get(id)
+  if (held) push(held, frameResize(cols, rows))
 }
 
-function push(id: string, frame: Buffer): void {
-  const held = recorded.get(id)
-  if (!held) return
-
+function push(held: Recorded, frame: Buffer): void {
   held.lastRecordAt = Date.now()
   held.changed = true
   // Still accumulated while broken, because the next checkpoint replaces the log
@@ -212,13 +232,12 @@ function push(id: string, frame: Buffer): void {
   if (held.pendingBytes > MAX_PENDING_BYTES) {
     if (!held.broken) {
       log.warn(
-        { id },
+        { id: held.id },
         '[history] the disk is not keeping up; dropping this log until the next checkpoint'
       )
     }
     held.broken = true
-    held.pending = []
-    held.pendingBytes = 0
+    take(held)
   }
 
   ensureTicking()
@@ -284,17 +303,13 @@ export function resetHistory(): void {
 }
 
 /** What a session is holding, so the bounds above are observable. */
-export function historyState(id: string): {
-  generation: number
-  seq: number
-  pendingBytes: number
-  logBytes: number
-  broken: boolean
-} | null {
+export function historyState(
+  id: string
+): { pendingBytes: number; logBytes: number; broken: boolean } | null {
   const held = recorded.get(id)
   if (!held) return null
-  const { generation, seq, pendingBytes, logBytes, broken } = held
-  return { generation, seq, pendingBytes, logBytes, broken }
+  const { pendingBytes, logBytes, broken } = held
+  return { pendingBytes, logBytes, broken }
 }
 
 /** Run every pending operation to completion. For tests, and for nothing else. */
@@ -308,10 +323,6 @@ export async function settleHistory(): Promise<void> {
     await Promise.all(tails)
     if (![...recorded.values()].some((held) => held.queued > 0)) return
   }
-}
-
-function logPath(held: Recorded): string {
-  return path.join(held.dir, LOG_FILE)
 }
 
 /**
@@ -334,13 +345,60 @@ function enqueue(held: Recorded, op: () => Promise<unknown>): Promise<void> {
   return held.tail
 }
 
+/**
+ * Take everything not yet written, and leave the record empty.
+ *
+ * One function because `pending` and `pendingBytes` have to move together, and
+ * the five places that used to do it by hand each restated that invariant
+ * without enforcing it -- a sixth that forgot the byte count would have broken
+ * the `MAX_PENDING_BYTES` bound silently.
+ */
+function take(held: Recorded): Buffer[] {
+  const frames = held.pending
+  held.pending = []
+  held.pendingBytes = 0
+  return frames
+}
+
+/**
+ * Replace the log, opening a generation.
+ *
+ * Opening one is four things that are only correct together: write a header
+ * carrying it, adopt it, restart `seq`, and trust the file again. Three call
+ * sites used to do those by hand, in three slightly different orders.
+ *
+ * The body is assembled here rather than passed in because the layout -- a
+ * header, then whole batches, and a fresh generation opening on batch one -- is
+ * the format's rule, and a caller building it from format primitives is a caller
+ * that has to remember the rule.
+ */
+async function openGeneration(
+  held: Recorded,
+  generation: number,
+  carried: Buffer[]
+): Promise<void> {
+  const body = carried.length
+    ? Buffer.concat([writeHeader(generation), frameBatch(1), ...carried])
+    : writeHeader(generation)
+  try {
+    await fs.writeFile(held.logPath, body, { mode: 0o600 })
+    held.generation = generation
+    held.logBytes = body.length
+    held.seq = carried.length ? 1 : 0
+    held.broken = false
+  } catch (err) {
+    // Left untrusted rather than appended to over an unknown prefix: a partial
+    // rewrite is a file whose remaining bytes have no established length.
+    log.warn({ err, id: held.id }, '[history] could not replace the log')
+    held.broken = true
+    throw err
+  }
+}
+
 async function reset(held: Recorded): Promise<void> {
-  const header = writeHeader(held.generation)
   await fs.rm(held.dir, { recursive: true, force: true })
   await fs.mkdir(held.dir, { recursive: true, mode: 0o700 })
-  await fs.writeFile(logPath(held), header, { mode: 0o600 })
-  held.logBytes = header.length
-  held.broken = false
+  await openGeneration(held, held.generation, [])
 }
 
 /**
@@ -353,12 +411,18 @@ async function flushPending(held: Recorded): Promise<void> {
   if (!held.pending.length || held.broken) return
 
   held.seq += 1
-  const body = Buffer.concat([frameBatch(held.seq), ...held.pending])
-  held.pending = []
-  held.pendingBytes = 0
+  const prefix = frameBatch(held.seq)
+  const frames = take(held)
+  // The total is passed rather than summed, and the marker is unshifted rather
+  // than spread. `pending` is bounded by bytes and not by count, so with small
+  // frames it holds a great many -- and a spread of that array is an argument
+  // list of that length.
+  const total = frames.reduce((n, f) => n + f.length, prefix.length)
+  frames.unshift(prefix)
+  const body = Buffer.concat(frames, total)
 
   try {
-    await fs.appendFile(logPath(held), body)
+    await fs.appendFile(held.logPath, body)
     held.logBytes += body.length
   } catch (err) {
     // Not put back. A retry that succeeded after a later batch had been written
@@ -394,17 +458,10 @@ async function fold(held: Recorded): Promise<void> {
     { id: held.id, bytes: held.logBytes },
     '[history] could not checkpoint a log past its cap; dropping it'
   )
-  held.generation += 1
-  const header = writeHeader(held.generation)
-  try {
-    await fs.writeFile(logPath(held), header, { mode: 0o600 })
-    held.logBytes = header.length
-    held.seq = 0
-    held.broken = false
-  } catch (err) {
-    log.warn({ err, id: held.id }, '[history] could not drop the log either')
-    held.broken = true
-  }
+  take(held)
+  await openGeneration(held, held.generation + 1, []).catch(() => {
+    /* already reported, and already marked untrusted */
+  })
 }
 
 /**
@@ -422,73 +479,55 @@ async function checkpoint(held: Recorded): Promise<void> {
   const cutSeq = held.seq
   const scrollback = readScrollback(held.id)
   const drained = serializeScreen(held.id)
-  const superseded = held.pending
-  held.pending = []
-  held.pendingBytes = 0
+  const supersededBytes = held.pendingBytes
+  const superseded = take(held)
 
   const snapshot = await drained
-  if (!snapshot) {
-    // No model to checkpoint from -- it faulted, or the session is gone. The
-    // frames are still the truth about what happened, so they go back at the
-    // front and the log carries on.
-    restore(held, superseded)
-    await flushPending(held)
-    return
-  }
-
   const generation = held.generation + 1
-  const landed = writeCheckpoint(held.dir, {
-    screen: snapshot.screen,
-    scrollback,
-    cols: snapshot.cols,
-    rows: snapshot.rows,
-    title: snapshot.title,
-    cwd: snapshot.cwd,
-    generation,
-    seq: cutSeq
-  })
+  const landed =
+    snapshot !== null &&
+    (await writeCheckpoint(held.dir, {
+      screen: snapshot.screen,
+      scrollback,
+      cols: snapshot.cols,
+      rows: snapshot.rows,
+      title: snapshot.title,
+      cwd: snapshot.cwd,
+      generation,
+      seq: cutSeq
+    }))
 
   if (!landed) {
-    restore(held, superseded)
+    // Either there was no model to checkpoint from -- it faulted, or the session
+    // is gone -- or the write did not land. Those frames are still the truth
+    // about what happened, so they go back at the front and the log carries on.
+    restore(held, superseded, supersededBytes)
     await flushPending(held)
     return
   }
 
   // From here the frames in `superseded` are inside the checkpoint and must not
   // be replayed over it. Only what arrived during the serialize is carried.
-  held.generation = generation
   held.lastCheckpointAt = Date.now()
-  const carried = held.pending
-  held.pending = []
-  held.pendingBytes = 0
+  const carried = take(held)
   held.changed = carried.length > 0
-
-  // The carried frames get a batch marker of their own: seq restarts with the
-  // generation, so the log always opens on a batch rather than on frames that
-  // belong to one written before the checkpoint.
-  const body = Buffer.concat(
-    carried.length
-      ? [writeHeader(generation), frameBatch(1), ...carried]
-      : [writeHeader(generation)]
-  )
-  try {
-    await fs.writeFile(logPath(held), body, { mode: 0o600 })
-    held.logBytes = body.length
-    held.seq = carried.length ? 1 : 0
-    held.broken = false
-  } catch (err) {
+  await openGeneration(held, generation, carried).catch(() => {
     // The checkpoint is already durable, so the screen survives; what is lost is
-    // the little that came after it. The log is left untrusted until the next
-    // checkpoint replaces it, rather than appended to over an unknown prefix.
-    log.warn({ err, id: held.id }, '[history] checkpointed, but could not replace the log')
-    held.broken = true
-  }
+    // the little that came after it. Reported and marked there.
+  })
 }
 
-function restore(held: Recorded, superseded: Buffer[]): void {
+/**
+ * Put frames back at the front, with the byte count they came with.
+ *
+ * Carried rather than recomputed: it was `held.pendingBytes` at the moment they
+ * were taken, so walking the whole array to work it out again is a pass over
+ * everything unwritten for a number already known.
+ */
+function restore(held: Recorded, superseded: Buffer[], bytes: number): void {
   if (!superseded.length) return
-  held.pending = superseded.concat(held.pending)
-  held.pendingBytes = held.pending.reduce((total, frame) => total + frame.length, 0)
+  for (let i = superseded.length - 1; i >= 0; i--) held.pending.unshift(superseded[i]!)
+  held.pendingBytes += bytes
 }
 
 /**

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -80,6 +80,21 @@ const DEFAULT_TIMING: HistoryTiming = {
 let timing: HistoryTiming = DEFAULT_TIMING
 
 /**
+ * How large a log may grow before it is folded into a checkpoint.
+ *
+ * Half of `MAX_CHECKPOINT_BYTES`, so the log can never be the larger half of the
+ * pair and a session's history on disk is bounded by the two together. The same
+ * shape as the memory bound in `terminal-scrollback`: a cap with the compaction
+ * that enforces it, rather than a cap nobody applies.
+ *
+ * This, not `checkpointMs`, is what actually bounds a busy terminal. A terminal
+ * producing a megabyte a second never falls quiet and would otherwise put thirty
+ * megabytes on disk between checkpoints, all of it to be replayed through a VT
+ * parser on the next start.
+ */
+export const MAX_LOG_BYTES = 1024 * 1024
+
+/**
  * How much unwritten output a session may hold before it is given up on.
  *
  * Reached only when the disk has stopped taking writes, since a tick drains this
@@ -358,6 +373,41 @@ async function flushPending(held: Recorded): Promise<void> {
 }
 
 /**
+ * Fold a log that has outgrown its cap into a checkpoint.
+ *
+ * A checkpoint already replaces the log rather than appending past it, so
+ * compaction is not a separate mechanism -- it is the ordinary checkpoint,
+ * asked for by size instead of by time.
+ *
+ * When one cannot be written the log is thrown away instead, and the generation
+ * is moved so that what is left cannot be replayed onto the checkpoint still
+ * sitting beside it. That loses history, which is the point: a session whose
+ * screen model has faulted would otherwise append for the life of the server
+ * with nothing able to bound it, and the last good checkpoint is still there to
+ * restore from.
+ */
+async function fold(held: Recorded): Promise<void> {
+  await checkpoint(held)
+  if (held.logBytes <= MAX_LOG_BYTES) return
+
+  log.warn(
+    { id: held.id, bytes: held.logBytes },
+    '[history] could not checkpoint a log past its cap; dropping it'
+  )
+  held.generation += 1
+  const header = writeHeader(held.generation)
+  try {
+    await fs.writeFile(logPath(held), header, { mode: 0o600 })
+    held.logBytes = header.length
+    held.seq = 0
+    held.broken = false
+  } catch (err) {
+    log.warn({ err, id: held.id }, '[history] could not drop the log either')
+    held.broken = true
+  }
+}
+
+/**
  * Write the screen, then replace the log with whatever arrived while it was
  * being written.
  *
@@ -475,7 +525,10 @@ function tick(): void {
     if (held.queued > 0) continue
 
     if (held.pending.length) {
-      void enqueue(held, () => flushPending(held))
+      void enqueue(held, async () => {
+        await flushPending(held)
+        if (held.logBytes > MAX_LOG_BYTES) await fold(held)
+      })
       continue
     }
 

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -261,6 +261,28 @@ export function stopHistory(id: string): void {
 }
 
 /**
+ * Remove what is on disk for a session this writer is not recording.
+ *
+ * `stopHistory` is for a terminal that was being written to and has gone. This
+ * is for one that was restored from a previous run and then claimed or
+ * dismissed: nothing here is tracking it, so there is no record to clear and no
+ * queue to run behind -- only files that no longer describe anything reachable.
+ *
+ * Refused once sealed, for the same reason as `stopHistory`: a shutdown writes
+ * every terminal's screen and then kills the PTYs, and the teardown that follows
+ * must not remove what it has just written.
+ */
+export async function discardHistory(id: string): Promise<void> {
+  if (!dataDir || sealed) return
+  const dir = historyDir(dataDir, id)
+  try {
+    await fs.rm(dir, { recursive: true, force: true })
+  } catch (err) {
+    log.warn({ err, id }, '[history] could not remove history for a session that was claimed')
+  }
+}
+
+/**
  * Write every session's screen out, for a server that is going down.
  *
  * Seals first, so the PTY teardown that follows cannot remove what this writes.

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -1,0 +1,488 @@
+import fs from 'fs/promises'
+import path from 'path'
+import log from '../logger'
+import { serializeScreen } from '../terminal-screen'
+import { readScrollback } from '../terminal-scrollback'
+import { frameBatch, frameOutput, frameResize, writeHeader } from './log'
+import { historyDir, writeCheckpoint, LOG_FILE } from './checkpoint'
+
+/**
+ * What turns a terminal's output into a checkpoint and a log on disk.
+ *
+ * `log.ts` says what the bytes look like and `checkpoint.ts` says how one file
+ * lands durably. This is the part with state: which sessions are being recorded,
+ * what has not reached the disk yet, and when to pay for a checkpoint.
+ *
+ * ## The failure this is built for
+ *
+ * A process crash — `kill -9`, an uncaught throw, the OOM killer — not power
+ * loss. That distinction decides where the fsyncs go. Appends are ordinary
+ * writes: the kernel already holds them once `write` returns, so a process that
+ * dies loses nothing that was appended, and paying for a sync on the hottest
+ * path in the server to also survive a power cut would be a bad trade against
+ * terminal output. The checkpoint is rare, so it syncs, and `checkpoint.ts`
+ * syncs the directory too.
+ *
+ * What a crash does cost is whatever is still in `pending` — at most one tick of
+ * output. Bounded and named rather than hidden.
+ *
+ * ## Why a queue per session
+ *
+ * Every disk operation for one session runs behind the last, because a
+ * checkpoint and a truncate against the same two files cannot interleave. That
+ * exclusivity is per directory and buys nothing across directories, so there is
+ * no global tail: a session whose disk is slow must not hold up the checkpoint
+ * of a session on the same machine that is about to be asked for its history.
+ *
+ * ## Why the log is truncated at every checkpoint
+ *
+ * A checkpoint is the screen as of the moment it was taken, so every frame
+ * before it is superseded. Rewriting the log rather than appending past it means
+ * recovery is `checkpoint + every frame in the log`, with nothing to skip and no
+ * seq arithmetic to get wrong — and it is where the on-disk size is bounded,
+ * which is what stops `~/.vorn` growing for the life of a session.
+ *
+ * The generation is what makes that safe. The checkpoint lands first; if the
+ * process dies before the log is rewritten, the old log is still sitting there
+ * describing what happened before a checkpoint that already includes it.
+ * Replaying it would double every byte. It carries the old generation, the
+ * checkpoint carries the new one, and recovery refuses the pair.
+ */
+
+/**
+ * When this writes, in milliseconds.
+ *
+ * - `tickMs` -- how often accumulated frames are pushed to the log.
+ * - `quiesceMs` -- how long a terminal must be quiet before its screen is worth
+ *   writing. An agent that finished and is waiting is the case this exists for,
+ *   and it should settle a second or two after going quiet rather than waiting
+ *   out the interval below.
+ * - `checkpointMs` -- the longest a busy terminal goes without one. A terminal
+ *   producing output continuously never falls quiet, so this is what bounds how
+ *   much log a crash leaves to replay.
+ *
+ * Passed rather than fixed because the numbers are a trade -- replay length
+ * against I/O -- and the only honest way to set them is to measure both sides at
+ * several values. The defaults are what the server runs at.
+ */
+export interface HistoryTiming {
+  tickMs: number
+  quiesceMs: number
+  checkpointMs: number
+}
+
+const DEFAULT_TIMING: HistoryTiming = {
+  tickMs: 250,
+  quiesceMs: 2_000,
+  checkpointMs: 30_000
+}
+
+let timing: HistoryTiming = DEFAULT_TIMING
+
+/**
+ * How much unwritten output a session may hold before it is given up on.
+ *
+ * Reached only when the disk has stopped taking writes, since a tick drains this
+ * every 250ms. Holding it would trade a disk problem for a memory one.
+ */
+const MAX_PENDING_BYTES = 4 * 1024 * 1024
+
+interface Recorded {
+  id: string
+  dir: string
+  generation: number
+  /** The last batch written to the log. A batch is one flush, not one write. */
+  seq: number
+  pending: Buffer[]
+  pendingBytes: number
+  logBytes: number
+  /** Whether anything has been recorded since the last checkpoint. */
+  changed: boolean
+  /**
+   * Set when the log on disk can no longer be trusted to be whole -- an append
+   * that failed, or output dropped because the disk stopped taking it. Appending
+   * past either would leave a hole in the middle of a file that replays
+   * forwards, which is worse than a stale screen. Cleared by the next
+   * checkpoint, which replaces the log rather than adding to it.
+   */
+  broken: boolean
+  lastRecordAt: number
+  lastCheckpointAt: number
+  /** The per-session queue. One operation at a time, in the order asked for. */
+  tail: Promise<void>
+  queued: number
+}
+
+const recorded = new Map<string, Recorded>()
+
+let dataDir: string | null = null
+let ticker: NodeJS.Timeout | null = null
+
+/**
+ * Sealed once the server is shutting down.
+ *
+ * `shutdown()` checkpoints every session and only then kills the PTYs, and a
+ * dying PTY runs the same teardown as one that exited on its own -- which
+ * removes a session's history, because a terminal whose process is gone has
+ * none worth keeping. Without this the last act of a clean shutdown would be to
+ * delete every checkpoint it had just written.
+ */
+let sealed = false
+
+/**
+ * Where history is written, or nowhere.
+ *
+ * Explicit rather than `getDataDir()` at each call, which throws before the
+ * database is open. Until this is called every entry point below is a no-op, so
+ * nothing that runs early has to know about the ordering.
+ */
+export function configureHistory(dir: string, over: Partial<HistoryTiming> = {}): void {
+  dataDir = dir
+  timing = { ...DEFAULT_TIMING, ...over }
+  sealed = false
+}
+
+/** Begin recording a terminal, replacing any history left under its id. */
+export function startHistory(id: string): void {
+  if (!dataDir || sealed) return
+  stopHistory(id)
+
+  const held: Recorded = {
+    id,
+    dir: historyDir(dataDir, id),
+    generation: 1,
+    seq: 0,
+    pending: [],
+    pendingBytes: 0,
+    logBytes: 0,
+    changed: false,
+    broken: false,
+    lastRecordAt: Date.now(),
+    lastCheckpointAt: Date.now(),
+    tail: Promise.resolve(),
+    queued: 0
+  }
+  recorded.set(id, held)
+  enqueue(held, () => reset(held))
+}
+
+/**
+ * Record output, on the flush that already coalesces it.
+ *
+ * Called from `flushBuffer` rather than from `onData` for the same reason
+ * `feedScreen` is: node-pty emits a few bytes at a time while somebody types,
+ * and this way a burst of keystrokes is one frame rather than thirty.
+ */
+export function recordOutput(id: string, data: string): void {
+  if (!data) return
+  push(id, frameOutput(data))
+}
+
+/** Record a resize, with the numbers node-pty was given. */
+export function recordResize(id: string, cols: number, rows: number): void {
+  push(id, frameResize(cols, rows))
+}
+
+function push(id: string, frame: Buffer): void {
+  const held = recorded.get(id)
+  if (!held) return
+
+  held.lastRecordAt = Date.now()
+  held.changed = true
+  // Still accumulated while broken, because the next checkpoint replaces the log
+  // wholesale and these frames belong after it. Only the appending stops.
+  held.pending.push(frame)
+  held.pendingBytes += frame.length
+
+  if (held.pendingBytes > MAX_PENDING_BYTES) {
+    if (!held.broken) {
+      log.warn(
+        { id },
+        '[history] the disk is not keeping up; dropping this log until the next checkpoint'
+      )
+    }
+    held.broken = true
+    held.pending = []
+    held.pendingBytes = 0
+  }
+
+  ensureTicking()
+}
+
+/**
+ * Stop recording a terminal and remove what was written for it.
+ *
+ * A PTY that has exited leaves nothing worth restoring -- the same reasoning
+ * that already drops its scrollback and its screen model. Refused once sealed,
+ * so a shutdown does not undo its own work.
+ */
+export function stopHistory(id: string): void {
+  const held = recorded.get(id)
+  if (!held) return
+  recorded.delete(id)
+  if (sealed) return
+  held.pending = []
+  held.pendingBytes = 0
+  enqueue(held, () => fs.rm(held.dir, { recursive: true, force: true }))
+}
+
+/**
+ * Write every session's screen out, for a server that is going down.
+ *
+ * Seals first, so the PTY teardown that follows cannot remove what this writes.
+ *
+ * The wait is bounded and the work is not: an operation past the deadline runs
+ * to completion and this simply stops waiting on it. Cancelling would leave a
+ * half-written log to save time on a path where `SHUTDOWN_DEADLINE_MS` is
+ * already the backstop.
+ */
+export async function flushHistory(): Promise<void> {
+  sealed = true
+  stopTicking()
+
+  const all = Promise.all(
+    [...recorded.values()].map((held) => enqueue(held, () => checkpoint(held)))
+  )
+  let timer: NodeJS.Timeout | undefined
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      log.warn('[history] gave up waiting for checkpoints; they are still running')
+      resolve()
+    }, FLUSH_DEADLINE_MS)
+  })
+  try {
+    await Promise.race([all.then(() => undefined), deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+const FLUSH_DEADLINE_MS = 5_000
+
+/** Test-only, mirroring `resetScrollback` and `resetScreens`. */
+export function resetHistory(): void {
+  stopTicking()
+  recorded.clear()
+  dataDir = null
+  timing = DEFAULT_TIMING
+  sealed = false
+}
+
+/** What a session is holding, so the bounds above are observable. */
+export function historyState(id: string): {
+  generation: number
+  seq: number
+  pendingBytes: number
+  logBytes: number
+  broken: boolean
+} | null {
+  const held = recorded.get(id)
+  if (!held) return null
+  const { generation, seq, pendingBytes, logBytes, broken } = held
+  return { generation, seq, pendingBytes, logBytes, broken }
+}
+
+/** Run every pending operation to completion. For tests, and for nothing else. */
+export async function settleHistory(): Promise<void> {
+  // Looped, because an operation can enqueue another -- a checkpoint that finds
+  // no screen falls back to a flush. Bounded so a test hangs on an assertion
+  // rather than on this.
+  for (let round = 0; round < 16; round++) {
+    const tails = [...recorded.values()].map((held) => held.tail)
+    if (!tails.length) return
+    await Promise.all(tails)
+    if (![...recorded.values()].some((held) => held.queued > 0)) return
+  }
+}
+
+function logPath(held: Recorded): string {
+  return path.join(held.dir, LOG_FILE)
+}
+
+/**
+ * Put one operation at the end of this session's queue.
+ *
+ * Rejections are swallowed here rather than at each call site: every operation
+ * below already reports its own failures, and an escaped rejection from a timer
+ * has no caller to reach.
+ */
+function enqueue(held: Recorded, op: () => Promise<unknown>): Promise<void> {
+  held.queued += 1
+  held.tail = held.tail
+    .then(op)
+    .catch((err) => {
+      log.warn({ err, id: held.id }, '[history] a write failed')
+    })
+    .then(() => {
+      held.queued -= 1
+    })
+  return held.tail
+}
+
+async function reset(held: Recorded): Promise<void> {
+  const header = writeHeader(held.generation)
+  await fs.rm(held.dir, { recursive: true, force: true })
+  await fs.mkdir(held.dir, { recursive: true, mode: 0o700 })
+  await fs.writeFile(logPath(held), header, { mode: 0o600 })
+  held.logBytes = header.length
+  held.broken = false
+}
+
+/**
+ * Append what has accumulated, as one batch.
+ *
+ * The batch marker goes in here rather than beside every write because a batch
+ * is what reaches the disk together, and that is the unit a torn tail cuts.
+ */
+async function flushPending(held: Recorded): Promise<void> {
+  if (!held.pending.length || held.broken) return
+
+  held.seq += 1
+  const body = Buffer.concat([frameBatch(held.seq), ...held.pending])
+  held.pending = []
+  held.pendingBytes = 0
+
+  try {
+    await fs.appendFile(logPath(held), body)
+    held.logBytes += body.length
+  } catch (err) {
+    // Not put back. A retry that succeeded after a later batch had been written
+    // would put the log out of order, and holding it grows without bound against
+    // a disk that has stopped answering.
+    log.warn(
+      { err, id: held.id },
+      '[history] could not append; this log waits for the next checkpoint'
+    )
+    held.broken = true
+  }
+}
+
+/**
+ * Write the screen, then replace the log with whatever arrived while it was
+ * being written.
+ *
+ * The first four statements are deliberately one synchronous block, and the
+ * order inside it is the correctness argument. `serializeScreen` queues an empty
+ * write behind everything already given to xterm and resolves when the parser
+ * reaches it, so the screen it returns is exactly the output recorded before
+ * this line ran -- but only if nothing is recorded between taking `seq` and
+ * placing that marker. Nothing can be: there is no await between them.
+ */
+async function checkpoint(held: Recorded): Promise<void> {
+  const cutSeq = held.seq
+  const scrollback = readScrollback(held.id)
+  const drained = serializeScreen(held.id)
+  const superseded = held.pending
+  held.pending = []
+  held.pendingBytes = 0
+
+  const snapshot = await drained
+  if (!snapshot) {
+    // No model to checkpoint from -- it faulted, or the session is gone. The
+    // frames are still the truth about what happened, so they go back at the
+    // front and the log carries on.
+    restore(held, superseded)
+    await flushPending(held)
+    return
+  }
+
+  const generation = held.generation + 1
+  const landed = writeCheckpoint(held.dir, {
+    screen: snapshot.screen,
+    scrollback,
+    cols: snapshot.cols,
+    rows: snapshot.rows,
+    title: snapshot.title,
+    cwd: snapshot.cwd,
+    generation,
+    seq: cutSeq
+  })
+
+  if (!landed) {
+    restore(held, superseded)
+    await flushPending(held)
+    return
+  }
+
+  // From here the frames in `superseded` are inside the checkpoint and must not
+  // be replayed over it. Only what arrived during the serialize is carried.
+  held.generation = generation
+  held.lastCheckpointAt = Date.now()
+  const carried = held.pending
+  held.pending = []
+  held.pendingBytes = 0
+  held.changed = carried.length > 0
+
+  // The carried frames get a batch marker of their own: seq restarts with the
+  // generation, so the log always opens on a batch rather than on frames that
+  // belong to one written before the checkpoint.
+  const body = Buffer.concat(
+    carried.length
+      ? [writeHeader(generation), frameBatch(1), ...carried]
+      : [writeHeader(generation)]
+  )
+  try {
+    await fs.writeFile(logPath(held), body, { mode: 0o600 })
+    held.logBytes = body.length
+    held.seq = carried.length ? 1 : 0
+    held.broken = false
+  } catch (err) {
+    // The checkpoint is already durable, so the screen survives; what is lost is
+    // the little that came after it. The log is left untrusted until the next
+    // checkpoint replaces it, rather than appended to over an unknown prefix.
+    log.warn({ err, id: held.id }, '[history] checkpointed, but could not replace the log')
+    held.broken = true
+  }
+}
+
+function restore(held: Recorded, superseded: Buffer[]): void {
+  if (!superseded.length) return
+  held.pending = superseded.concat(held.pending)
+  held.pendingBytes = held.pending.reduce((total, frame) => total + frame.length, 0)
+}
+
+/**
+ * One timer for every session, started on demand and stopped when there is
+ * nothing left to write.
+ *
+ * A timer per session would be a hundred timers for a hundred terminals, and an
+ * interval that runs for the life of the server would tick four times a second
+ * through every idle night. Unref'd either way, so it is never the reason this
+ * process is still alive.
+ */
+function ensureTicking(): void {
+  if (ticker) return
+  ticker = setInterval(tick, timing.tickMs)
+  ticker.unref?.()
+}
+
+function stopTicking(): void {
+  if (!ticker) return
+  clearInterval(ticker)
+  ticker = null
+}
+
+function tick(): void {
+  const now = Date.now()
+  let working = false
+
+  for (const held of recorded.values()) {
+    // Anything unwritten keeps the timer alive, including a session that is
+    // merely not quiet yet -- it is owed a checkpoint, and stopping here would
+    // leave it owed one until its terminal next produced output.
+    if (!held.changed && !held.pending.length) continue
+    working = true
+    if (held.queued > 0) continue
+
+    if (held.pending.length) {
+      void enqueue(held, () => flushPending(held))
+      continue
+    }
+
+    const quiet = now - held.lastRecordAt >= timing.quiesceMs
+    const overdue = now - held.lastCheckpointAt >= timing.checkpointMs
+    if (quiet || overdue) void enqueue(held, () => checkpoint(held))
+  }
+
+  if (!working) stopTicking()
+}

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -451,8 +451,13 @@ async function flushPending(held: Recorded): Promise<void> {
  * restore from.
  */
 async function fold(held: Recorded): Promise<void> {
-  await checkpoint(held)
-  if (held.logBytes <= MAX_LOG_BYTES) return
+  // Asked, not inferred. An earlier version re-read `logBytes` to work out
+  // whether the checkpoint had landed, which is wrong in one reachable case: a
+  // checkpoint that succeeded while a megabyte of output arrived during its
+  // fsyncs leaves a log legitimately over the cap, and the log would then be
+  // thrown away along with every byte in it -- on a healthy path, not the
+  // faulted one this fallback is for.
+  if (await checkpoint(held)) return
 
   log.warn(
     { id: held.id, bytes: held.logBytes },
@@ -475,7 +480,7 @@ async function fold(held: Recorded): Promise<void> {
  * this line ran -- but only if nothing is recorded between taking `seq` and
  * placing that marker. Nothing can be: there is no await between them.
  */
-async function checkpoint(held: Recorded): Promise<void> {
+async function checkpoint(held: Recorded): Promise<boolean> {
   const cutSeq = held.seq
   const scrollback = readScrollback(held.id)
   const drained = serializeScreen(held.id)
@@ -503,7 +508,7 @@ async function checkpoint(held: Recorded): Promise<void> {
     // about what happened, so they go back at the front and the log carries on.
     restore(held, superseded, supersededBytes)
     await flushPending(held)
-    return
+    return false
   }
 
   // From here the frames in `superseded` are inside the checkpoint and must not
@@ -515,6 +520,7 @@ async function checkpoint(held: Recorded): Promise<void> {
     // The checkpoint is already durable, so the screen survives; what is lost is
     // the little that came after it. Reported and marked there.
   })
+  return true
 }
 
 /**

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -297,7 +297,7 @@ export async function flushHistory(): Promise<void> {
   stopTicking()
 
   const all = Promise.all(
-    [...recorded.values()].map((held) => enqueue(held, () => checkpoint(held)))
+    [...recorded.values()].map((held) => enqueue(held, () => checkpoint(held, true)))
   )
   let timer: NodeJS.Timeout | undefined
   const deadline = new Promise<void>((resolve) => {
@@ -502,7 +502,7 @@ async function fold(held: Recorded): Promise<void> {
  * this line ran -- but only if nothing is recorded between taking `seq` and
  * placing that marker. Nothing can be: there is no await between them.
  */
-async function checkpoint(held: Recorded): Promise<boolean> {
+async function checkpoint(held: Recorded, closing = false): Promise<boolean> {
   const cutSeq = held.seq
   const scrollback = readScrollback(held.id)
   const drained = serializeScreen(held.id)
@@ -521,7 +521,11 @@ async function checkpoint(held: Recorded): Promise<boolean> {
       title: snapshot.title,
       cwd: snapshot.cwd,
       generation,
-      seq: cutSeq
+      seq: cutSeq,
+      // Only the flush on the way out. Everything else -- the clock, the size
+      // cap -- leaves this unset, which is what makes its absence mean "this
+      // run did not get to say goodbye".
+      ...(closing && { closedCleanly: true })
     }))
 
   if (!landed) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,6 +36,7 @@ import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server
 import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
 import { configureHistory, flushHistory } from './history/writer'
+import { recoverHistory } from './history/recovery'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
 import { getTaskImagePath as resolveTaskImagePath } from './task-images'
@@ -450,6 +451,17 @@ export async function startServer(
   // serve`, so a check that lived only there would be late or absent exactly
   // where it matters.
   if (endpoint) watchEndpoint(() => endpoint.holds())
+
+  // Only now, and for two reasons. It is after `registerAllMethods()`, so
+  // nothing here races the first debounced `saveSessions`. And it is after the
+  // endpoint claim, so a server that arrives second exits above rather than
+  // replaying every terminal on the machine and then standing down.
+  //
+  // That leaves a window between the listen and this line where a client could
+  // ask for history that is not loaded yet. Named rather than hidden: nothing
+  // asks for it at all until a pane is built to.
+  const { sessionManager: persisted } = await import('./session-persistence')
+  await recoverHistory(dataDir, persisted.getPreviousSessions())
 
   // Published together, after the claim, because they are one announcement: the
   // port says where, the credential says how, and a reader that finds one

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -37,6 +37,8 @@ import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protoc
 import { ptyManager } from './pty-manager'
 import { configureHistory, flushHistory } from './history/writer'
 import { recoverHistory } from './history/recovery'
+import { seedRestored, markRecovered } from './restored-sessions'
+import { sessionManager } from './session-persistence'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
 import { getTaskImagePath as resolveTaskImagePath } from './task-images'
@@ -334,6 +336,13 @@ export async function startServer(
     log.info(`[server] serving web app from ${webDistDir}`)
   }
 
+  // Before `registerAllMethods()`, and that ordering is the point rather than
+  // tidiness. Registering wires `startAutoSave`, and `startInboxWorker()` on the
+  // next line can launch a workflow session -- so a save can fire from here, and
+  // a save is a whole-table replace. Seeding after it would mean the records
+  // this is holding had already been erased by the thing it exists to survive.
+  const carriedOver = seedRestored(sessionManager.readPreviousSessions())
+
   // Register all RPC methods
   registerAllMethods()
   scheduler.startInboxWorker()
@@ -462,8 +471,7 @@ export async function startServer(
   // this server until both of those exist, so there is no moment where one can
   // ask for history that has not been read yet. The cost is that discovery waits
   // on it -- measured at 77ms for fifty terminals.
-  const { sessionManager } = await import('./session-persistence')
-  await recoverHistory(dataDir, sessionManager.readPreviousSessions())
+  markRecovered((await recoverHistory(dataDir, carriedOver)).recovered)
 
   // Published together, after the claim, because they are one announcement: the
   // port says where, the credential says how, and a reader that finds one

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -463,7 +463,7 @@ export async function startServer(
   // ask for history that has not been read yet. The cost is that discovery waits
   // on it -- measured at 77ms for fifty terminals.
   const { sessionManager } = await import('./session-persistence')
-  await recoverHistory(dataDir, sessionManager.getPreviousSessions())
+  await recoverHistory(dataDir, sessionManager.readPreviousSessions())
 
   // Published together, after the claim, because they are one announcement: the
   // port says where, the credential says how, and a reader that finds one

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,6 +35,7 @@ import { getDataDir, dbCountActiveConnectorInboxLeases } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
 import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
+import { configureHistory, flushHistory } from './history/writer'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
 import { getTaskImagePath as resolveTaskImagePath } from './task-images'
@@ -113,6 +114,10 @@ export async function startServer(
   // Anything launched from a session inherits VORN_DATA_DIR and can then find the
   // port and credential files even when --data-dir moved them.
   setLaunchDataDir(dataDir)
+  // Before anything listens, so there is no window where a session is created
+  // and then never recorded. Nothing is written until a terminal exists, and a
+  // server that loses the endpoint claim exits without ever having one.
+  configureHistory(dataDir)
 
   // Who this server is, so a desktop can decide whether to adopt it instead of
   // starting a second one on the same data directory. The channel is passed by
@@ -483,6 +488,14 @@ export async function startServer(
     // Stop the periodic timer first, then do one final synchronous save
     sessionManager.stopAutoSave()
     sessionManager.persistNow()
+    // The last few milliseconds of output, then every terminal's screen, before
+    // anything kills a PTY. After `killAll()` the buffers this reads have been
+    // emptied; before `persistNow()` the sessions these belong to are not yet
+    // saved. Awaited because serializing a screen is asynchronous by necessity,
+    // and bounded from the inside -- it is on the same path as the unref'd
+    // `SHUTDOWN_DEADLINE_MS` and must not be able to spend all of it.
+    ptyManager.flushPendingOutput()
+    await flushHistory()
     hookServer.stop()
     clearLocalCredential()
     uninstallHooks()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -457,11 +457,13 @@ export async function startServer(
   // endpoint claim, so a server that arrives second exits above rather than
   // replaying every terminal on the machine and then standing down.
   //
-  // That leaves a window between the listen and this line where a client could
-  // ask for history that is not loaded yet. Named rather than hidden: nothing
-  // asks for it at all until a pane is built to.
-  const { sessionManager: persisted } = await import('./session-persistence')
-  await recoverHistory(dataDir, persisted.getPreviousSessions())
+  // It runs before the port file and the credential below, which closes the
+  // window the plan for this expected to have to live with: a client cannot find
+  // this server until both of those exist, so there is no moment where one can
+  // ask for history that has not been read yet. The cost is that discovery waits
+  // on it -- measured at 77ms for fifty terminals.
+  const { sessionManager } = await import('./session-persistence')
+  await recoverHistory(dataDir, sessionManager.getPreviousSessions())
 
   // Published together, after the claim, because they are one announcement: the
   // port says where, the credential says how, and a reader that finds one
@@ -476,7 +478,6 @@ export async function startServer(
   const { uninstallHooks } = await import('./hook-installer')
   const { uninstallAllCopilotHooks } = await import('./copilot-hook-installer')
   const { hookStatusMapper } = await import('./hook-status-mapper')
-  const { sessionManager } = await import('./session-persistence')
 
   // Two failures, and neither is retried -- by the time either is visible this
   // has already cleared the credential and removed the port file, so a second

--- a/packages/server/src/launch-tokens.ts
+++ b/packages/server/src/launch-tokens.ts
@@ -33,7 +33,7 @@ import type { AiAgentType } from '@vornrun/shared/types'
  * worse day.
  */
 
-export interface Token {
+interface Token {
   /** As it appeared, quotes and all. */
   raw: string
   /** With quoting removed, which is what the shell would pass along. */
@@ -124,7 +124,7 @@ export function tokenize(line: string): Token[] | null {
   return tokens
 }
 
-export interface Span {
+interface Span {
   start: number
   end: number
 }
@@ -172,11 +172,7 @@ const SELECTORS: Record<string, string[]> = {
  * `/usr/local/bin/tools/claude` safe to have as a command and an argument merely
  * ending in `/claude` safe to leave alone.
  */
-export function findSelectorSpans(
-  line: string,
-  agentType: AiAgentType,
-  argsFrom: number
-): Span[] | null {
+function findSelectorSpans(line: string, agentType: AiAgentType, argsFrom: number): Span[] | null {
   const tokens = tokenize(line)
   if (!tokens) return null
 

--- a/packages/server/src/launch-tokens.ts
+++ b/packages/server/src/launch-tokens.ts
@@ -135,32 +135,53 @@ function isValue(token: Token | undefined): boolean {
 }
 
 /**
- * A flag and, when it has one, the token carrying its value.
+ * A flag and, when it takes one, the token carrying its value.
  *
- * `--flag=value` is one span. `--flag value` is two, but only when the next
- * token does not itself begin with a dash -- a bare `--resume` is the
- * interactive picker, which is still a selector, and swallowing the flag after
- * it would remove something else.
+ * `--flag=value` is always one span. `--flag value` is two only for flags that
+ * *take* a value, and only when the next token does not itself begin with a dash
+ * -- a bare `--resume` is the interactive picker, which is still a selector, and
+ * the thing after it is then somebody else's argument.
+ *
+ * The distinction is load-bearing. `--continue` takes no value, so treating the
+ * next token as one turned `claude --continue 'fix the failing test'` into
+ * `claude` and dropped the prompt on the floor. That is precisely the failure
+ * this module exists to avoid: not a refusal, but a rewrite that runs something
+ * different from what was written.
  */
-function flagSpans(tokens: Token[], at: number, names: string[]): Span[] | null {
+function flagSpans(tokens: Token[], at: number, selectors: Selectors): Span[] | null {
   const token = tokens[at]!
-  for (const name of names) {
+  for (const name of selectors.withValue) {
     if (token.value === name) {
       const next = tokens[at + 1]
       return isValue(next) ? [span(token), span(next!)] : [span(token)]
     }
     if (token.value.startsWith(`${name}=`)) return [span(token)]
   }
+  for (const name of selectors.bare) {
+    if (token.value === name) return [span(token)]
+  }
   return null
 }
 
 const span = (t: Token): Span => ({ start: t.start, end: t.end })
 
-/** The flag shapes that can be proven to select a session, per agent. */
-const SELECTORS: Record<string, string[]> = {
-  claude: ['--resume', '-r', '--continue', '-c', '--session-id'],
-  copilot: ['--resume', '--session-id'],
-  opencode: ['--session', '-s']
+/**
+ * The flag shapes that can be proven to select a session, per agent.
+ *
+ * Split by whether the flag takes a value, because that decides whether the
+ * token after it belongs to the flag or to the person who wrote the line.
+ */
+interface Selectors {
+  /** `--flag value` and `--flag=value`. */
+  withValue: string[]
+  /** No argument; whatever follows is not theirs. */
+  bare: string[]
+}
+
+const SELECTORS: Record<string, Selectors> = {
+  claude: { withValue: ['--resume', '-r', '--session-id'], bare: ['--continue', '-c'] },
+  copilot: { withValue: ['--resume', '--session-id'], bare: [] },
+  opencode: { withValue: ['--session', '-s'], bare: [] }
 }
 
 /**
@@ -192,11 +213,18 @@ function findSelectorSpans(line: string, agentType: AiAgentType, argsFrom: numbe
     return found.length ? found : null
   }
 
-  const names = SELECTORS[agentType]
-  if (!names) return null
+  const selectors = SELECTORS[agentType]
+  if (!selectors) return null
 
-  for (let at = 0; at < args.length; at++) {
-    const spans = flagSpans(args, at, names)
+  // Everything after a bare `--` is positional by convention, so a `--resume`
+  // there is somebody's prompt and not a flag at all. It is exactly how a prompt
+  // beginning with a dash gets passed, and rewriting it would change what the
+  // agent is asked rather than which session it opens.
+  const end = args.findIndex((t) => t.value === '--')
+  const scannable = end === -1 ? args : args.slice(0, end)
+
+  for (let at = 0; at < scannable.length; at++) {
+    const spans = flagSpans(scannable, at, selectors)
     if (!spans) continue
     found.push(...spans)
     at += spans.length - 1

--- a/packages/server/src/launch-tokens.ts
+++ b/packages/server/src/launch-tokens.ts
@@ -1,0 +1,241 @@
+import type { AiAgentType } from '@vornrun/shared/types'
+
+/**
+ * Reading a launch line well enough to remove a session selector from it, and
+ * refusing to when that cannot be done safely.
+ *
+ * ## Why the line and not the arguments
+ *
+ * A configured command is a string, and `buildAgentLaunchLine` interpolates it
+ * unescaped -- `npx -y @anthropic-ai/claude-code` is a working configuration, and
+ * the settings form splits its argument field on whitespace. So the executable is
+ * not `args[0]` and there is no array to inspect. What exists is a line, and it
+ * has to be read as one.
+ *
+ * ## Why refusing matters more than parsing
+ *
+ * The point of this is to leave exactly one selector on the line. Getting that
+ * wrong in the cautious direction ships two, which starts the wrong session;
+ * getting it wrong in the confident direction mangles somebody's command, which
+ * starts nothing and loses their configuration. So anything this cannot reason
+ * about is handed back untouched: an operator, an unterminated quote, a
+ * substitution. `foo && claude --resume x` must never have its `claude` read as
+ * an argument of `foo`, and the way to guarantee that is to decline the whole
+ * line rather than to be clever about it.
+ *
+ * ## What is not stripped, on purpose
+ *
+ * `-r<id>` joined into one token, and clustered shorts like `-ir`. A leading dash
+ * on the next token is ambiguous with another option's dash-leading value, and
+ * a cluster cannot be split without knowing which letters take arguments. Both
+ * are left alone, so a person who wrote one keeps it and ours is appended
+ * beside it. Two selectors is a worse launch; a rewritten command line is a
+ * worse day.
+ */
+
+export interface Token {
+  /** As it appeared, quotes and all. */
+  raw: string
+  /** With quoting removed, which is what the shell would pass along. */
+  value: string
+  /** Byte offsets into the line, so a splice can put back everything else. */
+  start: number
+  end: number
+}
+
+/** Anything that makes a line more than one simple command. */
+const REFUSED = new Set(['|', '&', ';', '<', '>', '(', ')', '\n'])
+
+/**
+ * Split a line into tokens, or answer null.
+ *
+ * Null is not a failure to be worked around -- it is the answer for every line
+ * this must not touch.
+ */
+export function tokenize(line: string): Token[] | null {
+  const tokens: Token[] = []
+  let i = 0
+
+  while (i < line.length) {
+    while (i < line.length && (line[i] === ' ' || line[i] === '\t')) i++
+    if (i >= line.length) break
+
+    const start = i
+    let value = ''
+
+    while (i < line.length) {
+      const ch = line[i]!
+      if (ch === ' ' || ch === '\t') break
+      if (REFUSED.has(ch)) return null
+      if (ch === '`') return null
+      if (ch === '$' && line[i + 1] === '(') return null
+
+      if (ch === "'") {
+        const close = line.indexOf("'", i + 1)
+        if (close === -1) return null
+        value += line.slice(i + 1, close)
+        i = close + 1
+        continue
+      }
+
+      if (ch === '"') {
+        i++
+        let closed = false
+        while (i < line.length) {
+          const c = line[i]!
+          if (c === '"') {
+            i++
+            closed = true
+            break
+          }
+          if (c === '`') return null
+          if (c === '$' && line[i + 1] === '(') return null
+          if (c === '\\' && i + 1 < line.length) {
+            const next = line[i + 1]!
+            if (next === '"' || next === '\\' || next === '$' || next === '`') {
+              value += next
+              i += 2
+              continue
+            }
+          }
+          value += c
+          i++
+        }
+        if (!closed) return null
+        continue
+      }
+
+      if (ch === '\\') {
+        // A trailing backslash is a line continuation, which means this is not
+        // the whole command.
+        if (i + 1 >= line.length) return null
+        value += line[i + 1]
+        i += 2
+        continue
+      }
+
+      value += ch
+      i++
+    }
+
+    tokens.push({ raw: line.slice(start, i), value, start, end: i })
+  }
+
+  return tokens
+}
+
+export interface Span {
+  start: number
+  end: number
+}
+
+/** Whether a token could be a flag's value rather than the next flag. */
+function isValue(token: Token | undefined): boolean {
+  return token !== undefined && !token.value.startsWith('-')
+}
+
+/**
+ * A flag and, when it has one, the token carrying its value.
+ *
+ * `--flag=value` is one span. `--flag value` is two, but only when the next
+ * token does not itself begin with a dash -- a bare `--resume` is the
+ * interactive picker, which is still a selector, and swallowing the flag after
+ * it would remove something else.
+ */
+function flagSpans(tokens: Token[], at: number, names: string[]): Span[] | null {
+  const token = tokens[at]!
+  for (const name of names) {
+    if (token.value === name) {
+      const next = tokens[at + 1]
+      return isValue(next) ? [span(token), span(next!)] : [span(token)]
+    }
+    if (token.value.startsWith(`${name}=`)) return [span(token)]
+  }
+  return null
+}
+
+const span = (t: Token): Span => ({ start: t.start, end: t.end })
+
+/** The flag shapes that can be proven to select a session, per agent. */
+const SELECTORS: Record<string, string[]> = {
+  claude: ['--resume', '-r', '--continue', '-c', '--session-id'],
+  copilot: ['--resume', '--session-id'],
+  opencode: ['--session', '-s']
+}
+
+/**
+ * Spans on the line that select a session, or null when none can be proven.
+ *
+ * `argsFrom` is where the configured command ends. `buildAgentLaunchLine`
+ * composed this line, so it knows that offset exactly rather than having to
+ * guess which token was the executable -- which is what makes
+ * `/usr/local/bin/tools/claude` safe to have as a command and an argument merely
+ * ending in `/claude` safe to leave alone.
+ */
+export function findSelectorSpans(
+  line: string,
+  agentType: AiAgentType,
+  argsFrom: number
+): Span[] | null {
+  const tokens = tokenize(line)
+  if (!tokens) return null
+
+  const args = tokens.filter((t) => t.start >= argsFrom)
+  const found: Span[] = []
+
+  if (agentType === 'codex') {
+    // A subcommand rather than a flag: `codex resume <id>` or `codex resume
+    // --last`. Only in the first argument position, so a `resume` appearing as a
+    // value further along is not one.
+    const first = args[0]
+    if (first?.value === 'resume') {
+      found.push(span(first))
+      const next = args[1]
+      if (next && (next.value === '--last' || !next.value.startsWith('-'))) found.push(span(next))
+    }
+    return found.length ? found : null
+  }
+
+  const names = SELECTORS[agentType]
+  if (!names) return null
+
+  for (let at = 0; at < args.length; at++) {
+    const spans = flagSpans(args, at, names)
+    if (!spans) continue
+    found.push(...spans)
+    at += spans.length - 1
+  }
+
+  return found.length ? found : null
+}
+
+/**
+ * The line with its session selectors removed, or unchanged when none could be
+ * proven.
+ *
+ * Rebuilt by copying the gaps out of the original rather than by re-joining
+ * tokens, so every byte outside a proven span survives exactly as it was --
+ * quoting style, spacing, `$VAR`, all of it.
+ */
+export function stripSessionSelectors(
+  line: string,
+  agentType: AiAgentType,
+  argsFrom: number
+): string {
+  const spans = findSelectorSpans(line, agentType, argsFrom)
+  if (!spans || spans.length === 0) return line
+
+  const ordered = [...spans].sort((a, b) => a.start - b.start)
+  let out = ''
+  let at = 0
+  for (const one of ordered) {
+    // Take the whitespace in front of it too, or removing a flag from the middle
+    // leaves a double space and removing the last one leaves a trailing space.
+    let from = one.start
+    while (from > at && (line[from - 1] === ' ' || line[from - 1] === '\t')) from--
+    out += line.slice(at, from)
+    at = one.end
+  }
+  out += line.slice(at)
+  return out
+}

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -559,6 +559,27 @@ class PtyManager extends EventEmitter {
 
   private static readonly BUFFER_FLUSH_MS = 8
 
+  /**
+   * Put bytes into a session's output as though the process had written them.
+   *
+   * There is exactly one caller and one reason: a resumed session hands a new
+   * process a terminal the previous one was still using, and something has to
+   * sit between the two runs saying so. Doing it in the client cannot work --
+   * the client is not what orders these bytes. A cold pane has not mounted when
+   * the resume starts, so it has no terminal to reset yet, and the screen it
+   * replays is written when it finally does mount, by which time the new
+   * process has been streaming for a second. The two interleave and what
+   * arrives is both frames at once with the escapes showing.
+   *
+   * Through `bufferData` rather than beside it, so this takes a sequence number,
+   * a place in the scrollback and a line in the history like any other output.
+   * That is what makes it arrive in the right order for a client that attaches
+   * in a minute as well as for the one watching now.
+   */
+  injectOutput(id: string, data: string): void {
+    this.bufferData(id, data)
+  }
+
   private bufferData(id: string, data: string): void {
     const existing = this.dataBuffers.get(id)
     this.dataBuffers.set(id, existing ? existing + data : data)

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -888,6 +888,25 @@ class PtyManager extends EventEmitter {
     this.ptys.delete(id)
   }
 
+  /**
+   * Put back a record released for a resume whose spawn then failed.
+   *
+   * Releasing is destructive on purpose -- it is what lets the replacement take
+   * the same id -- but a spawn that throws must not be the end of the session.
+   * The restored kind is handed back to `restored-sessions`; this is the other
+   * kind, a session that ended during this run and whose record lives here, and
+   * without this it was released and never put anywhere. The pane's next attempt
+   * found nothing and was told the session was gone.
+   *
+   * Reachable without malice, the same way the other one is: a project directory
+   * renamed, a worktree pruned, a volume unmounted.
+   */
+  restoreReleased(session: TerminalSession): void {
+    this.sessions.set(session.id, session)
+    this.normalizedPaths.set(session.id, normalizePath(session.worktreePath || session.projectPath))
+    if (!this.sessionOrder.includes(session.id)) this.sessionOrder.push(session.id)
+  }
+
   killPty(id: string): void {
     const p = this.ptys.get(id)
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -38,7 +38,13 @@ import { getShellIntegration } from './shell-integration'
 import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
-import { createScreen, feedScreen, resizeScreen, clearScreen, screenCwd } from './terminal-screen'
+import {
+  createScreen,
+  feedScreen,
+  resizeScreen,
+  clearScreen,
+  setCwdReporter
+} from './terminal-screen'
 import { startHistory, recordOutput, recordResize, stopHistory } from './history/writer'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 import { isDraining, DRAINING_MESSAGE } from './draining'
@@ -105,6 +111,29 @@ class PtyManager extends EventEmitter {
   constructor() {
     super()
     setImmediate(() => this.cleanStaleTempKeys())
+    // Told when a shell moves, rather than checking after every flush. The
+    // report comes from inside xterm's parser, which is the only moment the new
+    // directory is actually known -- a flush ends before the bytes it delivered
+    // have been parsed, so anything reading there reads the previous value.
+    setCwdReporter((id, cwd) => this.noteShellCwd(id, cwd))
+  }
+
+  /**
+   * Keep a shell's record pointing at where the shell actually is.
+   *
+   * `shellCwd` was written once at spawn and never moved, so restoring a shell
+   * put somebody back where they started rather than where they were. This is
+   * the record that gets persisted and the one a restored shell is offered.
+   *
+   * Runs inside the parser, so it stays a map lookup and an event, and the save
+   * it triggers is debounced -- a script running `cd` in a loop costs one write
+   * rather than hundreds.
+   */
+  private noteShellCwd(id: string, cwd: string): void {
+    const session = this.sessions.get(id)
+    if (!session || session.agentType !== 'shell' || session.shellCwd === cwd) return
+    session.shellCwd = cwd
+    this.emit('session-cwd', id, cwd)
   }
 
   /** Remove stale temp key files from previous crashes (older than 1 hour) */
@@ -582,31 +611,7 @@ class PtyManager extends EventEmitter {
       appendScrollback(id, data)
       feedScreen(id, data)
       recordOutput(id, data)
-      this.followShellCwd(id)
     }
-  }
-
-  /**
-   * Keep a shell's session record pointing at where the shell actually is.
-   *
-   * The screen model already watches for the integration's cwd report; this
-   * carries it onto the record, which is the thing that gets persisted and the
-   * thing a restored shell is offered. Without it `shellCwd` stayed the
-   * directory the PTY was spawned in, so restoring landed somebody back where
-   * they started rather than where they were.
-   *
-   * Read after the flush rather than on every report, because the report
-   * arrives through xterm's parser and this is the point where that parser has
-   * been given the bytes. A save is scheduled only when it actually moved: `cd`
-   * happens far less often than output does, but output is constant.
-   */
-  private followShellCwd(id: string): void {
-    const session = this.sessions.get(id)
-    if (!session || session.agentType !== 'shell') return
-    const cwd = screenCwd(id)
-    if (!cwd || cwd === session.shellCwd) return
-    session.shellCwd = cwd
-    this.emit('session-cwd', id, cwd)
   }
 
   private clearBuffer(id: string): void {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -52,6 +52,9 @@ const MAX_OUTPUT_LINES = 1000
  * these too, and a literal in one place and a constant in another is how the two
  * come to disagree about what the program is rendering against.
  */
+/** The largest geometry a resize may ask for. See `resizePty`. */
+const MAX_GEOMETRY = 10_000
+
 const INITIAL_COLS = 80
 const INITIAL_ROWS = 24
 const IDLE_TIMEOUT_MS = 5000
@@ -744,6 +747,13 @@ class PtyManager extends EventEmitter {
    */
   resizePty(id: string, cols: number, rows: number): void {
     if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols <= 0 || rows <= 0) return
+    // Bounded as well as positive, because this now outlives the process. A
+    // resize frame stores its dimensions in sixteen bits, so a client asking for
+    // seventy thousand columns would be recorded as four thousand -- a durable
+    // disagreement between what the program was rendering against and what a
+    // replay lays it out at, and one that is re-applied on every subsequent
+    // start. Nothing a terminal is actually displayed at comes near this.
+    if (cols > MAX_GEOMETRY || rows > MAX_GEOMETRY) return
 
     const session = this.sessions.get(id)
     if (session) {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -860,6 +860,34 @@ class PtyManager extends EventEmitter {
     recordResize(id, cols, rows)
   }
 
+  /**
+   * Let go of a session that is about to start again under the same id.
+   *
+   * `killPty` was doing this job and doing three other things with it. Its
+   * process has already gone, so it emits `session-exit` for a session that is
+   * coming straight back, and -- when that session was the last one in a
+   * worktree -- broadcasts WORKTREE_CONFIRM_CLEANUP, which reaches the person as
+   * an offer to delete the worktree the agent is at that moment being resumed
+   * into. Taking it removes the tree out from under a running agent.
+   *
+   * It also called `stopHistory`, which queues a recursive remove of the very
+   * directory `startHistory` is about to reset a few lines later.
+   *
+   * So this releases the id and says nothing: the maps, the buffers and the
+   * screen model, which `createPty` is about to replace anyway.
+   */
+  releaseForResume(id: string): void {
+    this.drainBuffer(id)
+    this.clearBuffer(id)
+    this.sessions.delete(id)
+    this.normalizedPaths.delete(id)
+    this.clearSessionTracking(id)
+    this.flushSeq.delete(id)
+    clearScreen(id)
+    this.sessionOrder = this.sessionOrder.filter((sid) => sid !== id)
+    this.ptys.delete(id)
+  }
+
   killPty(id: string): void {
     const p = this.ptys.get(id)
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -746,6 +746,10 @@ class PtyManager extends EventEmitter {
    * says which of them won.
    */
   resizePty(id: string, cols: number, rows: number): void {
+    // An id this manager does not know is not merely a no-op below: the screen
+    // model is keyed by session id and a restored one exists without a PTY, so a
+    // cold pane fitting itself would reflow a screen nothing is drawing to.
+    if (!this.sessions.has(id)) return
     if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols <= 0 || rows <= 0) return
     // Bounded as well as positive, because this now outlives the process. A
     // resize frame stores its dimensions in sixteen bits, so a client asking for

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -38,6 +38,7 @@ import { getShellIntegration } from './shell-integration'
 import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
+import { feedScreen, resizeScreen, clearScreen } from './terminal-screen'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 import { isDraining, DRAINING_MESSAGE } from './draining'
 
@@ -530,7 +531,19 @@ class PtyManager extends EventEmitter {
     this.dataBuffers.delete(id)
     this.flushTimers.delete(id)
     if (data) {
+      // Clients first, always. What follows models the screen for nobody who is
+      // waiting; this line is a person watching their terminal, and it must not
+      // be behind anything that can fail or stall.
       this.emit('client-message', IPC.TERMINAL_DATA, { id, data })
+
+      // Fed from here rather than from `onData` for two reasons. `term.write`
+      // queues a macrotask per call and node-pty emits a few bytes at a time
+      // while somebody types, so this is one queued write per session per flush
+      // instead of one per keystroke. And it puts the model in step with the
+      // clients rather than ahead of them -- fed from `onData`, a screen read
+      // mid-flush would describe something nobody has seen yet.
+      const session = this.sessions.get(id)
+      feedScreen(id, data, session?.cols, session?.rows)
     }
   }
 
@@ -643,6 +656,11 @@ class PtyManager extends EventEmitter {
       this.deleteTempKey(id)
       this.clearSessionTracking(id)
       clearScrollback(id)
+      // Beside the scrollback it belongs to: the PTY is gone and nothing will
+      // draw into it again. The session record survives so the card can show an
+      // exit code, but its history does not -- that is pre-existing, and this
+      // matches it rather than quietly deciding otherwise.
+      clearScreen(id)
       this.sessionOrder = this.sessionOrder.filter((sid) => sid !== id)
 
       this.ptys.delete(id)
@@ -706,6 +724,8 @@ class PtyManager extends EventEmitter {
       session.rows = rows
     }
     this.ptys.get(id)?.resize(cols, rows)
+    // The same numbers, so the model wraps where the program does.
+    resizeScreen(id, cols, rows)
   }
 
   killPty(id: string): void {
@@ -726,6 +746,11 @@ class PtyManager extends EventEmitter {
     this.sessions.delete(id)
     this.normalizedPaths.delete(id)
     this.clearSessionTracking(id)
+    // Not beside a `clearScrollback`, because there is not one here -- but this
+    // path deletes the session outright, so nothing would ever feed or free the
+    // model again. A `Terminal` holds buffers; leaving it is a leak per closed
+    // session for the life of the server.
+    clearScreen(id)
     this.sessionOrder = this.sessionOrder.filter((sid) => sid !== id)
     this.ptys.delete(id)
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -191,13 +191,24 @@ class PtyManager extends EventEmitter {
     return buildLaunchLine(payload, this.agentCommands, getSafeEnv())
   }
 
-  createPty(payload: CreateTerminalPayload): TerminalSession {
+  /**
+   * @param reuseId Keep an existing session's id instead of minting one.
+   *
+   * Only resume passes this, and it is what makes a resumed session the same
+   * session rather than a replacement for it. Every client keys a pane by this
+   * id -- the xterm holding the replayed screen, the subscription carrying its
+   * output -- so a new id means a new pane, and the screen the person was
+   * looking at is thrown away at the moment they asked for it back. Reusing it
+   * also means the new run's history supersedes the old run's under the same
+   * name, which `startHistory` does on its own queue.
+   */
+  createPty(payload: CreateTerminalPayload, reuseId?: string): TerminalSession {
     // Refused rather than created: a session started on an endpoint this process
     // no longer holds is reachable through a name that now points elsewhere, so
     // nobody would ever see it. Existing sessions are untouched -- their clients
     // hold a descriptor, not a name.
     if (isDraining()) throw new Error(DRAINING_MESSAGE)
-    const id = crypto.randomUUID()
+    const id = reuseId ?? crypto.randomUUID()
     const shell = getDefaultShell(configManager.loadConfig().defaults.shell)
 
     // Check if this is a remote session
@@ -498,8 +509,9 @@ class PtyManager extends EventEmitter {
     return session
   }
 
-  createShellPty(cwd?: string): TerminalSession {
-    const id = crypto.randomUUID()
+  /** @param reuseId As `createPty`: a resumed shell keeps the pane it was in. */
+  createShellPty(cwd?: string, reuseId?: string): TerminalSession {
+    const id = reuseId ?? crypto.randomUUID()
     const shell = getDefaultShell(configManager.loadConfig().defaults.shell)
     const workingDir = cwd || os.homedir()
     const integration = getShellIntegration({

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -543,10 +543,16 @@ class PtyManager extends EventEmitter {
       // instead of one per keystroke. And it puts the model in step with the
       // clients rather than ahead of them -- fed from `onData`, a screen read
       // mid-flush would describe something nobody has seen yet.
+      // All three from here, on the same bytes, in one place.
+      //
+      // `appendScrollback` used to sit on `onData` instead, and that was not
+      // merely inconsistent -- it put the byte buffer ahead of the screen model
+      // by up to one flush. A checkpoint takes both at the same instant, so it
+      // could hold bytes in its scrollback that its screen had not seen; those
+      // bytes then arrived again as log frames after it, and a restore counted
+      // them twice. Fed from one point they cannot disagree.
+      appendScrollback(id, data)
       feedScreen(id, data)
-      // Beside the model rather than beside `appendScrollback`, and for the same
-      // reason: this is the coalesced write, so a burst of keystrokes is one
-      // frame on disk instead of thirty.
       recordOutput(id, data)
     }
   }
@@ -556,6 +562,13 @@ class PtyManager extends EventEmitter {
     if (timer) clearTimeout(timer)
     this.flushTimers.delete(id)
     this.dataBuffers.delete(id)
+  }
+
+  /** Push what is buffered now, without waiting out the timer that would. */
+  private drainBuffer(id: string): void {
+    const timer = this.flushTimers.get(id)
+    if (timer) clearTimeout(timer)
+    this.flushBuffer(id)
   }
 
   private clearSessionTracking(id: string): void {
@@ -653,20 +666,15 @@ class PtyManager extends EventEmitter {
 
     ptyProcess.onData((data: string) => {
       this.bufferData(id, data)
+      // The one consumer that wants raw chunks rather than coalesced ones: it
+      // reassembles partial lines and scans for bracketed paste, so it has to
+      // see the stream as it arrived. Everything else is fed from the flush.
       this.appendOutput(id, data)
-      // Kept unstripped, and deliberately alongside `appendOutput` rather than
-      // instead of it: one answers what the agent said, the other what a
-      // terminal should draw, and neither can be derived from the other.
-      appendScrollback(id, data)
     })
 
     ptyProcess.onExit(({ exitCode }) => {
-      // Flush any remaining buffered data before signaling exit
-      const pendingTimer = this.flushTimers.get(id)
-      if (pendingTimer) {
-        clearTimeout(pendingTimer)
-        this.flushBuffer(id)
-      }
+      // Whatever is buffered is the last thing this terminal ever printed.
+      this.drainBuffer(id)
       this.clearBuffer(id)
       this.deleteTempKey(id)
       this.clearSessionTracking(id)
@@ -753,12 +761,7 @@ class PtyManager extends EventEmitter {
   killPty(id: string): void {
     const p = this.ptys.get(id)
 
-    // Flush any remaining buffered data before killing
-    const pendingTimer = this.flushTimers.get(id)
-    if (pendingTimer) {
-      clearTimeout(pendingTimer)
-      this.flushBuffer(id)
-    }
+    this.drainBuffer(id)
     this.clearBuffer(id)
 
     // Delete session and PTY from maps BEFORE killing so the onExit handler
@@ -820,15 +823,15 @@ class PtyManager extends EventEmitter {
    * right while nothing outlived the process.
    */
   flushPendingOutput(): void {
-    for (const id of [...this.flushTimers.keys()]) {
-      const timer = this.flushTimers.get(id)
-      if (timer) clearTimeout(timer)
-      this.flushBuffer(id)
-    }
+    // Copied because `flushBuffer` deletes from the map it is walking.
+    for (const id of [...this.flushTimers.keys()]) this.drainBuffer(id)
   }
 
   killAll(): void {
-    // Clear all data buffers and flush timers (window is closing, no point flushing)
+    // Dropped rather than flushed. `shutdown()` calls `flushPendingOutput()`
+    // ahead of this precisely because these bytes do matter now that history
+    // outlives the process -- by the time this runs they have been written, and
+    // what is left is whatever arrived in between, with nowhere to go.
     for (const timer of this.flushTimers.values()) {
       clearTimeout(timer)
     }

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -39,6 +39,7 @@ import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
 import { createScreen, feedScreen, resizeScreen, clearScreen } from './terminal-screen'
+import { startHistory, recordOutput, recordResize, stopHistory } from './history/writer'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 import { isDraining, DRAINING_MESSAGE } from './draining'
 
@@ -543,6 +544,10 @@ class PtyManager extends EventEmitter {
       // clients rather than ahead of them -- fed from `onData`, a screen read
       // mid-flush would describe something nobody has seen yet.
       feedScreen(id, data)
+      // Beside the model rather than beside `appendScrollback`, and for the same
+      // reason: this is the coalesced write, so a burst of keystrokes is one
+      // frame on disk instead of thirty.
+      recordOutput(id, data)
     }
   }
 
@@ -642,6 +647,9 @@ class PtyManager extends EventEmitter {
    */
   private setupPtyEvents(id: string, ptyProcess: pty.IPty, cols: number, rows: number): void {
     createScreen(id, cols, rows)
+    // Replaces whatever was left under this id. A recovered session that is
+    // being respawned has history describing a process that is gone.
+    startHistory(id)
 
     ptyProcess.onData((data: string) => {
       this.bufferData(id, data)
@@ -668,6 +676,10 @@ class PtyManager extends EventEmitter {
       // exit code, but its history does not -- that is pre-existing, and this
       // matches it rather than quietly deciding otherwise.
       clearScreen(id)
+      // And the same for what was written for it. A terminal whose process has
+      // exited has nothing worth restoring -- refused during shutdown, where the
+      // PTYs are killed after the checkpoints have been written.
+      stopHistory(id)
       this.sessionOrder = this.sessionOrder.filter((sid) => sid !== id)
 
       this.ptys.delete(id)
@@ -735,6 +747,7 @@ class PtyManager extends EventEmitter {
     // this is reached from a fire-and-forget notification, and the model drains
     // its own queue before applying the size.
     void resizeScreen(id, cols, rows)
+    recordResize(id, cols, rows)
   }
 
   killPty(id: string): void {
@@ -760,6 +773,7 @@ class PtyManager extends EventEmitter {
     // model again. A `Terminal` holds buffers; leaving it is a leak per closed
     // session for the life of the server.
     clearScreen(id)
+    stopHistory(id)
     this.sessionOrder = this.sessionOrder.filter((sid) => sid !== id)
     this.ptys.delete(id)
 
@@ -793,6 +807,23 @@ class PtyManager extends EventEmitter {
       // Surface an exit event even if the PTY was already gone so the
       // renderer can complete any close-intent cleanup.
       this.emit('client-message', IPC.TERMINAL_EXIT, { id, exitCode: 0 })
+    }
+  }
+
+  /**
+   * Push out whatever is sitting in the flush buffers, without waiting for their
+   * timers.
+   *
+   * For shutdown. The buffers hold up to `BUFFER_FLUSH_MS` of output, and that
+   * output is the most recent thing the terminal showed -- the part somebody is
+   * most likely to want back. `killAll` below drops it deliberately, which was
+   * right while nothing outlived the process.
+   */
+  flushPendingOutput(): void {
+    for (const id of [...this.flushTimers.keys()]) {
+      const timer = this.flushTimers.get(id)
+      if (timer) clearTimeout(timer)
+      this.flushBuffer(id)
     }
   }
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -530,15 +530,40 @@ class PtyManager extends EventEmitter {
     }
   }
 
+  /**
+   * How many flushes each session has had.
+   *
+   * The number a client uses to tell what it already has. A pane attaching
+   * asks for the scrollback and is told which flush it reflects; every
+   * `terminal:data` carries the same counter, so anything at or below that
+   * number is already in what it was handed and anything above it is not.
+   *
+   * This works only because `flushBuffer` below is one synchronous block. The
+   * counter moves and the buffer it describes is appended in the same tick, with
+   * nothing awaited between them, so a reader that takes both in one turn cannot
+   * catch them disagreeing. **Introduce an `await` in there and this silently
+   * stops being true**, and the symptom is a terminal that duplicates or loses a
+   * few hundred milliseconds of output on attach.
+   */
+  private flushSeq = new Map<string, number>()
+
+  /** What the last flush of this session was numbered. */
+  lastFlushSeq(id: string): number {
+    return this.flushSeq.get(id) ?? 0
+  }
+
   private flushBuffer(id: string): void {
     const data = this.dataBuffers.get(id)
     this.dataBuffers.delete(id)
     this.flushTimers.delete(id)
     if (data) {
+      const seq = this.lastFlushSeq(id) + 1
+      this.flushSeq.set(id, seq)
+
       // Clients first, always. What follows models the screen for nobody who is
       // waiting; this line is a person watching their terminal, and it must not
       // be behind anything that can fail or stall.
-      this.emit('client-message', IPC.TERMINAL_DATA, { id, data })
+      this.emit('client-message', IPC.TERMINAL_DATA, { id, data, seq })
 
       // Fed from here rather than from `onData` for two reasons. `term.write`
       // queues a macrotask per call and node-pty emits a few bytes at a time
@@ -681,6 +706,7 @@ class PtyManager extends EventEmitter {
       this.clearBuffer(id)
       this.deleteTempKey(id)
       this.clearSessionTracking(id)
+      this.flushSeq.delete(id)
       clearScrollback(id)
       // Beside the scrollback it belongs to: the PTY is gone and nothing will
       // draw into it again. The session record survives so the card can show an
@@ -785,6 +811,7 @@ class PtyManager extends EventEmitter {
     this.sessions.delete(id)
     this.normalizedPaths.delete(id)
     this.clearSessionTracking(id)
+    this.flushSeq.delete(id)
     // Not beside a `clearScrollback`, because there is not one here -- but this
     // path deletes the session outright, so nothing would ever feed or free the
     // model again. A `Terminal` holds buffers; leaving it is a leak per closed
@@ -851,6 +878,7 @@ class PtyManager extends EventEmitter {
     }
     this.dataBuffers.clear()
     this.flushTimers.clear()
+    this.flushSeq.clear()
 
     // Clean up any remaining temp key files
     for (const sessionId of this.tempKeyPaths.keys()) {
@@ -882,6 +910,17 @@ class PtyManager extends EventEmitter {
    */
   livePtyCount(): number {
     return this.ptys.size
+  }
+
+  /**
+   * Whether a process is still behind this session.
+   *
+   * `getActiveSessions()` cannot answer it. That returns session *records*, and
+   * a record outlives its process -- only `killPty` removes one -- so a terminal
+   * that exited on its own is still in that list. This is the map that decides.
+   */
+  hasLivePty(id: string): boolean {
+    return this.ptys.has(id)
   }
 
   getActiveSessions(): TerminalSession[] {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -38,7 +38,7 @@ import { getShellIntegration } from './shell-integration'
 import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
-import { createScreen, feedScreen, resizeScreen, clearScreen } from './terminal-screen'
+import { createScreen, feedScreen, resizeScreen, clearScreen, screenCwd } from './terminal-screen'
 import { startHistory, recordOutput, recordResize, stopHistory } from './history/writer'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 import { isDraining, DRAINING_MESSAGE } from './draining'
@@ -582,7 +582,31 @@ class PtyManager extends EventEmitter {
       appendScrollback(id, data)
       feedScreen(id, data)
       recordOutput(id, data)
+      this.followShellCwd(id)
     }
+  }
+
+  /**
+   * Keep a shell's session record pointing at where the shell actually is.
+   *
+   * The screen model already watches for the integration's cwd report; this
+   * carries it onto the record, which is the thing that gets persisted and the
+   * thing a restored shell is offered. Without it `shellCwd` stayed the
+   * directory the PTY was spawned in, so restoring landed somebody back where
+   * they started rather than where they were.
+   *
+   * Read after the flush rather than on every report, because the report
+   * arrives through xterm's parser and this is the point where that parser has
+   * been given the bytes. A save is scheduled only when it actually moved: `cd`
+   * happens far less often than output does, but output is constant.
+   */
+  private followShellCwd(id: string): void {
+    const session = this.sessions.get(id)
+    if (!session || session.agentType !== 'shell') return
+    const cwd = screenCwd(id)
+    if (!cwd || cwd === session.shellCwd) return
+    session.shellCwd = cwd
+    this.emit('session-cwd', id, cwd)
   }
 
   private clearBuffer(id: string): void {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -38,7 +38,7 @@ import { getShellIntegration } from './shell-integration'
 import { configManager } from './config-manager'
 import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
-import { feedScreen, resizeScreen, clearScreen } from './terminal-screen'
+import { createScreen, feedScreen, resizeScreen, clearScreen } from './terminal-screen'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 import { isDraining, DRAINING_MESSAGE } from './draining'
 
@@ -260,7 +260,7 @@ class PtyManager extends EventEmitter {
     const launchLine = this.buildAgentLaunchLine(payload)
     setTimeout(() => ptyProcess.write(launchLine + '\r'), 300)
 
-    this.setupPtyEvents(id, ptyProcess)
+    this.setupPtyEvents(id, ptyProcess, INITIAL_COLS, INITIAL_ROWS)
     this.ptys.set(id, ptyProcess)
 
     const branch = effectiveBranch || getGitBranch(effectivePath)
@@ -423,7 +423,7 @@ class PtyManager extends EventEmitter {
     })
 
     // Forward all data to the renderer from the start
-    this.setupPtyEvents(id, ptyProcess)
+    this.setupPtyEvents(id, ptyProcess, INITIAL_COLS, INITIAL_ROWS)
     this.ptys.set(id, ptyProcess)
 
     // Clean up the prompt listener after connection or timeout
@@ -487,7 +487,7 @@ class PtyManager extends EventEmitter {
         VORN_SESSION_ID: id
       }
     })
-    this.setupPtyEvents(id, ptyProcess)
+    this.setupPtyEvents(id, ptyProcess, INITIAL_COLS, INITIAL_ROWS)
     this.ptys.set(id, ptyProcess)
 
     const shellCount =
@@ -542,8 +542,7 @@ class PtyManager extends EventEmitter {
       // instead of one per keystroke. And it puts the model in step with the
       // clients rather than ahead of them -- fed from `onData`, a screen read
       // mid-flush would describe something nobody has seen yet.
-      const session = this.sessions.get(id)
-      feedScreen(id, data, session?.cols, session?.rows)
+      feedScreen(id, data)
     }
   }
 
@@ -635,7 +634,15 @@ class PtyManager extends EventEmitter {
     )
   }
 
-  private setupPtyEvents(id: string, ptyProcess: pty.IPty): void {
+  /**
+   * @param cols - what the PTY was spawned at, passed rather than looked up.
+   *   Every caller runs this *before* registering the session, so a lookup here
+   *   finds nothing and silently falls back -- which is invisible while all
+   *   three spawn at the same size and wrong the moment one does not.
+   */
+  private setupPtyEvents(id: string, ptyProcess: pty.IPty, cols: number, rows: number): void {
+    createScreen(id, cols, rows)
+
     ptyProcess.onData((data: string) => {
       this.bufferData(id, data)
       this.appendOutput(id, data)
@@ -724,8 +731,10 @@ class PtyManager extends EventEmitter {
       session.rows = rows
     }
     this.ptys.get(id)?.resize(cols, rows)
-    // The same numbers, so the model wraps where the program does.
-    resizeScreen(id, cols, rows)
+    // The same numbers, so the model wraps where the program does. Not awaited:
+    // this is reached from a fire-and-forget notification, and the model drains
+    // its own queue before applying the size.
+    void resizeScreen(id, cols, rows)
   }
 
   killPty(id: string): void {

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -42,6 +42,16 @@ import { analyzeOutput, createStatusContext, StatusContext } from './status-pars
 import { isDraining, DRAINING_MESSAGE } from './draining'
 
 const MAX_OUTPUT_LINES = 1000
+
+/**
+ * What a PTY starts at, before any client has fitted itself to a pane.
+ *
+ * Named rather than repeated at each spawn site: the session record now carries
+ * these too, and a literal in one place and a constant in another is how the two
+ * come to disagree about what the program is rendering against.
+ */
+const INITIAL_COLS = 80
+const INITIAL_ROWS = 24
 const IDLE_TIMEOUT_MS = 5000
 const IDLE_TIMEOUT_HOOKS_MS = 30_000
 
@@ -217,8 +227,8 @@ class PtyManager extends EventEmitter {
 
     const ptyProcess = pty.spawn(shell, getShellArgs(), {
       name: 'xterm-256color',
-      cols: 80,
-      rows: 24,
+      cols: INITIAL_COLS,
+      rows: INITIAL_ROWS,
       cwd: effectivePath,
       // No shell integration: an agent paints its own full-screen interface
       // and is never drawn as command blocks. Installing the shim anyway made
@@ -260,6 +270,8 @@ class PtyManager extends EventEmitter {
       projectPath: payload.projectPath,
       status: 'running',
       createdAt: Date.now(),
+      cols: INITIAL_COLS,
+      rows: INITIAL_ROWS,
       pid: ptyProcess.pid,
       ...(payload.displayName
         ? { displayName: payload.displayName }
@@ -288,8 +300,8 @@ class PtyManager extends EventEmitter {
   ): TerminalSession {
     const ptyProcess = pty.spawn(shell, getShellArgs(), {
       name: 'xterm-256color',
-      cols: 80,
-      rows: 24,
+      cols: INITIAL_COLS,
+      rows: INITIAL_ROWS,
       cwd: os.homedir(),
       env: getSafeEnv()
     })
@@ -435,6 +447,8 @@ class PtyManager extends EventEmitter {
       projectPath: payload.projectPath,
       status: 'running',
       createdAt: Date.now(),
+      cols: INITIAL_COLS,
+      rows: INITIAL_ROWS,
       pid: ptyProcess.pid,
       remoteHostId: host.id,
       remoteHostLabel: host.label,
@@ -462,8 +476,8 @@ class PtyManager extends EventEmitter {
     // initialisation, so integration for them replaces the launch arguments.
     const ptyProcess = pty.spawn(shell, integration.args ?? getShellArgs(), {
       name: 'xterm-256color',
-      cols: 80,
-      rows: 24,
+      cols: INITIAL_COLS,
+      rows: INITIAL_ROWS,
       cwd: workingDir,
       env: {
         ...getSafeEnv(),
@@ -485,6 +499,8 @@ class PtyManager extends EventEmitter {
       projectPath: workingDir,
       status: 'running',
       createdAt: Date.now(),
+      cols: INITIAL_COLS,
+      rows: INITIAL_ROWS,
       pid: ptyProcess.pid,
       displayName: `Shell ${shellCount}`,
       shellCwd: workingDir
@@ -667,7 +683,28 @@ class PtyManager extends EventEmitter {
     }
   }
 
+  /**
+   * Change the geometry a program is rendering against.
+   *
+   * Guarded before anything is touched. This arrives as an RPC *notification*
+   * -- fire-and-forget, no caller to catch a throw -- and `resize(0, 0)` throws
+   * inside node-pty, so a client that fitted itself to a collapsed pane would
+   * take down the handler rather than be ignored.
+   *
+   * The session record is updated alongside the PTY, with the same numbers, so
+   * anything modelling the screen can agree with what the program is actually
+   * drawing against. Two clients still fight over it -- node-pty has always been
+   * last-writer-wins here and this does not change that -- but now the record
+   * says which of them won.
+   */
   resizePty(id: string, cols: number, rows: number): void {
+    if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols <= 0 || rows <= 0) return
+
+    const session = this.sessions.get(id)
+    if (session) {
+      session.cols = cols
+      session.rows = rows
+    }
     this.ptys.get(id)?.resize(cols, rows)
   }
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -556,6 +556,14 @@ export function registerAllMethods(): void {
   })
 
   registerMethod('terminal:readScrollback', ({ id }) => ({ data: readScrollback(id) }))
+  // Read in one tick on purpose: the scrollback and the flush counter move
+  // together inside `flushBuffer`, so taking both in the same turn is what
+  // guarantees the caller can trust one against the other.
+  registerMethod('terminal:attach', ({ id }) => ({
+    data: readScrollback(id),
+    seq: ptyManager.lastFlushSeq(id),
+    live: ptyManager.hasLivePty(id)
+  }))
   registerMethod('terminal:readOutput', ({ id, lines }) => ptyManager.getOutput(id, lines))
   registerMethod('shell:create', (cwd) => {
     const session = ptyManager.createShellPty(cwd)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -680,7 +680,13 @@ export function registerAllMethods(): void {
           fs.existsSync(remembered) &&
           fs.statSync(remembered).isDirectory()
         const cwd = usable ? remembered : (previous.worktreePath ?? previous.projectPath)
-        const session = ptyManager.createShellPty(cwd)
+        // The same id, which is what makes this the same pane rather than a new
+        // one beside it: the client keys its terminal by this, so a fresh id
+        // would hand back a blank shell and drop the screen being resumed. The
+        // previous run's history is not deleted here either -- `startHistory`
+        // resets it under this name, on the queue that owns it, and only once
+        // something is actually running.
+        const session = ptyManager.createShellPty(cwd, id)
         // Carried across on the server rather than grafted on by whichever
         // client asked. `createShellPty` names a session after its directory, so
         // without this a restored shell loses the project it belonged to -- which
@@ -695,17 +701,12 @@ export function registerAllMethods(): void {
           ...(previous.displayName !== undefined && { displayName: previous.displayName })
         })
         clientRegistry.broadcast(IPC.SESSION_CREATED, session)
-        // Only once something is running. Discarding first and spawning second
-        // meant a spawn that threw -- a project directory renamed, a worktree
-        // pruned, a volume unmounted -- left the record consumed, the history
-        // deleted and nothing to try again from.
-        if (restored) await forgetRestored(id)
         sessionManager.scheduleSave()
         return { ok: true as const, session }
       }
 
-      const session = ptyManager.createPty(buildRestorePayload(previous, resumeSessionId))
-      if (restored) await forgetRestored(id)
+      // Same id, same reasons as the shell branch above.
+      const session = ptyManager.createPty(buildRestorePayload(previous, resumeSessionId), id)
       sessionManager.scheduleSave()
       return { ok: true as const, session }
     } catch (err) {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -328,6 +328,15 @@ export function setServerPort(port: number): void {
  * At module scope rather than inside `registerAllMethods` because it captures
  * nothing from it, and out here it can be tested without standing up a socket.
  */
+/** Whether a path is a directory right now, answering false for every other case. */
+function isDirectory(at: string): boolean {
+  try {
+    return fs.statSync(at).isDirectory()
+  } catch {
+    return false
+  }
+}
+
 export async function forgetRestored(id: string): Promise<void> {
   clearScreen(id)
   // Recovery seeds a restored session's scrollback so a pane can be shown one
@@ -705,10 +714,11 @@ export function registerAllMethods(): void {
         // turns into where a process starts. A stale or fabricated path falls
         // back to the project rather than being spawned into.
         const remembered = previous.shellCwd
-        const usable =
-          remembered !== undefined &&
-          fs.existsSync(remembered) &&
-          fs.statSync(remembered).isDirectory()
+        // One question, asked once, and never allowed to throw. Asking whether it
+        // exists and then whether it is a directory is two questions with a gap
+        // between them: a directory removed in that gap turns a fallback into a
+        // rejected resume, and the fallback is the whole point of asking.
+        const usable = remembered !== undefined && isDirectory(remembered)
         const cwd = usable ? remembered : (previous.worktreePath ?? previous.projectPath)
         // The same id, which is what makes this the same pane rather than a new
         // one beside it: the client keys its terminal by this, so a fresh id
@@ -745,8 +755,11 @@ export function registerAllMethods(): void {
     } catch (err) {
       log.warn({ err, id }, '[restored] could not resume this session')
       // Put it back. A claim is destructive on purpose, but a claim whose spawn
-      // failed must not be the end of the session.
+      // failed must not be the end of the session. Both kinds, because both were
+      // taken: the carried-over record goes back to `restored-sessions`, and the
+      // one that ended during this run goes back to the pty manager it came from.
       if (restored) restoreHeld(restored)
+      else if (dead) ptyManager.restoreReleased(dead)
       return {
         ok: false as const,
         reason: 'failed' as const,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -642,6 +642,18 @@ export function registerAllMethods(): void {
 
   registerMethod('sessions:restored', () => listRestored())
 
+  /**
+   * What goes between the run that ended and the run taking its place.
+   *
+   * Leave the alternate screen, soft reset, default attributes, cursor shown,
+   * then a line of its own. A soft reset (DECSTR) and deliberately not a full
+   * one: RIS would clear the scrollback, and the scrollback is the thing being
+   * resumed. Without it the new process inherits the last one's scroll region,
+   * origin mode and unclosed attributes -- it assumes a terminal at its defaults
+   * and so never sets them -- and its first redraw lands inside the old frame.
+   */
+  const BETWEEN_RUNS = '\x1b[?1049l\x1b[!p\x1b[0m\x1b[?25h\r\n'
+
   registerMethod('sessions:resume', async ({ id, resumeSessionId }) => {
     // Claimed before anything is started, and that ordering is the point. Two
     // clients can be looking at the same cold pane; the second must be told it
@@ -700,6 +712,8 @@ export function registerAllMethods(): void {
           ...(previous.isWorktree !== undefined && { isWorktree: previous.isWorktree }),
           ...(previous.displayName !== undefined && { displayName: previous.displayName })
         })
+        // Synchronously, so it is in the buffer before the shell's first byte.
+        ptyManager.injectOutput(session.id, BETWEEN_RUNS)
         clientRegistry.broadcast(IPC.SESSION_CREATED, session)
         sessionManager.scheduleSave()
         return { ok: true as const, session }
@@ -707,6 +721,7 @@ export function registerAllMethods(): void {
 
       // Same id, same reasons as the shell branch above.
       const session = ptyManager.createPty(buildRestorePayload(previous, resumeSessionId), id)
+      ptyManager.injectOutput(session.id, BETWEEN_RUNS)
       sessionManager.scheduleSave()
       return { ok: true as const, session }
     } catch (err) {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -674,11 +674,11 @@ export function registerAllMethods(): void {
     if (!previous) return { ok: false as const, reason: 'gone' as const }
 
     try {
-      // Claimed, for the second kind. `killPty` is what removes a record whose
-      // process has already gone, and it takes the screen model and the history
-      // with it -- so this is the same forgetting the other branch does below,
-      // by the path that already existed for it.
-      if (dead) ptyManager.killPty(id)
+      // Claimed, for the second kind. Not `killPty`: that announces an exit for
+      // a session which is coming straight back, offers to delete the worktree
+      // this is about to resume into, and removes the history directory
+      // `startHistory` resets moments later.
+      if (dead) ptyManager.releaseForResume(id)
 
       if (previous.agentType === 'shell') {
         // The remembered directory only if it is still a directory. It was

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -12,7 +12,15 @@ import { detectIDEs, openInIDE } from './ide-detector'
 import { detectMobileProject } from './mobile-detector'
 import { detectInstalledAgents, clearAgentDetectionCache } from './agent-detector'
 import { clientRegistry } from './broadcast'
-import { restoredRecords } from './restored-sessions'
+import {
+  restoredRecords,
+  listRestored,
+  consumeRestored,
+  consumeAllRestored
+} from './restored-sessions'
+import { clearScreen } from './terminal-screen'
+import { discardHistory } from './history/writer'
+import { buildRestorePayload } from '@vornrun/shared/session-restore'
 import { readScrollback } from './terminal-scrollback'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
@@ -318,7 +326,19 @@ export function registerAllMethods(): void {
   registerMethod('terminal:create', (payload) => {
     return ptyManager.createPty(payload)
   })
-  registerMethod('terminal:kill', (id) => ptyManager.killPty(id))
+  registerMethod('terminal:kill', (id) => {
+    // A pane showing a session from the last run has no PTY to kill. Closing it
+    // is a decision about the record and the files, and it is the same decision
+    // resume makes -- so it goes through the same door, and a second client
+    // closing the same pane finds nothing rather than an error.
+    const restored = consumeRestored(id)
+    if (restored) {
+      clearScreen(id)
+      void discardHistory(id)
+      return
+    }
+    ptyManager.killPty(id)
+  })
   registerMethod('terminal:listActive', () => ptyManager.getActiveSessions())
   registerMethod('terminal:rename', ({ id, displayName }) => {
     ptyManager.renameSession(id, displayName)
@@ -588,7 +608,66 @@ export function registerAllMethods(): void {
 
   // Sessions
   registerMethod('sessions:getPrevious', () => sessionManager.getPreviousSessions())
-  registerMethod('sessions:clear', () => sessionManager.clear())
+  registerMethod('sessions:clear', () => {
+    // The offer is being declined for all of them at once. Same rule as closing
+    // one: the record goes and so does what was written for it.
+    for (const one of consumeAllRestored()) {
+      clearScreen(one.session.id)
+      void discardHistory(one.session.id)
+    }
+    sessionManager.clear()
+  })
+
+  registerMethod('sessions:restored', () => listRestored())
+
+  registerMethod('sessions:resume', ({ id, resumeSessionId }) => {
+    // Claimed before anything is started, and that ordering is the point. Two
+    // clients can be looking at the same cold pane; the second must be told it
+    // is gone rather than launching a second agent against one transcript.
+    const restored = consumeRestored(id)
+    if (!restored) return { ok: false as const, reason: 'gone' as const }
+
+    const previous = restored.session
+    try {
+      // The screen and the files described a session that is now being replaced
+      // by a live one. Cleared before the spawn, so the new session opens its own
+      // history rather than appending to a record of the old one.
+      clearScreen(id)
+      void discardHistory(id)
+
+      if (previous.agentType === 'shell') {
+        const cwd = previous.shellCwd ?? previous.worktreePath ?? previous.projectPath
+        const session = ptyManager.createShellPty(cwd)
+        // Carried across on the server rather than grafted on by whichever
+        // client asked. `createShellPty` names a session after its directory, so
+        // without this a restored shell loses the project it belonged to -- which
+        // it does today, for exactly this reason.
+        Object.assign(session, {
+          projectName: previous.projectName,
+          projectPath: previous.projectPath,
+          ...(previous.worktreePath !== undefined && { worktreePath: previous.worktreePath }),
+          ...(previous.worktreeName !== undefined && { worktreeName: previous.worktreeName }),
+          ...(previous.branch !== undefined && { branch: previous.branch }),
+          ...(previous.isWorktree !== undefined && { isWorktree: previous.isWorktree }),
+          ...(previous.displayName !== undefined && { displayName: previous.displayName })
+        })
+        clientRegistry.broadcast(IPC.SESSION_CREATED, session)
+        sessionManager.scheduleSave()
+        return { ok: true as const, session }
+      }
+
+      const session = ptyManager.createPty(buildRestorePayload(previous, resumeSessionId))
+      sessionManager.scheduleSave()
+      return { ok: true as const, session }
+    } catch (err) {
+      log.warn({ err, id }, '[restored] could not resume this session')
+      return {
+        ok: false as const,
+        reason: 'failed' as const,
+        message: err instanceof Error ? err.message : String(err)
+      }
+    }
+  })
   registerMethod('sessions:getRecent', (projectPath) => getRecentSessions(projectPath))
 
   // Resolve remote host by ID

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -12,6 +12,7 @@ import { detectIDEs, openInIDE } from './ide-detector'
 import { detectMobileProject } from './mobile-detector'
 import { detectInstalledAgents, clearAgentDetectionCache } from './agent-detector'
 import { clientRegistry } from './broadcast'
+import { restoredRecords } from './restored-sessions'
 import { readScrollback } from './terminal-scrollback'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
@@ -1530,7 +1531,14 @@ export function registerAllMethods(): void {
   // session-exit, SessionStart hook), this reduces reliance on the shutdown
   // path (which has a race with bridge.close and doesn't cover
   // force-quit / crash).
-  sessionManager.startAutoSave(() => ptyManager.getActiveSessions())
+  //
+  // Live sessions *and* the ones a previous run left unclaimed. A save is a
+  // whole-table replace, so persisting only the live set is what erased every
+  // record from the last run the moment a single pane was opened -- and with the
+  // record gone, the next start judged that session's history unreachable and
+  // deleted it. Holding them here is what makes a terminal survive more than one
+  // restart.
+  sessionManager.startAutoSave(() => [...ptyManager.getActiveSessions(), ...restoredRecords()])
 
   // ─── Hook server integration ──────────────────────────────────
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import crypto from 'node:crypto'
 import { registerMethod, registerNotification } from './ws-handler'
 import { ptyManager } from './pty-manager'
@@ -16,7 +17,8 @@ import {
   restoredRecords,
   listRestored,
   consumeRestored,
-  consumeAllRestored
+  consumeAllRestored,
+  restoreHeld
 } from './restored-sessions'
 import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
@@ -345,8 +347,16 @@ export function registerAllMethods(): void {
     // resume makes -- so it goes through the same door, and a second client
     // closing the same pane finds nothing rather than an error.
     if (consumeRestored(id)) {
-      // Nothing follows, so the caller does not wait on the files going.
-      void forgetRestored(id)
+      // Nothing follows, so the caller does not wait on the files going --
+      // but a rejection here still has to land somewhere.
+      void forgetRestored(id).catch((err) => {
+        log.warn({ err, id }, '[restored] could not forget a session that was closed')
+      })
+      // The row is only removed by a save, and saves are event-driven. Without
+      // this, closing a restored pane and quitting leaves the record behind --
+      // and the next start offers a session whose files have gone, as an empty
+      // pane the person already closed.
+      sessionManager.scheduleSave()
       return
     }
     ptyManager.killPty(id)
@@ -622,7 +632,11 @@ export function registerAllMethods(): void {
   registerMethod('sessions:clear', () => {
     // The offer is being declined for all of them at once. Same rule as closing
     // one: the record goes and so does what was written for it.
-    for (const one of consumeAllRestored()) void forgetRestored(one.session.id)
+    for (const one of consumeAllRestored()) {
+      void forgetRestored(one.session.id).catch((err) => {
+        log.warn({ err, id: one.session.id }, '[restored] could not forget a declined session')
+      })
+    }
     sessionManager.clear()
   })
 
@@ -632,20 +646,40 @@ export function registerAllMethods(): void {
     // Claimed before anything is started, and that ordering is the point. Two
     // clients can be looking at the same cold pane; the second must be told it
     // is gone rather than launching a second agent against one transcript.
+    // Two kinds of ended session, and only one of them is held here.
+    //
+    // A session carried over from a previous run is in `held`. One that exited
+    // during *this* run is not: its record outlives its process in the pty
+    // manager, which is what `hasLivePty` exists to tell apart. That second kind
+    // is the common one -- an agent finishing its turn -- and it was answered
+    // `gone`, which the pane reported as "resumed somewhere else" before
+    // deleting itself and its scrollback.
     const restored = consumeRestored(id)
-    if (!restored) return { ok: false as const, reason: 'gone' as const }
+    const dead = restored
+      ? undefined
+      : ptyManager.getActiveSessions().find((s) => s.id === id && !ptyManager.hasLivePty(id))
+    const previous = restored?.session ?? dead
+    if (!previous) return { ok: false as const, reason: 'gone' as const }
 
-    const previous = restored.session
     try {
-      // The screen and the files described a session that is now being replaced
-      // by a live one. Awaited rather than started, so "cleared before the
-      // spawn" is a fact rather than a hope: the reply carries a live session,
-      // and a caller that acts on it immediately must not find the old one's
-      // files still there.
-      await forgetRestored(id)
+      // Claimed, for the second kind. `killPty` is what removes a record whose
+      // process has already gone, and it takes the screen model and the history
+      // with it -- so this is the same forgetting the other branch does below,
+      // by the path that already existed for it.
+      if (dead) ptyManager.killPty(id)
 
       if (previous.agentType === 'shell') {
-        const cwd = previous.shellCwd ?? previous.worktreePath ?? previous.projectPath
+        // The remembered directory only if it is still a directory. It was
+        // reported by the shell over the tty, so anything that could write to
+        // that pane could have written it -- and a resume is the one moment it
+        // turns into where a process starts. A stale or fabricated path falls
+        // back to the project rather than being spawned into.
+        const remembered = previous.shellCwd
+        const usable =
+          remembered !== undefined &&
+          fs.existsSync(remembered) &&
+          fs.statSync(remembered).isDirectory()
+        const cwd = usable ? remembered : (previous.worktreePath ?? previous.projectPath)
         const session = ptyManager.createShellPty(cwd)
         // Carried across on the server rather than grafted on by whichever
         // client asked. `createShellPty` names a session after its directory, so
@@ -661,15 +695,24 @@ export function registerAllMethods(): void {
           ...(previous.displayName !== undefined && { displayName: previous.displayName })
         })
         clientRegistry.broadcast(IPC.SESSION_CREATED, session)
+        // Only once something is running. Discarding first and spawning second
+        // meant a spawn that threw -- a project directory renamed, a worktree
+        // pruned, a volume unmounted -- left the record consumed, the history
+        // deleted and nothing to try again from.
+        if (restored) await forgetRestored(id)
         sessionManager.scheduleSave()
         return { ok: true as const, session }
       }
 
       const session = ptyManager.createPty(buildRestorePayload(previous, resumeSessionId))
+      if (restored) await forgetRestored(id)
       sessionManager.scheduleSave()
       return { ok: true as const, session }
     } catch (err) {
       log.warn({ err, id }, '[restored] could not resume this session')
+      // Put it back. A claim is destructive on purpose, but a claim whose spawn
+      // failed must not be the end of the session.
+      if (restored) restoreHeld(restored)
       return {
         ok: false as const,
         reason: 'failed' as const,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -23,7 +23,7 @@ import {
 import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
-import { readScrollback } from './terminal-scrollback'
+import { clearScrollback, readScrollback } from './terminal-scrollback'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
 import { hookStatusMapper } from './hook-status-mapper'
@@ -318,6 +318,28 @@ export function setServerPort(port: number): void {
   serverPort = port
 }
 
+/**
+ * Let go of everything held for a session from a previous run.
+ *
+ * Called when one is claimed, closed or dismissed -- the three ways a carried
+ * over record stops being offered. All three end the same way, so they end in
+ * one place.
+ *
+ * At module scope rather than inside `registerAllMethods` because it captures
+ * nothing from it, and out here it can be tested without standing up a socket.
+ */
+export async function forgetRestored(id: string): Promise<void> {
+  clearScreen(id)
+  // Recovery seeds a restored session's scrollback so a pane can be shown one
+  // (`history/recovery.ts`). Nothing else ever frees it: this session has no PTY,
+  // so it never reaches the `clearScrollback` on the kill path, and letting the
+  // record go is the last thing that happens to it. Without this the bytes stay
+  // held for the life of the server -- the same reasoning that put `clearScreen`
+  // here.
+  clearScrollback(id)
+  await discardHistory(id)
+}
+
 export function registerAllMethods(): void {
   // Wire headless worktree counter into pty-manager for cleanup gating
   ptyManager.setHeadlessWorktreeCounter((worktreePath, excludeId) =>
@@ -336,10 +358,6 @@ export function registerAllMethods(): void {
    * its own history rather than appending to a record of the one it replaced,
    * and a declined one is not coming back.
    */
-  const forgetRestored = async (id: string): Promise<void> => {
-    clearScreen(id)
-    await discardHistory(id)
-  }
 
   registerMethod('terminal:kill', (id) => {
     // A pane showing a session from the last run has no PTY to kill. Closing it

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1681,6 +1681,13 @@ export function registerAllMethods(): void {
   })
 
   // Clean up Copilot hooks on session exit
+  // A shell moved. Saved on a debounce, so a script running `cd` in a loop costs
+  // one write rather than hundreds -- and what is being kept is where the shell
+  // ended up, not every step it took to get there.
+  ptyManager.on('session-cwd', () => {
+    sessionManager.scheduleSave()
+  })
+
   ptyManager.on('session-exit', (session) => {
     const inst = copilotInstallations.get(session.id)
     if (inst) {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -326,15 +326,27 @@ export function registerAllMethods(): void {
   registerMethod('terminal:create', (payload) => {
     return ptyManager.createPty(payload)
   })
+  /**
+   * Let go of what was kept for a session from the last run.
+   *
+   * The screen the server rebuilt and the files it rebuilt it from. Both go
+   * together, whether the record was claimed or declined -- a live session opens
+   * its own history rather than appending to a record of the one it replaced,
+   * and a declined one is not coming back.
+   */
+  const forgetRestored = async (id: string): Promise<void> => {
+    clearScreen(id)
+    await discardHistory(id)
+  }
+
   registerMethod('terminal:kill', (id) => {
     // A pane showing a session from the last run has no PTY to kill. Closing it
     // is a decision about the record and the files, and it is the same decision
     // resume makes -- so it goes through the same door, and a second client
     // closing the same pane finds nothing rather than an error.
-    const restored = consumeRestored(id)
-    if (restored) {
-      clearScreen(id)
-      void discardHistory(id)
+    if (consumeRestored(id)) {
+      // Nothing follows, so the caller does not wait on the files going.
+      void forgetRestored(id)
       return
     }
     ptyManager.killPty(id)
@@ -607,20 +619,16 @@ export function registerAllMethods(): void {
   })
 
   // Sessions
-  registerMethod('sessions:getPrevious', () => sessionManager.getPreviousSessions())
   registerMethod('sessions:clear', () => {
     // The offer is being declined for all of them at once. Same rule as closing
     // one: the record goes and so does what was written for it.
-    for (const one of consumeAllRestored()) {
-      clearScreen(one.session.id)
-      void discardHistory(one.session.id)
-    }
+    for (const one of consumeAllRestored()) void forgetRestored(one.session.id)
     sessionManager.clear()
   })
 
   registerMethod('sessions:restored', () => listRestored())
 
-  registerMethod('sessions:resume', ({ id, resumeSessionId }) => {
+  registerMethod('sessions:resume', async ({ id, resumeSessionId }) => {
     // Claimed before anything is started, and that ordering is the point. Two
     // clients can be looking at the same cold pane; the second must be told it
     // is gone rather than launching a second agent against one transcript.
@@ -630,10 +638,11 @@ export function registerAllMethods(): void {
     const previous = restored.session
     try {
       // The screen and the files described a session that is now being replaced
-      // by a live one. Cleared before the spawn, so the new session opens its own
-      // history rather than appending to a record of the old one.
-      clearScreen(id)
-      void discardHistory(id)
+      // by a live one. Awaited rather than started, so "cleared before the
+      // spawn" is a fact rather than a hope: the reply carries a live session,
+      // and a caller that acts on it immediately must not find the old one's
+      // files still there.
+      await forgetRestored(id)
 
       if (previous.agentType === 'shell') {
         const cwd = previous.shellCwd ?? previous.worktreePath ?? previous.projectPath
@@ -1680,7 +1689,6 @@ export function registerAllMethods(): void {
     broadcastWidgetUpdate()
   })
 
-  // Clean up Copilot hooks on session exit
   // A shell moved. Saved on a debounce, so a script running `cd` in a loop costs
   // one write rather than hundreds -- and what is being kept is where the shell
   // ended up, not every step it took to get there.
@@ -1688,6 +1696,7 @@ export function registerAllMethods(): void {
     sessionManager.scheduleSave()
   })
 
+  // Clean up Copilot hooks on session exit
   ptyManager.on('session-exit', (session) => {
     const inst = copilotInstallations.get(session.id)
     if (inst) {

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -1,0 +1,174 @@
+import type { TerminalSession } from '@vornrun/shared/types'
+import log from './logger'
+
+/**
+ * The sessions a previous run left behind that no pane has claimed yet.
+ *
+ * ## The bug this exists to close
+ *
+ * `saveSessions` is a whole-table replace fed by `ptyManager.getActiveSessions()`,
+ * and after a restart that map is empty. So opening a single pane replaced the
+ * entire `sessions` table with that one row, and every record from the previous
+ * run was gone half a second later. On the *next* start `recoverHistory` then
+ * found history for ids the database no longer knew, judged it unreachable --
+ * correctly, by its own rule -- and deleted it.
+ *
+ * Terminal history therefore survived exactly one restart, which is one fewer
+ * than the whole point of writing it down.
+ *
+ * ## Why hold records rather than soften the sweep
+ *
+ * The sweep's rule is sound and worth keeping intact: history is keyed by
+ * session id, `getPreviousSessions` is the only way a pane can ever name one, so
+ * an id the database does not know is unreachable. A grace period would stop the
+ * deletion without restoring the reachability -- the files would sit there with
+ * nothing able to ask for them, which is a leak wearing a fix's clothes.
+ *
+ * Holding the records keeps one deletion point and one rule. What ages out here
+ * is simply absent from the list handed to recovery, so the sweep removes its
+ * history in the same boot, for the same reason as everything else.
+ *
+ * ## What this deliberately does not do
+ *
+ * It does not seed `ptyManager`. `getActiveSessions()` feeds `terminal:listActive`,
+ * which feeds MCP's `list_sessions` and the web client's hydration; a dead
+ * session reported there would be a session an agent believes it can write to.
+ * And it does not touch `livePtyCount()`, which is what decides whether an idle
+ * server may leave -- holding records must never be the reason a machine stays
+ * awake.
+ */
+
+export interface RestoredSession {
+  session: TerminalSession
+  /**
+   * Roughly when it ended: the last save the previous process managed. It is the
+   * only thing on disk that says so, and the pane wants to tell somebody.
+   */
+  endedAt: number
+  /** Whether the server rebuilt a screen for it, so there is something to show. */
+  replayable: boolean
+  /** The log stopped short of its end, so the screen does too. */
+  partial: boolean
+}
+
+/**
+ * How long an unclaimed record is kept.
+ *
+ * Long enough that a machine left off over a long weekend still comes back to
+ * its terminals, short enough that a session abandoned a month ago is not still
+ * holding a pane's worth of disk. Measured from `saved_at`, which is the last
+ * time the previous run wrote the record down.
+ */
+export const MAX_RESTORED_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+const held = new Map<string, RestoredSession>()
+
+/**
+ * Whether the previous run's records have been read yet.
+ *
+ * `seedRestored` has to run before `registerAllMethods()`, which is what wires
+ * the auto-save -- and a save is a whole-table replace, so one firing before the
+ * seed would erase the very rows the seed is about to read. That ordering has no
+ * test: reaching it needs a session created in the window between the two, which
+ * only a workflow launched by the inbox worker can do.
+ *
+ * So it is checked instead. A save that arrives before the seed is the bug,
+ * announced once rather than silently taking a terminal's history with it.
+ */
+let seeded = false
+let warnedUnseeded = false
+
+/**
+ * Take the previous run's records, and answer with the ones worth keeping.
+ *
+ * The return value is what `recoverHistory` should be given: anything dropped
+ * here is absent from that list, so its history goes in the same sweep that
+ * removes every other unreachable tree.
+ *
+ * `null` in means `null` out. `readPreviousSessions` answers null when the
+ * database could not be read, and the difference between "there are none" and
+ * "I could not tell" is the difference between removing nothing and removing
+ * every terminal's history on one transient error.
+ */
+export function seedRestored(
+  previous: TerminalSession[] | null,
+  now: number = Date.now()
+): TerminalSession[] | null {
+  held.clear()
+  seeded = true
+  if (previous === null) return null
+
+  const keep: TerminalSession[] = []
+  let aged = 0
+  for (const session of previous) {
+    const endedAt = session.savedAt ?? session.createdAt ?? now
+    if (now - endedAt > MAX_RESTORED_AGE_MS) {
+      aged += 1
+      continue
+    }
+    held.set(session.id, { session, endedAt, replayable: false, partial: false })
+    keep.push(session)
+  }
+
+  if (held.size || aged) {
+    log.info({ holding: held.size, aged }, '[restored] sessions carried over from the last run')
+  }
+  return keep
+}
+
+/** Note which of them the server actually rebuilt a screen for. */
+export function markRecovered(recovered: Array<{ id: string; stopped: string }>): void {
+  for (const one of recovered) {
+    const entry = held.get(one.id)
+    if (!entry) continue
+    entry.replayable = true
+    entry.partial = one.stopped !== 'end'
+  }
+}
+
+/** What a client is offered. */
+export function listRestored(): RestoredSession[] {
+  return [...held.values()]
+}
+
+/**
+ * The records to persist beside the live ones.
+ *
+ * Without this the next save erases them, which is the whole bug.
+ */
+export function restoredRecords(): TerminalSession[] {
+  if (!seeded && !warnedUnseeded) {
+    warnedUnseeded = true
+    log.warn(
+      '[restored] a session save ran before the last run was read; its records are being replaced'
+    )
+  }
+  return [...held.values()].map((entry) => entry.session)
+}
+
+/**
+ * Claim one, exactly once.
+ *
+ * Atomic because two clients can be looking at the same cold pane: the second
+ * one to press resume must be told it is gone rather than starting a second
+ * agent against one transcript.
+ */
+export function consumeRestored(id: string): RestoredSession | null {
+  const entry = held.get(id)
+  if (!entry) return null
+  held.delete(id)
+  return entry
+}
+
+export function consumeAllRestored(): RestoredSession[] {
+  const all = [...held.values()]
+  held.clear()
+  return all
+}
+
+/** Test-only, mirroring the other module-level stores in this package. */
+export function resetRestored(): void {
+  held.clear()
+  seeded = false
+  warnedUnseeded = false
+}

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -79,7 +79,13 @@ export function seedRestored(
       aged += 1
       continue
     }
-    held.set(session.id, { session, endedAt, replayable: false, partial: false })
+    held.set(session.id, {
+      session,
+      endedAt,
+      replayable: false,
+      partial: false,
+      closedCleanly: false
+    })
     keep.push(session)
   }
 
@@ -90,12 +96,15 @@ export function seedRestored(
 }
 
 /** Note which of them the server actually rebuilt a screen for. */
-export function markRecovered(recovered: Array<{ id: string; stopped: string }>): void {
+export function markRecovered(
+  recovered: Array<{ id: string; stopped: string; closedCleanly: boolean }>
+): void {
   for (const one of recovered) {
     const entry = held.get(one.id)
     if (!entry) continue
     entry.replayable = true
     entry.partial = one.stopped !== 'end'
+    entry.closedCleanly = one.closedCleanly
   }
 }
 

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -127,6 +127,19 @@ export function consumeRestored(id: string): RestoredSession | null {
   return entry
 }
 
+/**
+ * Put one back, because the thing it was claimed for did not happen.
+ *
+ * Claiming is destructive on purpose -- it is what stops two clients starting
+ * two agents against one transcript. But a claim that then fails to spawn would
+ * otherwise leave the session in neither place: gone from here, never in the pty
+ * manager, and erased from the database by the next save. There would be nothing
+ * left to try again from.
+ */
+export function restoreHeld(entry: RestoredSession): void {
+  held.set(entry.session.id, entry)
+}
+
 export function consumeAllRestored(): RestoredSession[] {
   const all = [...held.values()]
   held.clear()

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -53,21 +53,6 @@ export const MAX_RESTORED_AGE_MS = 7 * 24 * 60 * 60 * 1000
 const held = new Map<string, RestoredSession>()
 
 /**
- * Whether the previous run's records have been read yet.
- *
- * `seedRestored` has to run before `registerAllMethods()`, which is what wires
- * the auto-save -- and a save is a whole-table replace, so one firing before the
- * seed would erase the very rows the seed is about to read. That ordering has no
- * test: reaching it needs a session created in the window between the two, which
- * only a workflow launched by the inbox worker can do.
- *
- * So it is checked instead. A save that arrives before the seed is the bug,
- * announced once rather than silently taking a terminal's history with it.
- */
-let seeded = false
-let warnedUnseeded = false
-
-/**
  * Take the previous run's records, and answer with the ones worth keeping.
  *
  * The return value is what `recoverHistory` should be given: anything dropped
@@ -84,7 +69,6 @@ export function seedRestored(
   now: number = Date.now()
 ): TerminalSession[] | null {
   held.clear()
-  seeded = true
   if (previous === null) return null
 
   const keep: TerminalSession[] = []
@@ -126,12 +110,6 @@ export function listRestored(): RestoredSession[] {
  * Without this the next save erases them, which is the whole bug.
  */
 export function restoredRecords(): TerminalSession[] {
-  if (!seeded && !warnedUnseeded) {
-    warnedUnseeded = true
-    log.warn(
-      '[restored] a session save ran before the last run was read; its records are being replaced'
-    )
-  }
   return [...held.values()].map((entry) => entry.session)
 }
 
@@ -158,6 +136,4 @@ export function consumeAllRestored(): RestoredSession[] {
 /** Test-only, mirroring the other module-level stores in this package. */
 export function resetRestored(): void {
   held.clear()
-  seeded = false
-  warnedUnseeded = false
 }

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -1,4 +1,4 @@
-import type { TerminalSession } from '@vornrun/shared/types'
+import type { RestoredSession, TerminalSession } from '@vornrun/shared/types'
 import log from './logger'
 
 /**
@@ -38,18 +38,7 @@ import log from './logger'
  * awake.
  */
 
-export interface RestoredSession {
-  session: TerminalSession
-  /**
-   * Roughly when it ended: the last save the previous process managed. It is the
-   * only thing on disk that says so, and the pane wants to tell somebody.
-   */
-  endedAt: number
-  /** Whether the server rebuilt a screen for it, so there is something to show. */
-  replayable: boolean
-  /** The log stopped short of its end, so the screen does too. */
-  partial: boolean
-}
+export type { RestoredSession }
 
 /**
  * How long an unclaimed record is kept.

--- a/packages/server/src/session-persistence.ts
+++ b/packages/server/src/session-persistence.ts
@@ -55,18 +55,17 @@ class SessionManager {
     }
   }
 
-  getPreviousSessions(): TerminalSession[] {
-    return this.readPreviousSessions() ?? []
-  }
-
   /**
-   * The same list, with "there are none" told apart from "could not read them".
+   * What the last run left, with "there are none" told apart from "could not
+   * read them".
    *
-   * `getPreviousSessions` answers `[]` for both, which is right for its callers:
-   * a client asking what was open gets an empty list either way and nothing is
-   * lost. It is wrong for a caller that acts on absence. Terminal history is
-   * keyed by session id and swept when no session claims it, so one transient
-   * database error read as "no sessions" is every terminal's history removed.
+   * That distinction is the whole point of the null. Terminal history is keyed
+   * by session id and swept when no session claims it, so one transient database
+   * error read as "there are no sessions" is every terminal's history removed.
+   *
+   * There was a second reader that flattened null to `[]`, for an RPC no client
+   * called after the app stopped asking the database what was open and started
+   * asking the server what exists. Both are gone.
    */
   readPreviousSessions(): TerminalSession[] | null {
     try {

--- a/packages/server/src/session-persistence.ts
+++ b/packages/server/src/session-persistence.ts
@@ -56,13 +56,26 @@ class SessionManager {
   }
 
   getPreviousSessions(): TerminalSession[] {
+    return this.readPreviousSessions() ?? []
+  }
+
+  /**
+   * The same list, with "there are none" told apart from "could not read them".
+   *
+   * `getPreviousSessions` answers `[]` for both, which is right for its callers:
+   * a client asking what was open gets an empty list either way and nothing is
+   * lost. It is wrong for a caller that acts on absence. Terminal history is
+   * keyed by session id and swept when no session claims it, so one transient
+   * database error read as "no sessions" is every terminal's history removed.
+   */
+  readPreviousSessions(): TerminalSession[] | null {
     try {
       const sessions = dbGetPreviousSessions()
       log.info(`[session-persistence] loaded ${sessions.length} previous session(s)`)
       return sessions
     } catch (err) {
       log.warn({ err }, '[session-persistence] getPreviousSessions failed:')
-      return []
+      return null
     }
   }
 

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -1,0 +1,198 @@
+import headless from '@xterm/headless'
+import serializeAddon from '@xterm/addon-serialize'
+import log from './logger'
+
+/**
+ * Default-imported and destructured, not `import { Terminal } from ...`.
+ *
+ * Both packages are plain CommonJS -- no `exports` map, no `module` field -- and
+ * they build their exports in a way Node's named-export detection cannot see.
+ * Under the bundler the named form works; under `tsx`, which is how the server
+ * runs in development and in several tests, it fails at import time with
+ * "does not provide an export named 'Terminal'". That is a server which will not
+ * start, so the shape that works in both is the one to use.
+ */
+const { Terminal } = headless
+const { SerializeAddon } = serializeAddon
+type Terminal = InstanceType<typeof Terminal>
+type SerializeAddon = InstanceType<typeof SerializeAddon>
+
+/**
+ * What the terminal currently looks like, as a screen rather than as bytes.
+ *
+ * `terminal-scrollback` keeps the bytes a terminal emitted, which is what a
+ * client needs in order to draw. This keeps what those bytes *mean*: where the
+ * cursor is, which modes are set, whether the alternate screen is active, what
+ * colour each cell is. Neither can be derived from the other, so both are kept —
+ * a checkpoint of a byte buffer is just a smaller byte buffer, while a
+ * checkpoint of a screen is a state something can be restored to.
+ *
+ * Nothing consumes this yet. `terminal:readScrollback` has no caller outside the
+ * server either; both are groundwork for attaching to a live session rather than
+ * relaunching it, and for sending each client what changed on screen instead of
+ * every byte.
+ *
+ * ## This emulator must never answer a query
+ *
+ * A terminal that is asked who it is answers. Feed one `\x1b[c` and it produces
+ * `\x1b[?62;...c`; the same is true of cursor-position reports, mode queries and
+ * half a dozen others. That is correct behaviour for the terminal a person is
+ * looking at, and this is not that terminal.
+ *
+ * The client's xterm is already the thing that answers — its `onData` is wired
+ * to `terminal:write`, which writes to the PTY. A second emulator answering the
+ * same query would interleave a second reply into the PTY's *input* stream, and
+ * the shell would take it as literal keystrokes: a stray `[?62;1;2c` typed at
+ * the prompt that nobody typed.
+ *
+ * Every reply xterm produces goes through one place — `CoreService.triggerDataEvent`,
+ * whose whole tail is `this._onData.fire(data)`. With no subscriber that is a
+ * no-op. So the protection here is an absence rather than a flag: **nothing in
+ * this file subscribes to `onData` or `onBinary`, and nothing may.** A flag
+ * defaulting to off would be worse, because it would look like a thing that
+ * could be turned on.
+ *
+ * Verified rather than assumed: feeding `\x1b[c` to a 5.5.0 headless terminal
+ * with a listener attached does fire it. The hazard is real; the absence is what
+ * closes it.
+ */
+
+/**
+ * No scrollback at all.
+ *
+ * The client runs 2000 lines, and matching that would cost roughly five megabytes
+ * per session at a realistic 200x50 — a quarter of a gigabyte across fifty of
+ * them, to duplicate history that is already held twice: once as bytes in
+ * `terminal-scrollback`, once as stripped lines in `pty-manager`. This models
+ * the *screen*, which is the thing neither of those can answer for.
+ *
+ * It also makes a resize cheap. Shrinking reflows and discards what falls off
+ * the top, so a phone briefly fitting a session to sixty columns would otherwise
+ * permanently truncate what the desktop had.
+ */
+const SCROLLBACK = 0
+
+/**
+ * Mirrors the client's terminal, and the mirroring is the point.
+ *
+ * `allowProposedApi` matches `terminal-registry.ts` because the serialize addon
+ * needs it. Nothing about colours or fonts is copied: a headless terminal has no
+ * renderer, and a theme would only be a second copy of a value to drift.
+ *
+ * The one difference is scrollback, above, and it is deliberate. Any *other*
+ * divergence — a different core version, a width-table addon the client does not
+ * load — moves where a line wraps, and a screen that wraps differently is not
+ * the screen the user is looking at. That is why the version here is pinned to
+ * the client's 5.5, and why `@xterm/addon-unicode11` is deliberately absent: the
+ * client uses xterm's built-in v6 width tables, and a server on v11 would wrap
+ * an emoji at a different column.
+ */
+function create(cols: number, rows: number): Held {
+  const term = new Terminal({ cols, rows, scrollback: SCROLLBACK, allowProposedApi: true })
+  const serializer = new SerializeAddon()
+  term.loadAddon(serializer)
+  return { term, serializer, pending: Promise.resolve() }
+}
+
+interface Held {
+  term: Terminal
+  serializer: SerializeAddon
+  /** The last write, so a read can wait for it. See `serializeScreen`. */
+  pending: Promise<void>
+}
+
+const screens = new Map<string, Held>()
+
+/** What a PTY starts at, when a session has not said otherwise. */
+const FALLBACK_COLS = 80
+const FALLBACK_ROWS = 24
+
+/**
+ * Feed output to the screen model.
+ *
+ * Never throws. This sits on the path that broadcasts live output to every
+ * attached client, and a screen model is worth nothing beside a terminal that
+ * stopped updating — so a terminal that faults is dropped and the session
+ * carries on without one.
+ */
+export function feedScreen(id: string, data: string, cols?: number, rows?: number): void {
+  try {
+    let held = screens.get(id)
+    if (!held) {
+      held = create(cols ?? FALLBACK_COLS, rows ?? FALLBACK_ROWS)
+      screens.set(id, held)
+    }
+    const term = held.term
+    held.pending = new Promise<void>((resolve) => term.write(data, resolve))
+  } catch (err) {
+    log.warn({ err, id }, '[screen] dropping the screen model for this session')
+    clearScreen(id)
+  }
+}
+
+/**
+ * Follow a resize.
+ *
+ * The values must be the ones node-pty was given, because the program is
+ * rendering against those: a model one column wider wraps in a different place,
+ * and every line after the first divergence is wrong.
+ */
+export function resizeScreen(id: string, cols: number, rows: number): void {
+  const held = screens.get(id)
+  if (!held) return
+  try {
+    held.term.resize(cols, rows)
+  } catch (err) {
+    log.warn({ err, id }, '[screen] dropping the screen model for this session')
+    clearScreen(id)
+  }
+}
+
+/**
+ * The screen as escape sequences that reproduce it.
+ *
+ * Async, and that is not a convenience. `term.write` is queued, not applied —
+ * xterm defers the parse to a macrotask — so serializing straight after a write
+ * returns whatever had been parsed by then, which is usually nothing and
+ * occasionally most of it. That failure is invisible in a test that happens to
+ * yield and reappears under load.
+ */
+export async function serializeScreen(id: string): Promise<string> {
+  const held = screens.get(id)
+  if (!held) return ''
+  await held.pending
+  try {
+    return held.serializer.serialize()
+  } catch (err) {
+    log.warn({ err, id }, '[screen] could not serialize')
+    return ''
+  }
+}
+
+/**
+ * Forget a terminal that has gone.
+ *
+ * `dispose()` rather than a map delete: a `Terminal` holds buffers and internal
+ * services, and dropping the reference alone leaves every session ever closed
+ * resident for the life of the server.
+ */
+export function clearScreen(id: string): void {
+  const held = screens.get(id)
+  if (!held) return
+  screens.delete(id)
+  try {
+    held.term.dispose()
+  } catch (err) {
+    log.warn({ err, id }, '[screen] could not dispose a terminal')
+  }
+}
+
+/** How many models are held. For the measurement that bounds this. */
+export function screenCount(): number {
+  return screens.size
+}
+
+/** Test-only, mirroring `resetScrollback`. */
+export function resetScreens(): void {
+  for (const id of [...screens.keys()]) clearScreen(id)
+}

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -117,18 +117,17 @@ function create(cols: number, rows: number): Held {
   // not carry, so they are caught as they go past. Neither is a reply -- these
   // are notifications from the program, and observing one sends nothing back.
   //
-  // Both run from xterm's own timer, not from `feedScreen`, so a throw in either
-  // reaches the top of the process rather than any `try` in this file -- and the
-  // server installs no `uncaughtException` handler. That is the whole server and
-  // every session, killed by a program printing an odd string. So both are
-  // wrapped, and neither may assume anything about what it was handed.
+  // The title is stored and nothing more. A property write cannot throw, and an
+  // earlier version wrapped it anyway, which made a no-op look load-bearing.
   term.onTitleChange((title) => {
-    try {
-      held.title = title
-    } catch {
-      /* nothing a title can do is worth a process */
-    }
+    held.title = title
   })
+  // The cwd handler is the one that can. It runs from xterm's own timer rather
+  // than from `feedScreen`, so a throw here reaches the top of the process past
+  // every `try` in this file -- and the server installs no `uncaughtException`
+  // handler. `decodeURIComponent` throws on a lone percent, which is a path a
+  // shell can genuinely be sitting in, so that would be the whole server and
+  // every session killed by a directory name.
   term.parser.registerOscHandler(7, (payload) => {
     try {
       // `file://host/path`, per the convention every shell integration uses.
@@ -269,13 +268,26 @@ export async function resizeScreen(id: string, cols: number, rows: number): Prom
     // differently from the terminal it models is the failure this exists to
     // avoid, and it would show up as a screen that is subtly wrong rather than
     // one that is obviously broken.
-    await new Promise<void>((resolve) => held.term.write('', resolve))
+    await drain(held)
     held.term.resize(cols, rows)
     held.cols = cols
     held.rows = rows
   } catch (err) {
     drop(id, err)
   }
+}
+
+/**
+ * Wait for everything already written to have been parsed.
+ *
+ * An empty write, queued behind everything in flight, resolving only once the
+ * parser reaches it. That is the whole mechanism: writes are applied in order,
+ * so waiting on the last one waits on all of them. Both callers need it and for
+ * the same reason -- `term.write` returns before anything is parsed, so acting
+ * on the buffer straight after a write acts on whatever happened to be done.
+ */
+function drain(held: Held): Promise<void> {
+  return new Promise<void>((resolve) => held.term.write('', resolve))
 }
 
 /** Give up on a session's model. The session itself carries on without one. */
@@ -317,10 +329,7 @@ export async function serializeScreen(id: string): Promise<ScreenSnapshot | null
   const held = screens.get(id)
   if (!held) return null
   try {
-    // An empty write, queued behind everything already in flight, resolving only
-    // once the parser has reached it. That is the whole drain: writes are applied
-    // in order, so waiting for the last one waits for all of them.
-    await new Promise<void>((resolve) => held.term.write('', resolve))
+    await drain(held)
     return {
       screen: held.serializer.serialize(),
       cols: held.cols,

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -1,6 +1,7 @@
 import * as headless from '@xterm/headless'
 import * as serializeAddon from '@xterm/addon-serialize'
 import log from './logger'
+import { OSC_PRIVATE } from './shell-integration/protocol'
 
 /**
  * Reached through an interop dance rather than by name, and it earns its keep.
@@ -120,7 +121,7 @@ const MAX_LABEL_UNITS = 512
  * client uses xterm's built-in v6 width tables, and a server on v11 would wrap
  * an emoji at a different column.
  */
-function create(cols: number, rows: number): Held {
+function create(id: string, cols: number, rows: number): Held {
   const term = new Terminal({ cols, rows, scrollback: SCROLLBACK, allowProposedApi: true })
   const serializer = new SerializeAddon()
   term.loadAddon(serializer)
@@ -165,12 +166,24 @@ function create(cols: number, rows: number): Held {
   //
   // Same discipline as above, and for the same reason -- this runs from xterm's
   // timer, where a throw reaches the top of a process with no handler behind it.
-  term.parser.registerOscHandler(5522, (payload) => {
+  term.parser.registerOscHandler(OSC_PRIVATE, (payload) => {
     try {
-      const [kind, ...rest] = payload.split(';')
-      if (kind === 'cwd' && rest.length) {
-        const path = rest.join(';')
-        if (path) held.cwd = path.slice(0, MAX_LABEL_UNITS)
+      // The integration also emits `cmd;` and `dur;` on this number, once per
+      // command a shell runs. Matched by prefix so those cost nothing: splitting
+      // first allocated two arrays and a string before discarding them.
+      if (payload.startsWith('cwd;')) {
+        const next = payload.slice(4, 4 + MAX_LABEL_UNITS)
+        if (next && next !== held.cwd) {
+          held.cwd = next
+          // Told, not polled. An earlier version had `pty-manager` read this
+          // after every flush, which cannot work: xterm parses on its own timer,
+          // so at the moment a flush ends this handler has not run for the bytes
+          // that flush just delivered. It read the previous value -- and since
+          // `cd` is usually the last thing in a burst, nothing came along
+          // afterwards to correct it. The record lagged by one flush, which for
+          // a shell somebody then walked away from is for ever.
+          reportCwd?.(id, next)
+        }
       }
     } catch {
       /* an unreadable cwd is not worth anything at all */
@@ -285,7 +298,7 @@ export function createScreen(
 ): void {
   clearScreen(id)
   try {
-    const held = create(cols, rows)
+    const held = create(id, cols, rows)
     // A restored screen is rebuilt from escape sequences, and neither of these
     // is one -- they arrive as notifications the serializer does not round-trip.
     // The checkpoint has been storing both since it was written and recovery
@@ -432,6 +445,20 @@ export function clearScreen(id: string): void {
   }
 }
 
+/**
+ * Told when a terminal says it has moved.
+ *
+ * One reporter for the process, set once at start-up, mirroring the renderer's
+ * own `setCwdReporter`. It is called from inside xterm's parser, so it must not
+ * throw and must not be slow -- `pty-manager`'s does a map lookup and an event.
+ */
+type CwdReporter = (id: string, cwd: string) => void
+let reportCwd: CwdReporter | null = null
+
+export function setCwdReporter(fn: CwdReporter | null): void {
+  reportCwd = fn
+}
+
 /** How many models are held. For the measurement that bounds this. */
 export function screenCount(): number {
   return screens.size
@@ -440,16 +467,4 @@ export function screenCount(): number {
 /** Test-only, mirroring `resetScrollback`. */
 export function resetScreens(): void {
   for (const id of [...screens.keys()]) clearScreen(id)
-}
-
-/**
- * Where this terminal's shell last said it was.
- *
- * Empty until a shell with Vorn's integration reports one. Read by
- * `pty-manager`, which writes it onto the session record so a restored shell can
- * be offered the directory somebody was actually in rather than the one it was
- * launched in.
- */
-export function screenCwd(id: string): string {
-  return screens.get(id)?.cwd ?? ''
 }

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -93,6 +93,19 @@ const SCROLLBACK = 0
 const MAX_QUEUED_UNITS = 4 * 1024 * 1024
 
 /**
+ * How much of a title or a cwd is kept.
+ *
+ * Both are stored for the life of the terminal and both travel in the
+ * checkpoint, and xterm will hand over an OSC payload of up to ten million
+ * characters. One `\x1b]0;` followed by five megabytes -- which an agent
+ * printing the contents of a file it was asked to read can produce without
+ * anybody intending it -- would put every checkpoint for that session over its
+ * size cap, permanently, for as long as the terminal lives. Nothing that is
+ * genuinely a title or a path comes near this.
+ */
+const MAX_LABEL_UNITS = 512
+
+/**
  * Mirrors the client's terminal, and the mirroring is the point.
  *
  * `allowProposedApi` matches `terminal-registry.ts` because the serialize addon
@@ -120,7 +133,7 @@ function create(cols: number, rows: number): Held {
   // The title is stored and nothing more. A property write cannot throw, and an
   // earlier version wrapped it anyway, which made a no-op look load-bearing.
   term.onTitleChange((title) => {
-    held.title = title
+    held.title = title.slice(0, MAX_LABEL_UNITS)
   })
   // The cwd handler is the one that can. It runs from xterm's own timer rather
   // than from `feedScreen`, so a throw here reaches the top of the process past
@@ -134,7 +147,7 @@ function create(cols: number, rows: number): Held {
       const raw = payload.replace(/^file:\/\/[^/]*/, '')
       // `decodeURIComponent` throws on a stray `%` -- and a directory named
       // `100%` is a directory somebody has. Left encoded rather than lost.
-      if (raw) held.cwd = tryDecode(raw)
+      if (raw) held.cwd = tryDecode(raw).slice(0, MAX_LABEL_UNITS)
     } catch {
       /* an unreadable cwd is not worth anything at all */
     }
@@ -261,33 +274,56 @@ export async function resizeScreen(id: string, cols: number, rows: number): Prom
   const held = screens.get(id)
   if (!held) return
   try {
-    // Drained first, and that ordering is the whole point. Writes are queued, so
+    // At the drain, and that ordering is the whole point. Writes are queued, so
     // resizing straight away reflows bytes that arrived *before* the resize at
     // the size that came *after* it -- and the client, which parsed those bytes
     // before it refitted, wraps them somewhere else. A model that wraps
     // differently from the terminal it models is the failure this exists to
     // avoid, and it would show up as a screen that is subtly wrong rather than
     // one that is obviously broken.
-    await drain(held)
-    held.term.resize(cols, rows)
-    held.cols = cols
-    held.rows = rows
+    //
+    // At the marker rather than after it, for the reason `atDrain` gives: bytes
+    // parsed while the loop unwinds would be laid out at the old width by a
+    // program that had already been told the new one.
+    await atDrain(held, () => {
+      held.term.resize(cols, rows)
+      held.cols = cols
+      held.rows = rows
+    })
   } catch (err) {
     drop(id, err)
   }
 }
 
 /**
- * Wait for everything already written to have been parsed.
+ * Read the buffer at the point everything written so far has been parsed, and
+ * nothing written later has.
  *
- * An empty write, queued behind everything in flight, resolving only once the
- * parser reaches it. That is the whole mechanism: writes are applied in order,
- * so waiting on the last one waits on all of them. Both callers need it and for
- * the same reason -- `term.write` returns before anything is parsed, so acting
- * on the buffer straight after a write acts on whatever happened to be done.
+ * The callback of an empty write is the only such point, and it has to be *used*
+ * rather than merely awaited. xterm invokes it from inside its own parse loop
+ * and then carries on consuming the rest of the queue for up to twelve
+ * milliseconds before returning -- so a `then` or an `await` on it runs as a
+ * microtask, which cannot execute until that loop unwinds, by which time later
+ * writes have been parsed too.
+ *
+ * That is not theoretical. A checkpoint asks for the screen, the flush timer
+ * fires before the parser reaches the marker, and the snapshot comes back
+ * holding output whose frames were also written to the log after it -- so a
+ * restore applies those bytes twice. It reproduces on the first attempt.
+ *
+ * `read` therefore runs at the marker, synchronously, and its answer is what
+ * resolves.
  */
-function drain(held: Held): Promise<void> {
-  return new Promise<void>((resolve) => held.term.write('', resolve))
+function atDrain<T>(held: Held, read: () => T): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    held.term.write('', () => {
+      try {
+        resolve(read())
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
+    })
+  })
 }
 
 /** Give up on a session's model. The session itself carries on without one. */
@@ -329,14 +365,13 @@ export async function serializeScreen(id: string): Promise<ScreenSnapshot | null
   const held = screens.get(id)
   if (!held) return null
   try {
-    await drain(held)
-    return {
+    return await atDrain(held, () => ({
       screen: held.serializer.serialize(),
       cols: held.cols,
       rows: held.rows,
       title: held.title,
       cwd: held.cwd
-    }
+    }))
   } catch (err) {
     log.warn({ err, id }, '[screen] could not serialize')
     return null

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -173,7 +173,13 @@ function create(id: string, cols: number, rows: number): Held {
       // first allocated two arrays and a string before discarding them.
       if (payload.startsWith('cwd;')) {
         const next = payload.slice(4, 4 + MAX_LABEL_UNITS)
-        if (next && next !== held.cwd) {
+        // Shaped like a path before it is believed. Anything on the other end of
+        // the tty can write this sequence -- a `cat` of a file from a repository
+        // somebody cloned, a crafted commit message under `git log`, an agent
+        // relaying what it read. It is not shell input, but it does become the
+        // directory a resumed shell is started in, so it is checked here rather
+        // than trusted for the life of the session.
+        if (next && isPlausiblePath(next) && next !== held.cwd) {
           held.cwd = next
           // Told, not polled. An earlier version had `pty-manager` read this
           // after every flush, which cannot work: xterm parses on its own timer,
@@ -192,6 +198,22 @@ function create(id: string, cols: number, rows: number): Held {
   })
 
   return held
+}
+
+/**
+ * Whether a reported directory is shaped like one.
+ *
+ * Not a security boundary on its own -- a person can `cd` anywhere and the whole
+ * point of following this is that they did. What it rules out is a value that
+ * was never a path: a relative fragment, or one carrying control characters that
+ * would make the rest of the system read it as something other than what it is.
+ * The decision a forged-but-plausible path could lead to is guarded where it is
+ * taken: the offer names the directory, and starting one is a click.
+ */
+function isPlausiblePath(value: string): boolean {
+  if (!value.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(value)) return false
+  // eslint-disable-next-line no-control-regex
+  return !/[\u0000-\u001f\u007f]/.test(value)
 }
 
 /** Percent-decoded where that is possible, left alone where it is not. */

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -154,6 +154,29 @@ function create(cols: number, rows: number): Held {
     // False: this is an observation, not a takeover. xterm goes on handling it.
     return false
   })
+  // And the one Vorn's own shells actually emit.
+  //
+  // The handler above listens on OSC 7, which is the convention other terminals
+  // use -- and Vorn's shell integration has always emitted `5522;cwd;<path>`
+  // instead, namespaced so it cannot collide with a standard sequence. So the
+  // cwd this model captured was empty for every Vorn shell, and the checkpoint
+  // has been carrying an empty field since it was written. Both are registered:
+  // OSC 7 for a shell configured by hand or by another tool, 5522 for ours.
+  //
+  // Same discipline as above, and for the same reason -- this runs from xterm's
+  // timer, where a throw reaches the top of a process with no handler behind it.
+  term.parser.registerOscHandler(5522, (payload) => {
+    try {
+      const [kind, ...rest] = payload.split(';')
+      if (kind === 'cwd' && rest.length) {
+        const path = rest.join(';')
+        if (path) held.cwd = path.slice(0, MAX_LABEL_UNITS)
+      }
+    } catch {
+      /* an unreadable cwd is not worth anything at all */
+    }
+    return false
+  })
 
   return held
 }
@@ -254,10 +277,23 @@ export function feedScreen(id: string, data: string): void {
  * means `feedScreen` is a map lookup and a write, on a path that runs for every
  * chunk of every session.
  */
-export function createScreen(id: string, cols: number, rows: number): void {
+export function createScreen(
+  id: string,
+  cols: number,
+  rows: number,
+  labels?: { title?: string; cwd?: string }
+): void {
   clearScreen(id)
   try {
-    screens.set(id, create(cols, rows))
+    const held = create(cols, rows)
+    // A restored screen is rebuilt from escape sequences, and neither of these
+    // is one -- they arrive as notifications the serializer does not round-trip.
+    // The checkpoint has been storing both since it was written and recovery
+    // never put them back, so a session came back with no title and no
+    // directory however carefully the rest of it was replayed.
+    if (labels?.title) held.title = labels.title.slice(0, MAX_LABEL_UNITS)
+    if (labels?.cwd) held.cwd = labels.cwd.slice(0, MAX_LABEL_UNITS)
+    screens.set(id, held)
   } catch (err) {
     drop(id, err)
   }
@@ -404,4 +440,16 @@ export function screenCount(): number {
 /** Test-only, mirroring `resetScrollback`. */
 export function resetScreens(): void {
   for (const id of [...screens.keys()]) clearScreen(id)
+}
+
+/**
+ * Where this terminal's shell last said it was.
+ *
+ * Empty until a shell with Vorn's integration reports one. Read by
+ * `pty-manager`, which writes it onto the session record so a restored shell can
+ * be offered the directory somebody was actually in rather than the one it was
+ * launched in.
+ */
+export function screenCwd(id: string): string {
+  return screens.get(id)?.cwd ?? ''
 }

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -84,6 +84,15 @@ type SerializeAddon = InstanceType<typeof SerializeAddon>
 const SCROLLBACK = 0
 
 /**
+ * How far the parser may fall behind before chunks are skipped.
+ *
+ * A screenful at a generous size is a few tens of kilobytes, so this is room for
+ * many of them -- enough that nothing normal is ever dropped -- while being far
+ * below the fifty megabytes xterm would otherwise hold before refusing.
+ */
+const MAX_QUEUED_UNITS = 4 * 1024 * 1024
+
+/**
  * Mirrors the client's terminal, and the mirroring is the point.
  *
  * `allowProposedApi` matches `terminal-registry.ts` because the serialize addon
@@ -102,21 +111,85 @@ function create(cols: number, rows: number): Held {
   const term = new Terminal({ cols, rows, scrollback: SCROLLBACK, allowProposedApi: true })
   const serializer = new SerializeAddon()
   term.loadAddon(serializer)
-  return { term, serializer, pending: Promise.resolve() }
+  const held: Held = { term, serializer, cols, rows, queued: 0, behind: false, title: '', cwd: '' }
+
+  // Two things the program says about itself that the serialized screen does
+  // not carry, so they are caught as they go past. Neither is a reply -- these
+  // are notifications from the program, and observing one sends nothing back.
+  //
+  // Both run from xterm's own timer, not from `feedScreen`, so a throw in either
+  // reaches the top of the process rather than any `try` in this file -- and the
+  // server installs no `uncaughtException` handler. That is the whole server and
+  // every session, killed by a program printing an odd string. So both are
+  // wrapped, and neither may assume anything about what it was handed.
+  term.onTitleChange((title) => {
+    try {
+      held.title = title
+    } catch {
+      /* nothing a title can do is worth a process */
+    }
+  })
+  term.parser.registerOscHandler(7, (payload) => {
+    try {
+      // `file://host/path`, per the convention every shell integration uses.
+      const raw = payload.replace(/^file:\/\/[^/]*/, '')
+      // `decodeURIComponent` throws on a stray `%` -- and a directory named
+      // `100%` is a directory somebody has. Left encoded rather than lost.
+      if (raw) held.cwd = tryDecode(raw)
+    } catch {
+      /* an unreadable cwd is not worth anything at all */
+    }
+    // False: this is an observation, not a takeover. xterm goes on handling it.
+    return false
+  })
+
+  return held
+}
+
+/** Percent-decoded where that is possible, left alone where it is not. */
+function tryDecode(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
 }
 
 interface Held {
   term: Terminal
   serializer: SerializeAddon
-  /** The last write, so a read can wait for it. See `serializeScreen`. */
-  pending: Promise<void>
+  cols: number
+  rows: number
+  /** Written but not yet parsed, in UTF-16 units. */
+  queued: number
+  /** Whether the last chunk was skipped, so the log says it once. */
+  behind: boolean
+  /** Last OSC 0/2. The addon does not carry it. */
+  title: string
+  /** Last OSC 7, as a path. The addon does not carry this either. */
+  cwd: string
+}
+
+/**
+ * A screen, and the things the serialized string does not say.
+ *
+ * `serialize()` emits cells, SGR, the final cursor position and a set of modes.
+ * Everything else a restorer needs has to be gathered beside it -- which is why
+ * this is a record rather than a string.
+ */
+export interface ScreenSnapshot {
+  /** Escape sequences that reproduce the screen. */
+  screen: string
+  /** The geometry it must be replayed at, or the wrap points do not match. */
+  cols: number
+  rows: number
+  /** Last window title the program set, if it set one. */
+  title: string
+  /** Working directory the shell last reported, if it reports one. */
+  cwd: string
 }
 
 const screens = new Map<string, Held>()
-
-/** What a PTY starts at, when a session has not said otherwise. */
-const FALLBACK_COLS = 80
-const FALLBACK_ROWS = 24
 
 /**
  * Feed output to the screen model.
@@ -126,18 +199,55 @@ const FALLBACK_ROWS = 24
  * stopped updating — so a terminal that faults is dropped and the session
  * carries on without one.
  */
-export function feedScreen(id: string, data: string, cols?: number, rows?: number): void {
-  try {
-    let held = screens.get(id)
-    if (!held) {
-      held = create(cols ?? FALLBACK_COLS, rows ?? FALLBACK_ROWS)
-      screens.set(id, held)
+export function feedScreen(id: string, data: string): void {
+  const held = screens.get(id)
+  if (!held) return
+
+  // Dropped rather than queued when the model is behind.
+  //
+  // xterm parses on a timer and holds everything not yet parsed. A PTY can
+  // outrun that -- `cat` of a large file arrives far faster than a VT parse --
+  // and xterm's own answer at fifty megabytes of backlog is to throw. That would
+  // cost the session its model permanently, having first held fifty megabytes to
+  // get there.
+  //
+  // So the backlog is bounded here instead, and the response to a full one is to
+  // skip the chunk. A model missing a screenful of a flood is repaired by the
+  // next repaint; a model that no longer exists is not repaired at all. The
+  // client is unaffected either way -- it got these bytes before this line ran.
+  if (held.queued > MAX_QUEUED_UNITS) {
+    if (!held.behind) {
+      held.behind = true
+      log.warn({ id }, '[screen] output is outrunning the screen model; skipping ahead')
     }
-    const term = held.term
-    held.pending = new Promise<void>((resolve) => term.write(data, resolve))
+    return
+  }
+
+  try {
+    held.queued += data.length
+    held.behind = false
+    held.term.write(data, () => {
+      held.queued = Math.max(0, held.queued - data.length)
+    })
   } catch (err) {
-    log.warn({ err, id }, '[screen] dropping the screen model for this session')
-    clearScreen(id)
+    drop(id, err)
+  }
+}
+
+/**
+ * Start modelling a terminal, at the geometry it was spawned with.
+ *
+ * Explicit rather than created on the first byte, so the geometry comes from the
+ * one place that knows it instead of being threaded through every flush. It also
+ * means `feedScreen` is a map lookup and a write, on a path that runs for every
+ * chunk of every session.
+ */
+export function createScreen(id: string, cols: number, rows: number): void {
+  clearScreen(id)
+  try {
+    screens.set(id, create(cols, rows))
+  } catch (err) {
+    drop(id, err)
   }
 }
 
@@ -148,19 +258,54 @@ export function feedScreen(id: string, data: string, cols?: number, rows?: numbe
  * rendering against those: a model one column wider wraps in a different place,
  * and every line after the first divergence is wrong.
  */
-export function resizeScreen(id: string, cols: number, rows: number): void {
+export async function resizeScreen(id: string, cols: number, rows: number): Promise<void> {
   const held = screens.get(id)
   if (!held) return
   try {
+    // Drained first, and that ordering is the whole point. Writes are queued, so
+    // resizing straight away reflows bytes that arrived *before* the resize at
+    // the size that came *after* it -- and the client, which parsed those bytes
+    // before it refitted, wraps them somewhere else. A model that wraps
+    // differently from the terminal it models is the failure this exists to
+    // avoid, and it would show up as a screen that is subtly wrong rather than
+    // one that is obviously broken.
+    await new Promise<void>((resolve) => held.term.write('', resolve))
     held.term.resize(cols, rows)
+    held.cols = cols
+    held.rows = rows
   } catch (err) {
-    log.warn({ err, id }, '[screen] dropping the screen model for this session')
-    clearScreen(id)
+    drop(id, err)
   }
 }
 
+/** Give up on a session's model. The session itself carries on without one. */
+function drop(id: string, err: unknown): void {
+  log.warn({ err, id }, '[screen] dropping the screen model for this session')
+  clearScreen(id)
+}
+
 /**
- * The screen as escape sequences that reproduce it.
+ * The screen, and what has to travel beside it.
+ *
+ * ## What this does not carry, and why
+ *
+ * The task asks for scrollback, dimensions, modes, the saved-cursor register,
+ * OSC 8 link ranges, the last title and the cwd. Dimensions, title and cwd are
+ * gathered here; modes and the alternate-screen flag come from the addon. Three
+ * do not, and it is better to say so than to let a caller assume:
+ *
+ * - **Scrollback** is deliberate: this model runs with none, for the reasons
+ *   beside `SCROLLBACK`. The bytes are already kept twice over elsewhere.
+ * - **The saved-cursor register** (DECSC) is not emitted by
+ *   `@xterm/addon-serialize` at 0.13. A program that saved a position and had
+ *   not yet restored it loses that, which shows up as a restore-cursor landing
+ *   at the origin.
+ * - **OSC 8 link ranges** are stored as cell attributes and the addon does not
+ *   round-trip them, so a restored screen has the link text without the link.
+ *
+ * Reaching those means either an addon that emits them or walking the buffer
+ * here. Neither belongs in the task that introduces the model, and both are
+ * cheaper once something actually reads a snapshot -- which nothing does yet.
  *
  * Async, and that is not a convenience. `term.write` is queued, not applied —
  * xterm defers the parse to a macrotask — so serializing straight after a write
@@ -168,15 +313,24 @@ export function resizeScreen(id: string, cols: number, rows: number): void {
  * occasionally most of it. That failure is invisible in a test that happens to
  * yield and reappears under load.
  */
-export async function serializeScreen(id: string): Promise<string> {
+export async function serializeScreen(id: string): Promise<ScreenSnapshot | null> {
   const held = screens.get(id)
-  if (!held) return ''
-  await held.pending
+  if (!held) return null
   try {
-    return held.serializer.serialize()
+    // An empty write, queued behind everything already in flight, resolving only
+    // once the parser has reached it. That is the whole drain: writes are applied
+    // in order, so waiting for the last one waits for all of them.
+    await new Promise<void>((resolve) => held.term.write('', resolve))
+    return {
+      screen: held.serializer.serialize(),
+      cols: held.cols,
+      rows: held.rows,
+      title: held.title,
+      cwd: held.cwd
+    }
   } catch (err) {
     log.warn({ err, id }, '[screen] could not serialize')
-    return ''
+    return null
   }
 }
 

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -1,19 +1,30 @@
-import headless from '@xterm/headless'
-import serializeAddon from '@xterm/addon-serialize'
+import * as headless from '@xterm/headless'
+import * as serializeAddon from '@xterm/addon-serialize'
 import log from './logger'
 
 /**
- * Default-imported and destructured, not `import { Terminal } from ...`.
+ * Reached through an interop dance rather than by name, and it earns its keep.
  *
  * Both packages are plain CommonJS -- no `exports` map, no `module` field -- and
- * they build their exports in a way Node's named-export detection cannot see.
- * Under the bundler the named form works; under `tsx`, which is how the server
- * runs in development and in several tests, it fails at import time with
- * "does not provide an export named 'Terminal'". That is a server which will not
- * start, so the shape that works in both is the one to use.
+ * build their exports in a way Node's named-export detection cannot see. That
+ * makes `import { Terminal } from '@xterm/headless'` fail at import time under
+ * `tsx`, which is how the server runs in development: a server that will not
+ * start, caught by `server-port-stability` spawning the real thing.
+ *
+ * Nor is a plain default import enough. Compiled to CommonJS the namespace *is*
+ * the exports object and there is no `default` at all; loaded as ESM the exports
+ * arrive under `default`, because the same detection failure that breaks the
+ * named form also leaves the namespace with nothing else on it. This file is
+ * loaded both ways -- the bundle, `tsx` and vitest do not agree -- so it takes
+ * whichever of the two actually holds the classes.
  */
-const { Terminal } = headless
-const { SerializeAddon } = serializeAddon
+function interop<T>(mod: unknown): T {
+  const ns = mod as { default?: T }
+  return ns?.default ?? (mod as T)
+}
+
+const { Terminal } = interop<typeof import('@xterm/headless')>(headless)
+const { SerializeAddon } = interop<typeof import('@xterm/addon-serialize')>(serializeAddon)
 type Terminal = InstanceType<typeof Terminal>
 type SerializeAddon = InstanceType<typeof SerializeAddon>
 

--- a/packages/server/src/terminal-scrollback.ts
+++ b/packages/server/src/terminal-scrollback.ts
@@ -30,8 +30,6 @@
  */
 const MAX_UNITS = 256 * 1024
 
-const buffers = new Map<string, string>()
-
 /**
  * Trim from the front, at a line boundary where there is one nearby.
  *
@@ -51,19 +49,81 @@ function trim(data: string): string {
   return boundary === -1 ? data.slice(cut) : data.slice(boundary + 1)
 }
 
+/**
+ * Chunks as they arrived, joined only when somebody reads.
+ *
+ * This used to be one string per terminal, re-formed on every append:
+ * `set(id, trim(get(id) + data))`. Once a buffer reached its cap that was two
+ * ~256 KB allocations per PTY chunk -- one to concatenate, one to slice -- and
+ * a busy agent produces chunks by the hundred per second. It was the most
+ * expensive thing on the hottest path in the server, for a value almost nothing
+ * reads.
+ *
+ * Appending is now a push, and the cost moves to `readScrollback`, which is
+ * where it belongs: reads are rare and deliberate, writes are constant and
+ * incidental. The running total is kept so the bound can be enforced without
+ * measuring the whole list.
+ *
+ * The trim itself is unchanged, including where it cuts. It runs against the
+ * joined result rather than per chunk, because a boundary can only be found in
+ * the text either side of it -- trimming chunk by chunk would cut at whatever
+ * edge a PTY write happened to land on, which is precisely the mid-sequence cut
+ * the boundary rule exists to avoid.
+ */
+interface Buffered {
+  chunks: string[]
+  units: number
+}
+
+const buffers = new Map<string, Buffered>()
+
 export function appendScrollback(id: string, data: string): void {
-  buffers.set(id, trim((buffers.get(id) ?? '') + data))
+  const held = buffers.get(id)
+  if (!held) {
+    buffers.set(id, { chunks: [data], units: data.length })
+    return
+  }
+
+  held.chunks.push(data)
+  held.units += data.length
+
+  // Compacted only when there is enough overshoot to be worth the join --
+  // otherwise a terminal sitting exactly at the cap would re-join on every
+  // chunk, which is the behaviour this replaced. The slack is bounded, so the
+  // real ceiling is `MAX_UNITS + COMPACT_SLACK` rather than `MAX_UNITS`.
+  if (held.units > MAX_UNITS + COMPACT_SLACK) compact(held)
+}
+
+/**
+ * How far a buffer may run past its cap before it is re-formed.
+ *
+ * A quarter of the cap: large enough that compaction is rare against a stream of
+ * small writes, small enough that the overshoot is a rounding error against the
+ * memory this bounds.
+ */
+const COMPACT_SLACK = MAX_UNITS / 4
+
+function compact(held: Buffered): void {
+  const trimmed = trim(held.chunks.join(''))
+  held.chunks = [trimmed]
+  held.units = trimmed.length
 }
 
 export function readScrollback(id: string): string {
-  return buffers.get(id) ?? ''
+  const held = buffers.get(id)
+  if (!held) return ''
+  // Compacted on the way out rather than joined and thrown away: a caller that
+  // reads twice should not pay twice, and the result is the same bytes either
+  // way.
+  compact(held)
+  return held.chunks[0] ?? ''
 }
 
 export function clearScrollback(id: string): void {
   buffers.delete(id)
 }
 
-/** Only for tests, which would otherwise leak state between cases. */
+/** Test-only, mirroring the map this module used to expose implicitly. */
 export function resetScrollback(): void {
   buffers.clear()
 }

--- a/packages/server/src/terminal-scrollback.ts
+++ b/packages/server/src/terminal-scrollback.ts
@@ -78,10 +78,10 @@ interface Buffered {
 const buffers = new Map<string, Buffered>()
 
 export function appendScrollback(id: string, data: string): void {
-  const held = buffers.get(id)
+  let held = buffers.get(id)
   if (!held) {
-    buffers.set(id, { chunks: [data], units: data.length })
-    return
+    held = { chunks: [], units: 0 }
+    buffers.set(id, held)
   }
 
   held.chunks.push(data)
@@ -91,6 +91,11 @@ export function appendScrollback(id: string, data: string): void {
   // otherwise a terminal sitting exactly at the cap would re-join on every
   // chunk, which is the behaviour this replaced. The slack is bounded, so the
   // real ceiling is `MAX_UNITS + COMPACT_SLACK` rather than `MAX_UNITS`.
+  //
+  // The first chunk goes through this too. An earlier version seeded the buffer
+  // and returned, so a single oversized write -- a `cat` of something large,
+  // arriving before anything else -- sat unbounded until the next append or
+  // read, which for a terminal that then goes quiet is indefinitely.
   if (held.units > MAX_UNITS + COMPACT_SLACK) compact(held)
 }
 
@@ -121,6 +126,17 @@ export function readScrollback(id: string): string {
 
 export function clearScrollback(id: string): void {
   buffers.delete(id)
+}
+
+/**
+ * How much this terminal is holding, before any join.
+ *
+ * Exposed because the bound is otherwise unobservable: `readScrollback` compacts
+ * on the way out, so a read is always within the cap no matter how much is being
+ * held behind it. What a test needs to see is the memory, not the answer.
+ */
+export function scrollbackUnitsHeld(id: string): number {
+  return buffers.get(id)?.units ?? 0
 }
 
 /** Test-only, mirroring the map this module used to expose implicitly. */

--- a/packages/server/src/terminal-scrollback.ts
+++ b/packages/server/src/terminal-scrollback.ts
@@ -124,6 +124,20 @@ export function readScrollback(id: string): string {
   return held.chunks[0] ?? ''
 }
 
+/**
+ * Replace a terminal's buffer with bytes from somewhere else.
+ *
+ * For recovery, which reconstructs it from a checkpoint and a log rather than
+ * from a PTY. It goes through the same bound as an append, because a checkpoint
+ * written by an older build -- or one whose cap was larger -- must not be able
+ * to seed a buffer past what this module promises to hold.
+ */
+export function seedScrollback(id: string, data: string): void {
+  const held: Buffered = { chunks: [data], units: data.length }
+  buffers.set(id, held)
+  compact(held)
+}
+
 export function clearScrollback(id: string): void {
   buffers.delete(id)
 }

--- a/packages/server/src/terminal-scrollback.ts
+++ b/packages/server/src/terminal-scrollback.ts
@@ -54,10 +54,15 @@ function trim(data: string): string {
  *
  * This used to be one string per terminal, re-formed on every append:
  * `set(id, trim(get(id) + data))`. Once a buffer reached its cap that was two
- * ~256 KB allocations per PTY chunk -- one to concatenate, one to slice -- and
- * a busy agent produces chunks by the hundred per second. It was the most
- * expensive thing on the hottest path in the server, for a value almost nothing
- * reads.
+ * ~256 KB allocations per write -- one to concatenate, one to slice -- and it
+ * was fed straight from `onData`, which a busy agent drives by the hundred per
+ * second. It was the most expensive thing on the hottest path in the server, for
+ * a value almost nothing reads.
+ *
+ * It is fed from the coalesced flush now rather than from `onData`, which cuts
+ * the number of writes again and, more importantly, keeps it in step with the
+ * screen model. The cost that remains is per byte rather than per write, so the
+ * chunk list still earns its place.
  *
  * Appending is now a push, and the cost moves to `readScrollback`, which is
  * where it belongs: reads are rare and deliberate, writes are constant and
@@ -119,8 +124,9 @@ export function readScrollback(id: string): string {
   if (!held) return ''
   // Compacted on the way out rather than joined and thrown away: a caller that
   // reads twice should not pay twice, and the result is the same bytes either
-  // way.
-  compact(held)
+  // way. Already-compact is the common case for the second read and for the
+  // checkpoint that follows one, so it costs nothing at all.
+  if (held.chunks.length > 1 || held.units > MAX_UNITS) compact(held)
   return held.chunks[0] ?? ''
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,7 @@
     "./json-schema-utils": "./src/json-schema-utils.ts",
     "./structured-output": "./src/structured-output.ts",
     "./config-scope": "./src/config-scope.ts",
+    "./session-restore": "./src/session-restore.ts",
     "./viewer-settings-store": "./src/viewer-settings-store.ts"
   }
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,5 +1,6 @@
 import type {
   CreateTerminalPayload,
+  RestoredSession,
   TerminalSession,
   HeadlessSession,
   AppConfig,
@@ -524,6 +525,28 @@ export interface RequestMethods {
   'config:load': { params: void; result: AppConfig }
   'config:save': { params: AppConfig; result: void }
   'sessions:getPrevious': { params: void; result: TerminalSession[] }
+  /**
+   * Sessions from the last run that no pane has taken yet.
+   *
+   * The server holds them, so two clients can be looking at the same one. Each
+   * says roughly when it ended and whether there is a screen to show, which is
+   * what a pane needs to say what it is looking at rather than pretending it is
+   * live.
+   */
+  'sessions:restored': { params: void; result: RestoredSession[] }
+  /**
+   * Claim one and start it, exactly once.
+   *
+   * `gone` is the honest answer to the second caller: another pane, another
+   * window or another device took it first, and starting a second agent against
+   * one transcript is the failure this prevents.
+   */
+  'sessions:resume': {
+    params: { id: string; resumeSessionId?: string }
+    result:
+      | { ok: true; session: TerminalSession }
+      | { ok: false; reason: 'gone' | 'failed'; message?: string }
+  }
   'sessions:clear': { params: void; result: void }
   'sessions:getRecent': { params: string | undefined; result: RecentSession[] }
   'git:isGitRepo': { params: string; result: boolean }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -524,7 +524,6 @@ export interface RequestMethods {
   'shell:create': { params: string | undefined; result: TerminalSession }
   'config:load': { params: void; result: AppConfig }
   'config:save': { params: AppConfig; result: void }
-  'sessions:getPrevious': { params: void; result: TerminalSession[] }
   /**
    * Sessions from the last run that no pane has taken yet.
    *

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -503,6 +503,23 @@ export interface RequestMethods {
    * agent may be never.
    */
   'terminal:readScrollback': { params: { id: string }; result: { data: string } }
+  /**
+   * Everything a pane needs to start showing a terminal it did not create.
+   *
+   * `data` is the scrollback; `seq` is the flush it reflects, so the caller can
+   * discard the live chunks it already has; `live` says whether a process is
+   * still behind it, which decides whether the pane is a terminal or a
+   * photograph of one. All three are read in the same tick, and that is what
+   * makes the pair trustworthy -- see `PtyManager.flushSeq`.
+   *
+   * It serves a session restored from disk as well as a running one. There is
+   * no process behind a restored session, so nothing can arrive while the answer
+   * is in flight and `seq` is zero.
+   */
+  'terminal:attach': {
+    params: { id: string }
+    result: { data: string; seq: number; live: boolean }
+  }
   'shell:create': { params: string | undefined; result: TerminalSession }
   'config:load': { params: void; result: AppConfig }
   'config:save': { params: AppConfig; result: void }
@@ -992,7 +1009,15 @@ export interface ServerNotifications {
   'server:identity': ServerIdentity
   /** Sent once a socket is admitted, so a client knows it may start sending. */
   'auth:ok': { userId: string }
-  'terminal:data': { id: string; data: string }
+  /**
+   * `seq` numbers the flush this chunk came from, counting up per session.
+   *
+   * It exists so a pane can attach without losing or repeating anything.
+   * `terminal:attach` answers with the scrollback *and* the flush it reflects;
+   * a client subscribes first, buffers, and then applies only the chunks
+   * numbered above what it was handed.
+   */
+  'terminal:data': { id: string; data: string; seq: number }
   'terminal:exit': { id: string; exitCode: number }
   'session:created': TerminalSession
   'session:updated': TerminalSession

--- a/packages/shared/src/session-restore.ts
+++ b/packages/shared/src/session-restore.ts
@@ -1,0 +1,33 @@
+import type { CreateTerminalPayload, TerminalSession } from './types'
+
+/**
+ * Turning a saved session back into a request to start one.
+ *
+ * Shared rather than renderer-only because resuming is now something the server
+ * does. A client asking for it would have to send a payload the server then
+ * trusts, and the fields here -- a worktree path, a project directory -- are the
+ * ones a session is launched into. The record is already on the server; it
+ * should build the request from it.
+ */
+export function buildRestorePayload(
+  s: TerminalSession,
+  resumeSessionId?: string
+): CreateTerminalPayload {
+  if (s.agentType === 'shell') {
+    throw new Error(
+      'buildRestorePayload: shell sessions restore via createShellTerminal, not createTerminal'
+    )
+  }
+  return {
+    agentType: s.agentType,
+    projectName: s.projectName,
+    projectPath: s.projectPath,
+    displayName: s.displayName,
+    branch: s.isWorktree ? s.branch : undefined,
+    existingWorktreePath: s.isWorktree ? s.worktreePath : undefined,
+    worktreeName: s.worktreeName,
+    useWorktree: (s.isWorktree && !s.worktreePath) || undefined,
+    remoteHostId: s.remoteHostId,
+    resumeSessionId
+  }
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -138,6 +138,14 @@ export interface RestoredSession {
   replayable: boolean
   /** The recorded history stops short of what actually happened. */
   partial: boolean
+  /**
+   * The last run shut down rather than being stopped under it.
+   *
+   * "You closed Vorn" and "something stopped it" are different events, and a
+   * pane that reports the second for the first reads like a fault report for an
+   * ordinary quit.
+   */
+  closedCleanly: boolean
 }
 
 export type AuthMethod = 'key-file' | 'key-stored' | 'password' | 'agent'

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -112,6 +112,15 @@ export interface TerminalSession {
   shellCwd?: string
   /** Shell session only: PTY exit code once the shell has exited. */
   shellExitCode?: number
+  /**
+   * When the record was last written down.
+   *
+   * Set by the database on save and read back by `getPreviousSessions`; a
+   * session that has never been persisted does not have one. It is the only
+   * thing on disk that says roughly when a run ended, which is what a pane
+   * restored from a previous process has to tell somebody.
+   */
+  savedAt?: number
 }
 
 export type AuthMethod = 'key-file' | 'key-stored' | 'password' | 'agent'

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1404,6 +1404,7 @@ export const IPC = {
   TERMINAL_WRITE: 'terminal:write',
   TERMINAL_RESIZE: 'terminal:resize',
   TERMINAL_KILL: 'terminal:kill',
+  TERMINAL_ATTACH: 'terminal:attach',
   TERMINAL_DATA: 'terminal:data',
   TERMINAL_EXIT: 'terminal:exit',
   SESSION_CREATED: 'session:created',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -123,6 +123,23 @@ export interface TerminalSession {
   savedAt?: number
 }
 
+/**
+ * A session from a previous run that no pane has taken yet.
+ *
+ * Held by the server rather than the client so two of them can be looking at the
+ * same one: the first to claim it gets it, and the second is told it is gone
+ * rather than starting a second agent against one transcript.
+ */
+export interface RestoredSession {
+  session: TerminalSession
+  /** Roughly when it ended: the last save the previous process managed. */
+  endedAt: number
+  /** Whether a screen was rebuilt for it, so a pane has something to show. */
+  replayable: boolean
+  /** The recorded history stops short of what actually happened. */
+  partial: boolean
+}
+
 export type AuthMethod = 'key-file' | 'key-stored' | 'password' | 'agent'
 
 export interface SSHKey {
@@ -1417,6 +1434,8 @@ export const IPC = {
   CONFIG_SAVE: 'config:save',
   CONFIG_CHANGED: 'config:changed',
   SESSIONS_GET_PREVIOUS: 'sessions:getPrevious',
+  SESSIONS_RESTORED: 'sessions:restored',
+  SESSIONS_RESUME: 'sessions:resume',
   SESSIONS_CLEAR: 'sessions:clear',
   SESSIONS_GET_RECENT: 'sessions:getRecent',
   DIALOG_OPEN_DIRECTORY: 'dialog:openDirectory',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1433,7 +1433,6 @@ export const IPC = {
   CONFIG_LOAD: 'config:load',
   CONFIG_SAVE: 'config:save',
   CONFIG_CHANGED: 'config:changed',
-  SESSIONS_GET_PREVIOUS: 'sessions:getPrevious',
   SESSIONS_RESTORED: 'sessions:restored',
   SESSIONS_RESUME: 'sessions:resume',
   SESSIONS_CLEAR: 'sessions:clear',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -87,6 +87,27 @@ export interface TerminalSession {
   hookSessionId?: string
   agentSessionId?: string
   statusSource?: 'hooks' | 'pattern'
+  /**
+   * The geometry the PTY is currently running at.
+   *
+   * Held because a program renders against it: wrap points, cursor position and
+   * every full-screen repaint are decided by these numbers, so anything that
+   * models the screen has to agree with them exactly. Nothing recorded them
+   * before -- all three spawn sites passed 80x24 to node-pty and `resizePty`
+   * forwarded new values without keeping them.
+   *
+   * Last writer wins between attached clients, because node-pty already works
+   * that way: a phone fitting to 60x20 and a desktop at 200x50 will fight, and
+   * whichever resized last is what the program is drawing against. That is a
+   * pre-existing behaviour, and this records it rather than changing it.
+   *
+   * Optional because not every `TerminalSession` has a PTY behind it -- a
+   * workflow builds a synthetic one to describe its source, and inventing a
+   * geometry for something that is not being drawn would be a fact nobody
+   * checked. Absent means "whatever a PTY starts at".
+   */
+  cols?: number
+  rows?: number
   /** Shell session only: working directory the PTY was started in. */
   shellCwd?: string
   /** Shell session only: PTY exit code once the shell has exited. */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1405,6 +1405,7 @@ export const IPC = {
   TERMINAL_RESIZE: 'terminal:resize',
   TERMINAL_KILL: 'terminal:kill',
   TERMINAL_ATTACH: 'terminal:attach',
+  TERMINAL_LIST_ACTIVE: 'terminal:listActive',
   TERMINAL_DATA: 'terminal:data',
   TERMINAL_EXIT: 'terminal:exit',
   SESSION_CREATED: 'session:created',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -418,7 +418,6 @@ export function createApiShim(wsUrl: string) {
     // ── Sessions ──
     listActiveSessions: () => rpc.invoke('terminal:listActive'),
     attachTerminal: (id: string) => rpc.invoke('terminal:attach', { id }),
-    getPreviousSessions: () => rpc.invoke('sessions:getPrevious'),
     getRestoredSessions: () => rpc.invoke('sessions:restored'),
     resumeSession: (params: { id: string; resumeSessionId?: string }) =>
       rpc.invoke('sessions:resume', params),

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -419,6 +419,13 @@ export function createApiShim(wsUrl: string) {
     listActiveSessions: () => rpc.invoke('terminal:listActive'),
     attachTerminal: (id: string) => rpc.invoke('terminal:attach', { id }),
     getRestoredSessions: () => rpc.invoke('sessions:restored'),
+    // The desktop hears this from its own launcher, which is the thing that
+    // notices a server has died and starts another. A web client has no
+    // launcher: it reconnects to whatever answers the address it was given, and
+    // has no way to be told that what answered is a different process. Present
+    // so the surface matches, and so a caller does not have to know which client
+    // it is running in.
+    onServerReplaced: (_callback: () => void) => () => {},
     resumeSession: (params: { id: string; resumeSessionId?: string }) =>
       rpc.invoke('sessions:resume', params),
     clearPreviousSessions: () => rpc.invoke('sessions:clear'),

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -386,7 +386,7 @@ export function createApiShim(wsUrl: string) {
     createShellTerminal: (cwd?: string) => rpc.invoke('shell:create', cwd),
 
     // ── Terminal Events ──
-    onTerminalData: (callback: (event: { id: string; data: string }) => void) =>
+    onTerminalData: (callback: (event: { id: string; data: string; seq: number }) => void) =>
       rpc.on('terminal:data', callback as (p: unknown) => void),
     onTerminalExit: (callback: (event: { id: string; exitCode: number }) => void) =>
       rpc.on('terminal:exit', callback as (p: unknown) => void),
@@ -417,6 +417,7 @@ export function createApiShim(wsUrl: string) {
 
     // ── Sessions ──
     listActiveSessions: () => rpc.invoke('terminal:listActive'),
+    attachTerminal: (id: string) => rpc.invoke('terminal:attach', { id }),
     getPreviousSessions: () => rpc.invoke('sessions:getPrevious'),
     clearPreviousSessions: () => rpc.invoke('sessions:clear'),
     getRecentSessions: (projectPath?: string) => rpc.invoke('sessions:getRecent', projectPath),

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -419,6 +419,9 @@ export function createApiShim(wsUrl: string) {
     listActiveSessions: () => rpc.invoke('terminal:listActive'),
     attachTerminal: (id: string) => rpc.invoke('terminal:attach', { id }),
     getPreviousSessions: () => rpc.invoke('sessions:getPrevious'),
+    getRestoredSessions: () => rpc.invoke('sessions:restored'),
+    resumeSession: (params: { id: string; resumeSessionId?: string }) =>
+      rpc.invoke('sessions:resume', params),
     clearPreviousSessions: () => rpc.invoke('sessions:clear'),
     getRecentSessions: (projectPath?: string) => rpc.invoke('sessions:getRecent', projectPath),
     renameSession: (id: string, displayName: string) =>

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import { setArtifactNotify } from './artifact-watcher'
 import { SURFACE } from '../shared/surface'
 import {
   LOCAL_SERVER_RUNNING_CHANNEL,
+  SERVER_REPLACED_CHANNEL,
   STOP_SESSIONS_AND_SERVER_CHANNEL
 } from '../shared/adoption-channels'
 import {
@@ -21,7 +22,8 @@ import {
   getServerBridge,
   getLastAdoptionRefusal,
   AdoptionRefusedError,
-  probeSessions
+  probeSessions,
+  onServerReplaced
 } from './server/server-launcher'
 import { readHostSettings } from './server/host-store'
 import { registerConnectHandlers, showConnectWindow } from './server/connect-window'
@@ -425,6 +427,14 @@ app.whenReady().then(async () => {
   // Before launchServer, unlike everything else: these are what let someone
   // correct an unreachable host, so they cannot depend on reaching one.
   registerConnectHandlers()
+  // A crash-relaunch gives this app a different server holding none of the old
+  // PTYs. The bridge reconnects on its own, but the panes have no way to notice:
+  // their content lives in the renderer, so a frozen terminal looks exactly like
+  // a quiet one and goes on taking input for a process that is gone.
+  onServerReplaced(() => {
+    mainWindow?.webContents.send(SERVER_REPLACED_CHANNEL)
+  })
+
   let bridge: ServerBridge
   try {
     bridge = await launchServer()

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -129,6 +129,7 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.CONFIG_SAVE, (_, config) => requireBridge().request(IPC.CONFIG_SAVE, config))
 
   // Sessions
+  safeHandle(IPC.TERMINAL_ATTACH, (_, id) => requireBridge().request(IPC.TERMINAL_ATTACH, { id }))
   safeHandle(IPC.SESSIONS_GET_PREVIOUS, () => requireBridge().request(IPC.SESSIONS_GET_PREVIOUS))
   safeHandle(IPC.SESSIONS_CLEAR, () => requireBridge().request(IPC.SESSIONS_CLEAR))
   safeHandle(IPC.SESSIONS_GET_RECENT, (_, projectPath) =>

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -131,7 +131,6 @@ export function registerIpcHandlers(): void {
   // Sessions
   safeHandle(IPC.TERMINAL_ATTACH, (_, id) => requireBridge().request(IPC.TERMINAL_ATTACH, { id }))
   safeHandle(IPC.TERMINAL_LIST_ACTIVE, () => requireBridge().request(IPC.TERMINAL_LIST_ACTIVE))
-  safeHandle(IPC.SESSIONS_GET_PREVIOUS, () => requireBridge().request(IPC.SESSIONS_GET_PREVIOUS))
   safeHandle(IPC.SESSIONS_RESTORED, () => requireBridge().request(IPC.SESSIONS_RESTORED))
   safeHandle(IPC.SESSIONS_RESUME, (_, params) =>
     requireBridge().request(IPC.SESSIONS_RESUME, params)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -132,6 +132,10 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.TERMINAL_ATTACH, (_, id) => requireBridge().request(IPC.TERMINAL_ATTACH, { id }))
   safeHandle(IPC.TERMINAL_LIST_ACTIVE, () => requireBridge().request(IPC.TERMINAL_LIST_ACTIVE))
   safeHandle(IPC.SESSIONS_GET_PREVIOUS, () => requireBridge().request(IPC.SESSIONS_GET_PREVIOUS))
+  safeHandle(IPC.SESSIONS_RESTORED, () => requireBridge().request(IPC.SESSIONS_RESTORED))
+  safeHandle(IPC.SESSIONS_RESUME, (_, params) =>
+    requireBridge().request(IPC.SESSIONS_RESUME, params)
+  )
   safeHandle(IPC.SESSIONS_CLEAR, () => requireBridge().request(IPC.SESSIONS_CLEAR))
   safeHandle(IPC.SESSIONS_GET_RECENT, (_, projectPath) =>
     requireBridge().request(IPC.SESSIONS_GET_RECENT, projectPath)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -130,6 +130,7 @@ export function registerIpcHandlers(): void {
 
   // Sessions
   safeHandle(IPC.TERMINAL_ATTACH, (_, id) => requireBridge().request(IPC.TERMINAL_ATTACH, { id }))
+  safeHandle(IPC.TERMINAL_LIST_ACTIVE, () => requireBridge().request(IPC.TERMINAL_LIST_ACTIVE))
   safeHandle(IPC.SESSIONS_GET_PREVIOUS, () => requireBridge().request(IPC.SESSIONS_GET_PREVIOUS))
   safeHandle(IPC.SESSIONS_CLEAR, () => requireBridge().request(IPC.SESSIONS_CLEAR))
   safeHandle(IPC.SESSIONS_GET_RECENT, (_, projectPath) =>

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -502,7 +502,7 @@ function onServerExit(detail: string, endpointTaken = false): void {
         // Whether or not the address changed, this is a different process and it
         // holds none of the PTYs the old one did. The bridge reconnects by
         // itself; the panes have no way to find out, so they are told.
-        notifyServerReplaced()
+        announceReplacement()
       })
       .catch((err) => {
         // Not re-entered here. The child now carries its own `exit` handler from
@@ -902,6 +902,38 @@ function notifyServerReplaced(): void {
   } catch (err) {
     log.warn({ err }, '[launcher] could not announce the replacement server')
   }
+}
+
+/** Set while a replacement is announced but the bridge has not reconnected. */
+let replacementPending = false
+
+/**
+ * Say a server was replaced, once the replacement can actually be asked
+ * anything.
+ *
+ * The port answering and this app being able to talk to it are two events, and
+ * the gap between them is a whole reconnect. Announcing at the first one told
+ * every pane to go and ask what the server still had, and the bridge rejected
+ * the question -- `Cannot send request: not connected` -- one line before it
+ * connected. The panes read that as "no answer, leave the board alone", so a
+ * server dying under a running app changed nothing on screen: the exact freeze
+ * the announcement exists to end.
+ */
+function announceReplacement(): void {
+  // Nothing was pointed at the old server, so nothing is holding a pane for it.
+  // The first launch of the app comes through here too.
+  if (!bridge) return
+  if (bridge.isConnected) {
+    notifyServerReplaced()
+    return
+  }
+  // Restarts can outpace reconnects. One listener, not one per attempt.
+  if (replacementPending) return
+  replacementPending = true
+  bridge.once('connected', () => {
+    replacementPending = false
+    notifyServerReplaced()
+  })
 }
 
 export function getServerBridge(): ServerBridge | null {

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -499,6 +499,10 @@ function onServerExit(detail: string, endpointTaken = false): void {
           log.info(`[launcher] server came back on ${port}; repointing the bridge`)
           bridge.retarget(url)
         }
+        // Whether or not the address changed, this is a different process and it
+        // holds none of the PTYs the old one did. The bridge reconnects by
+        // itself; the panes have no way to find out, so they are told.
+        notifyServerReplaced()
       })
       .catch((err) => {
         // Not re-entered here. The child now carries its own `exit` handler from
@@ -877,6 +881,27 @@ async function adoptSomethingRunning(dataDir: string): Promise<ServerBridge | nu
   }
 
   return null
+}
+
+/**
+ * Told when the server has been replaced, so the window can be told.
+ *
+ * A callback rather than a direct send, because this module knows about servers
+ * and not about windows -- `src/main/index.ts` owns the one and wires it here.
+ */
+type ServerReplacedListener = () => void
+let serverReplacedListener: ServerReplacedListener | null = null
+
+export function onServerReplaced(listener: ServerReplacedListener | null): void {
+  serverReplacedListener = listener
+}
+
+function notifyServerReplaced(): void {
+  try {
+    serverReplacedListener?.()
+  } catch (err) {
+    log.warn({ err }, '[launcher] could not announce the replacement server')
+  }
 }
 
 export function getServerBridge(): ServerBridge | null {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,6 +64,16 @@ const api = {
   attachTerminal: (id: string): Promise<{ data: string; seq: number; live: boolean }> =>
     ipcRenderer.invoke(IPC.TERMINAL_ATTACH, id),
 
+  /**
+   * What the server has, which is not the same as what the database remembers.
+   *
+   * The web client has asked this since it was written; the desktop never could,
+   * which is why its start-up read the saved list and relaunched from it. It is
+   * the same question and it deserves the same answer.
+   */
+  listActiveSessions: (): Promise<TerminalSession[]> =>
+    ipcRenderer.invoke(IPC.TERMINAL_LIST_ACTIVE),
+
   createShellTerminal: (cwd?: string): Promise<TerminalSession> =>
     ipcRenderer.invoke(IPC.SHELL_CREATE, cwd),
 
@@ -137,7 +147,8 @@ const api = {
     }
   },
 
-  getPreviousSessions: () => ipcRenderer.invoke(IPC.SESSIONS_GET_PREVIOUS),
+  getPreviousSessions: (): Promise<TerminalSession[]> =>
+    ipcRenderer.invoke(IPC.SESSIONS_GET_PREVIOUS),
 
   clearPreviousSessions: () => ipcRenderer.invoke(IPC.SESSIONS_CLEAR),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,12 +60,18 @@ const api = {
 
   killTerminal: (id: string) => ipcRenderer.invoke(IPC.TERMINAL_KILL, id),
 
+  /** Everything a pane needs to show a terminal it did not create. */
+  attachTerminal: (id: string): Promise<{ data: string; seq: number; live: boolean }> =>
+    ipcRenderer.invoke(IPC.TERMINAL_ATTACH, id),
+
   createShellTerminal: (cwd?: string): Promise<TerminalSession> =>
     ipcRenderer.invoke(IPC.SHELL_CREATE, cwd),
 
-  onTerminalData: (callback: (event: { id: string; data: string }) => void) => {
-    const listener = (_: Electron.IpcRendererEvent, event: { id: string; data: string }): void =>
-      callback(event)
+  onTerminalData: (callback: (event: { id: string; data: string; seq: number }) => void) => {
+    const listener = (
+      _: Electron.IpcRendererEvent,
+      event: { id: string; data: string; seq: number }
+    ): void => callback(event)
     ipcRenderer.on(IPC.TERMINAL_DATA, listener)
     return () => {
       ipcRenderer.removeListener(IPC.TERMINAL_DATA, listener)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -148,9 +148,6 @@ const api = {
     }
   },
 
-  getPreviousSessions: (): Promise<TerminalSession[]> =>
-    ipcRenderer.invoke(IPC.SESSIONS_GET_PREVIOUS),
-
   /** Sessions from the last run that no pane has taken yet. */
   getRestoredSessions: (): Promise<RestoredSession[]> => ipcRenderer.invoke(IPC.SESSIONS_RESTORED),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,7 @@ import { captureViewerSettings, withViewerSettings } from '@vornrun/shared/viewe
 import {
   CreateTerminalPayload,
   TerminalSession,
+  RestoredSession,
   ResizePayload,
   AppConfig,
   RecentSession,
@@ -149,6 +150,17 @@ const api = {
 
   getPreviousSessions: (): Promise<TerminalSession[]> =>
     ipcRenderer.invoke(IPC.SESSIONS_GET_PREVIOUS),
+
+  /** Sessions from the last run that no pane has taken yet. */
+  getRestoredSessions: (): Promise<RestoredSession[]> => ipcRenderer.invoke(IPC.SESSIONS_RESTORED),
+
+  /** Claim one and start it. `gone` means another pane took it first. */
+  resumeSession: (params: {
+    id: string
+    resumeSessionId?: string
+  }): Promise<
+    { ok: true; session: TerminalSession } | { ok: false; reason: string; message?: string }
+  > => ipcRenderer.invoke(IPC.SESSIONS_RESUME, params),
 
   clearPreviousSessions: () => ipcRenderer.invoke(IPC.SESSIONS_CLEAR),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import {
   LOCAL_SERVER_RUNNING_CHANNEL,
+  SERVER_REPLACED_CHANNEL,
   STOP_SESSIONS_AND_SERVER_CHANNEL,
   type LocalServerNotice
 } from '../shared/adoption-channels'
@@ -128,6 +129,20 @@ const api = {
     ipcRenderer.on(IPC.CONFIG_CHANGED, listener)
     return () => {
       ipcRenderer.removeListener(IPC.CONFIG_CHANGED, listener)
+    }
+  },
+
+  /**
+   * The server behind this app has been replaced by a different process.
+   *
+   * Sent after a crash-relaunch. Everything the old one was holding is gone, so
+   * a pane showing a terminal is showing a photograph and does not know it.
+   */
+  onServerReplaced: (callback: () => void) => {
+    const listener = (): void => callback()
+    ipcRenderer.on(SERVER_REPLACED_CHANNEL, listener)
+    return () => {
+      ipcRenderer.removeListener(SERVER_REPLACED_CHANNEL, listener)
     }
   },
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,7 +26,7 @@ import {
   stopWorkflowRun,
   applyGateDecision
 } from './lib/workflow-execution'
-import type { WorkflowExecution } from '../shared/types'
+import type { TerminalSession, WorkflowExecution } from '../shared/types'
 import { CommandPalette } from './components/CommandPalette'
 import { SessionRestoredBanner } from './components/SessionRestoredBanner'
 import { GridToolbar } from './components/GridToolbar'
@@ -74,7 +74,7 @@ import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
 import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
-import { resolveResumeSessionId, buildRestorePayload } from './lib/session-utils'
+import { resolveResumeSessionId, buildRestorePayload, reconcileSessions } from './lib/session-utils'
 
 export function App() {
   const {
@@ -182,30 +182,34 @@ export function App() {
         if (Number(config.defaults.hasSeenOnboarding ?? 0) < ONBOARDING_VERSION) {
           useAppStore.getState().setOnboardingOpen(true)
         }
-        // Web: hydrate already-running sessions that started before we connected
-        if (isWeb && 'listActiveSessions' in window.api) {
-          try {
-            const active = (await (
-              window.api as { listActiveSessions: () => Promise<unknown[]> }
-            ).listActiveSessions()) as import('../shared/types').TerminalSession[]
-            const state = useAppStore.getState()
-            for (const session of active) {
-              if (!state.terminals.has(session.id)) {
-                state.addTerminal(session)
-              }
-            }
-          } catch (err) {
-            console.error('[App] failed to hydrate active sessions:', err)
-          }
+        // What the server actually has, asked before what the database
+        // remembers, because they are different questions and only one of them
+        // is about the present.
+        //
+        // The web client has done this since it was written and the desktop
+        // never could, so a desktop restart read the saved list and launched a
+        // replacement for every session -- including the ones that had never
+        // stopped. A pane bound here is the same terminal, with the same
+        // process, mid-turn if it was mid-turn; the seeding happens in
+        // `terminal-registry` when the pane's terminal is built.
+        let active: TerminalSession[] = []
+        try {
+          active = await window.api.listActiveSessions()
+        } catch (err) {
+          console.error('[App] failed to adopt running sessions:', err)
         }
-
-        if (prev && prev.length > 0) {
+        const { adopt, orphaned } = reconcileSessions(active, prev ?? [])
+        const store = useAppStore.getState()
+        for (const session of adopt) {
+          if (!store.terminals.has(session.id)) store.addTerminal(session)
+        }
+        if (orphaned.length > 0) {
           if (config.defaults.reopenSessions) {
             // Auto-restore sessions — prefer hook-correlated session ID (exact),
             // fall back to scanning agent history when hooks weren't active.
             // Shells restore as fresh PTYs in their saved cwd (no resume concept).
             const claimed = new Set<string>()
-            for (const s of prev) {
+            for (const s of orphaned) {
               if (s.agentType === 'shell') {
                 const cwd = s.shellCwd ?? s.worktreePath ?? s.projectPath
                 const session = await window.api.createShellTerminal(cwd)
@@ -233,7 +237,7 @@ export function App() {
             }
             window.api.clearPreviousSessions()
           } else {
-            useAppStore.getState().setSessionBanner(true, prev)
+            useAppStore.getState().setSessionBanner(true, orphaned)
           }
         }
       } catch (err) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -194,7 +194,10 @@ export function App() {
         // The same reconciliation runs again whenever the server is replaced;
         // see `board-sync`.
         const reopen = config.defaults.reopenSessions ?? true
-        await syncBoard({ showCold: reopen })
+        // On means both halves of what it has always meant: the panes come back,
+        // and the sessions behind them are started again. Only the ones that were
+        // stopped -- see `resumeAll`.
+        await syncBoard({ showCold: reopen, resume: reopen })
 
         if (!reopen) {
           // Panes stay off the board, and the banner offers to bring them in.
@@ -220,7 +223,11 @@ export function App() {
     // exactly like a quiet one, and goes on taking input for a process that is
     // gone. Asking again is the only way any of them find out.
     const removeReplacedListener = window.api.onServerReplaced?.(() => {
-      void syncBoard({ showCold: true })
+      // The same rule as start-up, deliberately: a session stopped by a server
+      // dying is stopped whether or not the app happened to be open at the time,
+      // so one setting decides both.
+      const reopen = useAppStore.getState().config?.defaults.reopenSessions ?? true
+      void syncBoard({ showCold: true, resume: reopen })
     })
 
     // Pointed at a host while a server is still running on this machine. Said

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,7 +26,7 @@ import {
   stopWorkflowRun,
   applyGateDecision
 } from './lib/workflow-execution'
-import type { RestoredSession, TerminalSession, WorkflowExecution } from '../shared/types'
+import type { WorkflowExecution } from '../shared/types'
 import { CommandPalette } from './components/CommandPalette'
 import { SessionRestoredBanner } from './components/SessionRestoredBanner'
 import { GridToolbar } from './components/GridToolbar'
@@ -75,7 +75,7 @@ import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
 import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
-import { coldSessions } from './lib/session-utils'
+import { syncBoard } from './lib/board-sync'
 import { markPaneEnded } from './lib/session-resume'
 
 export function App() {
@@ -169,19 +169,7 @@ export function App() {
     })
     ;(async () => {
       try {
-        // All three started together. Config is awaited first because
-        // everything below reads it, but the two session questions do not
-        // depend on it -- and on the web client each is a round trip to another
-        // machine.
-        const configPromise = window.api.loadConfig()
-        const boardPromise = Promise.all([
-          window.api.listActiveSessions(),
-          window.api.getRestoredSessions()
-        ]).catch((err) => {
-          console.error('[App] failed to read what the server has:', err)
-          return [[], []] as [TerminalSession[], RestoredSession[]]
-        })
-        const config = await configPromise
+        const config = await window.api.loadConfig()
         useAppStore.getState().setConfig(config)
         if (config.defaults.fontSize) {
           setDefaultFontSize(config.defaults.fontSize)
@@ -199,52 +187,24 @@ export function App() {
         }
         // What the server actually has, asked before what the database
         // remembers, because they are different questions and only one of them
-        // is about the present.
+        // is about the present. The desktop could not ask this until now, so a
+        // restart read the saved list and launched a replacement for every
+        // session -- including the ones that had never stopped.
         //
-        // The web client has done this since it was written and the desktop
-        // never could, so a desktop restart read the saved list and launched a
-        // replacement for every session -- including the ones that had never
-        // stopped. A pane bound here is the same terminal, with the same
-        // process, mid-turn if it was mid-turn; the seeding happens in
-        // `terminal-registry` when the pane's terminal is built.
-        // Both questions go to the server: what is running, and what it is
-        // still holding from the last run. The saved list is not consulted at
-        // all any more -- it says what existed when it was last written down,
-        // which is neither of those.
-        const [active, carried] = await boardPromise
-        const store = useAppStore.getState()
-        for (const session of active) {
-          if (!store.terminals.has(session.id)) store.addTerminal(session)
-        }
-        const cold = coldSessions(active, carried)
+        // The same reconciliation runs again whenever the server is replaced;
+        // see `board-sync`.
+        const reopen = config.defaults.reopenSessions ?? true
+        await syncBoard({ showCold: reopen })
 
-        if (cold.length > 0) {
-          if (config.defaults.reopenSessions) {
-            // The panes come back. The agents do not.
-            //
-            // This used to launch a replacement for every saved session --
-            // silently, on start-up, spending tokens and starting processes on
-            // somebody's behalf before they had looked at the screen. Now each
-            // pane shows the last thing its terminal printed and says the
-            // session ended, and resuming is a decision with a button behind it.
-            //
-            // The setting keeps its name and loses a meaning it should not have
-            // had: it governs whether panes reappear, not whether agents are
-            // relaunched. Every tool that restores terminals works this way --
-            // the view comes back, the program does not.
-            for (const one of cold) {
-              useAppStore.getState().addTerminal(one.session, {
-                reason: 'server-stopped',
-                at: one.endedAt,
-                replayed: one.replayable,
-                partial: one.partial,
-                ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
-              })
-            }
-          } else {
+        if (!reopen) {
+          // Panes stay off the board, and the banner offers to bring them in.
+          // It no longer relaunches anything: taking it shows the last screen
+          // each terminal drew, and resuming is still a separate decision.
+          const carried = await window.api.getRestoredSessions().catch(() => [])
+          if (carried.length > 0) {
             useAppStore.getState().setSessionBanner(
               true,
-              cold.map((one) => one.session)
+              carried.map((one) => one.session)
             )
           }
         }
@@ -252,6 +212,16 @@ export function App() {
         console.error('[App] startup initialization failed:', err)
       }
     })()
+
+    // The server behind this app has been replaced -- it crashed and the
+    // launcher started another. The bridge reconnects by itself, but nothing
+    // about a pane changes when that happens: its terminal keeps showing what it
+    // was showing, because that content lives here. So a frozen pane looks
+    // exactly like a quiet one, and goes on taking input for a process that is
+    // gone. Asking again is the only way any of them find out.
+    const removeReplacedListener = window.api.onServerReplaced?.(() => {
+      void syncBoard({ showCold: true })
+    })
 
     // Pointed at a host while a server is still running on this machine. Said
     // out loud, because an agent working on a machine whose app is showing
@@ -563,6 +533,7 @@ export function App() {
 
     return () => {
       disposeGlobalDataListener()
+      removeReplacedListener?.()
       removeLocalServerListener?.()
       removeExitListener()
       removeSessionCreatedListener()

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -50,7 +50,8 @@ import {
   setDefaultFontSize,
   initGlobalDataListener,
   disposeGlobalDataListener,
-  setKeyRedirectHandler
+  setKeyRedirectHandler,
+  setNotLiveReporter
 } from './lib/terminal-registry'
 import {
   setCwdReporter,
@@ -74,7 +75,8 @@ import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
 import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
-import { reconcileSessions } from './lib/session-utils'
+import { coldSessions } from './lib/session-utils'
+import { markPaneEnded } from './lib/session-resume'
 
 export function App() {
   const {
@@ -143,6 +145,10 @@ export function App() {
 
   useEffect(() => {
     initGlobalDataListener()
+    // An attach that finds nothing running is how a window opened onto a dead
+    // terminal learns it is looking at a photograph. Start-up reconciliation
+    // cannot tell it: the session was not there when this client started.
+    setNotLiveReporter(markPaneEnded)
     // The capture path has to know before any command finishes, so it is read
     // from config rather than passed down through the view tree.
     setDomBlockRendering(useAppStore.getState().config?.defaults.domBlockRendering ?? true)
@@ -163,7 +169,19 @@ export function App() {
     })
     ;(async () => {
       try {
-        const config = await window.api.loadConfig()
+        // All three started together. Config is awaited first because
+        // everything below reads it, but the two session questions do not
+        // depend on it -- and on the web client each is a round trip to another
+        // machine.
+        const configPromise = window.api.loadConfig()
+        const boardPromise = Promise.all([
+          window.api.listActiveSessions(),
+          window.api.getRestoredSessions()
+        ]).catch((err) => {
+          console.error('[App] failed to read what the server has:', err)
+          return [[], []] as [TerminalSession[], RestoredSession[]]
+        })
+        const config = await configPromise
         useAppStore.getState().setConfig(config)
         if (config.defaults.fontSize) {
           setDefaultFontSize(config.defaults.fontSize)
@@ -193,22 +211,12 @@ export function App() {
         // still holding from the last run. The saved list is not consulted at
         // all any more -- it says what existed when it was last written down,
         // which is neither of those.
-        let active: TerminalSession[] = []
-        let carried: RestoredSession[] = []
-        try {
-          ;[active, carried] = await Promise.all([
-            window.api.listActiveSessions(),
-            window.api.getRestoredSessions()
-          ])
-        } catch (err) {
-          console.error('[App] failed to read what the server has:', err)
-        }
-
-        const { adopt, cold } = reconcileSessions(active, carried)
+        const [active, carried] = await boardPromise
         const store = useAppStore.getState()
-        for (const session of adopt) {
+        for (const session of active) {
           if (!store.terminals.has(session.id)) store.addTerminal(session)
         }
+        const cold = coldSessions(active, carried)
 
         if (cold.length > 0) {
           if (config.defaults.reopenSessions) {
@@ -240,13 +248,6 @@ export function App() {
             )
           }
         }
-
-        // Nothing calls `clearPreviousSessions()` here any more. A record is
-        // consumed on the server when a pane takes it -- by resuming or by
-        // closing -- so it survives a start that nobody acted on, and two
-        // clients can be looking at the same one safely. Clearing the list as a
-        // side effect of having restored meant a failed restore lost the record
-        // too, with nothing to try again from.
       } catch (err) {
         console.error('[App] startup initialization failed:', err)
       }
@@ -303,6 +304,20 @@ export function App() {
       if (!terminal) return
 
       state.updateStatus(id, 'idle')
+      // And say so. A terminal whose process has gone looked exactly like one
+      // that was merely quiet -- a frozen buffer, an idle dot, nothing to tell
+      // them apart. That is the state a pane restored from a previous run is
+      // in, reached from the other side, so it says the same thing.
+      state.markEnded(id, {
+        reason: 'exited',
+        at: Date.now(),
+        // Nothing was replayed: this pane watched it happen.
+        replayed: false,
+        ...(terminal.session.shellExitCode !== undefined && {
+          exitCode: terminal.session.shellExitCode
+        }),
+        ...(terminal.session.shellCwd !== undefined && { cwd: terminal.session.shellCwd })
+      })
 
       if (terminal.session.agentType !== 'shell') {
         const assignedTask = (state.config?.tasks || []).find(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,7 +26,7 @@ import {
   stopWorkflowRun,
   applyGateDecision
 } from './lib/workflow-execution'
-import type { TerminalSession, WorkflowExecution } from '../shared/types'
+import type { RestoredSession, TerminalSession, WorkflowExecution } from '../shared/types'
 import { CommandPalette } from './components/CommandPalette'
 import { SessionRestoredBanner } from './components/SessionRestoredBanner'
 import { GridToolbar } from './components/GridToolbar'
@@ -74,7 +74,7 @@ import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
 import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
-import { resolveResumeSessionId, buildRestorePayload, reconcileSessions } from './lib/session-utils'
+import { reconcileSessions } from './lib/session-utils'
 
 export function App() {
   const {
@@ -163,10 +163,7 @@ export function App() {
     })
     ;(async () => {
       try {
-        const [config, prev] = await Promise.all([
-          window.api.loadConfig(),
-          window.api.getPreviousSessions()
-        ])
+        const config = await window.api.loadConfig()
         useAppStore.getState().setConfig(config)
         if (config.defaults.fontSize) {
           setDefaultFontSize(config.defaults.fontSize)
@@ -192,54 +189,64 @@ export function App() {
         // stopped. A pane bound here is the same terminal, with the same
         // process, mid-turn if it was mid-turn; the seeding happens in
         // `terminal-registry` when the pane's terminal is built.
+        // Both questions go to the server: what is running, and what it is
+        // still holding from the last run. The saved list is not consulted at
+        // all any more -- it says what existed when it was last written down,
+        // which is neither of those.
         let active: TerminalSession[] = []
+        let carried: RestoredSession[] = []
         try {
-          active = await window.api.listActiveSessions()
+          ;[active, carried] = await Promise.all([
+            window.api.listActiveSessions(),
+            window.api.getRestoredSessions()
+          ])
         } catch (err) {
-          console.error('[App] failed to adopt running sessions:', err)
+          console.error('[App] failed to read what the server has:', err)
         }
-        const { adopt, orphaned } = reconcileSessions(active, prev ?? [])
+
+        const { adopt, cold } = reconcileSessions(active, carried)
         const store = useAppStore.getState()
         for (const session of adopt) {
           if (!store.terminals.has(session.id)) store.addTerminal(session)
         }
-        if (orphaned.length > 0) {
+
+        if (cold.length > 0) {
           if (config.defaults.reopenSessions) {
-            // Auto-restore sessions — prefer hook-correlated session ID (exact),
-            // fall back to scanning agent history when hooks weren't active.
-            // Shells restore as fresh PTYs in their saved cwd (no resume concept).
-            const claimed = new Set<string>()
-            for (const s of orphaned) {
-              if (s.agentType === 'shell') {
-                const cwd = s.shellCwd ?? s.worktreePath ?? s.projectPath
-                const session = await window.api.createShellTerminal(cwd)
-                const restored =
-                  s.projectName && s.projectPath
-                    ? {
-                        ...session,
-                        projectName: s.projectName,
-                        projectPath: s.projectPath,
-                        worktreePath: s.worktreePath,
-                        worktreeName: s.worktreeName,
-                        branch: s.branch,
-                        isWorktree: s.isWorktree
-                      }
-                    : session
-                useAppStore.getState().addTerminal(restored)
-                continue
-              }
-              const resumeSessionId = await resolveResumeSessionId(s, claimed)
-              if (resumeSessionId) claimed.add(resumeSessionId)
-              const session = await window.api.createTerminal(
-                buildRestorePayload(s, resumeSessionId)
-              )
-              useAppStore.getState().addTerminal(session)
+            // The panes come back. The agents do not.
+            //
+            // This used to launch a replacement for every saved session --
+            // silently, on start-up, spending tokens and starting processes on
+            // somebody's behalf before they had looked at the screen. Now each
+            // pane shows the last thing its terminal printed and says the
+            // session ended, and resuming is a decision with a button behind it.
+            //
+            // The setting keeps its name and loses a meaning it should not have
+            // had: it governs whether panes reappear, not whether agents are
+            // relaunched. Every tool that restores terminals works this way --
+            // the view comes back, the program does not.
+            for (const one of cold) {
+              useAppStore.getState().addTerminal(one.session, {
+                reason: 'server-stopped',
+                at: one.endedAt,
+                replayed: one.replayable,
+                partial: one.partial,
+                ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
+              })
             }
-            window.api.clearPreviousSessions()
           } else {
-            useAppStore.getState().setSessionBanner(true, orphaned)
+            useAppStore.getState().setSessionBanner(
+              true,
+              cold.map((one) => one.session)
+            )
           }
         }
+
+        // Nothing calls `clearPreviousSessions()` here any more. A record is
+        // consumed on the server when a pane takes it -- by resuming or by
+        // closing -- so it survives a start that nobody acted on, and two
+        // clients can be looking at the same one safely. Clearing the list as a
+        // side effect of having restored meant a failed restore lost the record
+        // too, with nothing to try again from.
       } catch (err) {
         console.error('[App] startup initialization failed:', err)
       }

--- a/src/renderer/components/AgentCard.tsx
+++ b/src/renderer/components/AgentCard.tsx
@@ -6,7 +6,7 @@ import { TerminalPane } from './TerminalPane'
 import { terminalTextIndentPx } from '../lib/terminal-indent'
 import { CardHeader } from './card/CardHeader'
 import { CardStatusBar } from './card/CardStatusBar'
-import { IntentBar } from './IntentBar'
+import { SessionComposer } from './card/SessionComposer'
 import { PaneColumn } from './PaneColumn'
 import { SplitDivider } from './SplitDivider'
 import { DEFAULT_SPLIT_RATIO } from '../lib/split-ratio'
@@ -237,7 +237,7 @@ export const AgentCard = memo(
             </div>
 
             {!isFocused && (
-              <IntentBar
+              <SessionComposer
                 terminalId={terminalId}
                 compact
                 indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks)}

--- a/src/renderer/components/FocusedTerminal.tsx
+++ b/src/renderer/components/FocusedTerminal.tsx
@@ -8,7 +8,7 @@ import { AgentStatusIcon } from './AgentStatusIcon'
 import { InlineRename } from './InlineRename'
 import { CardHeader } from './card/CardHeader'
 import { CardStatusBar } from './card/CardStatusBar'
-import { IntentBar } from './IntentBar'
+import { SessionComposer } from './card/SessionComposer'
 import { MobileFontSizeControl } from './MobileFontSizeControl'
 import { MobileTerminalKeybar } from './MobileTerminalKeybar'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
@@ -274,12 +274,11 @@ export function FocusedTerminal() {
 
             {/* +4 for this pane's own container padding, so the caret lands in
             the terminal's text column. */}
-            {!isMobile && (
-              <IntentBar
-                terminalId={effectiveId}
-                indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks) + 4}
-              />
-            )}
+            <SessionComposer
+              terminalId={effectiveId}
+              indentPx={terminalTextIndentPx(terminal.session.agentType, domBlocks) + 4}
+              hideIntentBar={isMobile}
+            />
 
             {!isMobile && <CardStatusBar terminalId={effectiveId} />}
           </div>

--- a/src/renderer/components/SessionRestoredBanner.tsx
+++ b/src/renderer/components/SessionRestoredBanner.tsx
@@ -1,31 +1,36 @@
 import { useState } from 'react'
 import { useAppStore } from '../stores'
 import { RotateCcw, X } from 'lucide-react'
-import { resolveResumeSessionId, buildRestorePayload } from '../lib/session-utils'
+import { showEndedSession } from '../lib/session-resume'
 
 export function SessionRestoredBanner() {
   const previousSessions = useAppStore((s) => s.previousSessions)
   const setSessionBanner = useAppStore((s) => s.setSessionBanner)
-  const addTerminal = useAppStore((s) => s.addTerminal)
   const [restoring, setRestoring] = useState(false)
 
+  // Dismissing hides the offer for this launch and leaves the records alone.
+  // It used to clear them, so a glance at the banner and a wrong click threw
+  // away every terminal's history -- and there was nothing left to change your
+  // mind from. The server retires them on its own once they age out.
   const handleDismiss = (): void => {
     setSessionBanner(false)
-    window.api.clearPreviousSessions()
   }
 
+  // Shows the panes. It does not relaunch anything, which is the same rule the
+  // rest of start-up now follows: the view comes back, the agent does not.
+  //
+  // This used to build a launch payload and call `createTerminal` per session --
+  // a second implementation of resume that grew apart from the real one, and one
+  // that bypassed the server's claim, so two clients pressing it started two
+  // agents against one transcript.
   const handleRestore = async (): Promise<void> => {
     setRestoring(true)
-    const claimed = new Set<string>()
-    for (const prev of previousSessions) {
-      const resumeSessionId = await resolveResumeSessionId(prev, claimed)
-      if (resumeSessionId) claimed.add(resumeSessionId)
-      const session = await window.api.createTerminal(buildRestorePayload(prev, resumeSessionId))
-      addTerminal(session)
+    try {
+      for (const prev of previousSessions) await showEndedSession(prev.id)
+    } finally {
+      setSessionBanner(false)
+      setRestoring(false)
     }
-    setSessionBanner(false)
-    window.api.clearPreviousSessions()
-    setRestoring(false)
   }
 
   return (

--- a/src/renderer/components/TabView.tsx
+++ b/src/renderer/components/TabView.tsx
@@ -16,7 +16,7 @@ import { PromptLauncher } from './PromptLauncher'
 import { InlineRename } from './InlineRename'
 import { CardContextMenu } from './CardContextMenu'
 import { CardStatusBar } from './card/CardStatusBar'
-import { IntentBar } from './IntentBar'
+import { SessionComposer } from './card/SessionComposer'
 import { getDisplayName, getBranchLabel } from '../lib/terminal-display'
 import { closeTerminalSession } from '../lib/terminal-close'
 import { buildTooltip } from '../lib/tab-tooltip'
@@ -640,7 +640,7 @@ export function TabView() {
               )}
             </div>
             {activeTabId && activeTerminal && (
-              <IntentBar
+              <SessionComposer
                 terminalId={activeTabId}
                 indentPx={terminalTextIndentPx(activeTerminal.session.agentType, domBlocks)}
               />

--- a/src/renderer/components/TerminalsCard.tsx
+++ b/src/renderer/components/TerminalsCard.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '../stores'
 import { activePanelIndex } from '../stores/types'
 import { PaneCard, PaneControls } from './PaneCard'
 import { TerminalPane } from './TerminalPane'
-import { IntentBar } from './IntentBar'
+import { SessionComposer } from './card/SessionComposer'
 import { terminalsPaneId } from '../lib/pane-id'
 import { getDisplayName } from '../lib/terminal-display'
 import { terminalTextIndentPx } from '../lib/terminal-indent'
@@ -207,7 +207,7 @@ export const TerminalsCard = memo(
           />
         </div>
 
-        <IntentBar
+        <SessionComposer
           terminalId={active.id}
           compact
           indentPx={terminalTextIndentPx(active.agentType, domBlocks)}

--- a/src/renderer/components/card/EndedStrip.tsx
+++ b/src/renderer/components/card/EndedStrip.tsx
@@ -4,7 +4,8 @@ import type { EndedSession } from '../../stores/types'
 import { useAppStore } from '../../stores'
 import { shortenCwd } from '../../lib/command-blocks'
 import { formatRelativeTime } from '../../lib/format-time'
-import { resumeEndedSession, dismissEndedSession } from '../../lib/session-resume'
+import { resumeEndedSession } from '../../lib/session-resume'
+import { closeTerminalSession } from '../../lib/terminal-close'
 
 interface Props {
   terminalId: string
@@ -61,6 +62,9 @@ export function EndedStrip({ terminalId, ended, compact }: Props) {
           {' · '}
           {formatRelativeTime(new Date(ended.at).toISOString())}
         </span>
+        {!ended.replayed && (
+          <span className="text-ink-faint">{' · nothing of its screen was kept'}</span>
+        )}
         {ended.partial && (
           <span className="text-ink-faint">{' · the last moments were not recorded'}</span>
         )}
@@ -84,7 +88,7 @@ export function EndedStrip({ terminalId, ended, compact }: Props) {
       </button>
 
       <button
-        onClick={() => void dismissEndedSession(terminalId)}
+        onClick={() => void closeTerminalSession(terminalId)}
         disabled={busy}
         title="Close this pane"
         aria-label="Close this pane"

--- a/src/renderer/components/card/EndedStrip.tsx
+++ b/src/renderer/components/card/EndedStrip.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { Play, Terminal as TerminalIcon, X } from 'lucide-react'
+import type { EndedSession } from '../../stores/types'
+import { useAppStore } from '../../stores'
+import { shortenCwd } from '../../lib/command-blocks'
+import { formatRelativeTime } from '../../lib/format-time'
+import { resumeEndedSession, dismissEndedSession } from '../../lib/session-resume'
+
+interface Props {
+  terminalId: string
+  ended: EndedSession
+  /** Grid-card variant: one line, no room for the directory. */
+  compact?: boolean
+}
+
+/**
+ * What a pane says when nothing is running behind it.
+ *
+ * It stands where the intent bar does, and replaces it rather than stacking
+ * above it: a session with no process takes no input, so a composer here would
+ * be a control that silently does nothing. That slot is also the only one every
+ * surface already has -- the card, the tab body, the focused pane and the
+ * terminals panel all render a full-width row under the terminal -- which is how
+ * this reaches tab mode, where there is no card header at all.
+ *
+ * ## Why it is not the accent colour
+ *
+ * Bronzo means a live piece of work is blocked on a person: a waiting session,
+ * an open approval gate. This is not that. A crash ends every pane at once, so
+ * the accent would land on the whole screen and stop meaning anything anywhere
+ * -- which is the dilution the colour rules warn about. The case for using it is
+ * real, because resuming *is* a decision only a person can make; it loses to the
+ * fact that this state arrives in bulk and the accent does not survive that.
+ */
+export function EndedStrip({ terminalId, ended, compact }: Props) {
+  const [busy, setBusy] = useState(false)
+  const isShell = useAppStore((s) => s.terminals.get(terminalId)?.session.agentType === 'shell')
+  const cwd = shortenCwd(ended.cwd ?? null)
+
+  const cause =
+    ended.reason === 'exited'
+      ? ended.exitCode !== undefined
+        ? `exited with ${ended.exitCode}`
+        : 'exited'
+      : 'the server stopped'
+
+  return (
+    <div
+      className="flex shrink-0 items-center gap-2.5 border-t border-white/[0.06] py-1.5 pl-3 pr-2"
+      role="status"
+    >
+      {/* A square, not a dot. The dot vocabulary belongs to session status, and
+          this is not a status -- it is the absence of one. */}
+      <span aria-hidden className="h-[7px] w-[7px] shrink-0 bg-ink-ghost" />
+
+      <span className="min-w-0 flex-1 truncate text-[11px] text-ink-secondary">
+        <span className="text-ink">Ended</span>
+        <span className="text-ink-faint">
+          {' · '}
+          {cause}
+          {' · '}
+          {formatRelativeTime(new Date(ended.at).toISOString())}
+        </span>
+        {ended.partial && (
+          <span className="text-ink-faint">{' · the last moments were not recorded'}</span>
+        )}
+        {!compact && isShell && cwd && <span className="text-ink-faint">{` · ${cwd}`}</span>}
+      </span>
+
+      <button
+        onClick={async () => {
+          setBusy(true)
+          try {
+            await resumeEndedSession(terminalId)
+          } finally {
+            setBusy(false)
+          }
+        }}
+        disabled={busy}
+        className="flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] text-ink-secondary transition-colors hover:bg-white/[0.08] hover:text-ink disabled:opacity-40"
+      >
+        {isShell ? <TerminalIcon size={11} /> : <Play size={11} />}
+        {isShell ? 'New shell here' : 'Resume'}
+      </button>
+
+      <button
+        onClick={() => void dismissEndedSession(terminalId)}
+        disabled={busy}
+        title="Close this pane"
+        aria-label="Close this pane"
+        className="shrink-0 rounded p-1 text-ink-faint transition-colors hover:bg-white/[0.08] hover:text-ink disabled:opacity-40"
+      >
+        <X size={11} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/components/card/EndedStrip.tsx
+++ b/src/renderer/components/card/EndedStrip.tsx
@@ -38,12 +38,17 @@ export function EndedStrip({ terminalId, ended, compact }: Props) {
   const isShell = useAppStore((s) => s.terminals.get(terminalId)?.session.agentType === 'shell')
   const cwd = shortenCwd(ended.cwd ?? null)
 
+  // Three endings, and telling them apart is most of the value here. Reporting
+  // an ordinary quit as though something had stopped the server reads like a
+  // fault report for closing an app.
   const cause =
     ended.reason === 'exited'
       ? ended.exitCode !== undefined
         ? `exited with ${ended.exitCode}`
         : 'exited'
-      : 'the server stopped'
+      : ended.reason === 'app-closed'
+        ? 'Vorn was closed'
+        : 'the server stopped unexpectedly'
 
   return (
     <div

--- a/src/renderer/components/card/SessionComposer.tsx
+++ b/src/renderer/components/card/SessionComposer.tsx
@@ -1,0 +1,33 @@
+import { useAppStore } from '../../stores'
+import { IntentBar } from '../IntentBar'
+import { EndedStrip } from './EndedStrip'
+
+interface Props {
+  terminalId: string
+  compact?: boolean
+  indentPx?: number
+  /**
+   * Suppress the composer without suppressing the strip.
+   *
+   * The focused pane hides its intent bar on mobile, where the keyboard owns
+   * that space. A pane whose session has ended still has something to say
+   * there, and it is not a place to type.
+   */
+  hideIntentBar?: boolean
+}
+
+/**
+ * The row beneath a terminal: a place to type, or a note saying why there is
+ * not one.
+ *
+ * One component rather than a condition at each of the four surfaces that render
+ * this row, so a pane cannot end up offering a composer for a session that
+ * cannot take input -- which is what would happen the first time somebody added
+ * a fifth surface and copied three of the four call sites.
+ */
+export function SessionComposer({ terminalId, compact, indentPx, hideIntentBar }: Props) {
+  const ended = useAppStore((s) => s.terminals.get(terminalId)?.ended)
+  if (ended) return <EndedStrip terminalId={terminalId} ended={ended} compact={compact} />
+  if (hideIntentBar) return null
+  return <IntentBar terminalId={terminalId} compact={compact} indentPx={indentPx} />
+}

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -101,7 +101,7 @@ export function GeneralSettings() {
         {/* Reopen Sessions */}
         <SettingRow
           label="Reopen Sessions on Startup"
-          description="Bring back the panes you had open, showing the last screen each one drew. Agents that are still running are reconnected to; ones that ended wait for you to resume them."
+          description="Bring back the panes you had open. Agents still running are reconnected to, keeping the turn they were in; ones whose process was stopped are started again where they left off, and shells reopen in the directory they were in."
         >
           <ToggleSwitch
             checked={config.defaults.reopenSessions ?? true}

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -101,10 +101,10 @@ export function GeneralSettings() {
         {/* Reopen Sessions */}
         <SettingRow
           label="Reopen Sessions on Startup"
-          description="Automatically restore previous sessions when the app starts"
+          description="Bring back the panes you had open, showing the last screen each one drew. Agents that are still running are reconnected to; ones that ended wait for you to resume them."
         >
           <ToggleSwitch
-            checked={config.defaults.reopenSessions ?? false}
+            checked={config.defaults.reopenSessions ?? true}
             onChange={(reopenSessions) => updateDefaults({ reopenSessions })}
           />
         </SettingRow>

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -1,6 +1,7 @@
 import type { RestoredSession, TerminalSession } from '../../shared/types'
 import { useAppStore } from '../stores'
 import { coldSessions } from './session-utils'
+import { resumeEndedSession } from './session-resume'
 
 /**
  * Make the board agree with what the server actually has.
@@ -17,7 +18,11 @@ import { coldSessions } from './session-utils'
  * quiet for a moment, which is the one thing a pane must never look like when it
  * is a photograph.
  */
-export async function syncBoard(options: { showCold: boolean }): Promise<void> {
+export async function syncBoard(options: { showCold: boolean; resume: boolean }): Promise<void> {
+  // Sessions this pass found ended, which is not the same as sessions that are
+  // ended. A pane the person already chose to leave sitting there must not be
+  // started again by the next reconciliation that happens to run.
+  const justEnded: string[] = []
   const answers = await Promise.all([
     window.api.listActiveSessions(),
     window.api.getRestoredSessions()
@@ -44,6 +49,7 @@ export async function syncBoard(options: { showCold: boolean }): Promise<void> {
   for (const [id, term] of useAppStore.getState().terminals) {
     if (live.has(id) || term.ended) continue
     const held = heldById.get(id)
+    justEnded.push(id)
     useAppStore.getState().markEnded(id, {
       reason: held?.closedCleanly ? 'app-closed' : 'server-stopped',
       // A held record knows when its run ended. Without one the best available
@@ -58,17 +64,46 @@ export async function syncBoard(options: { showCold: boolean }): Promise<void> {
     })
   }
 
-  if (!options.showCold) return
-
   // And the ones with no pane at all yet: ended before this window opened.
-  for (const one of coldSessions(active, carried)) {
-    if (useAppStore.getState().terminals.has(one.session.id)) continue
-    useAppStore.getState().addTerminal(one.session, {
-      reason: one.closedCleanly ? 'app-closed' : 'server-stopped',
-      at: one.endedAt,
-      replayed: one.replayable,
-      partial: one.partial,
-      ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
-    })
+  if (options.showCold)
+    for (const one of coldSessions(active, carried)) {
+      if (useAppStore.getState().terminals.has(one.session.id)) continue
+      justEnded.push(one.session.id)
+      useAppStore.getState().addTerminal(one.session, {
+        reason: one.closedCleanly ? 'app-closed' : 'server-stopped',
+        at: one.endedAt,
+        replayed: one.replayable,
+        partial: one.partial,
+        ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
+      })
+    }
+
+  if (options.resume) await resumeAll(justEnded)
+}
+
+/**
+ * Start again what this pass found stopped -- not everything that is stopped.
+ *
+ * Only ids this reconciliation marked itself, which is what keeps two kinds of
+ * ended session out of it. A pane somebody looked at and chose to leave sitting
+ * there is skipped above, because it was already ended when this began. So is an
+ * agent that exited on its own -- a finished turn, a `/quit` -- which the exit
+ * handler marked at the time; relaunching that would be a surprise the first
+ * time and a loop every time after. Both are the same rule: this starts sessions
+ * that were stopped, never sessions that stopped.
+ *
+ * One at a time, because each one spawns a process: six panes resuming together
+ * is six agents starting in the same instant, and going in order means they come
+ * back in the order they were in.
+ */
+async function resumeAll(ids: string[]): Promise<void> {
+  for (const id of ids) {
+    // Read again rather than carried: each resume above it awaited a spawn, and
+    // an exit or a close for this pane could have arrived in that gap.
+    const term = useAppStore.getState().terminals.get(id)
+    if (!term?.ended) continue
+    // A failure leaves the pane ended and its strip on screen, which is already
+    // the offer to try again by hand. Nothing is said twice.
+    await resumeEndedSession(id, { automatic: true })
   }
 }

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -31,9 +31,14 @@ let inFlight: Promise<void> | null = null
 
 export function syncBoard(options: { showCold: boolean; resume: boolean }): Promise<void> {
   const run = (inFlight ?? Promise.resolve()).catch(() => undefined).then(() => reconcile(options))
-  inFlight = run.finally(() => {
-    if (inFlight === run) inFlight = null
+  // Tracked separately from what is returned. `finally` hands back a new promise
+  // rather than the one it was called on, so comparing against `run` here never
+  // matched and the reset never happened -- passes stayed chained off a promise
+  // that had settled long ago.
+  const tracked: Promise<void> = run.finally(() => {
+    if (inFlight === tracked) inFlight = null
   })
+  inFlight = tracked
   return run
 }
 
@@ -116,6 +121,8 @@ async function reconcile(options: { showCold: boolean; resume: boolean }): Promi
  * back in the order they were in.
  */
 async function resumeAll(ids: string[]): Promise<void> {
+  // One set for the pass, not one per pane. See `resumeEndedSession`.
+  const claimed = new Set<string>()
   for (const id of ids) {
     // Read again rather than carried: each resume above it awaited a spawn, and
     // an exit or a close for this pane could have arrived in that gap.
@@ -123,6 +130,6 @@ async function resumeAll(ids: string[]): Promise<void> {
     if (!term?.ended) continue
     // A failure leaves the pane ended and its strip on screen, which is already
     // the offer to try again by hand. Nothing is said twice.
-    await resumeEndedSession(id, { automatic: true })
+    await resumeEndedSession(id, { automatic: true, claimed })
   }
 }

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -1,0 +1,74 @@
+import type { RestoredSession, TerminalSession } from '../../shared/types'
+import { useAppStore } from '../stores'
+import { coldSessions } from './session-utils'
+
+/**
+ * Make the board agree with what the server actually has.
+ *
+ * Two questions -- what is running, and what is left of what is not -- asked at
+ * the two moments the answer can change out from under a pane: when the app
+ * starts, and when the server behind it is replaced.
+ *
+ * That second moment is the one this exists for. A pane's content lives in the
+ * renderer, so when a server dies nothing about the pane changes: the terminal
+ * keeps showing what it was showing, the bridge quietly reconnects to a
+ * replacement holding none of the old PTYs, and the pane goes on accepting input
+ * for a process that is gone. It looks exactly like a terminal that has been
+ * quiet for a moment, which is the one thing a pane must never look like when it
+ * is a photograph.
+ */
+export async function syncBoard(options: { showCold: boolean }): Promise<void> {
+  const answers = await Promise.all([
+    window.api.listActiveSessions(),
+    window.api.getRestoredSessions()
+  ]).catch((err) => {
+    console.error('[board] failed to read what the server has:', err)
+    return null
+  })
+  // A board left as it is beats a board rebuilt from an answer nobody gave.
+  if (!answers) return
+  const [active, carried]: [TerminalSession[], RestoredSession[]] = answers
+
+  const store = useAppStore.getState()
+  const live = new Set(active.map((s) => s.id))
+  const heldById = new Map(carried.map((one) => [one.session.id, one]))
+
+  // Anything the server has that this board does not. A session started from a
+  // phone, or by a workflow, or before this window existed.
+  for (const session of active) {
+    if (!store.terminals.has(session.id)) store.addTerminal(session)
+  }
+
+  // Panes this board is holding for sessions the server no longer runs. On a
+  // first start there are none; after a replacement this is all of them.
+  for (const [id, term] of useAppStore.getState().terminals) {
+    if (live.has(id) || term.ended) continue
+    const held = heldById.get(id)
+    useAppStore.getState().markEnded(id, {
+      reason: held?.closedCleanly ? 'app-closed' : 'server-stopped',
+      // A held record knows when its run ended. Without one the best available
+      // answer is when this pane last saw anything.
+      at: held?.endedAt ?? term.lastOutputTimestamp,
+      // Whether there is a rebuilt screen behind it. False means the pane is
+      // showing what it happens to still have in its own buffer and nothing
+      // more, which the strip says out loud.
+      replayed: held?.replayable ?? false,
+      ...(held?.partial !== undefined && { partial: held.partial }),
+      ...(term.session.shellCwd !== undefined && { cwd: term.session.shellCwd })
+    })
+  }
+
+  if (!options.showCold) return
+
+  // And the ones with no pane at all yet: ended before this window opened.
+  for (const one of coldSessions(active, carried)) {
+    if (useAppStore.getState().terminals.has(one.session.id)) continue
+    useAppStore.getState().addTerminal(one.session, {
+      reason: one.closedCleanly ? 'app-closed' : 'server-stopped',
+      at: one.endedAt,
+      replayed: one.replayable,
+      partial: one.partial,
+      ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
+    })
+  }
+}

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -18,7 +18,26 @@ import { resumeEndedSession } from './session-resume'
  * quiet for a moment, which is the one thing a pane must never look like when it
  * is a photograph.
  */
-export async function syncBoard(options: { showCold: boolean; resume: boolean }): Promise<void> {
+/**
+ * The pass in flight, so a second caller waits for it rather than racing it.
+ *
+ * Two of these overlapping is not a hypothetical: start-up runs one, a server
+ * replaced moments later runs another, and in development the mount effect runs
+ * twice by design. Both passes then read the same cold records, both ask to
+ * resume them, and the loser is told the session is gone -- which used to delete
+ * the pane the winner had just brought back.
+ */
+let inFlight: Promise<void> | null = null
+
+export function syncBoard(options: { showCold: boolean; resume: boolean }): Promise<void> {
+  const run = (inFlight ?? Promise.resolve()).catch(() => undefined).then(() => reconcile(options))
+  inFlight = run.finally(() => {
+    if (inFlight === run) inFlight = null
+  })
+  return run
+}
+
+async function reconcile(options: { showCold: boolean; resume: boolean }): Promise<void> {
   // Sessions this pass found ended, which is not the same as sessions that are
   // ended. A pane the person already chose to leave sitting there must not be
   // started again by the next reconciliation that happens to run.

--- a/src/renderer/lib/command-blocks.ts
+++ b/src/renderer/lib/command-blocks.ts
@@ -272,6 +272,29 @@ function bufferOf(term: Terminal): BufferLike {
 }
 
 /**
+ * Panes holding a screen they did not draw themselves.
+ *
+ * A pane that attaches to a session already running is seeded with what that
+ * session has shown so far, and that screen then lives in the terminal and
+ * nowhere else -- the block log is a renderer thing and does not survive the
+ * window that built it. So the first command to finish would hand its own rows
+ * to the log, call `term.clear()`, and take the whole restored screen with it:
+ * everything from before the pane was opened gone at the first prompt.
+ */
+const seededFromServer = new Set<string>()
+
+/**
+ * Say a pane was seeded rather than grown from an empty terminal.
+ *
+ * Told by whoever does the seeding rather than discovered here, for the same
+ * reason the cwd is: this module is about blocks and should not have to know
+ * how a terminal came to have something in it.
+ */
+export function markSeededFromServer(terminalId: string): void {
+  seededFromServer.add(terminalId)
+}
+
+/**
  * Hand a finished command to the DOM log and clear the terminal.
  *
  * term.clear() keeps the current prompt line and drops everything above it,
@@ -280,6 +303,23 @@ function bufferOf(term: Terminal): BufferLike {
  */
 function liftBlockToDom(term: Terminal, terminalId: string, block: CommandBlock): void {
   const start = (block.marker as IMarker).line
+
+  // Once per seeded pane, and before the clear below can reach it. No command
+  // produced this, so it is logged without one -- the same shape a shell that
+  // cannot report its command text already produces.
+  if (seededFromServer.delete(terminalId) && start > 0) {
+    captureBlock({
+      terminalId,
+      buffer: bufferOf(term),
+      startLine: 0,
+      endLine: start - 1,
+      command: null,
+      exitCode: 0,
+      durationMs: 0,
+      cwd: null
+    })
+  }
+
   const end = term.buffer.active.baseY + term.buffer.active.cursorY
   captureBlock({
     terminalId,

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -23,7 +23,11 @@ export async function showEndedSession(id: string): Promise<void> {
   const one = carried.find((r) => r.session.id === id)
   if (!one) return
   useAppStore.getState().addTerminal(one.session, {
-    reason: 'server-stopped',
+    // The record says which ending this was; `board-sync` reads it and this did
+    // not. Taking the banner's offer after an ordinary quit therefore produced a
+    // pane reporting that the server had stopped unexpectedly -- a fault report
+    // for closing an app.
+    reason: one.closedCleanly ? 'app-closed' : 'server-stopped',
     at: one.endedAt,
     replayed: one.replayable,
     partial: one.partial,

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from '../stores'
 import { toast } from '../components/Toast'
 import { resolveResumeSessionId } from './session-utils'
+import { settleTerminalForResume } from './terminal-registry'
 
 /**
  * Taking a session from a previous run, or letting it go.
@@ -57,6 +58,11 @@ export async function resumeEndedSession(
   } catch {
     // No exact match found. The agent's own picker is better than refusing.
   }
+
+  // Before the ask, not after: the resumed process can write the instant it
+  // exists, and this pane is still carrying the emulator state its last session
+  // left behind.
+  settleTerminalForResume(terminalId)
 
   const result = await window.api.resumeSession({ id: terminalId, resumeSessionId })
   if (!result.ok) {

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -31,8 +31,19 @@ export async function showEndedSession(id: string): Promise<void> {
   })
 }
 
-/** Start it again, and put the live session where the ended one was sitting. */
-export async function resumeEndedSession(terminalId: string): Promise<void> {
+/**
+ * Start it again, and put the live session where the ended one was sitting.
+ *
+ * `automatic` marks the resumes nobody clicked -- the ones start-up and a
+ * replaced server do on their own when "Reopen Sessions on Startup" is on. They
+ * say nothing when they fail: the pane keeps its ended strip, which is already
+ * the offer to try by hand, and a crash that ends six panes would otherwise
+ * stack six toasts saying so.
+ */
+export async function resumeEndedSession(
+  terminalId: string,
+  options: { automatic?: boolean } = {}
+): Promise<void> {
   const state = useAppStore.getState()
   const previous = state.terminals.get(terminalId)?.session
   if (!previous) return
@@ -53,10 +64,10 @@ export async function resumeEndedSession(terminalId: string): Promise<void> {
       // Another pane, window or device took it first. Nothing to resume and
       // nothing to keep showing.
       useAppStore.getState().removeTerminal(terminalId)
-      toast('That session was resumed somewhere else')
+      if (!options.automatic) toast('That session was resumed somewhere else')
       return
     }
-    toast.error(result.message ?? 'Could not resume that session')
+    if (!options.automatic) toast.error(result.message ?? 'Could not resume that session')
     return
   }
 

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -62,9 +62,13 @@ export async function resumeEndedSession(
   if (!result.ok) {
     if (result.reason === 'gone') {
       // Another pane, window or device took it first. Nothing to resume and
-      // nothing to keep showing.
+      // nothing to keep showing -- but only when a person asked for this. An
+      // automatic resume that loses the claim has almost always lost it to this
+      // same app, and deleting the pane then removes the one the winner just
+      // brought back, silently, because automatic resumes say nothing.
+      if (options.automatic) return
       useAppStore.getState().removeTerminal(terminalId)
-      if (!options.automatic) toast('That session was resumed somewhere else')
+      toast('That session was resumed somewhere else')
       return
     }
     if (!options.automatic) toast.error(result.message ?? 'Could not resume that session')

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -42,7 +42,7 @@ export async function showEndedSession(id: string): Promise<void> {
  */
 export async function resumeEndedSession(
   terminalId: string,
-  options: { automatic?: boolean } = {}
+  options: { automatic?: boolean; claimed?: Set<string> } = {}
 ): Promise<void> {
   const state = useAppStore.getState()
   const previous = state.terminals.get(terminalId)?.session
@@ -53,7 +53,15 @@ export async function resumeEndedSession(
   // and already lives here; the server is given the answer, not the search.
   let resumeSessionId: string | undefined
   try {
-    resumeSessionId = await resolveResumeSessionId(previous)
+    // `claimed` carries across a whole pass. Where an agent cannot be asked for
+    // an exact id -- codex and opencode support resuming but not pinning, so
+    // there is never an `agentSessionId` to use -- this falls back to scanning
+    // the agent's own history and taking the first match for the project. Two
+    // panes resolved independently would take the same one, and the pass would
+    // start two agents against a single transcript: the thing the record's own
+    // claim exists to prevent, undone one layer down.
+    resumeSessionId = await resolveResumeSessionId(previous, options.claimed)
+    if (resumeSessionId) options.claimed?.add(resumeSessionId)
   } catch {
     // No exact match found. The agent's own picker is better than refusing.
   }

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -1,0 +1,55 @@
+import { useAppStore } from '../stores'
+import { toast } from '../components/Toast'
+import { resolveResumeSessionId } from './session-utils'
+
+/**
+ * Taking a session from a previous run, or letting it go.
+ *
+ * Both go through the server, which holds the record and hands it out once. Two
+ * panes can be showing the same ended session -- a desktop and a phone, or two
+ * windows -- and the second to act is told it is gone rather than starting a
+ * second agent against one transcript.
+ */
+
+/** Start it again, and put the live session where the ended one was sitting. */
+export async function resumeEndedSession(terminalId: string): Promise<void> {
+  const state = useAppStore.getState()
+  const previous = state.terminals.get(terminalId)?.session
+  if (!previous) return
+
+  // Which agent-side conversation to continue. Resolved here rather than on the
+  // server because it fans out to the agent history, which is a client concern
+  // and already lives here; the server is given the answer, not the search.
+  let resumeSessionId: string | undefined
+  try {
+    resumeSessionId = await resolveResumeSessionId(previous)
+  } catch {
+    // No exact match found. The agent's own picker is better than refusing.
+  }
+
+  const result = await window.api.resumeSession({ id: terminalId, resumeSessionId })
+  if (!result.ok) {
+    if (result.reason === 'gone') {
+      // Another pane, window or device took it first. Nothing to resume and
+      // nothing to keep showing.
+      useAppStore.getState().removeTerminal(terminalId)
+      toast('That session was resumed somewhere else')
+      return
+    }
+    toast(result.message ?? 'Could not resume that session')
+    return
+  }
+
+  useAppStore.getState().replaceTerminal(terminalId, result.session)
+}
+
+/** Decline the offer. The record and what was written for it both go. */
+export async function dismissEndedSession(terminalId: string): Promise<void> {
+  useAppStore.getState().removeTerminal(terminalId)
+  try {
+    await window.api.killTerminal(terminalId)
+  } catch {
+    // The record is the server's to forget; a pane that has already gone from
+    // this client is not worth a message about it.
+  }
+}

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -1,7 +1,6 @@
 import { useAppStore } from '../stores'
 import { toast } from '../components/Toast'
 import { resolveResumeSessionId } from './session-utils'
-import { settleTerminalForResume } from './terminal-registry'
 
 /**
  * Taking a session from a previous run, or letting it go.
@@ -58,11 +57,6 @@ export async function resumeEndedSession(
   } catch {
     // No exact match found. The agent's own picker is better than refusing.
   }
-
-  // Before the ask, not after: the resumed process can write the instant it
-  // exists, and this pane is still carrying the emulator state its last session
-  // left behind.
-  settleTerminalForResume(terminalId)
 
   const result = await window.api.resumeSession({ id: terminalId, resumeSessionId })
   if (!result.ok) {

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -11,6 +11,26 @@ import { resolveResumeSessionId } from './session-utils'
  * second agent against one transcript.
  */
 
+/**
+ * Put an ended session on screen without starting anything.
+ *
+ * The server still holds its record and the screen it rebuilt from disk; this
+ * asks for both and adds the pane. Used by the banner, which offers to bring
+ * panes back rather than to relaunch agents -- the same rule start-up follows.
+ */
+export async function showEndedSession(id: string): Promise<void> {
+  const carried = await window.api.getRestoredSessions()
+  const one = carried.find((r) => r.session.id === id)
+  if (!one) return
+  useAppStore.getState().addTerminal(one.session, {
+    reason: 'server-stopped',
+    at: one.endedAt,
+    replayed: one.replayable,
+    partial: one.partial,
+    ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
+  })
+}
+
 /** Start it again, and put the live session where the ended one was sitting. */
 export async function resumeEndedSession(terminalId: string): Promise<void> {
   const state = useAppStore.getState()
@@ -36,20 +56,29 @@ export async function resumeEndedSession(terminalId: string): Promise<void> {
       toast('That session was resumed somewhere else')
       return
     }
-    toast(result.message ?? 'Could not resume that session')
+    toast.error(result.message ?? 'Could not resume that session')
     return
   }
 
   useAppStore.getState().replaceTerminal(terminalId, result.session)
 }
 
-/** Decline the offer. The record and what was written for it both go. */
-export async function dismissEndedSession(terminalId: string): Promise<void> {
-  useAppStore.getState().removeTerminal(terminalId)
-  try {
-    await window.api.killTerminal(terminalId)
-  } catch {
-    // The record is the server's to forget; a pane that has already gone from
-    // this client is not worth a message about it.
-  }
+/**
+ * Say what a pane should do when an attach finds nothing behind it.
+ *
+ * Wired once at start-up. A window opened onto a terminal that died while it was
+ * closed has no start-up reconciliation to tell it, so the attach is where it
+ * finds out -- and this is the only place that knows what the pane should then
+ * look like.
+ */
+export function markPaneEnded(terminalId: string): void {
+  const state = useAppStore.getState()
+  const term = state.terminals.get(terminalId)
+  if (!term || term.ended) return
+  state.markEnded(terminalId, {
+    reason: 'server-stopped',
+    at: term.lastOutputTimestamp,
+    replayed: true,
+    ...(term.session.shellCwd !== undefined && { cwd: term.session.shellCwd })
+  })
 }

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -366,3 +366,26 @@ export function resolveActiveProject() {
   const ws = state.activeWorkspace
   return projects.find((p) => (p.workspaceId ?? 'personal') === ws)
 }
+
+/**
+ * What the server has against what the database remembers.
+ *
+ * Two different questions, and start-up used to ask only the second. A saved
+ * record says a session existed when it was last written down; a running PTY
+ * says one exists now. Where both agree the pane binds to the process that never
+ * stopped -- relaunching it as well would put a second agent on the same work,
+ * and the first would carry on unattached.
+ *
+ * The server is the authority on the first list, so a session it reports that
+ * nothing saved still gets a pane: it exists, whatever the database thinks.
+ */
+export function reconcileSessions(
+  active: TerminalSession[],
+  saved: TerminalSession[]
+): { adopt: TerminalSession[]; orphaned: TerminalSession[] } {
+  const running = new Set(active.map((s) => s.id))
+  return {
+    adopt: active,
+    orphaned: saved.filter((s) => !running.has(s.id))
+  }
+}

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -3,7 +3,6 @@ import {
   getProjectRemoteHostId,
   type TerminalSession,
   type RecentSession,
-  type CreateTerminalPayload,
   type ProjectConfig,
   type AiAgentType
 } from '../../shared/types'
@@ -82,6 +81,8 @@ function isDefined<T>(value: T | undefined): value is T {
  * @param claimed - session IDs already assigned to other terminals in this
  *   restore batch; prevents multiple terminals from resuming the same session.
  */
+export { buildRestorePayload } from '@vornrun/shared/session-restore'
+
 export async function resolveResumeSessionId(
   s: TerminalSession,
   claimed: Set<string> = new Set()
@@ -150,29 +151,6 @@ export function resolveProjectName(
     return projectPath === normalized || isManagedWorktreePath(session.projectPath, p.path)
   })
   return project?.name || displayBasename || 'untitled'
-}
-
-export function buildRestorePayload(
-  s: TerminalSession,
-  resumeSessionId?: string
-): CreateTerminalPayload {
-  if (s.agentType === 'shell') {
-    throw new Error(
-      'buildRestorePayload: shell sessions restore via createShellTerminal, not createTerminal'
-    )
-  }
-  return {
-    agentType: s.agentType,
-    projectName: s.projectName,
-    projectPath: s.projectPath,
-    displayName: s.displayName,
-    branch: s.isWorktree ? s.branch : undefined,
-    existingWorktreePath: s.isWorktree ? s.worktreePath : undefined,
-    worktreeName: s.worktreeName,
-    useWorktree: (s.isWorktree && !s.worktreePath) || undefined,
-    remoteHostId: s.remoteHostId,
-    resumeSessionId
-  }
 }
 
 /**

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -3,6 +3,7 @@ import {
   getProjectRemoteHostId,
   type TerminalSession,
   type RecentSession,
+  type RestoredSession,
   type ProjectConfig,
   type AiAgentType
 } from '../../shared/types'
@@ -346,24 +347,26 @@ export function resolveActiveProject() {
 }
 
 /**
- * What the server has against what the database remembers.
+ * Two answers from the server, made into one board.
  *
- * Two different questions, and start-up used to ask only the second. A saved
- * record says a session existed when it was last written down; a running PTY
- * says one exists now. Where both agree the pane binds to the process that never
- * stopped -- relaunching it as well would put a second agent on the same work,
- * and the first would carry on unattached.
+ * The server is asked what is running and what it is still holding from the last
+ * run, and those are separate round trips -- so a resume happening elsewhere
+ * between them can put one id in both answers. A session that is running is not
+ * also ended, and the live one wins: the alternative is two panes for one
+ * terminal, one of them a photograph offering to start what is already going.
  *
- * The server is the authority on the first list, so a session it reports that
- * nothing saved still gets a pane: it exists, whatever the database thinks.
+ * The saved list is not consulted at all. It used to be the only question asked
+ * at start-up, and it is the wrong one: it says what existed when it was last
+ * written down. Between them these two say what exists now and what is left of
+ * what does not, which is the whole board.
  */
 export function reconcileSessions(
   active: TerminalSession[],
-  saved: TerminalSession[]
-): { adopt: TerminalSession[]; orphaned: TerminalSession[] } {
+  restored: RestoredSession[]
+): { adopt: TerminalSession[]; cold: RestoredSession[] } {
   const running = new Set(active.map((s) => s.id))
   return {
     adopt: active,
-    orphaned: saved.filter((s) => !running.has(s.id))
+    cold: restored.filter((one) => !running.has(one.session.id))
   }
 }

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -11,6 +11,8 @@ import { useAppStore } from '../stores'
 import { toast } from '../components/Toast'
 import { closeTerminalsPanel } from './terminal-close'
 
+export { buildRestorePayload } from '@vornrun/shared/session-restore'
+
 function normalizeComparablePath(p: string): string {
   const normalized = p.replace(/\\/g, '/').replace(/\/+$/, '')
   if (!normalized) return '/'
@@ -82,8 +84,6 @@ function isDefined<T>(value: T | undefined): value is T {
  * @param claimed - session IDs already assigned to other terminals in this
  *   restore batch; prevents multiple terminals from resuming the same session.
  */
-export { buildRestorePayload } from '@vornrun/shared/session-restore'
-
 export async function resolveResumeSessionId(
   s: TerminalSession,
   claimed: Set<string> = new Set()
@@ -347,26 +347,17 @@ export function resolveActiveProject() {
 }
 
 /**
- * Two answers from the server, made into one board.
+ * The sessions the server is holding that are not also running.
  *
- * The server is asked what is running and what it is still holding from the last
- * run, and those are separate round trips -- so a resume happening elsewhere
- * between them can put one id in both answers. A session that is running is not
- * also ended, and the live one wins: the alternative is two panes for one
- * terminal, one of them a photograph offering to start what is already going.
- *
- * The saved list is not consulted at all. It used to be the only question asked
- * at start-up, and it is the wrong one: it says what existed when it was last
- * written down. Between them these two say what exists now and what is left of
- * what does not, which is the whole board.
+ * Two separate round trips answer "what is running" and "what is left of what is
+ * not", so a resume happening elsewhere between them can put one id in both. The
+ * live one wins: the alternative is two panes for one terminal, one of them a
+ * photograph offering to start what is already going.
  */
-export function reconcileSessions(
+export function coldSessions(
   active: TerminalSession[],
   restored: RestoredSession[]
-): { adopt: TerminalSession[]; cold: RestoredSession[] } {
+): RestoredSession[] {
   const running = new Set(active.map((s) => s.id))
-  return {
-    adopt: active,
-    cold: restored.filter((one) => !running.has(one.session.id))
-  }
+  return restored.filter((one) => !running.has(one.session.id))
 }

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -815,12 +815,18 @@ export function onTerminalScroll(
 export function destroyTerminal(terminalId: string): void {
   const entry = registry.get(terminalId)
   if (!entry) return
-  // Flush any pending batched writes before destroying
+  // Flush any pending batched writes before destroying. Joined by their data:
+  // these became `{ data, seq }` when attaching needed a way to tell what a seed
+  // already contained, and this line kept joining the objects -- which type-
+  // checks, and writes `[object Object]` instead of the output it exists to save.
   const chunks = pendingWrites.get(terminalId)
   if (chunks) {
-    entry.term.write(chunks.join(''))
+    entry.term.write(chunks.map((chunk) => chunk.data).join(''))
     pendingWrites.delete(terminalId)
   }
+  // A seed still in flight would otherwise resolve and write into a terminal
+  // that no longer exists.
+  hydrating.delete(terminalId)
   statusHandlers.delete(terminalId)
   entry._disposeCommandBlocks?.()
   entry._disposeCommandBlocks = null

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -25,6 +25,26 @@ interface TerminalEntry {
 export const TERMINAL_ID_ATTR = 'data-terminal-id'
 
 const registry = new Map<string, TerminalEntry>()
+
+/**
+ * Terminals currently being written a screen from the past.
+ *
+ * A replayed screen is a recording, and recordings contain the questions the
+ * old program asked its terminal -- who are you, where is the cursor, what
+ * colour is the background. Written into a real emulator those are asked again,
+ * and this one answers, because answering is what a terminal does. The answers
+ * go down the pty as though they had been typed: the shell echoes them, tries to
+ * run them, and the pane fills with `rgb:d4d4/d4d4/d8d8` and `execute:`.
+ *
+ * The program that asked is gone and nothing is waiting for a reply, so during
+ * a seed there is nobody to answer and the replies are dropped. Only during the
+ * seed -- a live program asking the same question is owed a real answer.
+ *
+ * The server's own screen model has been guarded against this since it was
+ * written (`pty-manager-screen.test.ts`); the client had the same hole and no
+ * seeded screen to fall into it until this branch.
+ */
+const seeding = new Set<string>()
 const readyCallbacks = new Map<string, Set<() => void>>()
 
 // --- Write batching: single global listener + requestAnimationFrame ---
@@ -103,6 +123,7 @@ export function disposeGlobalDataListener(): void {
   }
   pendingWrites.clear()
   hydrating.clear()
+  seeding.clear()
 }
 
 /**
@@ -157,7 +178,11 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
     try {
       const { data, seq, live } = await window.api.attachTerminal(terminalId)
       if (data) {
-        entry.term.write(data)
+        // Cleared from the write callback, which xterm runs once these bytes
+        // have been parsed -- so it covers every reply they provoke and nothing
+        // after them.
+        seeding.add(terminalId)
+        entry.term.write(data, () => seeding.delete(terminalId))
         // This screen is now in the terminal and nowhere else. Said out loud so
         // the first finished command lifts it into the block log rather than
         // clearing it away.
@@ -264,6 +289,9 @@ export function getEffectiveFontSize(size?: number): number {
 const rendererIsMac = navigator.platform.toUpperCase().includes('MAC')
 
 function createTerminalEntry(terminalId: string): TerminalEntry {
+  // A write callback that never ran -- a pane torn down mid-seed -- would
+  // otherwise leave this id suppressed for as long as the window lives.
+  seeding.delete(terminalId)
   const term = new Terminal({ ...TERM_OPTIONS, fontSize: getEffectiveFontSize() })
   const fitAddon = new FitAddon()
   term.loadAddon(fitAddon)
@@ -368,6 +396,7 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
 
   // Forward keystrokes to pty
   term.onData((data) => {
+    if (seeding.has(terminalId)) return
     window.api.writeTerminal(terminalId, data)
   })
 

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -46,10 +46,14 @@ let rafId: number | null = null
  * written -- then the ones the seed already contains are dropped by their number
  * and the rest are applied in order.
  */
-const hydrating = new Map<string, Chunk[]>()
+interface Hydration {
+  /** Live chunks arriving while the seed is in flight. */
+  held: Chunk[]
+  /** The seed itself, so concurrent callers join it rather than starting another. */
+  done: Promise<void>
+}
 
-/** Seeds in flight, so concurrent callers join one rather than starting several. */
-const hydrations = new Map<string, Promise<void>>()
+const hydrating = new Map<string, Hydration>()
 
 function scheduleFlush(): void {
   if (rafId !== null) return
@@ -59,9 +63,9 @@ function scheduleFlush(): void {
 function flushWrites(): void {
   rafId = null
   for (const [id, chunks] of pendingWrites) {
-    const holding = hydrating.get(id)
-    if (holding) {
-      holding.push(...chunks)
+    const seeding = hydrating.get(id)
+    if (seeding) {
+      for (const chunk of chunks) seeding.held.push(chunk)
       continue
     }
     const data = chunks.length === 1 ? chunks[0].data : chunks.map((c) => c.data).join('')
@@ -99,7 +103,6 @@ export function disposeGlobalDataListener(): void {
   }
   pendingWrites.clear()
   hydrating.clear()
-  hydrations.clear()
 }
 
 /**
@@ -126,8 +129,8 @@ export function disposeGlobalDataListener(): void {
  * terminal seeded twice has its scrollback twice.
  */
 export function hydrateTerminal(terminalId: string): Promise<void> {
-  const already = hydrations.get(terminalId)
-  if (already) return already
+  const already = hydrating.get(terminalId)
+  if (already) return already.done
 
   const entry = registry.get(terminalId)
   if (!entry || entry._hydrated) return Promise.resolve()
@@ -136,35 +139,54 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
   if (typeof window.api?.attachTerminal !== 'function') return Promise.resolve()
   entry._hydrated = true
 
-  hydrating.set(terminalId, [])
-  const run = (async () => {
+  const state: Hydration = { held: [], done: Promise.resolve() }
+  hydrating.set(terminalId, state)
+
+  /** Everything held, in order, as one write. xterm queues a task per call. */
+  const flushHeld = (above = -1): void => {
+    const kept = state.held.filter((chunk) => chunk.seq > above)
+    if (!kept.length) return
+    const data = kept.map((chunk) => chunk.data).join('')
+    entry.term.write(data)
+    // Live, unlike the seed: a bell that rang while the seed was in flight rang
+    // just now, and holding it back for a round trip would drop it entirely.
+    statusHandlers.get(terminalId)?.(data)
+  }
+
+  state.done = (async () => {
     try {
-      const { data, seq } = await window.api.attachTerminal(terminalId)
+      const { data, seq, live } = await window.api.attachTerminal(terminalId)
       if (data) entry.term.write(data)
-      for (const chunk of hydrating.get(terminalId) ?? []) {
-        if (chunk.seq <= seq) continue
-        entry.term.write(chunk.data)
-        // These are live, unlike the seed above them. A bell that rang while the
-        // seed was in flight rang just now, and holding it back for the length
-        // of a round trip would drop the notification entirely.
-        statusHandlers.get(terminalId)?.(chunk.data)
-      }
+      flushHeld(seq)
+      // The one moment a pane learns the truth about its session. A window
+      // opened onto a terminal that died while it was closed has no start-up
+      // reconciliation to tell it -- this is where it finds out.
+      if (live === false) reportNotLive?.(terminalId)
     } catch (err) {
       console.error('[terminal] could not attach', terminalId, err)
       // Held chunks are still the truth about what happened; let them through
       // rather than losing them to a failed seed, and allow another try.
-      for (const chunk of hydrating.get(terminalId) ?? []) {
-        entry.term.write(chunk.data)
-        statusHandlers.get(terminalId)?.(chunk.data)
-      }
+      flushHeld()
       entry._hydrated = false
     } finally {
       hydrating.delete(terminalId)
-      hydrations.delete(terminalId)
     }
   })()
-  hydrations.set(terminalId, run)
-  return run
+  return state.done
+}
+
+/**
+ * Told when an attach finds nothing running behind a terminal.
+ *
+ * Set once at start-up by the app, which turns it into the pane's ended state.
+ * Kept as a reporter rather than an import so this module stays about terminals
+ * and knows nothing about the store.
+ */
+type NotLiveReporter = (terminalId: string) => void
+let reportNotLive: NotLiveReporter | null = null
+
+export function setNotLiveReporter(fn: NotLiveReporter | null): void {
+  reportNotLive = fn
 }
 
 // --- Status detection handler registry ---

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -627,34 +627,6 @@ export function getTerminalSelection(terminalId: string): string {
   return entry.term.getSelection()
 }
 
-/**
- * Put a terminal into a known state before a resumed process writes to it.
- *
- * Resuming keeps the pane, which is the point -- the replayed screen stays and
- * the new process continues underneath it. But it also keeps everything the
- * previous session left behind in the emulator: a scroll region, origin mode,
- * an alternate screen it never came back from, an unclosed attribute run. The
- * new process assumes a terminal at its defaults and never sets them, so its
- * first redraw lands inside the last one's margins and what the person sees is
- * the two frames on top of each other with the escape sequences showing.
- *
- * A soft reset (DECSTR) is the whole fix, and it is deliberately not a full one:
- * `reset()` would clear the scrollback, which is the thing being resumed.
- *
- * Written before the resume is asked for rather than after it returns. Output
- * from the new process can arrive the instant it exists, and a reset landing
- * mid-stream would undo the setup it had already done.
- */
-export function settleTerminalForResume(terminalId: string): void {
-  const entry = registry.get(terminalId)
-  if (!entry) return
-  entry.term.write(
-    // Leave the alternate screen, soft reset, default attributes, cursor shown,
-    // and begin on a line of its own.
-    '\x1b[?1049l\x1b[!p\x1b[0m\x1b[?25h\r\n'
-  )
-}
-
 export function clearTerminalSelection(terminalId: string): void {
   registry.get(terminalId)?.term.clearSelection()
 }

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -48,6 +48,9 @@ let rafId: number | null = null
  */
 const hydrating = new Map<string, Chunk[]>()
 
+/** Seeds in flight, so concurrent callers join one rather than starting several. */
+const hydrations = new Map<string, Promise<void>>()
+
 function scheduleFlush(): void {
   if (rafId !== null) return
   rafId = requestAnimationFrame(flushWrites)
@@ -96,6 +99,7 @@ export function disposeGlobalDataListener(): void {
   }
   pendingWrites.clear()
   hydrating.clear()
+  hydrations.clear()
 }
 
 /**
@@ -117,38 +121,50 @@ export function disposeGlobalDataListener(): void {
  * it never reaches a status handler. Replaying a screen must not ring a bell an
  * agent rang an hour ago.
  *
- * Idempotent per entry: a second window, a reconnect and a re-render all land
- * here, and a terminal that has already been seeded must not be seeded again.
+ * Idempotent, and shared: a second window, a reconnect and a re-render all land
+ * here, and one already in flight is joined rather than started again. A
+ * terminal seeded twice has its scrollback twice.
  */
-export async function hydrateTerminal(terminalId: string): Promise<void> {
+export function hydrateTerminal(terminalId: string): Promise<void> {
+  const already = hydrations.get(terminalId)
+  if (already) return already
+
   const entry = registry.get(terminalId)
-  if (!entry || entry._hydrated) return
+  if (!entry || entry._hydrated) return Promise.resolve()
+  // Absent on an older client surface, and in tests that mock a smaller one. A
+  // terminal with nothing to be seeded from simply carries on live.
+  if (typeof window.api?.attachTerminal !== 'function') return Promise.resolve()
   entry._hydrated = true
 
   hydrating.set(terminalId, [])
-  try {
-    const { data, seq } = await window.api.attachTerminal(terminalId)
-    if (data) entry.term.write(data)
-    for (const chunk of hydrating.get(terminalId) ?? []) {
-      if (chunk.seq <= seq) continue
-      entry.term.write(chunk.data)
-      // These are live, unlike the seed above them. A bell that rang while the
-      // seed was in flight rang just now, and holding it back for the length of
-      // a round trip would drop the notification entirely.
-      statusHandlers.get(terminalId)?.(chunk.data)
+  const run = (async () => {
+    try {
+      const { data, seq } = await window.api.attachTerminal(terminalId)
+      if (data) entry.term.write(data)
+      for (const chunk of hydrating.get(terminalId) ?? []) {
+        if (chunk.seq <= seq) continue
+        entry.term.write(chunk.data)
+        // These are live, unlike the seed above them. A bell that rang while the
+        // seed was in flight rang just now, and holding it back for the length
+        // of a round trip would drop the notification entirely.
+        statusHandlers.get(terminalId)?.(chunk.data)
+      }
+    } catch (err) {
+      console.error('[terminal] could not attach', terminalId, err)
+      // Held chunks are still the truth about what happened; let them through
+      // rather than losing them to a failed seed, and allow another try.
+      for (const chunk of hydrating.get(terminalId) ?? []) {
+        entry.term.write(chunk.data)
+        statusHandlers.get(terminalId)?.(chunk.data)
+      }
+      entry._hydrated = false
+    } finally {
+      hydrating.delete(terminalId)
+      hydrations.delete(terminalId)
     }
-  } catch (err) {
-    console.error('[terminal] could not attach', terminalId, err)
-    // Held chunks are still the truth about what happened; let them through
-    // rather than losing them to a failed seed.
-    for (const chunk of hydrating.get(terminalId) ?? []) {
-      entry.term.write(chunk.data)
-      statusHandlers.get(terminalId)?.(chunk.data)
-    }
-    entry._hydrated = false
-  } finally {
-    hydrating.delete(terminalId)
-  }
+  })()
+  hydrations.set(terminalId, run)
+  return run
 }
 
 // --- Status detection handler registry ---
@@ -343,6 +359,16 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
   entry._disposeCommandBlocks = disposeCommandBlocks
 
   registry.set(terminalId, entry)
+
+  // Every terminal is seeded, not only the ones adopted from a previous run.
+  //
+  // Started here rather than left to whoever created the pane, and started the
+  // moment the entry exists, because the hold that makes seeding safe has to be
+  // in place before the first live chunk is written. A terminal this client
+  // created a moment ago is seeded from an empty scrollback and nothing happens;
+  // one that was already running gets everything it missed. Two paths through
+  // one door beats a flag saying which door this was.
+  void hydrateTerminal(terminalId)
 
   const cbs = readyCallbacks.get(terminalId)
   if (cbs) {

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -83,9 +83,12 @@ function scheduleFlush(): void {
 function flushWrites(): void {
   rafId = null
   for (const [id, chunks] of pendingWrites) {
-    const seeding = hydrating.get(id)
-    if (seeding) {
-      for (const chunk of chunks) seeding.held.push(chunk)
+    // Not `seeding`: that is a module-level Set in this file now, and a local
+    // of the same name holding something else entirely is a trap for whoever
+    // edits this next.
+    const hydration = hydrating.get(id)
+    if (hydration) {
+      for (const chunk of chunks) hydration.held.push(chunk)
       continue
     }
     const data = chunks.length === 1 ? chunks[0].data : chunks.map((c) => c.data).join('')

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -627,6 +627,34 @@ export function getTerminalSelection(terminalId: string): string {
   return entry.term.getSelection()
 }
 
+/**
+ * Put a terminal into a known state before a resumed process writes to it.
+ *
+ * Resuming keeps the pane, which is the point -- the replayed screen stays and
+ * the new process continues underneath it. But it also keeps everything the
+ * previous session left behind in the emulator: a scroll region, origin mode,
+ * an alternate screen it never came back from, an unclosed attribute run. The
+ * new process assumes a terminal at its defaults and never sets them, so its
+ * first redraw lands inside the last one's margins and what the person sees is
+ * the two frames on top of each other with the escape sequences showing.
+ *
+ * A soft reset (DECSTR) is the whole fix, and it is deliberately not a full one:
+ * `reset()` would clear the scrollback, which is the thing being resumed.
+ *
+ * Written before the resume is asked for rather than after it returns. Output
+ * from the new process can arrive the instant it exists, and a reset landing
+ * mid-stream would undo the setup it had already done.
+ */
+export function settleTerminalForResume(terminalId: string): void {
+  const entry = registry.get(terminalId)
+  if (!entry) return
+  entry.term.write(
+    // Leave the alternate screen, soft reset, default attributes, cursor shown,
+    // and begin on a line of its own.
+    '\x1b[?1049l\x1b[!p\x1b[0m\x1b[?25h\r\n'
+  )
+}
+
 export function clearTerminalSelection(terminalId: string): void {
   registry.get(terminalId)?.term.clearSelection()
 }

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -174,9 +174,24 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
     statusHandlers.get(terminalId)?.(data)
   }
 
+  /**
+   * Whether the pane this seed was started for is still the one holding the id.
+   *
+   * `destroyTerminal` can run while the attach is in flight, and the id can be
+   * mounted again straight after -- a view swap, a pane closed and reopened.
+   * The closure still holds the old entry, so the seed would write into a
+   * terminal that has been disposed. xterm does not object to that (it neither
+   * throws nor drops the callback, which is worth saying because it means the
+   * damage is silent), but `flushHeld` also feeds whatever status handler is
+   * registered for the id -- and by then that belongs to the new pane, which
+   * would be handed the old pane's bytes and read a status out of them.
+   */
+  const stillOurs = (): boolean => registry.get(terminalId) === entry
+
   state.done = (async () => {
     try {
       const { data, seq, live } = await window.api.attachTerminal(terminalId)
+      if (!stillOurs()) return
       if (data) {
         // Cleared from the write callback, which xterm runs once these bytes
         // have been parsed -- so it covers every reply they provoke and nothing
@@ -195,6 +210,7 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
       if (live === false) reportNotLive?.(terminalId)
     } catch (err) {
       console.error('[terminal] could not attach', terminalId, err)
+      if (!stillOurs()) return
       // Held chunks are still the truth about what happened; let them through
       // rather than losing them to a failed seed, and allow another try.
       flushHeld()

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -17,6 +17,8 @@ interface TerminalEntry {
   _loadRenderer?: (() => void) | null
   _gpuAddon?: { dispose(): void } | null
   _disposeCommandBlocks?: (() => void) | null
+  /** Whether this terminal has already been seeded from the server. */
+  _hydrated?: boolean
 }
 
 /** data attribute on the persistent wrapper, read by TerminalHost for event delegation. */
@@ -26,8 +28,25 @@ const registry = new Map<string, TerminalEntry>()
 const readyCallbacks = new Map<string, Set<() => void>>()
 
 // --- Write batching: single global listener + requestAnimationFrame ---
-const pendingWrites = new Map<string, string[]>()
+interface Chunk {
+  data: string
+  /** Which flush of that session this came from. See `PtyManager.flushSeq`. */
+  seq: number
+}
+
+const pendingWrites = new Map<string, Chunk[]>()
 let rafId: number | null = null
+
+/**
+ * Sessions being seeded right now.
+ *
+ * A pane that did not create its terminal has to be given what the terminal
+ * already shows before it applies anything live, and the two must not cross. So
+ * live chunks are held from before the seed is asked for until after it has been
+ * written -- then the ones the seed already contains are dropped by their number
+ * and the rest are applied in order.
+ */
+const hydrating = new Map<string, Chunk[]>()
 
 function scheduleFlush(): void {
   if (rafId !== null) return
@@ -37,10 +56,18 @@ function scheduleFlush(): void {
 function flushWrites(): void {
   rafId = null
   for (const [id, chunks] of pendingWrites) {
-    const data = chunks.length === 1 ? chunks[0] : chunks.join('')
+    const holding = hydrating.get(id)
+    if (holding) {
+      holding.push(...chunks)
+      continue
+    }
+    const data = chunks.length === 1 ? chunks[0].data : chunks.map((c) => c.data).join('')
     const entry = registry.get(id)
     if (entry) entry.term.write(data)
-    statusHandlers.get(id)?.(data)
+    // Only when it was actually written. A handler that fires for a terminal
+    // nothing drew into is reporting something nobody saw -- and the one handler
+    // that exists rings a bell.
+    if (entry) statusHandlers.get(id)?.(data)
   }
   pendingWrites.clear()
 }
@@ -49,12 +76,12 @@ let removeGlobalDataListener: (() => void) | null = null
 
 export function initGlobalDataListener(): void {
   if (removeGlobalDataListener) return
-  removeGlobalDataListener = window.api.onTerminalData(({ id, data }) => {
+  removeGlobalDataListener = window.api.onTerminalData(({ id, data, seq }) => {
     const existing = pendingWrites.get(id)
     if (existing) {
-      existing.push(data)
+      existing.push({ data, seq })
     } else {
-      pendingWrites.set(id, [data])
+      pendingWrites.set(id, [{ data, seq }])
     }
     scheduleFlush()
   })
@@ -68,6 +95,60 @@ export function disposeGlobalDataListener(): void {
     rafId = null
   }
   pendingWrites.clear()
+  hydrating.clear()
+}
+
+/**
+ * Show a terminal this pane did not create.
+ *
+ * Ordering is the whole of it, and getting it wrong is invisible until somebody
+ * reads their scrollback:
+ *
+ *   1. Start holding live chunks. Before asking, not after -- anything that
+ *      arrives while the request is in flight belongs after the seed, and there
+ *      is no way to recover it once it has been written ahead of one.
+ *   2. Ask. The answer carries the scrollback and the flush it reflects, read on
+ *      the server in a single tick so the two cannot disagree.
+ *   3. Write the seed, then the held chunks numbered above it. Anything at or
+ *      below that number is already in the seed; applying it again would print
+ *      those bytes twice.
+ *
+ * The seed goes straight to the terminal rather than through the batch above, so
+ * it never reaches a status handler. Replaying a screen must not ring a bell an
+ * agent rang an hour ago.
+ *
+ * Idempotent per entry: a second window, a reconnect and a re-render all land
+ * here, and a terminal that has already been seeded must not be seeded again.
+ */
+export async function hydrateTerminal(terminalId: string): Promise<void> {
+  const entry = registry.get(terminalId)
+  if (!entry || entry._hydrated) return
+  entry._hydrated = true
+
+  hydrating.set(terminalId, [])
+  try {
+    const { data, seq } = await window.api.attachTerminal(terminalId)
+    if (data) entry.term.write(data)
+    for (const chunk of hydrating.get(terminalId) ?? []) {
+      if (chunk.seq <= seq) continue
+      entry.term.write(chunk.data)
+      // These are live, unlike the seed above them. A bell that rang while the
+      // seed was in flight rang just now, and holding it back for the length of
+      // a round trip would drop the notification entirely.
+      statusHandlers.get(terminalId)?.(chunk.data)
+    }
+  } catch (err) {
+    console.error('[terminal] could not attach', terminalId, err)
+    // Held chunks are still the truth about what happened; let them through
+    // rather than losing them to a failed seed.
+    for (const chunk of hydrating.get(terminalId) ?? []) {
+      entry.term.write(chunk.data)
+      statusHandlers.get(terminalId)?.(chunk.data)
+    }
+    entry._hydrated = false
+  } finally {
+    hydrating.delete(terminalId)
+  }
 }
 
 // --- Status detection handler registry ---

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -168,7 +168,16 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
 
   /** Everything held, in order, as one write. xterm queues a task per call. */
   const flushHeld = (above = -1): void => {
-    const kept = state.held.filter((chunk) => chunk.seq > above)
+    // A chunk whose sequence cannot be compared cannot be deduplicated, and the
+    // choice is then between showing it twice and not showing it at all. Twice
+    // is visible and a person can see what happened; dropping it is silent, and
+    // losing output is the failure this whole mechanism exists to prevent. The
+    // protocol requires `seq`, so this only arises against a server that is not
+    // keeping to it -- which is exactly when guessing is the wrong thing to do.
+    const kept = state.held.filter(
+      (chunk) =>
+        !Number.isFinite(chunk.seq) || !Number.isFinite(above) || (chunk.seq as number) > above
+    )
     if (!kept.length) return
     const data = kept.map((chunk) => chunk.data).join('')
     entry.term.write(data)

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -2,7 +2,7 @@ import { Terminal, type ITerminalAddon } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import '@xterm/xterm/css/xterm.css'
-import { attachCommandBlocks, jumpToCommand } from './command-blocks'
+import { attachCommandBlocks, jumpToCommand, markSeededFromServer } from './command-blocks'
 import type { BufferMetrics } from './spine-layout'
 import { TERMINAL_BACKGROUND } from '../../shared/surface'
 
@@ -156,7 +156,13 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
   state.done = (async () => {
     try {
       const { data, seq, live } = await window.api.attachTerminal(terminalId)
-      if (data) entry.term.write(data)
+      if (data) {
+        entry.term.write(data)
+        // This screen is now in the terminal and nowhere else. Said out loud so
+        // the first finished command lifts it into the block log rather than
+        // clearing it away.
+        markSeededFromServer(terminalId)
+      }
       flushHeld(seq)
       // The one moment a pane learns the truth about its session. A window
       // opened onto a terminal that died while it was closed has no start-up

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -170,16 +170,6 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       return { terminals: next }
     }),
 
-  clearEnded: (id) =>
-    set((state) => {
-      const next = new Map(state.terminals)
-      const term = next.get(id)
-      if (!term) return { terminals: state.terminals }
-      const { ended: _ended, ...live } = term
-      next.set(id, live)
-      return { terminals: next }
-    }),
-
   replaceTerminal: (previousId, session) =>
     set((state) => {
       const next = new Map(state.terminals)

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -13,14 +13,19 @@ import { clearDirty } from '../lib/editor-dirty'
 export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice> = (set) => ({
   terminals: new Map(),
 
-  addTerminal: (session) =>
+  addTerminal: (session, ended) =>
     set((state) => {
       const next = new Map(state.terminals)
       next.set(session.id, {
         id: session.id,
         session,
         status: session.status,
-        lastOutputTimestamp: Date.now()
+        // For a session from a previous run this is when it ended, not now.
+        // Several views sort by it, and stamping every restored pane with the
+        // current time would put a terminal nobody has touched in days at the
+        // top of the list.
+        lastOutputTimestamp: ended?.at ?? Date.now(),
+        ...(ended !== undefined && { ended })
       })
       const order = state.terminalOrder.includes(session.id)
         ? state.terminalOrder
@@ -155,6 +160,43 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       if (term) next.set(id, { ...term, status })
       window.api.notifyWidgetStatus()
       return { terminals: next }
+    }),
+
+  markEnded: (id, ended) =>
+    set((state) => {
+      const next = new Map(state.terminals)
+      const term = next.get(id)
+      if (term) next.set(id, { ...term, ended })
+      return { terminals: next }
+    }),
+
+  clearEnded: (id) =>
+    set((state) => {
+      const next = new Map(state.terminals)
+      const term = next.get(id)
+      if (!term) return { terminals: state.terminals }
+      const { ended: _ended, ...live } = term
+      next.set(id, live)
+      return { terminals: next }
+    }),
+
+  replaceTerminal: (previousId, session) =>
+    set((state) => {
+      const next = new Map(state.terminals)
+      next.delete(previousId)
+      next.set(session.id, {
+        id: session.id,
+        session,
+        status: session.status,
+        lastOutputTimestamp: Date.now()
+      })
+      // In place, so a resumed card keeps the slot it was already occupying.
+      const order = state.terminalOrder.map((id) => (id === previousId ? session.id : id))
+      window.api.notifyWidgetStatus()
+      return {
+        terminals: next,
+        terminalOrder: order.includes(session.id) ? order : [...order, session.id]
+      }
     }),
 
   updateLastOutput: (id, timestamp) =>

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -208,7 +208,13 @@ export interface DevicePaneState {
  * every one of those readings. The pane says the rest.
  */
 export interface EndedSession {
-  reason: 'server-stopped' | 'exited'
+  /**
+   * `app-closed` — Vorn was quit and its server went with it.
+   * `server-stopped` — it stopped without getting to shut down: a crash, a kill,
+   *   a machine losing power.
+   * `exited` — the terminal's own process finished while somebody was watching.
+   */
+  reason: 'app-closed' | 'server-stopped' | 'exited'
   /** Unix ms. The last save the previous run managed, or when the PTY exited. */
   at: number
   /** A screen was replayed into this pane, so it is showing something real. */

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -235,7 +235,6 @@ export interface TerminalsSlice {
   addTerminal: (session: TerminalSession, ended?: EndedSession) => void
   removeTerminal: (id: string) => void
   markEnded: (id: string, ended: EndedSession) => void
-  clearEnded: (id: string) => void
   /**
    * Swap a resumed session in where the old one sat.
    *

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -199,17 +199,51 @@ export interface DevicePaneState {
   name: string
 }
 
+/**
+ * Why a pane has no process behind it, and what there is to show instead.
+ *
+ * Deliberately not a member of `AgentStatus`. That type is read by the status
+ * parser, the hook mapper, the database column, the filter, notifications and
+ * four tone maps, and a session whose process is gone genuinely *is* idle by
+ * every one of those readings. The pane says the rest.
+ */
+export interface EndedSession {
+  reason: 'server-stopped' | 'exited'
+  /** Unix ms. The last save the previous run managed, or when the PTY exited. */
+  at: number
+  /** A screen was replayed into this pane, so it is showing something real. */
+  replayed: boolean
+  /** What is on screen stops short of what actually happened. */
+  partial?: boolean
+  /** Shells only, when it exited on its own. */
+  exitCode?: number
+  /** Shells only: the directory a fresh one would start in. */
+  cwd?: string
+}
+
 export interface TerminalState {
   id: string
   session: TerminalSession
   status: AgentStatus
   lastOutputTimestamp: number
+  /** Present only while nothing is running behind this pane. */
+  ended?: EndedSession
 }
 
 export interface TerminalsSlice {
   terminals: Map<string, TerminalState>
-  addTerminal: (session: TerminalSession) => void
+  addTerminal: (session: TerminalSession, ended?: EndedSession) => void
   removeTerminal: (id: string) => void
+  markEnded: (id: string, ended: EndedSession) => void
+  clearEnded: (id: string) => void
+  /**
+   * Swap a resumed session in where the old one sat.
+   *
+   * Resuming spawns a new session with a new id, and without this the card
+   * would leave its place on the grid and reappear at the end -- which reads as
+   * a pane that vanished and a different one that arrived.
+   */
+  replaceTerminal: (previousId: string, session: TerminalSession) => void
   updateStatus: (id: string, status: AgentStatus) => void
   updateLastOutput: (id: string, timestamp: number) => void
   renameTerminal: (id: string, displayName: string) => void

--- a/src/shared/adoption-channels.ts
+++ b/src/shared/adoption-channels.ts
@@ -16,6 +16,22 @@
  */
 export const LOCAL_SERVER_RUNNING_CHANNEL = 'local-server:still-running'
 
+/**
+ * The server this app talks to has been replaced by a different process.
+ *
+ * Sent after a crash-relaunch: the bridge reconnects on its own, but what it
+ * reconnects *to* has none of the PTYs the old one held. Without this the panes
+ * carry on showing what they were showing -- their content lives in the
+ * renderer, so nothing about them changes -- and they go on accepting input that
+ * reaches a terminal which no longer exists.
+ *
+ * The app's own start-up asks what is running and what is left of what is not.
+ * This is the same question, at the only other moment the answer can change out
+ * from under it. Not in the `IPC` map for the same reason as above: it is about
+ * a server rather than a call to one.
+ */
+export const SERVER_REPLACED_CHANNEL = 'local-server:replaced'
+
 export interface LocalServerNotice {
   /** How many sessions the local server was holding, when that could be read. */
   sessions: number | null

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -424,3 +424,74 @@ describe('agent-launch guards against shell sessions', () => {
     )
   })
 })
+
+describe('exactly one selector reaches the agent', () => {
+  /**
+   * A configured command may already carry one -- somebody who always resumes
+   * the same session, or who pinned an id by hand. Two of them compete, one wins
+   * silently, and the session that comes back is not the one that was asked for.
+   */
+  const count = (line: string, needle: RegExp): number => line.match(needle)?.length ?? 0
+
+  it('claude: a configured --resume does not survive beside ours', () => {
+    const line = buildAgentLaunchLine(
+      makePayload({ resumeSessionId: 'wanted' }),
+      { ...cmds, claude: { command: 'claude', args: ['--resume', 'stale'] } },
+      env
+    )
+
+    expect(count(line, /--resume/g)).toBe(1)
+    expect(line).toContain('--resume wanted')
+    expect(line).not.toContain('stale')
+  })
+
+  it('claude: a configured --session-id does not compete with a resume', () => {
+    const line = buildAgentLaunchLine(
+      makePayload({ resumeSessionId: 'wanted' }),
+      { ...cmds, claude: { command: 'claude', args: ['--session-id', 'pinned'] } },
+      env
+    )
+
+    expect(line).not.toContain('--session-id')
+    expect(count(line, /--resume/g)).toBe(1)
+  })
+
+  it('claude: everything else the person configured survives', () => {
+    const line = buildAgentLaunchLine(
+      makePayload({ resumeSessionId: 'wanted' }),
+      { ...cmds, claude: { command: 'claude', args: ['--model', 'opus', '--resume', 'stale'] } },
+      env
+    )
+
+    expect(line).toContain('--model opus')
+  })
+
+  it('codex: resuming no longer throws away the configured arguments', () => {
+    // It used to rebuild the line as `${command} resume ${id}`, so a model, a
+    // sandbox setting or an approval policy vanished -- and only on the resume
+    // path, so a session came back configured differently from the one it
+    // continues.
+    const line = buildAgentLaunchLine(
+      makePayload({ agentType: 'codex', resumeSessionId: 'wanted' }),
+      { ...cmds, codex: { command: 'codex', args: ['--model', 'o3'] } },
+      env
+    )
+
+    expect(line).toContain('--model o3')
+    expect(line).toContain('resume wanted')
+    expect(count(line, /\bresume\b/g)).toBe(1)
+  })
+
+  it('leaves a line it cannot read alone, and appends beside it', () => {
+    // Failing open. Two selectors is a worse launch; a rewritten command line is
+    // a worse day.
+    const line = buildAgentLaunchLine(
+      makePayload({ resumeSessionId: 'wanted' }),
+      { ...cmds, claude: { command: 'sh -c "claude --resume stale"', args: [] } },
+      env
+    )
+
+    expect(line).toContain('stale')
+    expect(line).toContain('--resume wanted')
+  })
+})

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -5,11 +5,13 @@ import type { RestoredSession, TerminalSession } from '../packages/shared/src/ty
 const listActiveSessions = vi.fn()
 const getRestoredSessions = vi.fn()
 const resumeSession = vi.fn()
+const getRecentSessions = vi.fn()
 Object.defineProperty(window, 'api', {
   value: {
     listActiveSessions,
     getRestoredSessions,
     resumeSession,
+    getRecentSessions,
     notifyWidgetStatus: vi.fn()
   },
   writable: true
@@ -57,6 +59,7 @@ beforeEach(() => {
   useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
   vi.clearAllMocks()
   live.length = 0
+  getRecentSessions.mockResolvedValue([])
   listActiveSessions.mockImplementation(async () => [...live])
   getRestoredSessions.mockResolvedValue([])
   // As the server does: a resumed session keeps its id -- that is what makes it
@@ -269,5 +272,40 @@ describe('two reconciliations at once', () => {
     await syncBoard({ showCold: true, resume: true })
 
     expect(useAppStore.getState().terminals.has('contested')).toBe(true)
+  })
+})
+
+describe('two panes resumed in one pass', () => {
+  it('do not both take the same agent transcript', async () => {
+    // codex and opencode can resume an exact session but cannot have an id
+    // pinned on a fresh launch, so there is never an `agentSessionId` and both
+    // fall back to scanning the agent's own history -- which returns the first
+    // match for the project. Resolved independently, two panes get the same id
+    // and the pass starts two agents against one conversation, which is the
+    // thing the record's own claim exists to prevent.
+    getRestoredSessions.mockResolvedValue([
+      held('one', { session: session({ id: 'one', agentType: 'codex' }) }),
+      held('two', { session: session({ id: 'two', agentType: 'codex' }) })
+    ])
+    getRecentSessions.mockResolvedValue([
+      {
+        sessionId: 'transcript-a',
+        agentType: 'codex',
+        canResumeExact: true,
+        projectPath: '/dev/vorn'
+      },
+      {
+        sessionId: 'transcript-b',
+        agentType: 'codex',
+        canResumeExact: true,
+        projectPath: '/dev/vorn'
+      }
+    ])
+
+    await syncBoard({ showCold: true, resume: true })
+
+    const taken = resumeSession.mock.calls.map((c) => c[0].resumeSessionId)
+    expect(taken).toHaveLength(2)
+    expect(new Set(taken).size).toBe(2)
   })
 })

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -4,8 +4,14 @@ import type { RestoredSession, TerminalSession } from '../packages/shared/src/ty
 
 const listActiveSessions = vi.fn()
 const getRestoredSessions = vi.fn()
+const resumeSession = vi.fn()
 Object.defineProperty(window, 'api', {
-  value: { listActiveSessions, getRestoredSessions, notifyWidgetStatus: vi.fn() },
+  value: {
+    listActiveSessions,
+    getRestoredSessions,
+    resumeSession,
+    notifyWidgetStatus: vi.fn()
+  },
   writable: true
 })
 
@@ -52,7 +58,14 @@ beforeEach(() => {
   vi.clearAllMocks()
   listActiveSessions.mockResolvedValue([])
   getRestoredSessions.mockResolvedValue([])
+  resumeSession.mockImplementation(async ({ id }: { id: string }) => ({
+    ok: true,
+    session: session({ id: `${id}-again` })
+  }))
 })
+
+/** The ids `sessions:resume` was asked for, in the order it was asked. */
+const resumed = (): string[] => resumeSession.mock.calls.map((c) => c[0].id)
 
 const ended = (id: string) => useAppStore.getState().terminals.get(id)?.ended
 
@@ -64,7 +77,7 @@ describe('a server that died under a running app', () => {
     listActiveSessions.mockResolvedValue([])
     getRestoredSessions.mockResolvedValue([])
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
 
     expect(ended('was-running')).toMatchObject({ reason: 'server-stopped', replayed: false })
   })
@@ -73,7 +86,7 @@ describe('a server that died under a running app', () => {
     useAppStore.getState().addTerminal(session({ id: 'one' }))
     getRestoredSessions.mockResolvedValue([held('one', { closedCleanly: true })])
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
 
     expect(ended('one')).toMatchObject({ reason: 'app-closed', replayed: true })
   })
@@ -82,7 +95,7 @@ describe('a server that died under a running app', () => {
     useAppStore.getState().addTerminal(session({ id: 'alive' }))
     listActiveSessions.mockResolvedValue([session({ id: 'alive' })])
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
 
     expect(ended('alive')).toBeUndefined()
   })
@@ -98,7 +111,7 @@ describe('a server that died under a running app', () => {
       exitCode: 1
     })
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
 
     expect(ended('exited')).toMatchObject({ reason: 'exited', exitCode: 1 })
   })
@@ -109,7 +122,7 @@ describe('what the server has that this board does not', () => {
     // Started from a phone, or by a workflow, or before this window opened.
     listActiveSessions.mockResolvedValue([session({ id: 'elsewhere' })])
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
 
     expect(useAppStore.getState().terminals.has('elsewhere')).toBe(true)
     expect(ended('elsewhere')).toBeUndefined()
@@ -118,7 +131,7 @@ describe('what the server has that this board does not', () => {
   it('shows one that ended before this window opened', async () => {
     getRestoredSessions.mockResolvedValue([held('from-last-run')])
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
 
     expect(ended('from-last-run')).toMatchObject({ reason: 'server-stopped', replayed: true })
   })
@@ -126,7 +139,7 @@ describe('what the server has that this board does not', () => {
   it('keeps it off the board when the setting says so', async () => {
     getRestoredSessions.mockResolvedValue([held('from-last-run')])
 
-    await syncBoard({ showCold: false })
+    await syncBoard({ showCold: false, resume: false })
 
     expect(useAppStore.getState().terminals.has('from-last-run')).toBe(false)
   })
@@ -139,10 +152,70 @@ describe('a server that would not answer', () => {
     listActiveSessions.mockRejectedValue(new Error('socket closed'))
     const quiet = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    await syncBoard({ showCold: true })
+    await syncBoard({ showCold: true, resume: false })
     quiet.mockRestore()
 
     expect(ended('alive')).toBeUndefined()
     expect(useAppStore.getState().terminals.has('alive')).toBe(true)
+  })
+})
+
+describe('starting again what was stopped', () => {
+  it('resumes a session whose server died, because that is what the setting means', async () => {
+    // "Reopen Sessions on Startup" meant this before the pane ever had a strip:
+    // the sessions come back, not just pictures of them.
+    getRestoredSessions.mockResolvedValue([held('stopped')])
+
+    await syncBoard({ showCold: true, resume: true })
+
+    expect(resumed()).toEqual(['stopped'])
+  })
+
+  it('never resumes one that exited on its own', async () => {
+    // An agent that finished its turn chose to end. Starting it again is a
+    // surprise the first time and a loop every time after.
+    useAppStore.getState().addTerminal(session({ id: 'finished' }), {
+      reason: 'exited',
+      at: 123,
+      replayed: false,
+      exitCode: 0
+    })
+
+    await syncBoard({ showCold: true, resume: true })
+
+    expect(resumed()).toEqual([])
+  })
+
+  it('starts nothing when the setting is off', async () => {
+    getRestoredSessions.mockResolvedValue([held('stopped')])
+
+    await syncBoard({ showCold: true, resume: false })
+
+    expect(resumed()).toEqual([])
+    expect(ended('stopped')).toBeDefined()
+  })
+
+  it('leaves alone a pane that was already sitting there ended', async () => {
+    // The setting is on and the server is replaced again -- a second crash, or a
+    // relaunch that took two attempts. A pane somebody looked at and chose not
+    // to resume must not be resumed by the next reconciliation that runs.
+    useAppStore.getState().addTerminal(session({ id: 'left-alone' }), {
+      reason: 'server-stopped',
+      at: 123,
+      replayed: true
+    })
+
+    await syncBoard({ showCold: true, resume: true })
+
+    expect(resumed()).toEqual([])
+  })
+
+  it('does not resume a session that is still running', async () => {
+    listActiveSessions.mockResolvedValue([session({ id: 'alive' })])
+    useAppStore.getState().addTerminal(session({ id: 'alive' }))
+
+    await syncBoard({ showCold: true, resume: true })
+
+    expect(resumed()).toEqual([])
   })
 })

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RestoredSession, TerminalSession } from '../packages/shared/src/types'
+
+const listActiveSessions = vi.fn()
+const getRestoredSessions = vi.fn()
+Object.defineProperty(window, 'api', {
+  value: { listActiveSessions, getRestoredSessions, notifyWidgetStatus: vi.fn() },
+  writable: true
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { syncBoard } from '../src/renderer/lib/board-sync'
+
+/**
+ * Making the board agree with what the server actually has.
+ *
+ * The case this exists for is a server dying under a running app. A pane's
+ * content lives in the renderer, so nothing about it changes: the terminal keeps
+ * showing what it was showing, the bridge reconnects to a replacement holding
+ * none of the old PTYs, and the pane goes on accepting input for a process that
+ * is gone. It looks exactly like a terminal that has been quiet for a moment,
+ * which is the one thing it must never look like when it is a photograph.
+ */
+
+function session(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: 'a-session',
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/dev/vorn',
+    status: 'running',
+    createdAt: 1,
+    pid: 1,
+    ...over
+  } as TerminalSession
+}
+
+function held(id: string, over: Partial<RestoredSession> = {}): RestoredSession {
+  return {
+    session: session({ id }),
+    endedAt: 1_700_000_000_000,
+    replayable: true,
+    partial: false,
+    closedCleanly: false,
+    ...over
+  }
+}
+
+beforeEach(() => {
+  useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
+  vi.clearAllMocks()
+  listActiveSessions.mockResolvedValue([])
+  getRestoredSessions.mockResolvedValue([])
+})
+
+const ended = (id: string) => useAppStore.getState().terminals.get(id)?.ended
+
+describe('a server that died under a running app', () => {
+  it('marks the panes it was holding, which nothing else would', async () => {
+    useAppStore.getState().addTerminal(session({ id: 'was-running' }))
+    // The replacement holds nothing, and the record was never saved as restored
+    // because the crash ran nothing.
+    listActiveSessions.mockResolvedValue([])
+    getRestoredSessions.mockResolvedValue([])
+
+    await syncBoard({ showCold: true })
+
+    expect(ended('was-running')).toMatchObject({ reason: 'server-stopped', replayed: false })
+  })
+
+  it('says a quit was a quit, when the replacement knows that', async () => {
+    useAppStore.getState().addTerminal(session({ id: 'one' }))
+    getRestoredSessions.mockResolvedValue([held('one', { closedCleanly: true })])
+
+    await syncBoard({ showCold: true })
+
+    expect(ended('one')).toMatchObject({ reason: 'app-closed', replayed: true })
+  })
+
+  it('leaves a pane alone while its process is still there', async () => {
+    useAppStore.getState().addTerminal(session({ id: 'alive' }))
+    listActiveSessions.mockResolvedValue([session({ id: 'alive' })])
+
+    await syncBoard({ showCold: true })
+
+    expect(ended('alive')).toBeUndefined()
+  })
+
+  it('does not overwrite what a pane already said about itself', async () => {
+    // A terminal that exited while somebody watched already carries its own
+    // reason and its exit code. A later sync must not flatten that into
+    // "the server stopped".
+    useAppStore.getState().addTerminal(session({ id: 'exited' }), {
+      reason: 'exited',
+      at: 123,
+      replayed: false,
+      exitCode: 1
+    })
+
+    await syncBoard({ showCold: true })
+
+    expect(ended('exited')).toMatchObject({ reason: 'exited', exitCode: 1 })
+  })
+})
+
+describe('what the server has that this board does not', () => {
+  it('gets a pane, however it came to exist', async () => {
+    // Started from a phone, or by a workflow, or before this window opened.
+    listActiveSessions.mockResolvedValue([session({ id: 'elsewhere' })])
+
+    await syncBoard({ showCold: true })
+
+    expect(useAppStore.getState().terminals.has('elsewhere')).toBe(true)
+    expect(ended('elsewhere')).toBeUndefined()
+  })
+
+  it('shows one that ended before this window opened', async () => {
+    getRestoredSessions.mockResolvedValue([held('from-last-run')])
+
+    await syncBoard({ showCold: true })
+
+    expect(ended('from-last-run')).toMatchObject({ reason: 'server-stopped', replayed: true })
+  })
+
+  it('keeps it off the board when the setting says so', async () => {
+    getRestoredSessions.mockResolvedValue([held('from-last-run')])
+
+    await syncBoard({ showCold: false })
+
+    expect(useAppStore.getState().terminals.has('from-last-run')).toBe(false)
+  })
+})
+
+describe('a server that would not answer', () => {
+  it('leaves the board as it is rather than emptying it', async () => {
+    // Rebuilding from an answer nobody gave would mark every live pane ended.
+    useAppStore.getState().addTerminal(session({ id: 'alive' }))
+    listActiveSessions.mockRejectedValue(new Error('socket closed'))
+    const quiet = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await syncBoard({ showCold: true })
+    quiet.mockRestore()
+
+    expect(ended('alive')).toBeUndefined()
+    expect(useAppStore.getState().terminals.has('alive')).toBe(true)
+  })
+})

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -56,13 +56,21 @@ function held(id: string, over: Partial<RestoredSession> = {}): RestoredSession 
 beforeEach(() => {
   useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
   vi.clearAllMocks()
-  listActiveSessions.mockResolvedValue([])
+  live.length = 0
+  listActiveSessions.mockImplementation(async () => [...live])
   getRestoredSessions.mockResolvedValue([])
-  resumeSession.mockImplementation(async ({ id }: { id: string }) => ({
-    ok: true,
-    session: session({ id: `${id}-again` })
-  }))
+  // As the server does: a resumed session keeps its id -- that is what makes it
+  // the same pane -- and is running by the time the call returns, so a later
+  // reconciliation sees it live rather than ended.
+  resumeSession.mockImplementation(async ({ id }: { id: string }) => {
+    const back = session({ id })
+    live.push(back)
+    return { ok: true, session: back }
+  })
 })
+
+/** What the server currently has running, which resuming adds to. */
+const live: TerminalSession[] = []
 
 /** The ids `sessions:resume` was asked for, in the order it was asked. */
 const resumed = (): string[] => resumeSession.mock.calls.map((c) => c[0].id)
@@ -217,5 +225,49 @@ describe('starting again what was stopped', () => {
     await syncBoard({ showCold: true, resume: true })
 
     expect(resumed()).toEqual([])
+  })
+})
+
+describe('two reconciliations at once', () => {
+  it('resumes each session once, however many passes overlap', async () => {
+    // Start-up runs one and a replaced server runs another moments later; in
+    // development the mount effect runs twice on its own. Both passes see the
+    // same cold records. Before they were serialised, the loser was told the
+    // session was gone and deleted the pane the winner had just brought back --
+    // which is how a board ended up with one pane for two live sessions.
+    getRestoredSessions.mockResolvedValue([held('one'), held('two')])
+    // The second pass asks the server what is running before the first pass has
+    // resumed anything, and is answered after it has. Its answer is therefore
+    // already stale when it is used -- which is the whole race, and why running
+    // the passes one after another is the only thing that settles it.
+    let answer: () => void = () => {}
+    const held_back = new Promise<void>((r) => (answer = r))
+    listActiveSessions
+      .mockImplementationOnce(async () => [...live])
+      .mockImplementationOnce(async () => {
+        const snapshot = [...live]
+        await held_back
+        return snapshot
+      })
+
+    const first = syncBoard({ showCold: true, resume: true })
+    const second = syncBoard({ showCold: true, resume: true })
+    await first
+    answer()
+    await second
+
+    expect(resumed().sort()).toEqual(['one', 'two'])
+  })
+
+  it('keeps the pane when an automatic resume loses the claim', async () => {
+    // The claim is almost always lost to this same app, and an automatic resume
+    // says nothing when it fails -- so removing the pane here made one vanish
+    // with no explanation anywhere.
+    getRestoredSessions.mockResolvedValue([held('contested')])
+    resumeSession.mockResolvedValue({ ok: false, reason: 'gone' })
+
+    await syncBoard({ showCold: true, resume: true })
+
+    expect(useAppStore.getState().terminals.has('contested')).toBe(true)
   })
 })

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -19,6 +19,7 @@ Object.defineProperty(window, 'api', {
 
 import { useAppStore } from '../src/renderer/stores'
 import { syncBoard } from '../src/renderer/lib/board-sync'
+import { showEndedSession } from '../src/renderer/lib/session-resume'
 
 /**
  * Making the board agree with what the server actually has.
@@ -307,5 +308,26 @@ describe('two panes resumed in one pass', () => {
     const taken = resumeSession.mock.calls.map((c) => c[0].resumeSessionId)
     expect(taken).toHaveLength(2)
     expect(new Set(taken).size).toBe(2)
+  })
+})
+
+describe('bringing an ended pane in from the banner', () => {
+  it('says a quit was a quit, as the board does', async () => {
+    // The banner offers to show panes without starting anything, and the record
+    // it reads says which ending this was. Reporting every one of them as a
+    // server that stopped unexpectedly turns closing the app into a fault report.
+    getRestoredSessions.mockResolvedValue([held('quit', { closedCleanly: true })])
+
+    await showEndedSession('quit')
+
+    expect(ended('quit')).toMatchObject({ reason: 'app-closed' })
+  })
+
+  it('still says so when the server really did stop', async () => {
+    getRestoredSessions.mockResolvedValue([held('crashed', { closedCleanly: false })])
+
+    await showEndedSession('crashed')
+
+    expect(ended('crashed')).toMatchObject({ reason: 'server-stopped' })
   })
 })

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -15,6 +15,12 @@ Object.defineProperty(window, 'api', {
   writable: true
 })
 
+const steps = vi.hoisted(() => [] as string[])
+vi.mock('../src/renderer/lib/terminal-registry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/renderer/lib/terminal-registry')>()),
+  settleTerminalForResume: (id: string) => steps.push(`settled ${id}`)
+}))
+
 import { useAppStore } from '../src/renderer/stores'
 import { syncBoard } from '../src/renderer/lib/board-sync'
 
@@ -62,7 +68,9 @@ beforeEach(() => {
   // As the server does: a resumed session keeps its id -- that is what makes it
   // the same pane -- and is running by the time the call returns, so a later
   // reconciliation sees it live rather than ended.
+  steps.length = 0
   resumeSession.mockImplementation(async ({ id }: { id: string }) => {
+    steps.push(`resumed ${id}`)
     const back = session({ id })
     live.push(back)
     return { ok: true, session: back }
@@ -269,5 +277,21 @@ describe('two reconciliations at once', () => {
     await syncBoard({ showCold: true, resume: true })
 
     expect(useAppStore.getState().terminals.has('contested')).toBe(true)
+  })
+})
+
+describe('the terminal a resumed process writes into', () => {
+  it('is settled before the resume is asked for, not after it returns', async () => {
+    // The pane is kept on purpose, so it still carries whatever the last session
+    // left in the emulator -- a scroll region, an alternate screen it never came
+    // back from. The new process assumes defaults and never sets them, so its
+    // first redraw lands inside the old one's margins. Doing this after the call
+    // returns would be too late and worse: output can arrive the instant the
+    // process exists, and the reset would then undo setup it had already done.
+    getRestoredSessions.mockResolvedValue([held('one')])
+
+    await syncBoard({ showCold: true, resume: true })
+
+    expect(steps).toEqual(['settled one', 'resumed one'])
   })
 })

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -15,12 +15,6 @@ Object.defineProperty(window, 'api', {
   writable: true
 })
 
-const steps = vi.hoisted(() => [] as string[])
-vi.mock('../src/renderer/lib/terminal-registry', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../src/renderer/lib/terminal-registry')>()),
-  settleTerminalForResume: (id: string) => steps.push(`settled ${id}`)
-}))
-
 import { useAppStore } from '../src/renderer/stores'
 import { syncBoard } from '../src/renderer/lib/board-sync'
 
@@ -68,9 +62,7 @@ beforeEach(() => {
   // As the server does: a resumed session keeps its id -- that is what makes it
   // the same pane -- and is running by the time the call returns, so a later
   // reconciliation sees it live rather than ended.
-  steps.length = 0
   resumeSession.mockImplementation(async ({ id }: { id: string }) => {
-    steps.push(`resumed ${id}`)
     const back = session({ id })
     live.push(back)
     return { ok: true, session: back }
@@ -277,21 +269,5 @@ describe('two reconciliations at once', () => {
     await syncBoard({ showCold: true, resume: true })
 
     expect(useAppStore.getState().terminals.has('contested')).toBe(true)
-  })
-})
-
-describe('the terminal a resumed process writes into', () => {
-  it('is settled before the resume is asked for, not after it returns', async () => {
-    // The pane is kept on purpose, so it still carries whatever the last session
-    // left in the emulator -- a scroll region, an alternate screen it never came
-    // back from. The new process assumes defaults and never sets them, so its
-    // first redraw lands inside the old one's margins. Doing this after the call
-    // returns would be too late and worse: output can arrive the instant the
-    // process exists, and the reset would then undo setup it had already done.
-    getRestoredSessions.mockResolvedValue([held('one')])
-
-    await syncBoard({ showCold: true, resume: true })
-
-    expect(steps).toEqual(['settled one', 'resumed one'])
   })
 })

--- a/tests/command-blocks.test.ts
+++ b/tests/command-blocks.test.ts
@@ -12,6 +12,8 @@ import {
   type TrackerHost
 } from '../src/renderer/lib/command-blocks'
 import { captureBlock, clearBlockLog, getBlockLog } from '../src/renderer/lib/block-log'
+import { markSeededFromServer, setDomBlockRendering } from '../src/renderer/lib/command-blocks'
+import { registerBlockLogView } from '../src/renderer/lib/block-log'
 
 class FakeMarker implements MarkerLike {
   isDisposed = false
@@ -802,5 +804,122 @@ describe('a shell that also emits markers itself', () => {
     t.handleSequence('D;0')
     expect(finished.map((b) => b.exitCode)).toEqual([3, 0])
     expect(finished[1].command).toBe('pwd')
+  })
+})
+
+describe('a pane seeded with a screen it did not draw', () => {
+  /**
+   * A pane attaching to a session already running is given what that session
+   * has shown so far, and that screen then lives in the terminal and nowhere
+   * else -- the block log dies with the window that built it. Lifting a
+   * finished command calls `term.clear()`, which drops everything above the
+   * prompt, so the first command after attaching used to take the whole
+   * restored screen with it: reopen, type anything, and the session's history
+   * is gone.
+   */
+  const ID = 'seeded-term'
+
+  function cellOf(ch: string): Record<string, () => unknown> {
+    return {
+      getChars: () => ch,
+      getWidth: () => 1,
+      getFgColor: () => 0,
+      getBgColor: () => 0,
+      isFgDefault: () => true,
+      isBgDefault: () => true,
+      isFgRGB: () => false,
+      isBgRGB: () => false,
+      isBold: () => 0,
+      isItalic: () => 0,
+      isDim: () => 0,
+      isUnderline: () => 0,
+      isInverse: () => 0,
+      isStrikethrough: () => 0
+    }
+  }
+
+  function terminalHolding(lines: string[], markerAt: number) {
+    const handlers = new Map<number, (data: string) => boolean>()
+    const clear = vi.fn()
+    const term = {
+      registerDecoration: vi.fn(() => undefined),
+      options: { theme: {} },
+      cols: 80,
+      clear,
+      buffer: {
+        active: {
+          type: 'normal',
+          baseY: 0,
+          cursorY: 0,
+          length: lines.length,
+          getLine: (y: number) =>
+            lines[y] === undefined
+              ? undefined
+              : { length: lines[y].length, getCell: (x: number) => cellOf(lines[y][x] ?? ' ') }
+        },
+        onBufferChange: () => ({ dispose: () => {} })
+      },
+      registerMarker: () => new FakeMarker(markerAt),
+      parser: {
+        registerOscHandler: (id: number, cb: (data: string) => boolean) => {
+          handlers.set(id, cb)
+          return { dispose: () => handlers.delete(id) }
+        },
+        registerCsiHandler: () => ({ dispose: () => {} })
+      }
+    }
+    return { handlers, clear, asTerminal: term as unknown as Terminal }
+  }
+
+  beforeEach(() => {
+    clearBlockLog(ID)
+    setDomBlockRendering(true)
+    registerBlockLogView(ID)
+  })
+
+  /** OSC 133 carries no command text, so blocks are told apart by what is in them. */
+  const holding = (needle: string): number =>
+    getBlockLog(ID).filter((b) => JSON.stringify(b.rows).includes(needle)).length
+
+  function runOneCommand(handlers: Map<number, (data: string) => boolean>): void {
+    const osc133 = handlers.get(133)!
+    osc133('A')
+    osc133('C')
+    osc133('D;0')
+  }
+
+  it('lifts the restored screen into the log before the first clear reaches it', () => {
+    const { handlers, clear, asTerminal } = terminalHolding(['from before', 'the pane', '$ ls'], 2)
+    attachCommandBlocks(ID, asTerminal)
+    markSeededFromServer(ID)
+
+    runOneCommand(handlers)
+
+    // Two: what was restored, and the command just run.
+    expect(getBlockLog(ID)).toHaveLength(2)
+    expect(holding('from before')).toBe(1)
+    expect(clear).toHaveBeenCalled()
+  })
+
+  it('does it once, not on every command after', () => {
+    const { handlers, asTerminal } = terminalHolding(['from before', 'the pane', '$ ls'], 2)
+    attachCommandBlocks(ID, asTerminal)
+    markSeededFromServer(ID)
+
+    runOneCommand(handlers)
+    runOneCommand(handlers)
+
+    expect(holding('from before')).toBe(1)
+  })
+
+  it('adds nothing for a pane that grew from an empty terminal', () => {
+    // Never seeded, so there is nothing above the first command that anything
+    // else is holding a copy of.
+    const { handlers, asTerminal } = terminalHolding(['$ ls'], 0)
+    attachCommandBlocks(ID, asTerminal)
+
+    runOneCommand(handlers)
+
+    expect(getBlockLog(ID)).toHaveLength(1)
   })
 })

--- a/tests/database-defaults.test.ts
+++ b/tests/database-defaults.test.ts
@@ -316,3 +316,20 @@ describe('two clients saving against the same server', () => {
     expect(loadConfig().revision).toBeGreaterThan(first)
   })
 })
+
+describe('reopening the panes you had open', () => {
+  it('is on unless somebody has turned it off', () => {
+    // It used to decide whether every saved session was relaunched, which spends
+    // tokens and starts processes -- worth asking about, so it was off. Bringing
+    // a pane back no longer does either. Left off, the whole restore behaved
+    // exactly as it had before: a banner, and an empty board.
+    expect(loadConfig().defaults.reopenSessions).toBe(true)
+  })
+
+  it('stays off once it has been', () => {
+    const config = loadConfig()
+    saveConfig({ ...config, defaults: { ...config.defaults, reopenSessions: false } })
+
+    expect(loadConfig().defaults.reopenSessions).toBe(false)
+  })
+})

--- a/tests/database-sessions.test.ts
+++ b/tests/database-sessions.test.ts
@@ -135,6 +135,33 @@ describe('session persistence (real SQLite)', () => {
   })
 })
 
+describe('what a shell needs to come back where it was', () => {
+  it('round-trips the directory the shell was actually in', () => {
+    // The column never existed, so `shellCwd` wrote to the record in memory and
+    // then vanished on read -- and restoring a shell always fell back to its
+    // project directory, which for anybody who had navigated anywhere was the
+    // wrong place.
+    saveSessions([makeSession({ agentType: 'shell', shellCwd: '/Users/x/dev/vorn/packages' })])
+
+    expect(getPreviousSessions()[0].shellCwd).toBe('/Users/x/dev/vorn/packages')
+  })
+
+  it('leaves it absent when a session never reported one', () => {
+    saveSessions([makeSession()])
+    expect(getPreviousSessions()[0].shellCwd).toBeUndefined()
+  })
+
+  it('hands back when the record was last written down', () => {
+    // The only thing on disk that says roughly when a run ended, which is what
+    // a pane restored from a previous process has to tell somebody. It has been
+    // selected and discarded since this table was written.
+    const before = Date.now()
+    saveSessions([makeSession()])
+
+    expect(getPreviousSessions()[0].savedAt).toBeGreaterThanOrEqual(before)
+  })
+})
+
 describe('verifySchema (real SQLite)', () => {
   it('is idempotent — running initTestDatabase twice does not throw', () => {
     teardown()

--- a/tests/database-sessions.test.ts
+++ b/tests/database-sessions.test.ts
@@ -150,11 +150,21 @@ describe('what a shell needs to come back where it was', () => {
     saveSessions([makeSession()])
     expect(getPreviousSessions()[0].shellCwd).toBeUndefined()
   })
+})
 
-  it('hands back when the record was last written down', () => {
-    // The only thing on disk that says roughly when a run ended, which is what
-    // a pane restored from a previous process has to tell somebody. It has been
-    // selected and discarded since this table was written.
+describe('when a record was last written down', () => {
+  it('keeps a stamp the record already carried', () => {
+    // Sessions held over from a previous run are persisted beside the live ones,
+    // and re-stamping them with now made their age reset on every save -- so the
+    // window they age out of never elapsed, and a pane reported a terminal as
+    // having ended moments ago however long it had really been gone.
+    const ended = Date.now() - 3 * 24 * 60 * 60 * 1000
+    saveSessions([makeSession({ savedAt: ended })])
+
+    expect(getPreviousSessions()[0].savedAt).toBe(ended)
+  })
+
+  it('stamps one that has never been written down', () => {
     const before = Date.now()
     saveSessions([makeSession()])
 

--- a/tests/ended-strip.test.tsx
+++ b/tests/ended-strip.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { TerminalSession } from '@vornrun/shared/types'
+
+const resumeMocks = vi.hoisted(() => ({
+  resumeEndedSession: vi.fn().mockResolvedValue(undefined),
+  dismissEndedSession: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../src/renderer/lib/session-resume', () => resumeMocks)
+
+const intentBar = vi.hoisted(() => ({
+  IntentBar: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid="intent-bar">{terminalId}</div>
+  )
+}))
+vi.mock('../src/renderer/components/IntentBar', () => intentBar)
+
+vi.mock('../src/renderer/lib/command-blocks', () => ({
+  shortenCwd: (c: string | null) => c
+}))
+
+import { SessionComposer } from '../src/renderer/components/card/SessionComposer'
+import { useAppStore } from '../src/renderer/stores'
+import type { EndedSession } from '../src/renderer/stores/types'
+
+/**
+ * What a pane offers when nothing is running behind it.
+ *
+ * The strip stands where the composer does and replaces it, because a session
+ * with no process takes no input -- a composer there would be a control that
+ * silently does nothing. That slot is also the only one every surface already
+ * has, which is what carries this into tab mode, where there is no card header
+ * at all to hang a notice on.
+ */
+
+const ID = 'a-session'
+
+function session(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: ID,
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/dev/vorn',
+    status: 'idle',
+    createdAt: Date.now(),
+    pid: 1,
+    ...over
+  } as TerminalSession
+}
+
+const ENDED: EndedSession = {
+  reason: 'server-stopped',
+  at: Date.now() - 3 * 60 * 60 * 1000,
+  replayed: true
+}
+
+function seed(s: TerminalSession, ended?: EndedSession): void {
+  useAppStore.setState({
+    terminals: new Map([
+      [
+        s.id,
+        {
+          id: s.id,
+          session: s,
+          status: s.status,
+          lastOutputTimestamp: ended?.at ?? Date.now(),
+          ...(ended && { ended })
+        }
+      ]
+    ])
+  })
+}
+
+beforeEach(() => {
+  resumeMocks.resumeEndedSession.mockClear()
+  resumeMocks.dismissEndedSession.mockClear()
+})
+afterEach(cleanup)
+
+describe('a pane with nothing running behind it', () => {
+  it('says so, instead of offering somewhere to type', () => {
+    seed(session(), ENDED)
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText('Ended')).toBeInTheDocument()
+    expect(screen.queryByTestId('intent-bar')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['a grid card', { compact: true }],
+    ['a tab body', {}],
+    ['the focused pane', { indentPx: 12 }]
+  ])('appears in %s', (_label, props) => {
+    // Every surface renders this one row, which is the reason the strip lives
+    // here rather than in the card header -- tab mode has no header.
+    seed(session(), ENDED)
+    render(<SessionComposer terminalId={ID} {...props} />)
+    expect(screen.getByText('Ended')).toBeInTheDocument()
+  })
+
+  it('appears on mobile, where the composer is suppressed', () => {
+    seed(session(), ENDED)
+    render(<SessionComposer terminalId={ID} hideIntentBar />)
+
+    expect(screen.getByText('Ended')).toBeInTheDocument()
+  })
+
+  it('says what happened and roughly when', () => {
+    seed(session(), ENDED)
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(/the server stopped/)).toBeInTheDocument()
+    expect(screen.getByText(/3h ago/)).toBeInTheDocument()
+  })
+
+  it('admits when what is on screen stops short', () => {
+    seed(session(), { ...ENDED, partial: true })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(/the last moments were not recorded/)).toBeInTheDocument()
+  })
+
+  it('names the exit code when a shell ended on its own', () => {
+    seed(session({ agentType: 'shell' }), {
+      reason: 'exited',
+      at: Date.now(),
+      replayed: true,
+      exitCode: 130
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(/exited with 130/)).toBeInTheDocument()
+  })
+})
+
+describe('what it offers', () => {
+  it('offers to resume an agent, and does not do it on its own', async () => {
+    seed(session(), ENDED)
+    render(<SessionComposer terminalId={ID} />)
+
+    const button = screen.getByRole('button', { name: /resume/i })
+    expect(resumeMocks.resumeEndedSession).not.toHaveBeenCalled()
+
+    button.click()
+    await waitFor(() => expect(resumeMocks.resumeEndedSession).toHaveBeenCalledWith(ID))
+  })
+
+  it('offers a shell a fresh one instead, because there is nothing to resume', () => {
+    seed(session({ agentType: 'shell', shellCwd: '~/dev/vorn' }), { ...ENDED, cwd: '~/dev/vorn' })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('button', { name: /new shell here/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^resume$/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/~\/dev\/vorn/)).toBeInTheDocument()
+  })
+
+  it('can be declined', () => {
+    seed(session(), ENDED)
+    render(<SessionComposer terminalId={ID} />)
+
+    screen.getByRole('button', { name: /close this pane/i }).click()
+    expect(resumeMocks.dismissEndedSession).toHaveBeenCalledWith(ID)
+  })
+})
+
+describe('a pane with a process behind it', () => {
+  it('gets its composer, unchanged', () => {
+    seed(session())
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByTestId('intent-bar')).toBeInTheDocument()
+    expect(screen.queryByText('Ended')).not.toBeInTheDocument()
+  })
+
+  it('gets nothing at all where the composer is suppressed', () => {
+    seed(session())
+    const { container } = render(<SessionComposer terminalId={ID} hideIntentBar />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('the accent', () => {
+  it('is not spent on this', () => {
+    // Bronzo means a live piece of work is blocked on a person. A crash ends
+    // every pane at once, so using it here would put the accent across the whole
+    // screen and it would stop meaning anything anywhere.
+    seed(session(), ENDED)
+    const { container } = render(<SessionComposer terminalId={ID} />)
+
+    expect(container.innerHTML).not.toContain('bronzo')
+  })
+})

--- a/tests/ended-strip.test.tsx
+++ b/tests/ended-strip.test.tsx
@@ -143,8 +143,29 @@ describe('what the strip says', () => {
     })
     render(<SessionComposer terminalId={ID} />)
 
-    expect(screen.getByRole('status')).toHaveTextContent('the server stopped')
+    expect(screen.getByRole('status')).toHaveTextContent('the server stopped unexpectedly')
     expect(screen.getByRole('status')).toHaveTextContent('3h ago')
+  })
+
+  it('tells a quit apart from something stopping the server', () => {
+    // Reporting an ordinary quit as though the server had been stopped under you
+    // reads like a fault report for closing an app.
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'app-closed', at: Date.now(), replayed: true })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Vorn was closed')
+    expect(screen.getByRole('status')).not.toHaveTextContent('unexpectedly')
+  })
+
+  it('says when it was not a quit', () => {
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('the server stopped unexpectedly')
   })
 
   it('names an exit code when there was one', () => {

--- a/tests/ended-strip.test.tsx
+++ b/tests/ended-strip.test.tsx
@@ -1,8 +1,19 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
-import type { TerminalSession } from '@vornrun/shared/types'
+
+const registryMocks = vi.hoisted(() => ({
+  pasteToTerminal: vi.fn(),
+  focusTerminal: vi.fn(),
+  scrollToBottom: vi.fn(),
+  registerSlot: vi.fn(),
+  unregisterSlot: vi.fn(),
+  hydrateTerminal: vi.fn(),
+  registerStatusHandler: vi.fn().mockReturnValue(() => {}),
+  onTerminalReady: vi.fn().mockReturnValue(() => {})
+}))
+vi.mock('../src/renderer/lib/terminal-registry', () => registryMocks)
 
 const resumeMocks = vi.hoisted(() => ({
   resumeEndedSession: vi.fn().mockResolvedValue(undefined),
@@ -10,29 +21,34 @@ const resumeMocks = vi.hoisted(() => ({
 }))
 vi.mock('../src/renderer/lib/session-resume', () => resumeMocks)
 
-const intentBar = vi.hoisted(() => ({
+// The composer's other branch pulls in the whole intent bar; this file is about
+// which branch is taken, not what the bar does.
+vi.mock('../src/renderer/components/IntentBar', () => ({
   IntentBar: ({ terminalId }: { terminalId: string }) => (
     <div data-testid="intent-bar">{terminalId}</div>
   )
 }))
-vi.mock('../src/renderer/components/IntentBar', () => intentBar)
 
-vi.mock('../src/renderer/lib/command-blocks', () => ({
-  shortenCwd: (c: string | null) => c
-}))
+Object.defineProperty(window, 'api', {
+  value: {
+    notifyWidgetStatus: vi.fn(),
+    killTerminal: vi.fn().mockResolvedValue(undefined)
+  },
+  writable: true
+})
 
-import { SessionComposer } from '../src/renderer/components/card/SessionComposer'
+import type { TerminalSession } from '../packages/shared/src/types'
 import { useAppStore } from '../src/renderer/stores'
-import type { EndedSession } from '../src/renderer/stores/types'
+import { SessionComposer } from '../src/renderer/components/card/SessionComposer'
 
 /**
- * What a pane offers when nothing is running behind it.
+ * The row beneath a terminal, when there is nothing behind the terminal.
  *
- * The strip stands where the composer does and replaces it, because a session
- * with no process takes no input -- a composer there would be a control that
- * silently does nothing. That slot is also the only one every surface already
- * has, which is what carries this into tab mode, where there is no card header
- * at all to hang a notice on.
+ * Two things are being pinned. That a pane with no process shows what happened
+ * instead of a place to type -- a composer there is a control that silently
+ * does nothing. And that it does so on every surface, including tab mode, which
+ * renders no card header at all and is where a per-call-site condition would
+ * have been forgotten.
  */
 
 const ID = 'a-session'
@@ -44,47 +60,38 @@ function session(over: Partial<TerminalSession> = {}): TerminalSession {
     projectName: 'vorn',
     projectPath: '/dev/vorn',
     status: 'idle',
-    createdAt: Date.now(),
+    createdAt: 1,
     pid: 1,
     ...over
   } as TerminalSession
 }
 
-const ENDED: EndedSession = {
-  reason: 'server-stopped',
-  at: Date.now() - 3 * 60 * 60 * 1000,
-  replayed: true
-}
-
-function seed(s: TerminalSession, ended?: EndedSession): void {
-  useAppStore.setState({
-    terminals: new Map([
-      [
-        s.id,
-        {
-          id: s.id,
-          session: s,
-          status: s.status,
-          lastOutputTimestamp: ended?.at ?? Date.now(),
-          ...(ended && { ended })
-        }
-      ]
-    ])
-  })
-}
-
 beforeEach(() => {
-  resumeMocks.resumeEndedSession.mockClear()
-  resumeMocks.dismissEndedSession.mockClear()
+  useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
+  vi.clearAllMocks()
 })
 afterEach(cleanup)
 
-describe('a pane with nothing running behind it', () => {
-  it('says so, instead of offering somewhere to type', () => {
-    seed(session(), ENDED)
+describe('which row a pane gets', () => {
+  it('offers a place to type while something is running', () => {
+    useAppStore.getState().addTerminal(session())
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByTestId('intent-bar')).toBeInTheDocument()
+    expect(screen.queryByText('Ended')).not.toBeInTheDocument()
+  })
+
+  it('says what happened instead, once nothing is', () => {
+    useAppStore.getState().addTerminal(session(), {
+      reason: 'server-stopped',
+      at: Date.now() - 3_600_000,
+      replayed: true
+    })
     render(<SessionComposer terminalId={ID} />)
 
     expect(screen.getByText('Ended')).toBeInTheDocument()
+    // The composer is gone, not merely disabled. A session with no process
+    // takes no input, and a box that swallows typing is worse than none.
     expect(screen.queryByTestId('intent-bar')).not.toBeInTheDocument()
   })
 
@@ -92,104 +99,178 @@ describe('a pane with nothing running behind it', () => {
     ['a grid card', { compact: true }],
     ['a tab body', {}],
     ['the focused pane', { indentPx: 12 }]
-  ])('appears in %s', (_label, props) => {
-    // Every surface renders this one row, which is the reason the strip lives
-    // here rather than in the card header -- tab mode has no header.
-    seed(session(), ENDED)
+  ])('says it on %s', (_label, props) => {
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
     render(<SessionComposer terminalId={ID} {...props} />)
+
     expect(screen.getByText('Ended')).toBeInTheDocument()
   })
 
-  it('appears on mobile, where the composer is suppressed', () => {
-    seed(session(), ENDED)
+  it('still says it where the composer is suppressed', () => {
+    // The focused pane hides its intent bar on mobile, where the keyboard owns
+    // that space. A pane whose session ended still has something to say there.
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
     render(<SessionComposer terminalId={ID} hideIntentBar />)
 
     expect(screen.getByText('Ended')).toBeInTheDocument()
   })
 
-  it('says what happened and roughly when', () => {
-    seed(session(), ENDED)
-    render(<SessionComposer terminalId={ID} />)
-
-    expect(screen.getByText(/the server stopped/)).toBeInTheDocument()
-    expect(screen.getByText(/3h ago/)).toBeInTheDocument()
-  })
-
-  it('admits when what is on screen stops short', () => {
-    seed(session(), { ...ENDED, partial: true })
-    render(<SessionComposer terminalId={ID} />)
-
-    expect(screen.getByText(/the last moments were not recorded/)).toBeInTheDocument()
-  })
-
-  it('names the exit code when a shell ended on its own', () => {
-    seed(session({ agentType: 'shell' }), {
-      reason: 'exited',
-      at: Date.now(),
-      replayed: true,
-      exitCode: 130
-    })
-    render(<SessionComposer terminalId={ID} />)
-
-    expect(screen.getByText(/exited with 130/)).toBeInTheDocument()
-  })
-})
-
-describe('what it offers', () => {
-  it('offers to resume an agent, and does not do it on its own', async () => {
-    seed(session(), ENDED)
-    render(<SessionComposer terminalId={ID} />)
-
-    const button = screen.getByRole('button', { name: /resume/i })
-    expect(resumeMocks.resumeEndedSession).not.toHaveBeenCalled()
-
-    button.click()
-    await waitFor(() => expect(resumeMocks.resumeEndedSession).toHaveBeenCalledWith(ID))
-  })
-
-  it('offers a shell a fresh one instead, because there is nothing to resume', () => {
-    seed(session({ agentType: 'shell', shellCwd: '~/dev/vorn' }), { ...ENDED, cwd: '~/dev/vorn' })
-    render(<SessionComposer terminalId={ID} />)
-
-    expect(screen.getByRole('button', { name: /new shell here/i })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^resume$/i })).not.toBeInTheDocument()
-    expect(screen.getByText(/~\/dev\/vorn/)).toBeInTheDocument()
-  })
-
-  it('can be declined', () => {
-    seed(session(), ENDED)
-    render(<SessionComposer terminalId={ID} />)
-
-    screen.getByRole('button', { name: /close this pane/i }).click()
-    expect(resumeMocks.dismissEndedSession).toHaveBeenCalledWith(ID)
-  })
-})
-
-describe('a pane with a process behind it', () => {
-  it('gets its composer, unchanged', () => {
-    seed(session())
-    render(<SessionComposer terminalId={ID} />)
-
-    expect(screen.getByTestId('intent-bar')).toBeInTheDocument()
-    expect(screen.queryByText('Ended')).not.toBeInTheDocument()
-  })
-
-  it('gets nothing at all where the composer is suppressed', () => {
-    seed(session())
+  it('shows nothing at all where the composer is suppressed and the session is live', () => {
+    useAppStore.getState().addTerminal(session())
     const { container } = render(<SessionComposer terminalId={ID} hideIntentBar />)
 
     expect(container).toBeEmptyDOMElement()
   })
 })
 
-describe('the accent', () => {
-  it('is not spent on this', () => {
+describe('what the strip says', () => {
+  it('names the cause and how long ago', () => {
+    useAppStore.getState().addTerminal(session(), {
+      reason: 'server-stopped',
+      at: Date.now() - 3 * 3_600_000,
+      replayed: true
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('the server stopped')
+    expect(screen.getByRole('status')).toHaveTextContent('3h ago')
+  })
+
+  it('names an exit code when there was one', () => {
+    useAppStore.getState().addTerminal(session({ agentType: 'shell' }), {
+      reason: 'exited',
+      at: Date.now(),
+      replayed: true,
+      exitCode: 1
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('exited with 1')
+  })
+
+  it('admits when what is on screen is not the whole story', () => {
+    useAppStore.getState().addTerminal(session(), {
+      reason: 'server-stopped',
+      at: Date.now(),
+      replayed: true,
+      partial: true
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('the last moments were not recorded')
+  })
+
+  it('offers a shell a new one rather than a resume it cannot do', () => {
+    useAppStore.getState().addTerminal(session({ agentType: 'shell' }), {
+      reason: 'exited',
+      at: Date.now(),
+      replayed: true,
+      cwd: '/Users/x/dev/vorn'
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByRole('button', { name: /new shell here/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^resume$/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('the colour it does not use', () => {
+  it('never takes the accent', () => {
     // Bronzo means a live piece of work is blocked on a person. A crash ends
-    // every pane at once, so using it here would put the accent across the whole
-    // screen and it would stop meaning anything anywhere.
-    seed(session(), ENDED)
+    // every pane at once, so the accent would land on the whole screen and stop
+    // meaning anything anywhere.
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
     const { container } = render(<SessionComposer terminalId={ID} />)
 
-    expect(container.innerHTML).not.toContain('bronzo')
+    expect(container.innerHTML).not.toMatch(/bronzo/)
+  })
+})
+
+describe('acting on the offer', () => {
+  it('resumes through the server, which hands the record out once', async () => {
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
+    render(<SessionComposer terminalId={ID} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /resume/i }))
+
+    await waitFor(() => expect(resumeMocks.resumeEndedSession).toHaveBeenCalledWith(ID))
+  })
+
+  it('lets it go through the same door', async () => {
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
+    render(<SessionComposer terminalId={ID} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /close this pane/i }))
+
+    await waitFor(() => expect(resumeMocks.dismissEndedSession).toHaveBeenCalledWith(ID))
+  })
+})
+
+describe('resuming keeps the card where it was', () => {
+  it("puts the new session in the old one's place, not at the end", () => {
+    // Resuming spawns a session with a new id. Appending it would read as a
+    // pane that vanished and a different one that arrived somewhere else.
+    const store = useAppStore.getState()
+    store.addTerminal(session({ id: 'first' }))
+    store.addTerminal(session({ id: 'ended' }), {
+      reason: 'server-stopped',
+      at: Date.now(),
+      replayed: true
+    })
+    store.addTerminal(session({ id: 'last' }))
+
+    useAppStore.getState().replaceTerminal('ended', session({ id: 'resumed' }))
+
+    expect(useAppStore.getState().terminalOrder).toEqual(['first', 'resumed', 'last'])
+  })
+
+  it('leaves nothing of the session it replaced', () => {
+    const store = useAppStore.getState()
+    store.addTerminal(session({ id: 'ended' }), {
+      reason: 'server-stopped',
+      at: Date.now(),
+      replayed: true
+    })
+
+    useAppStore.getState().replaceTerminal('ended', session({ id: 'resumed' }))
+    const state = useAppStore.getState()
+
+    expect(state.terminals.has('ended')).toBe(false)
+    // And the replacement is live: no strip on a pane with a process behind it.
+    expect(state.terminals.get('resumed')?.ended).toBeUndefined()
+  })
+})
+
+describe('when a pane came back from a previous run', () => {
+  it('is not stamped with the time it was restored', () => {
+    // Several views sort by last output. Stamping every restored pane with the
+    // current time puts a terminal nobody has touched in days at the top.
+    const endedAt = Date.now() - 5 * 3_600_000
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: endedAt, replayed: true })
+
+    expect(useAppStore.getState().terminals.get(ID)?.lastOutputTimestamp).toBe(endedAt)
+  })
+
+  it('is never stamped zero, which would draw the spawning skeleton over it', () => {
+    // `lastOutputTimestamp === 0` is what the card and the tab body use to show
+    // a pane that has not produced anything yet. A replayed screen underneath
+    // that shimmer would be the wrong story twice over.
+    useAppStore
+      .getState()
+      .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
+
+    expect(useAppStore.getState().terminals.get(ID)?.lastOutputTimestamp).not.toBe(0)
   })
 })

--- a/tests/ended-strip.test.tsx
+++ b/tests/ended-strip.test.tsx
@@ -17,9 +17,16 @@ vi.mock('../src/renderer/lib/terminal-registry', () => registryMocks)
 
 const resumeMocks = vi.hoisted(() => ({
   resumeEndedSession: vi.fn().mockResolvedValue(undefined),
-  dismissEndedSession: vi.fn().mockResolvedValue(undefined)
+  showEndedSession: vi.fn().mockResolvedValue(undefined),
+  markPaneEnded: vi.fn()
 }))
 vi.mock('../src/renderer/lib/session-resume', () => resumeMocks)
+
+// Closing a cold pane goes through the same door every other close does.
+const closeMocks = vi.hoisted(() => ({
+  closeTerminalSession: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../src/renderer/lib/terminal-close', () => closeMocks)
 
 // The composer's other branch pulls in the whole intent bar; this file is about
 // which branch is taken, not what the bar does.
@@ -204,7 +211,7 @@ describe('acting on the offer', () => {
     await waitFor(() => expect(resumeMocks.resumeEndedSession).toHaveBeenCalledWith(ID))
   })
 
-  it('lets it go through the same door', async () => {
+  it('closes through the same path every other pane uses', async () => {
     useAppStore
       .getState()
       .addTerminal(session(), { reason: 'server-stopped', at: Date.now(), replayed: true })
@@ -212,7 +219,10 @@ describe('acting on the offer', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /close this pane/i }))
 
-    await waitFor(() => expect(resumeMocks.dismissEndedSession).toHaveBeenCalledWith(ID))
+    // Not a private teardown: `closeTerminalSession` clears focus and selection
+    // and disposes the terminal, and `terminal:kill` already understands a
+    // session with no process behind it.
+    await waitFor(() => expect(closeMocks.closeTerminalSession).toHaveBeenCalledWith(ID))
   })
 })
 

--- a/tests/helpers/measure-history.ts
+++ b/tests/helpers/measure-history.ts
@@ -18,6 +18,8 @@ import {
 } from '../../packages/server/src/history/writer'
 import { recoverHistory } from '../../packages/server/src/history/recovery'
 import { historyDir } from '../../packages/server/src/history/checkpoint'
+import { frameOutput } from '../../packages/server/src/history/log'
+import { chunks, ms, msAsync, CHUNKS, COLS, ROWS } from './measure-output'
 
 /**
  * What writing history costs, in the three places it is paid.
@@ -31,39 +33,27 @@ import { historyDir } from '../../packages/server/src/history/checkpoint'
  * Prints one line of JSON; the test reads it and decides.
  */
 
-const CHUNKS = 20_000
-const COLS = 200
-const ROWS = 50
 const SESSIONS = 50
 
-/** Output shaped like a working agent's: colour, cursor movement, varied text. */
-function chunks(): string[] {
-  const out: string[] = []
-  for (let i = 0; i < CHUNKS; i++) {
-    const fg = 30 + (i % 8)
-    out.push(
-      `\x1b[${(i % ROWS) + 1};1H\x1b[${fg}m` +
-        `⏺ packages/server/src/file-${i % 40}.ts:${i} ` +
-        `${'▁▂▃▄▅▆▇█'[i % 8]} done\x1b[0m\r\n`
-    )
-  }
-  return out
-}
-
-function ms(run: () => void): number {
-  const started = process.hrtime.bigint()
-  run()
-  return Number(process.hrtime.bigint() - started) / 1e6
-}
-
-async function msAsync(run: () => Promise<void>): Promise<number> {
-  const started = process.hrtime.bigint()
-  await run()
-  return Number(process.hrtime.bigint() - started) / 1e6
-}
+/**
+ * How many chunks one flush gathers.
+ *
+ * `PtyManager.BUFFER_FLUSH_MS` is 8, and node-pty delivers small chunks quickly
+ * under load, so a busy terminal's flush covers a great many of them. A hundred
+ * is a conservative reading of the twenty thousand chunks below arriving at a
+ * rate a terminal can actually produce.
+ */
+const PER_FLUSH = 100
 
 function scratch(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-measure-history-'))
+}
+
+/** Everything this module can be holding, in a fixed order. */
+function clean(): void {
+  resetHistory()
+  resetScreens()
+  resetScrollback()
 }
 
 /** Fill `count` sessions with a screenful each, and their logs with the rest. */
@@ -100,9 +90,7 @@ async function main(): Promise<void> {
     }
     await flushHistory()
     await recoverHistory(warm, [{ id: 'warm', cols: COLS, rows: ROWS }])
-    resetHistory()
-    resetScreens()
-    resetScrollback()
+    clean()
     fs.rmSync(warm, { recursive: true, force: true })
   }
 
@@ -112,10 +100,35 @@ async function main(): Promise<void> {
   // once per flush, and a flush coalesces every byte that arrived in eight
   // milliseconds. So the real figure is smaller than this by however many chunks
   // a flush covers.
+  //
+  // Measured directly rather than as a difference. An earlier version of this
+  // subtracted two whole-path timings and called the remainder the cost of an
+  // append; both samples are around forty milliseconds and the machine's noise
+  // is larger than the gap, so that number came out anywhere from three per cent
+  // to negative. What it is is the frame construction, and it can be timed on
+  // its own.
+  //
+  // Twice, because the two answer different questions. Per chunk is what the
+  // path would pay if history were recorded where the output arrives. Coalesced
+  // is what the server actually pays: `recordOutput` is called from the flush,
+  // which gathers eight milliseconds of output into one write, so the real unit
+  // is a batch of chunks rather than a chunk -- one encode and one checksum pass
+  // over the same bytes instead of a hundred of each.
+  const frameOnly = ms(() => {
+    for (const c of data) frameOutput(c)
+  })
+
+  const flushes: string[] = []
+  for (let at = 0; at < data.length; at += PER_FLUSH) {
+    flushes.push(data.slice(at, at + PER_FLUSH).join(''))
+  }
+  const frameCoalesced = ms(() => {
+    for (const f of flushes) frameOutput(f)
+  })
+
   let dir = scratch()
+  clean()
   configureHistory(dir)
-  resetScreens()
-  resetScrollback()
   createScreen('s', COLS, ROWS)
   let withoutHistory = ms(() => {
     for (const c of data) {
@@ -149,9 +162,7 @@ async function main(): Promise<void> {
   // Separately, because it is not on the hot path: the frames are handed to a
   // timer and written out behind it. What the terminal waits for is above.
   const appendToDiskMs = await msAsync(settleHistory)
-  resetHistory()
-  resetScreens()
-  resetScrollback()
+  clean()
   fs.rmSync(dir, { recursive: true, force: true })
 
   // ---- What a checkpoint costs, against session count. -----------------------
@@ -165,9 +176,7 @@ async function main(): Promise<void> {
 
   for (const count of [1, 10, SESSIONS]) {
     dir = scratch()
-    resetHistory()
-    resetScreens()
-    resetScrollback()
+    clean()
     configureHistory(dir)
     const ids = fill(count, screenful)
     // Everything at once, which is what `shutdown()` does and the worst this
@@ -175,16 +184,12 @@ async function main(): Promise<void> {
     checkpointMs[String(count)] = +(await msAsync(() => flushHistory())).toFixed(1)
 
     if (count === SESSIONS) {
-      bytesPerSession = Math.round(
-        ids.reduce(
-          (total, id) =>
-            total +
-            fs
-              .readdirSync(historyDir(dir, id))
-              .reduce((n, f) => n + fs.statSync(path.join(historyDir(dir, id), f)).size, 0),
-          0
-        ) / ids.length
-      )
+      let bytes = 0
+      for (const id of ids) {
+        const at = historyDir(dir, id)
+        for (const file of fs.readdirSync(at)) bytes += fs.statSync(path.join(at, file)).size
+      }
+      bytesPerSession = Math.round(bytes / ids.length)
       resetScreens()
       resetScrollback()
       recoverMs = +(
@@ -196,9 +201,7 @@ async function main(): Promise<void> {
         })
       ).toFixed(1)
     }
-    resetHistory()
-    resetScreens()
-    resetScrollback()
+    clean()
     fs.rmSync(dir, { recursive: true, force: true })
   }
 
@@ -208,7 +211,9 @@ async function main(): Promise<void> {
       sessions: SESSIONS,
       withoutHistoryMs: +withoutHistory.toFixed(1),
       withHistoryMs: +withHistory.toFixed(1),
-      appendOnlyMs: +(withHistory - withoutHistory).toFixed(1),
+      frameOnlyMs: +frameOnly.toFixed(1),
+      frameCoalescedMs: +frameCoalesced.toFixed(1),
+      perFlush: PER_FLUSH,
       appendToDiskMs: +appendToDiskMs.toFixed(1),
       checkpointMs,
       recoverMs,

--- a/tests/helpers/measure-history.ts
+++ b/tests/helpers/measure-history.ts
@@ -1,0 +1,220 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { appendScrollback, resetScrollback } from '../../packages/server/src/terminal-scrollback'
+import {
+  createScreen,
+  feedScreen,
+  serializeScreen,
+  resetScreens
+} from '../../packages/server/src/terminal-screen'
+import {
+  configureHistory,
+  startHistory,
+  recordOutput,
+  flushHistory,
+  settleHistory,
+  resetHistory
+} from '../../packages/server/src/history/writer'
+import { recoverHistory } from '../../packages/server/src/history/recovery'
+import { historyDir } from '../../packages/server/src/history/checkpoint'
+
+/**
+ * What writing history costs, in the three places it is paid.
+ *
+ * The interval this runs at is a trade -- how much log a crash leaves to replay,
+ * against how much I/O an idle machine does -- and the only honest way to pick a
+ * number is to measure both sides. So: what an append adds to the hottest path
+ * in the server, what a checkpoint costs against session count, and what a
+ * restart spends reading it all back.
+ *
+ * Prints one line of JSON; the test reads it and decides.
+ */
+
+const CHUNKS = 20_000
+const COLS = 200
+const ROWS = 50
+const SESSIONS = 50
+
+/** Output shaped like a working agent's: colour, cursor movement, varied text. */
+function chunks(): string[] {
+  const out: string[] = []
+  for (let i = 0; i < CHUNKS; i++) {
+    const fg = 30 + (i % 8)
+    out.push(
+      `\x1b[${(i % ROWS) + 1};1H\x1b[${fg}m` +
+        `⏺ packages/server/src/file-${i % 40}.ts:${i} ` +
+        `${'▁▂▃▄▅▆▇█'[i % 8]} done\x1b[0m\r\n`
+    )
+  }
+  return out
+}
+
+function ms(run: () => void): number {
+  const started = process.hrtime.bigint()
+  run()
+  return Number(process.hrtime.bigint() - started) / 1e6
+}
+
+async function msAsync(run: () => Promise<void>): Promise<number> {
+  const started = process.hrtime.bigint()
+  await run()
+  return Number(process.hrtime.bigint() - started) / 1e6
+}
+
+function scratch(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-measure-history-'))
+}
+
+/** Fill `count` sessions with a screenful each, and their logs with the rest. */
+function fill(count: number, data: string[]): string[] {
+  const ids: string[] = []
+  for (let i = 0; i < count; i++) {
+    const id = `session-${i}`
+    ids.push(id)
+    createScreen(id, COLS, ROWS)
+    startHistory(id)
+    for (const chunk of data) {
+      appendScrollback(id, chunk)
+      feedScreen(id, chunk)
+      recordOutput(id, chunk)
+    }
+  }
+  return ids
+}
+
+async function main(): Promise<void> {
+  const data = chunks()
+
+  // Warm the JIT so the first shape measured is not paying for compilation the
+  // others avoid.
+  {
+    const warm = scratch()
+    configureHistory(warm)
+    createScreen('warm', COLS, ROWS)
+    startHistory('warm')
+    for (const c of data.slice(0, 500)) {
+      appendScrollback('warm', c)
+      feedScreen('warm', c)
+      recordOutput('warm', c)
+    }
+    await flushHistory()
+    await recoverHistory(warm, [{ id: 'warm', cols: COLS, rows: ROWS }])
+    resetHistory()
+    resetScreens()
+    resetScrollback()
+    fs.rmSync(warm, { recursive: true, force: true })
+  }
+
+  // ---- What an append adds to the path every byte already takes. -------------
+  //
+  // Per chunk, which is the pessimistic reading: production calls `recordOutput`
+  // once per flush, and a flush coalesces every byte that arrived in eight
+  // milliseconds. So the real figure is smaller than this by however many chunks
+  // a flush covers.
+  let dir = scratch()
+  configureHistory(dir)
+  resetScreens()
+  resetScrollback()
+  createScreen('s', COLS, ROWS)
+  let withoutHistory = ms(() => {
+    for (const c of data) {
+      appendScrollback('s', c)
+      feedScreen('s', c)
+    }
+  })
+  // The parse is queued, so the loop finishing is not the work finishing.
+  // Draining inside the clock is the difference between measuring the work and
+  // measuring the scheduling of it.
+  withoutHistory += await msAsync(async () => {
+    await serializeScreen('s')
+  })
+
+  resetScreens()
+  resetScrollback()
+  resetHistory()
+  configureHistory(dir)
+  createScreen('t', COLS, ROWS)
+  startHistory('t')
+  let withHistory = ms(() => {
+    for (const c of data) {
+      appendScrollback('t', c)
+      feedScreen('t', c)
+      recordOutput('t', c)
+    }
+  })
+  withHistory += await msAsync(async () => {
+    await serializeScreen('t')
+  })
+  // Separately, because it is not on the hot path: the frames are handed to a
+  // timer and written out behind it. What the terminal waits for is above.
+  const appendToDiskMs = await msAsync(settleHistory)
+  resetHistory()
+  resetScreens()
+  resetScrollback()
+  fs.rmSync(dir, { recursive: true, force: true })
+
+  // ---- What a checkpoint costs, against session count. -----------------------
+  // Enough to fill the scrollback cap, so a checkpoint is the size a real
+  // session's is rather than the size an empty one's is. That buffer is the
+  // dominant part of what lands on disk.
+  const screenful = data.slice(0, 5_000)
+  const checkpointMs: Record<string, number> = {}
+  let recoverMs = 0
+  let bytesPerSession = 0
+
+  for (const count of [1, 10, SESSIONS]) {
+    dir = scratch()
+    resetHistory()
+    resetScreens()
+    resetScrollback()
+    configureHistory(dir)
+    const ids = fill(count, screenful)
+    // Everything at once, which is what `shutdown()` does and the worst this
+    // ever has to do in one go.
+    checkpointMs[String(count)] = +(await msAsync(() => flushHistory())).toFixed(1)
+
+    if (count === SESSIONS) {
+      bytesPerSession = Math.round(
+        ids.reduce(
+          (total, id) =>
+            total +
+            fs
+              .readdirSync(historyDir(dir, id))
+              .reduce((n, f) => n + fs.statSync(path.join(historyDir(dir, id), f)).size, 0),
+          0
+        ) / ids.length
+      )
+      resetScreens()
+      resetScrollback()
+      recoverMs = +(
+        await msAsync(async () => {
+          await recoverHistory(
+            dir,
+            ids.map((id) => ({ id, cols: COLS, rows: ROWS }))
+          )
+        })
+      ).toFixed(1)
+    }
+    resetHistory()
+    resetScreens()
+    resetScrollback()
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+
+  process.stdout.write(
+    JSON.stringify({
+      chunks: CHUNKS,
+      sessions: SESSIONS,
+      withoutHistoryMs: +withoutHistory.toFixed(1),
+      withHistoryMs: +withHistory.toFixed(1),
+      appendOnlyMs: +(withHistory - withoutHistory).toFixed(1),
+      appendToDiskMs: +appendToDiskMs.toFixed(1),
+      checkpointMs,
+      recoverMs,
+      bytesPerSession
+    }) + '\n'
+  )
+}
+
+void main()

--- a/tests/helpers/measure-output.ts
+++ b/tests/helpers/measure-output.ts
@@ -1,0 +1,39 @@
+/**
+ * The bytes every measurement of the write path is timed against, and the clock
+ * they are timed with.
+ *
+ * Shared because two harnesses report numbers that are meant to be read against
+ * each other — one says what the byte buffer and the screen model cost, the
+ * other what history adds to them — and that comparison stops meaning anything
+ * the moment one copy of the generator drifts from the other.
+ */
+
+export const CHUNKS = 20_000
+export const COLS = 200
+export const ROWS = 50
+
+/** Output shaped like a working agent's: colour, cursor movement, varied text. */
+export function chunks(): string[] {
+  const out: string[] = []
+  for (let i = 0; i < CHUNKS; i++) {
+    const fg = 30 + (i % 8)
+    out.push(
+      `\x1b[${(i % ROWS) + 1};1H\x1b[${fg}m` +
+        `⏺ packages/server/src/file-${i % 40}.ts:${i} ` +
+        `${'▁▂▃▄▅▆▇█'[i % 8]} done\x1b[0m\r\n`
+    )
+  }
+  return out
+}
+
+export function ms(run: () => void): number {
+  const started = process.hrtime.bigint()
+  run()
+  return Number(process.hrtime.bigint() - started) / 1e6
+}
+
+export async function msAsync(run: () => Promise<void>): Promise<number> {
+  const started = process.hrtime.bigint()
+  await run()
+  return Number(process.hrtime.bigint() - started) / 1e6
+}

--- a/tests/helpers/measure-screens.ts
+++ b/tests/helpers/measure-screens.ts
@@ -1,4 +1,5 @@
 import {
+  createScreen,
   feedScreen,
   serializeScreen,
   clearScreen,
@@ -61,7 +62,10 @@ async function cycle(round: number): Promise<{ held: number; after: number; mode
   await settle()
   const before = process.memoryUsage().heapUsed
 
-  for (let i = 0; i < SESSIONS; i++) feedScreen(`r${round}s${i}`, realisticPaint(i), COLS, ROWS)
+  for (let i = 0; i < SESSIONS; i++) {
+    createScreen(`r${round}s${i}`, COLS, ROWS)
+    feedScreen(`r${round}s${i}`, realisticPaint(i))
+  }
   // Serialized too, so the addon has done its work and nothing is lazily
   // unbuilt at the moment of measuring.
   for (let i = 0; i < SESSIONS; i++) await serializeScreen(`r${round}s${i}`)

--- a/tests/helpers/measure-screens.ts
+++ b/tests/helpers/measure-screens.ts
@@ -1,0 +1,100 @@
+import {
+  feedScreen,
+  serializeScreen,
+  clearScreen,
+  screenCount
+} from '../../packages/server/src/terminal-screen'
+
+/**
+ * What fifty screen models cost, measured in a process of their own.
+ *
+ * Run as a child rather than inside vitest, because the vitest worker's own heap
+ * — module graph, React, the rest of the suite — is noisier than the thing being
+ * measured. Needs `--expose-gc`; without it there is no way to distinguish
+ * "released" from "not yet collected", and a number that cannot tell those apart
+ * is not a measurement.
+ *
+ * Prints one line of JSON on stdout. The test reads it and decides.
+ */
+
+const SESSIONS = 50
+const COLS = 200
+const ROWS = 50
+
+/**
+ * Output shaped like a working agent's, not `'x'.repeat(n)`.
+ *
+ * A screen of identical ASCII is the best case for xterm's cell storage, so
+ * measuring against one would report a cost nobody actually pays. This has
+ * colour changes, cursor movement and varied text — the things that make cells
+ * differ from each other.
+ */
+function realisticPaint(seed: number): string {
+  const lines: string[] = [`\x1b[?1049h\x1b[2J\x1b[H`]
+  for (let row = 0; row < ROWS; row++) {
+    const fg = 30 + ((row + seed) % 8)
+    const bold = row % 3 === 0 ? '1;' : ''
+    lines.push(
+      `\x1b[${row + 1};1H\x1b[${bold}${fg}m` +
+        `session ${seed} line ${row} ` +
+        `${'▁▂▃▄▅▆▇█'[row % 8]} ` +
+        `packages/server/src/file-${row}.ts:${row * 7} ` +
+        `\x1b[0m`
+    )
+  }
+  return lines.join('')
+}
+
+async function settle(): Promise<void> {
+  // Twice, with a macrotask between: one pass does not finish, and anything
+  // reachable from a finalizer needs the second.
+  const gc = (globalThis as { gc?: () => void }).gc
+  if (!gc) throw new Error('run with --expose-gc')
+  gc()
+  await new Promise((r) => setTimeout(r, 50))
+  gc()
+  await new Promise((r) => setTimeout(r, 50))
+}
+
+/** Build fifty, measure, release, measure. */
+async function cycle(round: number): Promise<{ held: number; after: number; modelled: number }> {
+  await settle()
+  const before = process.memoryUsage().heapUsed
+
+  for (let i = 0; i < SESSIONS; i++) feedScreen(`r${round}s${i}`, realisticPaint(i), COLS, ROWS)
+  // Serialized too, so the addon has done its work and nothing is lazily
+  // unbuilt at the moment of measuring.
+  for (let i = 0; i < SESSIONS; i++) await serializeScreen(`r${round}s${i}`)
+
+  await settle()
+  const held = process.memoryUsage().heapUsed
+  const modelled = screenCount()
+
+  for (let i = 0; i < SESSIONS; i++) clearScreen(`r${round}s${i}`)
+  await settle()
+
+  return { held: held - before, after: process.memoryUsage().heapUsed - before, modelled }
+}
+
+async function main(): Promise<void> {
+  // Twice, because one round cannot tell a leak from the heap simply not
+  // returning to exactly where it started. A per-session leak accumulates; noise
+  // does not.
+  const first = await cycle(1)
+  const second = await cycle(2)
+
+  process.stdout.write(
+    JSON.stringify({
+      sessions: SESSIONS,
+      cols: COLS,
+      rows: ROWS,
+      modelled: first.modelled,
+      remaining: screenCount(),
+      heldBytes: first.held,
+      residualFirst: first.after,
+      residualSecond: second.after
+    }) + '\n'
+  )
+}
+
+void main()

--- a/tests/helpers/measure-write-path.ts
+++ b/tests/helpers/measure-write-path.ts
@@ -4,6 +4,7 @@ import {
   resetScrollback
 } from '../../packages/server/src/terminal-scrollback'
 import {
+  createScreen,
   feedScreen,
   serializeScreen,
   resetScreens
@@ -69,7 +70,8 @@ async function main(): Promise<void> {
   const scratch = { buf: '' }
   for (const c of warm) appendTheOldWay(scratch, c)
   for (const c of warm) appendScrollback('warm', c)
-  for (const c of warm) feedScreen('warm', c, COLS, ROWS)
+  createScreen('warm', COLS, ROWS)
+  for (const c of warm) feedScreen('warm', c)
   await serializeScreen('warm')
   resetScrollback()
   resetScreens()
@@ -79,19 +81,26 @@ async function main(): Promise<void> {
     for (const c of data) appendTheOldWay(before, c)
   })
 
+  // The read is inside the clock, not after it. The old shape paid its trim on
+  // every append, so timing the new shape's writes alone against that would be
+  // the old total against the new half -- flattering, and not the same
+  // question. This is every cost either shape pays to end up with the same
+  // bytes available.
   resetScrollback()
   const newBuffer = ms(() => {
     for (const c of data) appendScrollback('s', c)
+    readScrollback('s')
   })
-  readScrollback('s')
 
   resetScrollback()
   resetScreens()
+  createScreen('s', COLS, ROWS)
   const newBufferAndScreen = ms(() => {
     for (const c of data) {
       appendScrollback('s', c)
-      feedScreen('s', c, COLS, ROWS)
+      feedScreen('s', c)
     }
+    readScrollback('s')
   })
   // The parse is queued, so the write is not finished when the loop is. Waiting
   // for it is the difference between measuring the work and measuring the

--- a/tests/helpers/measure-write-path.ts
+++ b/tests/helpers/measure-write-path.ts
@@ -1,0 +1,115 @@
+import {
+  appendScrollback,
+  readScrollback,
+  resetScrollback
+} from '../../packages/server/src/terminal-scrollback'
+import {
+  feedScreen,
+  serializeScreen,
+  resetScreens
+} from '../../packages/server/src/terminal-screen'
+
+/**
+ * How long the server spends on each chunk of terminal output.
+ *
+ * This is the hottest path in the process: every byte an agent prints arrives
+ * here, and anything added to it is paid for on every keystroke of every session
+ * at once. Two things changed on it — the byte buffer stopped rebuilding itself
+ * per chunk, and a screen model was added — and "is it faster or slower than
+ * before" is not answerable by reasoning about which sounds heavier.
+ *
+ * So all three shapes are measured against the same bytes: the buffer as it used
+ * to be, the buffer as it is, and the buffer as it is with the model beside it.
+ * Prints one line of JSON; the test reads it and decides.
+ */
+
+const CHUNKS = 20_000
+const COLS = 200
+const ROWS = 50
+const MAX_UNITS = 256 * 1024
+
+/** Output shaped like a working agent's: colour, cursor movement, varied text. */
+function chunks(): string[] {
+  const out: string[] = []
+  for (let i = 0; i < CHUNKS; i++) {
+    const fg = 30 + (i % 8)
+    out.push(
+      `\x1b[${(i % ROWS) + 1};1H\x1b[${fg}m` +
+        `⏺ packages/server/src/file-${i % 40}.ts:${i} ` +
+        `${'▁▂▃▄▅▆▇█'[i % 8]} done\x1b[0m\r\n`
+    )
+  }
+  return out
+}
+
+/** The buffer exactly as it was: concatenate the whole thing, then re-slice it. */
+function appendTheOldWay(state: { buf: string }, data: string): void {
+  const joined = state.buf + data
+  if (joined.length <= MAX_UNITS) {
+    state.buf = joined
+    return
+  }
+  const cut = joined.length - MAX_UNITS
+  const boundary = joined.indexOf('\n', cut)
+  state.buf = boundary === -1 ? joined.slice(cut) : joined.slice(boundary + 1)
+}
+
+function ms(run: () => void): number {
+  const started = process.hrtime.bigint()
+  run()
+  return Number(process.hrtime.bigint() - started) / 1e6
+}
+
+async function main(): Promise<void> {
+  const data = chunks()
+
+  // Warm the JIT on each shape, so the first one measured is not paying for
+  // compilation the others avoid.
+  const warm = data.slice(0, 500)
+  const scratch = { buf: '' }
+  for (const c of warm) appendTheOldWay(scratch, c)
+  for (const c of warm) appendScrollback('warm', c)
+  for (const c of warm) feedScreen('warm', c, COLS, ROWS)
+  await serializeScreen('warm')
+  resetScrollback()
+  resetScreens()
+
+  const before = { buf: '' }
+  const oldBuffer = ms(() => {
+    for (const c of data) appendTheOldWay(before, c)
+  })
+
+  resetScrollback()
+  const newBuffer = ms(() => {
+    for (const c of data) appendScrollback('s', c)
+  })
+  readScrollback('s')
+
+  resetScrollback()
+  resetScreens()
+  const newBufferAndScreen = ms(() => {
+    for (const c of data) {
+      appendScrollback('s', c)
+      feedScreen('s', c, COLS, ROWS)
+    }
+  })
+  // The parse is queued, so the write is not finished when the loop is. Waiting
+  // for it is the difference between measuring the work and measuring the
+  // scheduling of it.
+  const drained = process.hrtime.bigint()
+  await serializeScreen('s')
+  const drainMs = Number(process.hrtime.bigint() - drained) / 1e6
+
+  process.stdout.write(
+    JSON.stringify({
+      chunks: CHUNKS,
+      bytes: data.reduce((n, c) => n + c.length, 0),
+      oldBufferMs: +oldBuffer.toFixed(1),
+      newBufferMs: +newBuffer.toFixed(1),
+      newBufferAndScreenMs: +(newBufferAndScreen + drainMs).toFixed(1),
+      screenOnlyMs: +(newBufferAndScreen + drainMs - newBuffer).toFixed(1)
+    }) + '\n'
+  )
+}
+
+void main()

--- a/tests/helpers/measure-write-path.ts
+++ b/tests/helpers/measure-write-path.ts
@@ -9,6 +9,7 @@ import {
   serializeScreen,
   resetScreens
 } from '../../packages/server/src/terminal-screen'
+import { chunks, ms, CHUNKS, COLS, ROWS } from './measure-output'
 
 /**
  * How long the server spends on each chunk of terminal output.
@@ -24,24 +25,7 @@ import {
  * Prints one line of JSON; the test reads it and decides.
  */
 
-const CHUNKS = 20_000
-const COLS = 200
-const ROWS = 50
 const MAX_UNITS = 256 * 1024
-
-/** Output shaped like a working agent's: colour, cursor movement, varied text. */
-function chunks(): string[] {
-  const out: string[] = []
-  for (let i = 0; i < CHUNKS; i++) {
-    const fg = 30 + (i % 8)
-    out.push(
-      `\x1b[${(i % ROWS) + 1};1H\x1b[${fg}m` +
-        `⏺ packages/server/src/file-${i % 40}.ts:${i} ` +
-        `${'▁▂▃▄▅▆▇█'[i % 8]} done\x1b[0m\r\n`
-    )
-  }
-  return out
-}
 
 /** The buffer exactly as it was: concatenate the whole thing, then re-slice it. */
 function appendTheOldWay(state: { buf: string }, data: string): void {
@@ -53,12 +37,6 @@ function appendTheOldWay(state: { buf: string }, data: string): void {
   const cut = joined.length - MAX_UNITS
   const boundary = joined.indexOf('\n', cut)
   state.buf = boundary === -1 ? joined.slice(cut) : joined.slice(boundary + 1)
-}
-
-function ms(run: () => void): number {
-  const started = process.hrtime.bigint()
-  run()
-  return Number(process.hrtime.bigint() - started) / 1e6
 }
 
 async function main(): Promise<void> {

--- a/tests/helpers/one-at-a-time.ts
+++ b/tests/helpers/one-at-a-time.ts
@@ -30,6 +30,22 @@ import path from 'node:path'
 const LOCK = path.join(os.tmpdir(), 'vorn-test-spawn.lock')
 const POLL_MS = 100
 
+/**
+ * How long a file will queue before giving up.
+ *
+ * Everything holding this lock runs one after another by construction, so the
+ * last one in line waits for the sum of all the others. That total is what this
+ * has to clear, and it grew each time a suite was added -- at 180 seconds the
+ * eighth file started failing in its `beforeAll`, which reads as a broken suite
+ * rather than a busy one and points at whichever file was unluckiest.
+ *
+ * Generous on purpose. Waiting is not the failure being guarded against; the
+ * lock already refuses to hand itself to a second worker while the first is
+ * alive, so a number here only decides how patient a queue is. It exists to stop
+ * a run hanging for ever, not to police how long these take.
+ */
+const ACQUIRE_TIMEOUT_MS = 600_000
+
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
 /** Who holds it, or null if nothing does. */
@@ -81,7 +97,7 @@ async function acquire(): Promise<void> {
 export function spawnsRealServers(): void {
   beforeAll(async () => {
     await acquire()
-  }, 180_000)
+  }, ACQUIRE_TIMEOUT_MS)
   afterAll(() => {
     // Only ours. The same rule the code under test lives by: no actor removes a
     // name it did not create. A worker that overran and lost the lock must not

--- a/tests/helpers/run-measurement.ts
+++ b/tests/helpers/run-measurement.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+/**
+ * Run a measurement script in a process of its own and read its answer.
+ *
+ * A child rather than this worker, because a vitest worker holds the module
+ * graph, React and whatever the rest of the suite left behind -- noise larger
+ * than most of what is worth measuring. The script prints one line of JSON on
+ * stdout; everything before it is noise from tsx and is ignored.
+ */
+export function runMeasurement<T>(
+  script: string,
+  options: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {}
+): T {
+  const full = path.join(__dirname, script)
+  const run = spawnSync('npx', ['tsx', full], {
+    cwd: path.join(__dirname, '..', '..'),
+    encoding: 'utf-8',
+    env: { ...process.env, ...options.env },
+    timeout: options.timeoutMs ?? 300_000
+  })
+  if (run.status !== 0) {
+    throw new Error(`measurement ${script} failed (${run.status}):\n${run.stderr}`)
+  }
+  const line = run.stdout.trim().split('\n').pop() ?? ''
+  return JSON.parse(line) as T
+}

--- a/tests/history-checkpoint.test.ts
+++ b/tests/history-checkpoint.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  writeCheckpoint,
+  readCheckpoint,
+  historyDir,
+  CHECKPOINT_FILE,
+  MAX_CHECKPOINT_BYTES,
+  type Checkpoint
+} from '../packages/server/src/history/checkpoint'
+
+/**
+ * Writing a file that a crash must not be able to catch half-done.
+ *
+ * The interesting assertions here are about what is *never* observable: a reader
+ * seeing a partial checkpoint, a scratch file surviving a failure, a directory
+ * left holding an entry that was never synced.
+ */
+
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-history-'))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+const sample = (over: Partial<Checkpoint> = {}): Checkpoint => ({
+  screen: '\x1b[31mred\x1b[0m',
+  scrollback: 'earlier output\r\n',
+  cols: 200,
+  rows: 50,
+  title: 'vorn — building',
+  cwd: '/Users/x/dev/vorn',
+  generation: 3,
+  seq: 1180,
+  ...over
+})
+
+describe('writing one', () => {
+  it('round-trips everything a restore needs', () => {
+    expect(writeCheckpoint(dir, sample())).toBe(true)
+    expect(readCheckpoint(dir)).toEqual(sample())
+  })
+
+  it('creates the directory it was given', () => {
+    const nested = historyDir(dir, 'a-session-id')
+    expect(writeCheckpoint(nested, sample())).toBe(true)
+    expect(readCheckpoint(nested)).toEqual(sample())
+  })
+
+  it('leaves no scratch file behind', () => {
+    writeCheckpoint(dir, sample())
+    expect(fs.readdirSync(dir)).toEqual([CHECKPOINT_FILE])
+  })
+
+  it('replaces the previous one atomically', () => {
+    writeCheckpoint(dir, sample({ seq: 1 }))
+    writeCheckpoint(dir, sample({ seq: 2 }))
+
+    expect(readCheckpoint(dir)?.seq).toBe(2)
+    expect(fs.readdirSync(dir)).toEqual([CHECKPOINT_FILE])
+  })
+
+  it('syncs the directory, not only the file', () => {
+    // A rename is atomic against other processes and not durable against power
+    // loss until the directory entry is synced. Two fsyncs: the file's contents
+    // before the rename makes them reachable, and the directory after.
+    const fsync = vi.spyOn(fs, 'fsyncSync')
+
+    writeCheckpoint(dir, sample())
+
+    expect(fsync.mock.calls.length, 'the directory fsync is the one that gets forgotten').toBe(2)
+  })
+})
+
+describe('a checkpoint that will not fit', () => {
+  it('is skipped whole rather than truncated', () => {
+    // Half a JSON document is not a smaller checkpoint, it is an unreadable one.
+    // Restoring from an older checkpoint and a longer log is strictly better.
+    const huge = sample({ scrollback: 'x'.repeat(MAX_CHECKPOINT_BYTES + 1) })
+
+    expect(writeCheckpoint(dir, huge)).toBe(false)
+    expect(fs.existsSync(path.join(dir, CHECKPOINT_FILE))).toBe(false)
+  })
+
+  it('leaves an earlier one in place', () => {
+    writeCheckpoint(dir, sample({ seq: 1 }))
+    writeCheckpoint(dir, sample({ seq: 2, scrollback: 'x'.repeat(MAX_CHECKPOINT_BYTES + 1) }))
+
+    expect(readCheckpoint(dir)?.seq, 'the older checkpoint was lost to a failed write').toBe(1)
+  })
+})
+
+describe('a write that fails part way', () => {
+  it('leaves nothing behind and says so', () => {
+    writeCheckpoint(dir, sample({ seq: 1 }))
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('no space left on device')
+    })
+
+    expect(writeCheckpoint(dir, sample({ seq: 2 }))).toBe(false)
+    // The old checkpoint survives, and no scratch file is left to be mistaken
+    // for one later.
+    expect(readCheckpoint(dir)?.seq).toBe(1)
+    expect(fs.readdirSync(dir)).toEqual([CHECKPOINT_FILE])
+  })
+
+  it('still writes when the filesystem refuses to sync at all', () => {
+    // Some filesystems will not open a directory for this, and some refuse the
+    // sync itself. Either way the rename is still atomic against other readers,
+    // so a checkpoint that is merely not power-loss-durable beats none -- and
+    // aborting here would throw away the very history this exists to keep.
+    vi.spyOn(fs, 'fsyncSync').mockImplementation(() => {
+      throw new Error('EINVAL')
+    })
+
+    expect(writeCheckpoint(dir, sample())).toBe(true)
+    expect(readCheckpoint(dir)).toEqual(sample())
+  })
+
+  it('still writes when the directory cannot even be opened to sync', () => {
+    const realOpen = fs.openSync
+    vi.spyOn(fs, 'openSync').mockImplementation(((p: string, flags: string, mode?: number) => {
+      if (p === dir) throw new Error('EISDIR')
+      return realOpen(p, flags as never, mode)
+    }) as never)
+
+    expect(writeCheckpoint(dir, sample())).toBe(true)
+    expect(readCheckpoint(dir)).toEqual(sample())
+  })
+})
+
+describe('reading one that is not there, or not right', () => {
+  it.each([
+    ['nothing at all', null],
+    ['an empty file', ''],
+    ['not JSON', 'VRNL\x01'],
+    ['JSON that is not a checkpoint', '{"hello":"world"}'],
+    ['a checkpoint missing its geometry', '{"screen":"","scrollback":"","title":"","cwd":""}'],
+    ['a checkpoint with a fractional seq', JSON.stringify({ ...sampleRaw(), seq: 1.5 })]
+  ])('answers null for %s', (_label, body) => {
+    // Every one of these is ordinary residue from a crash, and the answer to all
+    // of them is the same: there is nothing to restore from.
+    if (body !== null) fs.writeFileSync(path.join(dir, CHECKPOINT_FILE), body)
+    expect(readCheckpoint(dir)).toBeNull()
+  })
+})
+
+function sampleRaw(): Record<string, unknown> {
+  return {
+    screen: '',
+    scrollback: '',
+    cols: 80,
+    rows: 24,
+    title: '',
+    cwd: '',
+    generation: 1,
+    seq: 1
+  }
+}
+
+describe('where history lives', () => {
+  it('sits under a subdirectory, not beside the database', () => {
+    // `config-manager` watches the data directory itself. A log written there
+    // would wake that watcher on every chunk of terminal output.
+    expect(historyDir('/data', 'abc')).toBe(path.join('/data', 'history', 'abc'))
+  })
+
+  it('encodes an id that is not a safe path segment', () => {
+    const encoded = historyDir('/data', 'a/b?c:d')
+    expect(path.dirname(encoded)).toBe(path.join('/data', 'history'))
+    expect(path.basename(encoded)).not.toContain('/')
+  })
+})

--- a/tests/history-checkpoint.test.ts
+++ b/tests/history-checkpoint.test.ts
@@ -187,6 +187,27 @@ describe('reading one that is not there, or not right', () => {
   })
 })
 
+describe('an id that does not name a directory', () => {
+  // The only two that survive `encodeURIComponent` unchanged. Anything else with
+  // a slash in it -- `'../..'` becomes `'..%2F..'` -- is already one safe
+  // segment, which is what the encoding is for and what the case below checks.
+  it.each([
+    ['two dots, which name the data directory', '..'],
+    ['one dot, which names the history directory', '.']
+  ])('is refused rather than resolved: %s', (_label, id) => {
+    // `encodeURIComponent('..')` is `'..'`, so encoding is not the guarantee it
+    // reads as -- and the writer's `reset` begins by removing the directory it
+    // is given. Every id is a random UUID today; this is what makes that a
+    // property of the function rather than of its callers.
+    expect(() => historyDir('/data', id)).toThrow()
+  })
+
+  it('still accepts anything that is merely awkward', () => {
+    const at = historyDir('/data', 'a/b?c:d')
+    expect(path.dirname(at)).toBe(path.join('/data', 'history'))
+  })
+})
+
 describe('where history lives', () => {
   it('sits under a subdirectory, not beside the database', () => {
     // `config-manager` watches the data directory itself. A log written there

--- a/tests/history-checkpoint.test.ts
+++ b/tests/history-checkpoint.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'node:fs'
+import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import {
@@ -10,6 +11,32 @@ import {
   MAX_CHECKPOINT_BYTES,
   type Checkpoint
 } from '../packages/server/src/history/checkpoint'
+
+/**
+ * A handle that counts its own syncs, and can be told to refuse them.
+ *
+ * The write is asynchronous, so the fsyncs happen through `FileHandle.sync()`
+ * rather than a module function there is anything to spy on. Wrapping `open` is
+ * the seam: every handle it hands back is this one.
+ */
+function watchSyncs(options: { refuse?: boolean; refuseDir?: string } = {}): { count: number } {
+  const counter = { count: 0 }
+  const real = fsp.open
+  vi.spyOn(fsp, 'open').mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+    if (options.refuseDir !== undefined && args[0] === options.refuseDir) {
+      throw new Error('EISDIR')
+    }
+    const handle = await real(...args)
+    const sync = handle.sync.bind(handle)
+    handle.sync = async (): Promise<void> => {
+      counter.count += 1
+      if (options.refuse) throw new Error('EINVAL')
+      await sync()
+    }
+    return handle
+  }) as never)
+  return counter
+}
 
 /**
  * Writing a file that a crash must not be able to catch half-done.
@@ -43,95 +70,103 @@ const sample = (over: Partial<Checkpoint> = {}): Checkpoint => ({
 })
 
 describe('writing one', () => {
-  it('round-trips everything a restore needs', () => {
-    expect(writeCheckpoint(dir, sample())).toBe(true)
+  it('round-trips everything a restore needs', async () => {
+    expect(await writeCheckpoint(dir, sample())).toBe(true)
     expect(readCheckpoint(dir)).toEqual(sample())
   })
 
-  it('creates the directory it was given', () => {
+  it('creates the directory it was given', async () => {
     const nested = historyDir(dir, 'a-session-id')
-    expect(writeCheckpoint(nested, sample())).toBe(true)
+    expect(await writeCheckpoint(nested, sample())).toBe(true)
     expect(readCheckpoint(nested)).toEqual(sample())
   })
 
-  it('leaves no scratch file behind', () => {
-    writeCheckpoint(dir, sample())
+  it('leaves no scratch file behind', async () => {
+    await writeCheckpoint(dir, sample())
     expect(fs.readdirSync(dir)).toEqual([CHECKPOINT_FILE])
   })
 
-  it('replaces the previous one atomically', () => {
-    writeCheckpoint(dir, sample({ seq: 1 }))
-    writeCheckpoint(dir, sample({ seq: 2 }))
+  it('replaces the previous one atomically', async () => {
+    await writeCheckpoint(dir, sample({ seq: 1 }))
+    await writeCheckpoint(dir, sample({ seq: 2 }))
 
     expect(readCheckpoint(dir)?.seq).toBe(2)
     expect(fs.readdirSync(dir)).toEqual([CHECKPOINT_FILE])
   })
 
-  it('syncs the directory, not only the file', () => {
+  it('syncs the directory, not only the file', async () => {
     // A rename is atomic against other processes and not durable against power
     // loss until the directory entry is synced. Two fsyncs: the file's contents
     // before the rename makes them reachable, and the directory after.
-    const fsync = vi.spyOn(fs, 'fsyncSync')
+    const syncs = watchSyncs()
 
-    writeCheckpoint(dir, sample())
+    await writeCheckpoint(dir, sample())
 
-    expect(fsync.mock.calls.length, 'the directory fsync is the one that gets forgotten').toBe(2)
+    expect(syncs.count, 'the directory fsync is the one that gets forgotten').toBe(2)
+  })
+
+  it('never blocks the event loop while it does any of that', async () => {
+    // The whole point of a queue per session is that a slow disk under one
+    // terminal does not stop another. A synchronous write would have made that
+    // untrue of every terminal at once, and of every socket and request beside
+    // them.
+    let ticked = false
+    const beat = setInterval(() => {
+      ticked = true
+    }, 1)
+
+    await writeCheckpoint(dir, sample({ scrollback: 'x'.repeat(512 * 1024) }))
+    clearInterval(beat)
+
+    expect(ticked, 'nothing else ran while the checkpoint was being written').toBe(true)
   })
 })
 
 describe('a checkpoint that will not fit', () => {
-  it('is skipped whole rather than truncated', () => {
+  it('is skipped whole rather than truncated', async () => {
     // Half a JSON document is not a smaller checkpoint, it is an unreadable one.
     // Restoring from an older checkpoint and a longer log is strictly better.
     const huge = sample({ scrollback: 'x'.repeat(MAX_CHECKPOINT_BYTES + 1) })
 
-    expect(writeCheckpoint(dir, huge)).toBe(false)
+    expect(await writeCheckpoint(dir, huge)).toBe(false)
     expect(fs.existsSync(path.join(dir, CHECKPOINT_FILE))).toBe(false)
   })
 
-  it('leaves an earlier one in place', () => {
-    writeCheckpoint(dir, sample({ seq: 1 }))
-    writeCheckpoint(dir, sample({ seq: 2, scrollback: 'x'.repeat(MAX_CHECKPOINT_BYTES + 1) }))
+  it('leaves an earlier one in place', async () => {
+    await writeCheckpoint(dir, sample({ seq: 1 }))
+    await writeCheckpoint(dir, sample({ seq: 2, scrollback: 'x'.repeat(MAX_CHECKPOINT_BYTES + 1) }))
 
     expect(readCheckpoint(dir)?.seq, 'the older checkpoint was lost to a failed write').toBe(1)
   })
 })
 
 describe('a write that fails part way', () => {
-  it('leaves nothing behind and says so', () => {
-    writeCheckpoint(dir, sample({ seq: 1 }))
-    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-      throw new Error('no space left on device')
-    })
+  it('leaves nothing behind and says so', async () => {
+    await writeCheckpoint(dir, sample({ seq: 1 }))
+    vi.spyOn(fsp, 'rename').mockRejectedValue(new Error('no space left on device'))
 
-    expect(writeCheckpoint(dir, sample({ seq: 2 }))).toBe(false)
+    expect(await writeCheckpoint(dir, sample({ seq: 2 }))).toBe(false)
     // The old checkpoint survives, and no scratch file is left to be mistaken
     // for one later.
     expect(readCheckpoint(dir)?.seq).toBe(1)
     expect(fs.readdirSync(dir)).toEqual([CHECKPOINT_FILE])
   })
 
-  it('still writes when the filesystem refuses to sync at all', () => {
+  it('still writes when the filesystem refuses to sync at all', async () => {
     // Some filesystems will not open a directory for this, and some refuse the
     // sync itself. Either way the rename is still atomic against other readers,
     // so a checkpoint that is merely not power-loss-durable beats none -- and
     // aborting here would throw away the very history this exists to keep.
-    vi.spyOn(fs, 'fsyncSync').mockImplementation(() => {
-      throw new Error('EINVAL')
-    })
+    watchSyncs({ refuse: true })
 
-    expect(writeCheckpoint(dir, sample())).toBe(true)
+    expect(await writeCheckpoint(dir, sample())).toBe(true)
     expect(readCheckpoint(dir)).toEqual(sample())
   })
 
-  it('still writes when the directory cannot even be opened to sync', () => {
-    const realOpen = fs.openSync
-    vi.spyOn(fs, 'openSync').mockImplementation(((p: string, flags: string, mode?: number) => {
-      if (p === dir) throw new Error('EISDIR')
-      return realOpen(p, flags as never, mode)
-    }) as never)
+  it('still writes when the directory cannot even be opened to sync', async () => {
+    watchSyncs({ refuseDir: dir })
 
-    expect(writeCheckpoint(dir, sample())).toBe(true)
+    expect(await writeCheckpoint(dir, sample())).toBe(true)
     expect(readCheckpoint(dir)).toEqual(sample())
   })
 })
@@ -143,7 +178,7 @@ describe('reading one that is not there, or not right', () => {
     ['not JSON', 'VRNL\x01'],
     ['JSON that is not a checkpoint', '{"hello":"world"}'],
     ['a checkpoint missing its geometry', '{"screen":"","scrollback":"","title":"","cwd":""}'],
-    ['a checkpoint with a fractional seq', JSON.stringify({ ...sampleRaw(), seq: 1.5 })]
+    ['a checkpoint with a fractional seq', JSON.stringify({ ...sample(), seq: 1.5 })]
   ])('answers null for %s', (_label, body) => {
     // Every one of these is ordinary residue from a crash, and the answer to all
     // of them is the same: there is nothing to restore from.
@@ -151,19 +186,6 @@ describe('reading one that is not there, or not right', () => {
     expect(readCheckpoint(dir)).toBeNull()
   })
 })
-
-function sampleRaw(): Record<string, unknown> {
-  return {
-    screen: '',
-    scrollback: '',
-    cols: 80,
-    rows: 24,
-    title: '',
-    cwd: '',
-    generation: 1,
-    seq: 1
-  }
-}
 
 describe('where history lives', () => {
   it('sits under a subdirectory, not beside the database', () => {

--- a/tests/history-cost.process.test.ts
+++ b/tests/history-cost.process.test.ts
@@ -32,7 +32,11 @@ interface Measurement {
   withoutHistoryMs: number
   /** The same path with a frame recorded per chunk. */
   withHistoryMs: number
-  appendOnlyMs: number
+  /** Building a frame per chunk, timed on its own. */
+  frameOnlyMs: number
+  /** Building one per flush instead, which is what the server does. */
+  frameCoalescedMs: number
+  perFlush: number
   /** Pushing those frames to disk, which happens behind the path, not on it. */
   appendToDiskMs: number
   /** Checkpointing every session at once, by session count. */
@@ -46,21 +50,36 @@ describe('what a terminal that survives a crash costs', () => {
   const r = runMeasurement<Measurement>('measure-history.ts', { timeoutMs: 300_000 })
 
   it('adds little to the path every byte of output already takes', () => {
-    // The question that decides whether this belongs on the flush at all. A
-    // frame is a length, a checksum over the payload, and a push -- against a
-    // full VT parse of the same bytes, which was already there. Measured at
-    // roughly 38.6ms without and 39.7ms with, for twenty thousand chunks: about
-    // three per cent, and that is the pessimistic reading, because production
-    // records once per flush rather than once per chunk.
+    // The question that decides whether this belongs on the flush at all: a
+    // length, a checksum over the payload and a push, against a full VT parse of
+    // the same bytes that was already there.
+    //
+    // Measured directly rather than as a difference. Subtracting one whole-path
+    // timing from another put the answer inside this machine's noise -- two ~35ms
+    // samples whose gap came out anywhere from three per cent to negative -- so
+    // the number that used to be asserted here said nothing. This times the frame
+    // construction itself: 1.5ms against a 33ms path, for the same bytes.
     expect(
-      r.appendOnlyMs,
-      `${r.appendOnlyMs}ms added to ${r.withoutHistoryMs}ms for ${r.chunks} chunks`
+      r.frameCoalescedMs,
+      `${r.frameCoalescedMs}ms of framing on a ${r.withoutHistoryMs}ms path, ${r.chunks} chunks`
     ).toBeLessThan(r.withoutHistoryMs / 4)
+  })
+
+  it('is affordable because of the flush, not in spite of it', () => {
+    // The reason `recordOutput` is called from `flushBuffer` rather than from
+    // `onData`. A frame per chunk costs 13.5ms for these bytes; one per flush,
+    // over the same bytes, costs 1.5ms -- one encode and one checksum pass
+    // instead of a hundred of each. If that ratio collapses, something has moved
+    // the call back onto the per-chunk path.
+    expect(
+      r.frameCoalescedMs,
+      `${r.frameOnlyMs}ms per chunk, ${r.frameCoalescedMs}ms at ${r.perFlush} chunks a flush`
+    ).toBeLessThan(r.frameOnlyMs / 3)
   })
 
   it('does the disk work behind that path rather than on it', () => {
     // Frames accumulate and a timer writes them. What a terminal waits for is
-    // the append above; this is what happens afterwards, and it must stay the
+    // the framing above; this is what happens afterwards, and it must stay the
     // smaller of the two or the coalescing is not earning anything.
     expect(
       r.appendToDiskMs,
@@ -72,16 +91,17 @@ describe('what a terminal that survives a crash costs', () => {
     // What this catches is a shape change: a queue that became global, or a scan
     // that became quadratic, either of which turns a machine with fifty
     // terminals into one that cannot shut down. Five times the sessions were
-    // measured at 5.2 times the cost -- 121ms for ten, 627ms for fifty.
+    // measured at 4.7 times the cost -- 102ms for ten, 480ms for fifty.
     const ten = r.checkpointMs['10'] ?? 0
     const fifty = r.checkpointMs[String(r.sessions)] ?? 0
     expect(fifty, `${ten}ms for ten sessions, ${fifty}ms for ${r.sessions}`).toBeLessThan(ten * 10)
   })
 
   it('reads every terminal back for less than it cost to write them', () => {
-    // Recovery sits between the listen and the first client, so its cost is a
-    // window where history is not loaded yet. Measured at 77ms for fifty
-    // sessions, against 627ms to write them.
+    // Recovery runs before the port file and the credential are published, so
+    // its cost is not a window where history is missing -- it is a delay before
+    // anything can find the server at all. Measured at 62ms for fifty sessions,
+    // against 480ms to write them.
     expect(
       r.recoverMs,
       `${r.recoverMs}ms to restore ${r.sessions}, ${r.checkpointMs[String(r.sessions)]}ms to write them`

--- a/tests/history-cost.process.test.ts
+++ b/tests/history-cost.process.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { runMeasurement } from './helpers/run-measurement'
+import { spawnsRealServers } from './helpers/one-at-a-time'
+
+/**
+ * What keeping history costs, in the three places it is paid.
+ *
+ * The interval this runs at is a trade — how much log a crash leaves to replay,
+ * against how much work an idle machine does — and picking a number by reasoning
+ * about which sounds heavier is how a server ends up checkpointing fifty
+ * terminals every second. So the three costs are measured: what an append adds
+ * to the path every byte already takes, what checkpointing every session at once
+ * costs, and what a restart spends reading it back.
+ *
+ * In a child process for the same reason as the other two measurements: this
+ * worker holds the module graph and the rest of the suite, which is noise larger
+ * than most of what is being measured.
+ *
+ * The assertions are relationships between numbers from the same run, not
+ * ceilings on any one of them. Wall-clock on a loaded CI box is not a thing to
+ * assert against a constant, and a flaky performance test gets deleted rather
+ * than investigated — which leaves nothing. The absolute figures belong in the
+ * commit message, where they are a record rather than a trap.
+ */
+
+spawnsRealServers()
+
+interface Measurement {
+  chunks: number
+  sessions: number
+  /** The write path as it was before history: byte buffer and screen model. */
+  withoutHistoryMs: number
+  /** The same path with a frame recorded per chunk. */
+  withHistoryMs: number
+  appendOnlyMs: number
+  /** Pushing those frames to disk, which happens behind the path, not on it. */
+  appendToDiskMs: number
+  /** Checkpointing every session at once, by session count. */
+  checkpointMs: Record<string, number>
+  /** Restoring all of them on start. */
+  recoverMs: number
+  bytesPerSession: number
+}
+
+describe('what a terminal that survives a crash costs', () => {
+  const r = runMeasurement<Measurement>('measure-history.ts', { timeoutMs: 300_000 })
+
+  it('adds little to the path every byte of output already takes', () => {
+    // The question that decides whether this belongs on the flush at all. A
+    // frame is a length, a checksum over the payload, and a push -- against a
+    // full VT parse of the same bytes, which was already there. Measured at
+    // roughly 38.6ms without and 39.7ms with, for twenty thousand chunks: about
+    // three per cent, and that is the pessimistic reading, because production
+    // records once per flush rather than once per chunk.
+    expect(
+      r.appendOnlyMs,
+      `${r.appendOnlyMs}ms added to ${r.withoutHistoryMs}ms for ${r.chunks} chunks`
+    ).toBeLessThan(r.withoutHistoryMs / 4)
+  })
+
+  it('does the disk work behind that path rather than on it', () => {
+    // Frames accumulate and a timer writes them. What a terminal waits for is
+    // the append above; this is what happens afterwards, and it must stay the
+    // smaller of the two or the coalescing is not earning anything.
+    expect(
+      r.appendToDiskMs,
+      `${r.appendToDiskMs}ms of writing behind ${r.withHistoryMs}ms of path`
+    ).toBeLessThan(r.withHistoryMs)
+  })
+
+  it('checkpoints in time that grows with session count and not faster', () => {
+    // What this catches is a shape change: a queue that became global, or a scan
+    // that became quadratic, either of which turns a machine with fifty
+    // terminals into one that cannot shut down. Five times the sessions were
+    // measured at 5.2 times the cost -- 121ms for ten, 627ms for fifty.
+    const ten = r.checkpointMs['10'] ?? 0
+    const fifty = r.checkpointMs[String(r.sessions)] ?? 0
+    expect(fifty, `${ten}ms for ten sessions, ${fifty}ms for ${r.sessions}`).toBeLessThan(ten * 10)
+  })
+
+  it('reads every terminal back for less than it cost to write them', () => {
+    // Recovery sits between the listen and the first client, so its cost is a
+    // window where history is not loaded yet. Measured at 77ms for fifty
+    // sessions, against 627ms to write them.
+    expect(
+      r.recoverMs,
+      `${r.recoverMs}ms to restore ${r.sessions}, ${r.checkpointMs[String(r.sessions)]}ms to write them`
+    ).toBeLessThan(r.checkpointMs[String(r.sessions)] ?? 0)
+  })
+}, 300_000)

--- a/tests/history-crash.process.test.ts
+++ b/tests/history-crash.process.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest'
+import { spawnsRealServers } from './helpers/one-at-a-time'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+spawnsRealServers()
+
+/**
+ * A real server, a real shell, and a kill that runs nothing.
+ *
+ * Every other test of this writes history by calling the writer and reads it by
+ * calling recovery, in one process that politely tears itself down. None of them
+ * can fail the way the thing they model fails. `SIGKILL` runs no handler, no
+ * `finally`, no `process.on('exit')` -- whatever the kernel had flushed at that
+ * instant is the entire input to the next start, and that is the input this
+ * whole design exists for.
+ *
+ * So this one spawns the built server, asks it for a shell over the wire, waits
+ * for a checkpoint to appear on disk, kills it dead, and starts another on the
+ * same data directory. It also checks the wiring nothing else covers: that
+ * `configureHistory` runs at startup, that `pty-manager` records on the flush,
+ * and that recovery is reached in `startServer` at all.
+ *
+ * HOME is redirected as well as `--data-dir` for the reason `endpoint-race`
+ * gives: `shutdown()` writes `~/.claude/settings.json` regardless of the data
+ * dir, and without this these would uninstall the developer's own agent hooks.
+ */
+
+const SERVER = path.join(__dirname, '..', 'packages', 'server')
+const ENTRY = path.join(SERVER, 'dist', 'index.cjs')
+
+/** Distinct from the command that produces it, so an echoed prompt cannot pass. */
+const MARKER = 'VORN-RESTORED-OK'
+const COMMAND = `printf 'VORN-%s-OK\\n' RESTORED\r`
+
+beforeAll(() => {
+  // Always, not only when `dist/` is missing. The other process tests build on
+  // absence and that is enough for them, because what they assert has been in
+  // the bundle for a while. This one asserts a behaviour that is being written
+  // right now, and a bundle from before the edit passes every step until the
+  // last and then reports that history does not survive a crash -- which is true
+  // of the binary and false of the branch. It costs about a second.
+  const built = spawnSync('yarn', ['build'], { cwd: SERVER, stdio: 'inherit', shell: false })
+  if (built.status !== 0) throw new Error('could not build the server bundle for this test')
+  if (!fs.existsSync(ENTRY)) throw new Error(`the build produced no ${ENTRY}`)
+}, 180_000)
+
+let dir: string | null = null
+const running: ChildProcess[] = []
+let said = ''
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function dataDir(): string {
+  return path.join(dir as string, '.vorn')
+}
+
+function launch(): ChildProcess {
+  fs.mkdirSync(dataDir(), { recursive: true, mode: 0o700 })
+  const proc = spawn(process.execPath, [ENTRY, '--data-dir', dataDir(), '--port', '0'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+    env: {
+      ...process.env,
+      HOME: dir as string,
+      USERPROFILE: dir as string,
+      VORN_DATA_DIR: dataDir(),
+      VORN_IDLE_TIMEOUT_MS: '600000'
+    }
+  })
+  // Kept, not merely drained. An unread pipe fills at 64KB and blocks the
+  // writer, and when one of these fails the server's own log is the only thing
+  // that says why.
+  proc.stdout?.on('data', (d: Buffer) => {
+    said += String(d)
+  })
+  proc.stderr?.on('data', (d: Buffer) => {
+    said += String(d)
+  })
+  running.push(proc)
+  return proc
+}
+
+/** The tail of what the servers have said, for an assertion that needs to explain itself. */
+function saidSoFar(): string {
+  return said.split('\n').slice(-25).join('\n')
+}
+
+/**
+ * An authenticated socket, once the server has published where and how.
+ *
+ * `notPort` is the whole reason this is more than four lines. A server that was
+ * killed leaves its port file behind naming a port with nothing on it, so the
+ * replacement's file is indistinguishable from the corpse's until it is
+ * rewritten -- and connecting in between is an ECONNREFUSED that looks like a
+ * server which failed to start.
+ */
+async function connect(notPort?: number, timeoutMs = 30_000): Promise<import('ws').WebSocket> {
+  const portFile = path.join(dataDir(), 'ws-port')
+  const tokenFile = path.join(dataDir(), 'local-token')
+  const deadline = Date.now() + timeoutMs
+  let port: number | undefined
+  while (Date.now() < deadline) {
+    if (fs.existsSync(portFile) && fs.existsSync(tokenFile)) {
+      try {
+        const found: number = JSON.parse(fs.readFileSync(portFile, 'utf-8')).port
+        if (found !== notPort) {
+          port = found
+          break
+        }
+      } catch {
+        /* being rewritten */
+      }
+    }
+    await sleep(200)
+  }
+  if (port === undefined) throw new Error(`no server published a port. it said:\n${saidSoFar()}`)
+  const token = fs.readFileSync(tokenFile, 'utf-8').trim()
+  const { default: WebSocket } = await import('ws')
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, {
+    headers: { Authorization: `Bearer ${token}` }
+  })
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve)
+    ws.once('error', reject)
+  })
+  return ws
+}
+
+let nextId = 0
+
+function call<T>(ws: import('ws').WebSocket, method: string, params?: unknown): Promise<T> {
+  const id = ++nextId
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${method} never answered`)), 20_000)
+    const onMessage = (raw: Buffer): void => {
+      const msg = JSON.parse(String(raw))
+      if (msg.id !== id) return
+      clearTimeout(timer)
+      ws.off('message', onMessage)
+      if (msg.error) reject(new Error(`${method}: ${JSON.stringify(msg.error)}`))
+      else resolve(msg.result as T)
+    }
+    ws.on('message', onMessage)
+    ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+  })
+}
+
+function notify(ws: import('ws').WebSocket, method: string, params: unknown): void {
+  ws.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
+}
+
+async function until(done: () => boolean | Promise<boolean>, within: number): Promise<boolean> {
+  const deadline = Date.now() + within
+  while (Date.now() < deadline) {
+    if (await done()) return true
+    await sleep(250)
+  }
+  return false
+}
+
+afterEach(async () => {
+  said = ''
+  for (const proc of running.splice(0)) {
+    const pid = proc.pid
+    if (pid === undefined || !alive(pid)) continue
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      /* already gone */
+    }
+  }
+  await sleep(200)
+  if (dir) fs.rmSync(dir, { recursive: true, force: true })
+  dir = null
+})
+
+describe('a server that was killed rather than asked to stop', () => {
+  it('gives its terminals back to the server that starts next', async () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-crash-'))
+
+    const first = launch()
+    const pid = first.pid as number
+    let ws = await connect()
+    const wasOn: number = JSON.parse(fs.readFileSync(path.join(dataDir(), 'ws-port'), 'utf-8')).port
+
+    const session = await call<{ id: string }>(ws, 'shell:create', dir)
+    notify(ws, 'terminal:write', { id: session.id, data: COMMAND })
+
+    // The shell has to actually run it before there is anything to checkpoint.
+    const ran = await until(async () => {
+      const { data } = await call<{ data: string }>(ws, 'terminal:readScrollback', {
+        id: session.id
+      })
+      return data.includes(MARKER)
+    }, 20_000)
+    expect(ran, 'the shell never produced the output this test is about').toBe(true)
+
+    // And the server has to have written one. Quiescence is two seconds in
+    // production, so this is the wait that the interval buys.
+    const history = path.join(dataDir(), 'history', encodeURIComponent(session.id))
+    const wrote = await until(() => fs.existsSync(path.join(history, 'checkpoint.json')), 20_000)
+    expect(wrote, `no checkpoint under ${history}. it said:\n${saidSoFar()}`).toBe(true)
+    ws.close()
+
+    // Nothing runs from here. No shutdown, no flush, no unlink.
+    process.kill(pid, 'SIGKILL')
+    expect(await until(() => !alive(pid), 10_000), 'the server survived a SIGKILL').toBe(true)
+
+    launch()
+    ws = await connect(wasOn)
+
+    const previous = await call<Array<{ id: string }>>(ws, 'sessions:getPrevious')
+    expect(previous.map((s) => s.id)).toContain(session.id)
+
+    const { data } = await call<{ data: string }>(ws, 'terminal:readScrollback', { id: session.id })
+    ws.close()
+
+    // The whole claim, through a real process boundary: what the terminal
+    // printed before the crash is what the next server can hand back.
+    expect(data, 'the restored scrollback lost the output').toContain(MARKER)
+  }, 120_000)
+
+  it('leaves nothing behind for a terminal the next server cannot name', async () => {
+    // The sweep, against real residue rather than a fabricated directory. A
+    // crash leaves a directory per live terminal, and history keyed by an id no
+    // session record mentions is history nothing can ever ask for.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-crash-'))
+
+    const first = launch()
+    const pid = first.pid as number
+    let ws = await connect()
+    const wasOn: number = JSON.parse(fs.readFileSync(path.join(dataDir(), 'ws-port'), 'utf-8')).port
+    const session = await call<{ id: string }>(ws, 'shell:create', dir)
+    notify(ws, 'terminal:write', { id: session.id, data: COMMAND })
+
+    const history = path.join(dataDir(), 'history')
+    const wrote = await until(
+      () => fs.existsSync(path.join(history, encodeURIComponent(session.id), 'checkpoint.json')),
+      20_000
+    )
+    expect(wrote).toBe(true)
+    ws.close()
+    process.kill(pid, 'SIGKILL')
+    await until(() => !alive(pid), 10_000)
+
+    // A terminal from a run whose session record is long gone.
+    const orphan = path.join(history, encodeURIComponent('a-session-nothing-remembers'))
+    fs.mkdirSync(orphan, { recursive: true })
+    fs.copyFileSync(
+      path.join(history, encodeURIComponent(session.id), 'checkpoint.json'),
+      path.join(orphan, 'checkpoint.json')
+    )
+
+    launch()
+    ws = await connect(wasOn)
+    await call(ws, 'sessions:getPrevious')
+    ws.close()
+
+    expect(fs.existsSync(orphan), 'history nothing can name was left on disk').toBe(false)
+    expect(fs.existsSync(path.join(history, encodeURIComponent(session.id)))).toBe(true)
+  }, 120_000)
+})

--- a/tests/history-crash.process.test.ts
+++ b/tests/history-crash.process.test.ts
@@ -221,7 +221,9 @@ describe('a server that was killed rather than asked to stop', () => {
     launch()
     ws = await connect(wasOn)
 
-    const previous = await call<Array<{ id: string }>>(ws, 'sessions:getPrevious')
+    const previous = (await call<Array<{ session: { id: string } }>>(ws, 'sessions:restored')).map(
+      (r) => r.session
+    )
     expect(previous.map((s) => s.id)).toContain(session.id)
 
     const { data } = await call<{ data: string }>(ws, 'terminal:readScrollback', { id: session.id })
@@ -267,7 +269,9 @@ describe('a server that was killed rather than asked to stop', () => {
     ws = await connect(wasOn)
     wasOn = JSON.parse(fs.readFileSync(path.join(dataDir(), 'ws-port'), 'utf-8')).port
     expect(
-      (await call<Array<{ id: string }>>(ws, 'sessions:getPrevious')).map((s) => s.id)
+      (await call<Array<{ session: { id: string } }>>(ws, 'sessions:restored'))
+        .map((r) => r.session)
+        .map((s) => s.id)
     ).toContain(original.id)
 
     await call<{ id: string }>(ws, 'shell:create', dir)
@@ -280,7 +284,9 @@ describe('a server that was killed rather than asked to stop', () => {
     // Third run: the original must still be nameable, and still have its history.
     launch()
     ws = await connect(wasOn)
-    const previous = await call<Array<{ id: string }>>(ws, 'sessions:getPrevious')
+    const previous = (await call<Array<{ session: { id: string } }>>(ws, 'sessions:restored')).map(
+      (r) => r.session
+    )
     const { data } = await call<{ data: string }>(ws, 'terminal:readScrollback', {
       id: original.id
     })
@@ -327,7 +333,7 @@ describe('a server that was killed rather than asked to stop', () => {
 
     launch()
     ws = await connect(wasOn)
-    await call(ws, 'sessions:getPrevious')
+    await call(ws, 'sessions:restored')
     ws.close()
 
     expect(fs.existsSync(orphan), 'history nothing can name was left on disk').toBe(false)

--- a/tests/history-crash.process.test.ts
+++ b/tests/history-crash.process.test.ts
@@ -232,6 +232,68 @@ describe('a server that was killed rather than asked to stop', () => {
     expect(data, 'the restored scrollback lost the output').toContain(MARKER)
   }, 120_000)
 
+  it('keeps a terminal through a second restart, even after a new one is opened', async () => {
+    // The failure this catches is quiet and takes two restarts to show.
+    //
+    // A save is a whole-table replace fed by the live session map, and after a
+    // restart that map is empty. So opening a single new pane replaced the
+    // table with that one row, every record from the previous run went, and on
+    // the *next* start recovery judged their history unreachable -- correctly,
+    // by its own rule -- and deleted it. Terminal history survived exactly one
+    // restart, which is one fewer than the point of writing it down.
+    //
+    // One restart is not enough to see it: the first restore works. It is the
+    // second that comes back empty.
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-crash-'))
+
+    const first = launch()
+    let pid = first.pid as number
+    let ws = await connect()
+    let wasOn: number = JSON.parse(fs.readFileSync(path.join(dataDir(), 'ws-port'), 'utf-8')).port
+
+    const original = await call<{ id: string }>(ws, 'shell:create', dir)
+    notify(ws, 'terminal:write', { id: original.id, data: COMMAND })
+    const history = path.join(dataDir(), 'history', encodeURIComponent(original.id))
+    expect(await until(() => fs.existsSync(path.join(history, 'checkpoint.json')), 20_000)).toBe(
+      true
+    )
+    ws.close()
+    process.kill(pid, 'SIGKILL')
+    await until(() => !alive(pid), 10_000)
+
+    // Second run: open something new, which is what used to erase the record.
+    const second = launch()
+    pid = second.pid as number
+    ws = await connect(wasOn)
+    wasOn = JSON.parse(fs.readFileSync(path.join(dataDir(), 'ws-port'), 'utf-8')).port
+    expect(
+      (await call<Array<{ id: string }>>(ws, 'sessions:getPrevious')).map((s) => s.id)
+    ).toContain(original.id)
+
+    await call<{ id: string }>(ws, 'shell:create', dir)
+    // Past the 500ms save debounce, so the replace has certainly happened.
+    await sleep(2_000)
+    ws.close()
+    process.kill(pid, 'SIGKILL')
+    await until(() => !alive(pid), 10_000)
+
+    // Third run: the original must still be nameable, and still have its history.
+    launch()
+    ws = await connect(wasOn)
+    const previous = await call<Array<{ id: string }>>(ws, 'sessions:getPrevious')
+    const { data } = await call<{ data: string }>(ws, 'terminal:readScrollback', {
+      id: original.id
+    })
+    ws.close()
+
+    expect(
+      previous.map((s) => s.id),
+      'the record was erased by the second run'
+    ).toContain(original.id)
+    expect(fs.existsSync(history), 'its history was swept as unreachable').toBe(true)
+    expect(data, 'the terminal came back empty').toContain(MARKER)
+  }, 180_000)
+
   it('leaves nothing behind for a terminal the next server cannot name', async () => {
     // The sweep, against real residue rather than a fabricated directory. A
     // crash leaves a directory per live terminal, and history keyed by an id no

--- a/tests/history-log.test.ts
+++ b/tests/history-log.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  crc32,
+  writeHeader,
+  readHeader,
+  readFrames,
+  frameBatch,
+  frameOutput,
+  frameResize,
+  frameClear,
+  FORMAT_VERSION,
+  type Frame
+} from '../packages/server/src/history/log'
+
+/**
+ * Reading a file that was being written when the process died.
+ *
+ * That is not an edge case here, it is the design input: the whole reason this
+ * format exists is that a crash runs nothing, so the last thing on disk is
+ * whatever the kernel had flushed at the moment the process stopped. Every test
+ * below is a shape a real crash produces.
+ *
+ * Written before anything wrote a file, because a format that is wrong is
+ * discovered months later as a terminal that redraws strangely, and by then the
+ * bad files already exist.
+ */
+
+const log = (...frames: Buffer[]): Buffer => Buffer.concat([writeHeader(1), ...frames])
+
+describe('the header', () => {
+  it('round-trips', () => {
+    expect(readHeader(writeHeader(7))).toEqual({ formatVersion: FORMAT_VERSION, generation: 7 })
+  })
+
+  it.each([
+    ['an empty file', Buffer.alloc(0)],
+    ['a file shorter than the header', Buffer.from('VRN')],
+    ['a file that is not ours', Buffer.from('SQLite format 3\0')]
+  ])('refuses %s rather than guessing', (_label, buf) => {
+    // All three are ordinary things to find after a crash, and the answer to all
+    // three is the same: there is no history here, start again.
+    expect(readHeader(buf)).toBeNull()
+  })
+})
+
+describe('frames', () => {
+  it('round-trips every kind, in order', () => {
+    const buf = log(
+      frameBatch(1180),
+      frameOutput('\x1b[31mred\x1b[0m'),
+      frameResize(200, 50),
+      frameClear()
+    )
+
+    const { frames, reason } = readFrames(buf)
+
+    expect(reason).toBe('end')
+    expect(frames).toEqual<Frame[]>([
+      { kind: 'batch', seq: 1180 },
+      { kind: 'output', data: '\x1b[31mred\x1b[0m' },
+      { kind: 'resize', cols: 200, rows: 50 },
+      { kind: 'clear' }
+    ])
+  })
+
+  it('carries bytes that are not ASCII', () => {
+    const buf = log(frameOutput('▁▂▃ 日本語 🙂'))
+    expect(readFrames(buf).frames).toEqual([{ kind: 'output', data: '▁▂▃ 日本語 🙂' }])
+  })
+
+  it('carries an empty write without losing its place', () => {
+    const buf = log(frameOutput(''), frameOutput('after'))
+    expect(readFrames(buf).frames).toEqual([
+      { kind: 'output', data: '' },
+      { kind: 'output', data: 'after' }
+    ])
+  })
+})
+
+describe('a file the crash was in the middle of', () => {
+  it('replays its complete prefix and nothing else', () => {
+    const whole = log(frameOutput('first'), frameOutput('second'), frameOutput('third'))
+
+    // Cut inside the last frame's payload, which is where a crash lands.
+    const torn = whole.subarray(0, whole.length - 3)
+    const { frames, reason, consumed } = readFrames(torn)
+
+    expect(frames).toEqual([
+      { kind: 'output', data: 'first' },
+      { kind: 'output', data: 'second' }
+    ])
+    expect(reason).toBe('torn')
+    // Consumed points at the start of the incomplete frame, so a caller can
+    // truncate the file to exactly what was whole and append from there.
+    expect(consumed).toBe(whole.length - frameOutput('third').length)
+  })
+
+  it('survives a cut inside the frame header itself', () => {
+    const whole = log(frameOutput('first'), frameOutput('second'))
+    const torn = whole.subarray(0, whole.length - frameOutput('second').length + 3)
+
+    expect(readFrames(torn)).toMatchObject({
+      frames: [{ kind: 'output', data: 'first' }],
+      reason: 'torn'
+    })
+  })
+
+  it('refuses a length that runs past the end rather than trusting it', () => {
+    // A torn length field can read as an enormous number. Slicing on it would
+    // answer with a short buffer whose checksum then fails, reporting corruption
+    // where the truth is a tear.
+    const buf = log(frameOutput('x'))
+    buf.writeUInt32LE(0xffffff, buf.length - frameOutput('x').length + 1)
+
+    expect(readFrames(buf).reason).toBe('torn')
+  })
+})
+
+describe('a byte that changed', () => {
+  it('is caught, and ends the replay there', () => {
+    const whole = log(frameOutput('good'), frameOutput('corrupted'), frameOutput('after'))
+    const flipped = Buffer.from(whole)
+    // Somewhere inside the middle frame's payload.
+    const target = writeHeader(1).length + frameOutput('good').length + 9 + 2
+    flipped[target] ^= 0x20
+
+    const { frames, reason } = readFrames(flipped)
+
+    expect(frames).toEqual([{ kind: 'output', data: 'good' }])
+    expect(reason).toBe('checksum')
+  })
+
+  it('does not step over the bad frame to reach the good one after it', () => {
+    // The bytes after a frame nobody can vouch for have no established meaning.
+    // A slightly stale screen is a small wrong; one assembled from unverified
+    // bytes is an unbounded one.
+    const whole = log(frameOutput('good'), frameOutput('corrupted'), frameOutput('after'))
+    const flipped = Buffer.from(whole)
+    flipped[writeHeader(1).length + frameOutput('good').length + 9 + 2] ^= 0x20
+
+    expect(readFrames(flipped).frames).toHaveLength(1)
+  })
+
+  it('catches a flip in the length field too', () => {
+    const whole = log(frameOutput('hello'), frameOutput('world'))
+    const flipped = Buffer.from(whole)
+    flipped[writeHeader(1).length + 1] ^= 0x01
+
+    expect(readFrames(flipped).reason).not.toBe('end')
+  })
+})
+
+describe('a frame this version does not know', () => {
+  it('stops rather than skipping into the middle of something', () => {
+    const buf = log(frameOutput('known'))
+    // A kind from a future version, with a valid length and checksum.
+    const alien = Buffer.alloc(9)
+    alien.writeUInt8(0x7f, 0)
+    alien.writeUInt32LE(0, 1)
+    alien.writeUInt32LE(crc32(Buffer.alloc(0)), 5)
+
+    const { frames, reason } = readFrames(Buffer.concat([buf, alien]))
+
+    expect(frames).toEqual([{ kind: 'output', data: 'known' }])
+    expect(reason).toBe('unknown-kind')
+  })
+
+  it('reports a known kind with the wrong payload size as malformed', () => {
+    const bad = Buffer.alloc(9 + 2)
+    bad.writeUInt8(0x03, 0) // resize, which needs four bytes
+    bad.writeUInt32LE(2, 1)
+    bad.writeUInt32LE(crc32(Buffer.alloc(2)), 5)
+
+    expect(readFrames(Buffer.concat([writeHeader(1), bad])).reason).toBe('malformed')
+  })
+})
+
+describe('the checksum itself', () => {
+  it('matches the published CRC-32 of "123456789"', () => {
+    // The check value every IEEE CRC-32 implementation is tested against. Worth
+    // pinning: a subtly wrong table produces checksums that are perfectly
+    // self-consistent and agree with nothing else, including a future reader.
+    expect(crc32(Buffer.from('123456789'))).toBe(0xcbf43926)
+  })
+
+  it('is zero-length safe', () => {
+    expect(crc32(Buffer.alloc(0))).toBe(0)
+  })
+
+  it('changes when any single byte does', () => {
+    const base = Buffer.from('the quick brown fox')
+    for (let i = 0; i < base.length; i++) {
+      const altered = Buffer.from(base)
+      altered[i] ^= 0x01
+      expect(crc32(altered), `byte ${i} went unnoticed`).not.toBe(crc32(base))
+    }
+  })
+})

--- a/tests/history-log.test.ts
+++ b/tests/history-log.test.ts
@@ -7,7 +7,6 @@ import {
   frameBatch,
   frameOutput,
   frameResize,
-  frameClear,
   FORMAT_VERSION,
   type Frame
 } from '../packages/server/src/history/log'
@@ -27,6 +26,13 @@ import {
 
 const log = (...frames: Buffer[]): Buffer => Buffer.concat([writeHeader(1), ...frames])
 
+/** Our magic, a version we do not speak. The shape a future writer leaves. */
+function versioned(version: number): Buffer {
+  const buf = Buffer.from(writeHeader(1))
+  buf.writeUInt8(version, 4)
+  return buf
+}
+
 describe('the header', () => {
   it('round-trips', () => {
     expect(readHeader(writeHeader(7))).toEqual({ formatVersion: FORMAT_VERSION, generation: 7 })
@@ -35,7 +41,8 @@ describe('the header', () => {
   it.each([
     ['an empty file', Buffer.alloc(0)],
     ['a file shorter than the header', Buffer.from('VRN')],
-    ['a file that is not ours', Buffer.from('SQLite format 3\0')]
+    ['a file that is not ours', Buffer.from('SQLite format 3\0')],
+    ['a file from a version this one does not know', versioned(FORMAT_VERSION + 1)]
   ])('refuses %s rather than guessing', (_label, buf) => {
     // All three are ordinary things to find after a crash, and the answer to all
     // three is the same: there is no history here, start again.
@@ -45,12 +52,7 @@ describe('the header', () => {
 
 describe('frames', () => {
   it('round-trips every kind, in order', () => {
-    const buf = log(
-      frameBatch(1180),
-      frameOutput('\x1b[31mred\x1b[0m'),
-      frameResize(200, 50),
-      frameClear()
-    )
+    const buf = log(frameBatch(1180), frameOutput('\x1b[31mred\x1b[0m'), frameResize(200, 50))
 
     const { frames, reason } = readFrames(buf)
 
@@ -58,8 +60,7 @@ describe('frames', () => {
     expect(frames).toEqual<Frame[]>([
       { kind: 'batch', seq: 1180 },
       { kind: 'output', data: '\x1b[31mred\x1b[0m' },
-      { kind: 'resize', cols: 200, rows: 50 },
-      { kind: 'clear' }
+      { kind: 'resize', cols: 200, rows: 50 }
     ])
   })
 

--- a/tests/history-recovery.test.ts
+++ b/tests/history-recovery.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { recoverHistory } from '../packages/server/src/history/recovery'
+import {
+  historyDir,
+  writeCheckpoint,
+  readCheckpoint,
+  CHECKPOINT_FILE,
+  LOG_FILE,
+  type Checkpoint
+} from '../packages/server/src/history/checkpoint'
+import {
+  writeHeader,
+  frameBatch,
+  frameOutput,
+  frameResize
+} from '../packages/server/src/history/log'
+import {
+  configureHistory,
+  startHistory,
+  recordOutput,
+  recordResize,
+  flushHistory,
+  resetHistory
+} from '../packages/server/src/history/writer'
+import {
+  createScreen,
+  feedScreen,
+  serializeScreen,
+  resizeScreen,
+  resetScreens
+} from '../packages/server/src/terminal-screen'
+import {
+  appendScrollback,
+  readScrollback,
+  resetScrollback
+} from '../packages/server/src/terminal-scrollback'
+
+/**
+ * Reading back what the last process left.
+ *
+ * The end of this file is the one that matters: write history with the real
+ * writer, throw away every model the way a crash does, and restore. Everything
+ * above it is a shape a crash produces that the round trip cannot reach --
+ * a log from before the checkpoint beside it, a tail cut mid-frame, a directory
+ * for a session nothing can name.
+ */
+
+const ID = 'a-session'
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-recovery-'))
+  resetScreens()
+  resetScrollback()
+  resetHistory()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetHistory()
+  resetScreens()
+  resetScrollback()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+const sample = (over: Partial<Checkpoint> = {}): Checkpoint => ({
+  screen: 'from the checkpoint',
+  scrollback: 'from the checkpoint',
+  cols: 100,
+  rows: 30,
+  title: '',
+  cwd: '',
+  generation: 4,
+  seq: 9,
+  ...over
+})
+
+function put(checkpoint: Checkpoint | null, logGeneration?: number, ...frames: Buffer[]): void {
+  const at = historyDir(dir, ID)
+  fs.mkdirSync(at, { recursive: true })
+  if (checkpoint) writeCheckpoint(at, checkpoint)
+  if (logGeneration !== undefined) {
+    fs.writeFileSync(
+      path.join(at, LOG_FILE),
+      Buffer.concat([writeHeader(logGeneration), ...frames])
+    )
+  }
+}
+
+const only = [{ id: ID, cols: 80, rows: 24 }]
+
+const ESC = '\x1b'
+/** Built rather than a literal, which the control-character rule refuses. */
+const SGR = new RegExp(`${ESC}\\[[0-9;]*m`, 'g')
+
+/** What the restored screen draws, with the colour taken back out of it. */
+async function screenText(id = ID): Promise<string> {
+  const snapshot = await serializeScreen(id)
+  return (snapshot?.screen ?? '').replace(SGR, '')
+}
+
+describe('a checkpoint and the log that follows it', () => {
+  it('replays the log on top of the checkpoint', async () => {
+    put(sample(), 4, frameBatch(1), frameOutput(' and then the log'))
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.recovered).toEqual([
+      { id: ID, replayed: 2, stopped: 'end', fromCheckpoint: true }
+    ])
+    expect(readScrollback(ID)).toBe('from the checkpoint and then the log')
+    expect(await screenText()).toContain('from the checkpoint and then the log')
+  })
+
+  it('rebuilds at the geometry the checkpoint was taken at, not the one the record remembers', async () => {
+    // The screen is being rebuilt from bytes that wrapped at those columns. Any
+    // other width moves every line after the first wrap.
+    put(sample({ cols: 100, rows: 30 }), 4)
+
+    await recoverHistory(dir, [{ id: ID, cols: 40, rows: 10 }])
+
+    expect(await serializeScreen(ID)).toMatchObject({ cols: 100, rows: 30 })
+  })
+
+  it('follows a resize that happened after it', async () => {
+    put(sample(), 4, frameBatch(1), frameResize(132, 43))
+
+    await recoverHistory(dir, only)
+
+    expect(await serializeScreen(ID)).toMatchObject({ cols: 132, rows: 43 })
+  })
+})
+
+describe('a log that does not belong to the checkpoint beside it', () => {
+  it('is refused rather than replayed twice', async () => {
+    // The crash window the writer cannot close: the checkpoint landed and the
+    // log had not been replaced yet, so the log holds bytes the checkpoint
+    // already contains.
+    put(sample({ generation: 5 }), 4, frameBatch(1), frameOutput('from the checkpoint'))
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.recovered[0]?.replayed).toBe(0)
+    expect(readScrollback(ID)).toBe('from the checkpoint')
+  })
+
+  it('still restores the checkpoint itself', async () => {
+    put(sample({ generation: 5 }), 4, frameBatch(1), frameOutput('stale'))
+
+    await recoverHistory(dir, only)
+
+    expect(await screenText()).toContain('from the checkpoint')
+    expect(readScrollback(ID)).not.toContain('stale')
+  })
+})
+
+describe('a log with no checkpoint', () => {
+  it('is replayed from nothing, because it starts from nothing', async () => {
+    // A session that crashed before its first checkpoint has a complete log --
+    // exactly the short-lived session an interval was never going to cover.
+    put(null, 1, frameBatch(1), frameOutput('everything this terminal ever printed'))
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.recovered[0]).toMatchObject({ fromCheckpoint: false, replayed: 2 })
+    expect(readScrollback(ID)).toBe('everything this terminal ever printed')
+  })
+})
+
+describe('a file the crash was in the middle of', () => {
+  it('replays its whole prefix and says where it stopped', async () => {
+    const whole = Buffer.concat([frameBatch(1), frameOutput('kept'), frameOutput('torn away')])
+    const at = historyDir(dir, ID)
+    fs.mkdirSync(at, { recursive: true })
+    writeCheckpoint(at, sample())
+    fs.writeFileSync(
+      path.join(at, LOG_FILE),
+      Buffer.concat([writeHeader(4), whole.subarray(0, whole.length - 4)])
+    )
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.recovered[0]?.stopped).toBe('torn')
+    expect(readScrollback(ID)).toBe('from the checkpointkept')
+  })
+
+  it('does not step over a frame that failed its checksum', async () => {
+    const at = historyDir(dir, ID)
+    fs.mkdirSync(at, { recursive: true })
+    writeCheckpoint(at, sample())
+    const body = Buffer.concat([
+      writeHeader(4),
+      frameOutput('good'),
+      frameOutput('corrupted'),
+      frameOutput('after')
+    ])
+    body[writeHeader(4).length + frameOutput('good').length + 9 + 2] ^= 0x20
+    fs.writeFileSync(path.join(at, LOG_FILE), body)
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.recovered[0]?.stopped).toBe('checksum')
+    expect(readScrollback(ID)).toBe('from the checkpointgood')
+  })
+})
+
+describe('what is left of sessions that are gone', () => {
+  it('is removed, because nothing can name it any more', async () => {
+    // History is keyed by session id and `getPreviousSessions` is the only way a
+    // pane ever names one. A directory with no session behind it is not history
+    // somebody might want, it is history nobody can ask for.
+    put(sample(), 4)
+    fs.mkdirSync(historyDir(dir, 'a-session-that-ended'), { recursive: true })
+    writeCheckpoint(historyDir(dir, 'a-session-that-ended'), sample())
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.swept).toBe(1)
+    expect(fs.existsSync(historyDir(dir, 'a-session-that-ended'))).toBe(false)
+    expect(fs.existsSync(historyDir(dir, ID))).toBe(true)
+  })
+
+  it('leaves a session with no history alone', async () => {
+    const report = await recoverHistory(dir, [{ id: 'never-recorded', cols: 80, rows: 24 }])
+    expect(report).toEqual({ recovered: [], swept: 0 })
+  })
+
+  it('answers nothing on a first run, where there is no history directory at all', async () => {
+    expect(await recoverHistory(path.join(dir, 'nowhere'), only)).toEqual({
+      recovered: [],
+      swept: 0
+    })
+  })
+})
+
+describe('residue that is not history', () => {
+  it.each([
+    ['an empty directory', () => fs.mkdirSync(historyDir(dir, ID), { recursive: true })],
+    [
+      'a checkpoint that will not parse',
+      () => {
+        fs.mkdirSync(historyDir(dir, ID), { recursive: true })
+        fs.writeFileSync(path.join(historyDir(dir, ID), CHECKPOINT_FILE), 'not json')
+      }
+    ],
+    [
+      'a log that is not ours',
+      () => {
+        fs.mkdirSync(historyDir(dir, ID), { recursive: true })
+        fs.writeFileSync(path.join(historyDir(dir, ID), LOG_FILE), 'SQLite format 3\0')
+      }
+    ]
+  ])('restores nothing from %s rather than failing the startup', async (_label, leave) => {
+    leave()
+    const report = await recoverHistory(dir, only)
+    expect(report.recovered).toEqual([])
+  })
+})
+
+describe('the whole round trip', () => {
+  it('brings a terminal back through a crash that ran nothing', async () => {
+    // The test the rest of this file exists to support. Write with the real
+    // writer, throw away every in-memory model the way a SIGKILL does, and ask
+    // what a fresh process can rebuild.
+    configureHistory(dir, { tickMs: 5, quiesceMs: 500, checkpointMs: 60_000 })
+    createScreen(ID, 120, 40)
+    startHistory(ID)
+
+    const said = '\x1b[32m✓\x1b[0m tests passed, 402 of them\r\n'
+    for (const chunk of [said, 'and then some more output\r\n']) {
+      appendScrollback(ID, chunk)
+      feedScreen(ID, chunk)
+      recordOutput(ID, chunk)
+    }
+    // Both halves, the way `resizePty` does it: the model follows the program
+    // and the frame records that it did.
+    await resizeScreen(ID, 132, 43)
+    recordResize(ID, 132, 43)
+    await flushHistory()
+
+    // Everything this process was holding, gone.
+    resetScreens()
+    resetScrollback()
+    resetHistory()
+
+    const report = await recoverHistory(dir, only)
+
+    expect(report.recovered[0]?.fromCheckpoint).toBe(true)
+    expect(readScrollback(ID)).toContain('402 of them')
+    expect(await screenText()).toContain('402 of them')
+    expect(await screenText()).toContain('and then some more output')
+    // The colour survives, which is the reason none of this stores stripped text.
+    expect((await serializeScreen(ID))?.screen).toContain(`${ESC}[32m`)
+    expect(await serializeScreen(ID)).toMatchObject({ cols: 132, rows: 43 })
+  })
+
+  it('leaves the files it recovered from in place', async () => {
+    configureHistory(dir, { tickMs: 5, quiesceMs: 500, checkpointMs: 60_000 })
+    createScreen(ID, 80, 24)
+    startHistory(ID)
+    feedScreen(ID, 'output')
+    recordOutput(ID, 'output')
+    await flushHistory()
+    resetScreens()
+    resetScrollback()
+    resetHistory()
+
+    await recoverHistory(dir, only)
+
+    // A restart that crashes again should have the same thing to read. Nothing
+    // here is consumed by being read.
+    expect(readCheckpoint(historyDir(dir, ID))?.screen).toContain('output')
+  })
+})

--- a/tests/history-recovery.test.ts
+++ b/tests/history-recovery.test.ts
@@ -113,7 +113,7 @@ describe('a checkpoint and the log that follows it', () => {
     const report = await recoverHistory(dir, only)
 
     expect(report.recovered).toEqual([
-      { id: ID, replayed: 2, stopped: 'end', fromCheckpoint: true }
+      { id: ID, replayed: 2, stopped: 'end', fromCheckpoint: true, closedCleanly: false }
     ])
     expect(readScrollback(ID)).toBe('from the checkpoint and then the log')
     expect(await screenText()).toContain('from the checkpoint and then the log')
@@ -311,6 +311,23 @@ describe('the two things the serialized screen cannot carry', () => {
       title: 'vorn — building',
       cwd: '/Users/x/dev/vorn'
     })
+  })
+})
+
+describe('how the last run ended', () => {
+  it('says so when the shutdown got to write a final checkpoint', async () => {
+    // The only difference a pane can see. A crash runs nothing, so the last
+    // checkpoint it leaves is an ordinary periodic one -- which is why the flush
+    // on the way out is the only thing that sets this.
+    await put(sample({ closedCleanly: true }), 4)
+
+    expect((await recoverHistory(dir, only)).recovered[0]?.closedCleanly).toBe(true)
+  })
+
+  it('does not, for a checkpoint the clock wrote', async () => {
+    await put(sample(), 4)
+
+    expect((await recoverHistory(dir, only)).recovered[0]?.closedCleanly).toBe(false)
   })
 })
 

--- a/tests/history-recovery.test.ts
+++ b/tests/history-recovery.test.ts
@@ -298,6 +298,22 @@ describe('more terminals than are rebuilt at once', () => {
   })
 })
 
+describe('the two things the serialized screen cannot carry', () => {
+  it('are put back from the checkpoint', async () => {
+    // A title and a working directory arrive as notifications, not as escape
+    // sequences, so replaying the screen does not replay them. The checkpoint
+    // has stored both since it was written; recovery dropped them.
+    await put(sample({ title: 'vorn — building', cwd: '/Users/x/dev/vorn' }), 4)
+
+    await recoverHistory(dir, only)
+
+    expect(await serializeScreen(ID)).toMatchObject({
+      title: 'vorn — building',
+      cwd: '/Users/x/dev/vorn'
+    })
+  })
+})
+
 describe('a session list that could not be read', () => {
   it('sweeps nothing, because absence and failure look the same otherwise', async () => {
     // `getPreviousSessions` answers an empty list both when there are none and

--- a/tests/history-recovery.test.ts
+++ b/tests/history-recovery.test.ts
@@ -78,10 +78,14 @@ const sample = (over: Partial<Checkpoint> = {}): Checkpoint => ({
   ...over
 })
 
-function put(checkpoint: Checkpoint | null, logGeneration?: number, ...frames: Buffer[]): void {
+async function put(
+  checkpoint: Checkpoint | null,
+  logGeneration?: number,
+  ...frames: Buffer[]
+): Promise<void> {
   const at = historyDir(dir, ID)
   fs.mkdirSync(at, { recursive: true })
-  if (checkpoint) writeCheckpoint(at, checkpoint)
+  if (checkpoint) await writeCheckpoint(at, checkpoint)
   if (logGeneration !== undefined) {
     fs.writeFileSync(
       path.join(at, LOG_FILE),
@@ -104,7 +108,7 @@ async function screenText(id = ID): Promise<string> {
 
 describe('a checkpoint and the log that follows it', () => {
   it('replays the log on top of the checkpoint', async () => {
-    put(sample(), 4, frameBatch(1), frameOutput(' and then the log'))
+    await put(sample(), 4, frameBatch(1), frameOutput(' and then the log'))
 
     const report = await recoverHistory(dir, only)
 
@@ -118,7 +122,7 @@ describe('a checkpoint and the log that follows it', () => {
   it('rebuilds at the geometry the checkpoint was taken at, not the one the record remembers', async () => {
     // The screen is being rebuilt from bytes that wrapped at those columns. Any
     // other width moves every line after the first wrap.
-    put(sample({ cols: 100, rows: 30 }), 4)
+    await put(sample({ cols: 100, rows: 30 }), 4)
 
     await recoverHistory(dir, [{ id: ID, cols: 40, rows: 10 }])
 
@@ -126,7 +130,7 @@ describe('a checkpoint and the log that follows it', () => {
   })
 
   it('follows a resize that happened after it', async () => {
-    put(sample(), 4, frameBatch(1), frameResize(132, 43))
+    await put(sample(), 4, frameBatch(1), frameResize(132, 43))
 
     await recoverHistory(dir, only)
 
@@ -139,7 +143,7 @@ describe('a log that does not belong to the checkpoint beside it', () => {
     // The crash window the writer cannot close: the checkpoint landed and the
     // log had not been replaced yet, so the log holds bytes the checkpoint
     // already contains.
-    put(sample({ generation: 5 }), 4, frameBatch(1), frameOutput('from the checkpoint'))
+    await put(sample({ generation: 5 }), 4, frameBatch(1), frameOutput('from the checkpoint'))
 
     const report = await recoverHistory(dir, only)
 
@@ -148,7 +152,7 @@ describe('a log that does not belong to the checkpoint beside it', () => {
   })
 
   it('still restores the checkpoint itself', async () => {
-    put(sample({ generation: 5 }), 4, frameBatch(1), frameOutput('stale'))
+    await put(sample({ generation: 5 }), 4, frameBatch(1), frameOutput('stale'))
 
     await recoverHistory(dir, only)
 
@@ -161,7 +165,7 @@ describe('a log with no checkpoint', () => {
   it('is replayed from nothing, because it starts from nothing', async () => {
     // A session that crashed before its first checkpoint has a complete log --
     // exactly the short-lived session an interval was never going to cover.
-    put(null, 1, frameBatch(1), frameOutput('everything this terminal ever printed'))
+    await put(null, 1, frameBatch(1), frameOutput('everything this terminal ever printed'))
 
     const report = await recoverHistory(dir, only)
 
@@ -175,7 +179,7 @@ describe('a file the crash was in the middle of', () => {
     const whole = Buffer.concat([frameBatch(1), frameOutput('kept'), frameOutput('torn away')])
     const at = historyDir(dir, ID)
     fs.mkdirSync(at, { recursive: true })
-    writeCheckpoint(at, sample())
+    await writeCheckpoint(at, sample())
     fs.writeFileSync(
       path.join(at, LOG_FILE),
       Buffer.concat([writeHeader(4), whole.subarray(0, whole.length - 4)])
@@ -190,7 +194,7 @@ describe('a file the crash was in the middle of', () => {
   it('does not step over a frame that failed its checksum', async () => {
     const at = historyDir(dir, ID)
     fs.mkdirSync(at, { recursive: true })
-    writeCheckpoint(at, sample())
+    await writeCheckpoint(at, sample())
     const body = Buffer.concat([
       writeHeader(4),
       frameOutput('good'),
@@ -212,9 +216,9 @@ describe('what is left of sessions that are gone', () => {
     // History is keyed by session id and `getPreviousSessions` is the only way a
     // pane ever names one. A directory with no session behind it is not history
     // somebody might want, it is history nobody can ask for.
-    put(sample(), 4)
+    await put(sample(), 4)
     fs.mkdirSync(historyDir(dir, 'a-session-that-ended'), { recursive: true })
-    writeCheckpoint(historyDir(dir, 'a-session-that-ended'), sample())
+    await writeCheckpoint(historyDir(dir, 'a-session-that-ended'), sample())
 
     const report = await recoverHistory(dir, only)
 

--- a/tests/history-recovery.test.ts
+++ b/tests/history-recovery.test.ts
@@ -94,7 +94,7 @@ async function put(
   }
 }
 
-const only = [{ id: ID, cols: 80, rows: 24 }]
+const only = [{ id: ID }]
 
 const ESC = '\x1b'
 /** Built rather than a literal, which the control-character rule refuses. */
@@ -119,12 +119,12 @@ describe('a checkpoint and the log that follows it', () => {
     expect(await screenText()).toContain('from the checkpoint and then the log')
   })
 
-  it('rebuilds at the geometry the checkpoint was taken at, not the one the record remembers', async () => {
+  it('rebuilds at the geometry the checkpoint was taken at', async () => {
     // The screen is being rebuilt from bytes that wrapped at those columns. Any
     // other width moves every line after the first wrap.
     await put(sample({ cols: 100, rows: 30 }), 4)
 
-    await recoverHistory(dir, [{ id: ID, cols: 40, rows: 10 }])
+    await recoverHistory(dir, only)
 
     expect(await serializeScreen(ID)).toMatchObject({ cols: 100, rows: 30 })
   })
@@ -162,6 +162,17 @@ describe('a log that does not belong to the checkpoint beside it', () => {
 })
 
 describe('a log with no checkpoint', () => {
+  it('is rebuilt at the size a PTY is spawned at, which is where the log begins', async () => {
+    // Not a guess and not a default. A log with no checkpoint opens at the
+    // spawn, and a PTY is spawned at 80 by 24; any resize the terminal saw is a
+    // frame further down that same log.
+    await put(null, 1, frameBatch(1), frameOutput('from the very beginning'))
+
+    await recoverHistory(dir, only)
+
+    expect(await serializeScreen(ID)).toMatchObject({ cols: 80, rows: 24 })
+  })
+
   it('is replayed from nothing, because it starts from nothing', async () => {
     // A session that crashed before its first checkpoint has a complete log --
     // exactly the short-lived session an interval was never going to cover.
@@ -228,7 +239,7 @@ describe('what is left of sessions that are gone', () => {
   })
 
   it('leaves a session with no history alone', async () => {
-    const report = await recoverHistory(dir, [{ id: 'never-recorded', cols: 80, rows: 24 }])
+    const report = await recoverHistory(dir, [{ id: 'never-recorded' }])
     expect(report).toEqual({ recovered: [], swept: 0 })
   })
 
@@ -261,6 +272,59 @@ describe('residue that is not history', () => {
     leave()
     const report = await recoverHistory(dir, only)
     expect(report.recovered).toEqual([])
+  })
+})
+
+describe('more terminals than are rebuilt at once', () => {
+  it('stops at the cap, keeps the rest, and says it did', async () => {
+    // Each rebuilt terminal is a headless emulator held for the life of the
+    // process, because nothing has attached to one yet and so nothing disposes
+    // it. A cap nobody is told about reads as "everything was restored" on the
+    // one start where it was not.
+    const many = []
+    for (let i = 0; i < 55; i++) {
+      const id = `session-${i}`
+      many.push({ id })
+      fs.mkdirSync(historyDir(dir, id), { recursive: true })
+      await writeCheckpoint(historyDir(dir, id), sample())
+    }
+
+    const report = await recoverHistory(dir, many)
+
+    expect(report.recovered).toHaveLength(50)
+    expect(report.swept).toBe(0)
+    // Nothing was removed to make room; a later start can have them.
+    expect(fs.readdirSync(path.join(dir, 'history'))).toHaveLength(55)
+  })
+})
+
+describe('a session list that could not be read', () => {
+  it('sweeps nothing, because absence and failure look the same otherwise', async () => {
+    // `getPreviousSessions` answers an empty list both when there are none and
+    // when the database would not answer. Acting on the first is a sweep; acting
+    // on the second is every terminal's history removed for one transient error.
+    await put(sample(), 4)
+
+    const report = await recoverHistory(dir, null)
+
+    expect(report).toEqual({ recovered: [], swept: 0 })
+    expect(fs.existsSync(historyDir(dir, ID))).toBe(true)
+  })
+})
+
+describe('a scratch file a crash left half-written', () => {
+  it('is cleared rather than kept for ever under a name nothing reuses', async () => {
+    // `writeCheckpoint` removes its scratch file only when the write fails. A
+    // process that dies mid-write removes nothing, and up to two megabytes sits
+    // there for the life of the session directory.
+    await put(sample(), 4)
+    const leftover = path.join(historyDir(dir, ID), `.${CHECKPOINT_FILE}.deadbeefcafe`)
+    fs.writeFileSync(leftover, 'half a checkpoint')
+
+    await recoverHistory(dir, only)
+
+    expect(fs.existsSync(leftover)).toBe(false)
+    expect(readScrollback(ID)).toContain('from the checkpoint')
   })
 })
 

--- a/tests/history-writer.test.ts
+++ b/tests/history-writer.test.ts
@@ -12,8 +12,10 @@ import {
   flushHistory,
   settleHistory,
   historyState,
-  resetHistory
+  resetHistory,
+  MAX_LOG_BYTES
 } from '../packages/server/src/history/writer'
+import { recoverHistory } from '../packages/server/src/history/recovery'
 import {
   historyDir,
   readCheckpoint,
@@ -21,8 +23,17 @@ import {
   LOG_FILE
 } from '../packages/server/src/history/checkpoint'
 import { readHeader, readFrames, type Frame } from '../packages/server/src/history/log'
-import { createScreen, feedScreen, resetScreens } from '../packages/server/src/terminal-screen'
-import { appendScrollback, resetScrollback } from '../packages/server/src/terminal-scrollback'
+import {
+  createScreen,
+  feedScreen,
+  clearScreen,
+  resetScreens
+} from '../packages/server/src/terminal-screen'
+import {
+  appendScrollback,
+  readScrollback,
+  resetScrollback
+} from '../packages/server/src/terminal-scrollback'
 
 /**
  * Turning a running terminal into files a restart can read.
@@ -305,6 +316,53 @@ describe('shutting down', () => {
     await flushHistory()
 
     expect(outputs(logOf().frames)).toBe('')
+  })
+})
+
+describe('a log that outgrows its cap', () => {
+  const past = (): string => 'x'.repeat(MAX_LOG_BYTES + 1024)
+
+  it('is folded into a checkpoint rather than left to grow', async () => {
+    begin()
+    emit(ID, past())
+    await settle(3)
+
+    expect(historyState(ID)?.logBytes).toBeLessThanOrEqual(MAX_LOG_BYTES)
+    expect(readCheckpoint(historyDir(dir, ID))?.screen).toBeTruthy()
+  })
+
+  it('is bounded by size, not by waiting out the interval', async () => {
+    // A terminal producing output continuously never falls quiet, so the quiet
+    // window and the interval both pass it by. Nothing here waits for either.
+    begin()
+    emit(ID, past())
+    await settle(3)
+
+    expect(readCheckpoint(historyDir(dir, ID))?.generation).toBe(2)
+  })
+
+  it('is thrown away when no checkpoint can be written, and cannot be replayed after', async () => {
+    // A session whose screen model has faulted has nothing to checkpoint from,
+    // so the log is the only thing growing and nothing would ever bound it.
+    // Dropping it loses history on purpose; the last good checkpoint remains.
+    begin()
+    emit(ID, 'this much was checkpointed')
+    await quiesce()
+    expect(readCheckpoint(historyDir(dir, ID))?.generation).toBe(2)
+
+    clearScreen(ID)
+    recordOutput(ID, past())
+    await settle(3)
+
+    expect(historyState(ID)?.logBytes).toBeLessThanOrEqual(MAX_LOG_BYTES)
+    // The generation moved with the log and not with the checkpoint, which is
+    // what stops a truncated log being replayed onto a screen it does not follow.
+    expect(logOf().generation).toBe(3)
+    expect(readCheckpoint(historyDir(dir, ID))?.generation).toBe(2)
+
+    const report = await recoverHistory(dir, [{ id: ID, cols: 80, rows: 24 }])
+    expect(report.recovered[0]?.replayed).toBe(0)
+    expect(readScrollback(ID)).toBe('this much was checkpointed')
   })
 })
 

--- a/tests/history-writer.test.ts
+++ b/tests/history-writer.test.ts
@@ -382,6 +382,31 @@ describe('a log that outgrows its cap', () => {
     expect(readCheckpoint(historyDir(dir, ID))?.generation).toBe(2)
   })
 
+  it('keeps a log that is over the cap because the checkpoint that just landed took a while', async () => {
+    // The fold used to re-read `logBytes` to work out whether the checkpoint had
+    // landed. A checkpoint that succeeds while more than a megabyte arrives
+    // during its fsyncs leaves a log legitimately over the cap -- and every byte
+    // of it was thrown away, on the healthy path, not the faulted one the
+    // fallback exists for.
+    begin()
+    emit(ID, past())
+    // Arrives while the checkpoint is being written, so it is carried past it.
+    const during = 'y'.repeat(MAX_LOG_BYTES + 1024)
+    const real = fsp.rename
+    vi.spyOn(fsp, 'rename').mockImplementationOnce((async (...args: [never, never]) => {
+      emit(ID, during)
+      return real(...args)
+    }) as never)
+
+    await settle(4)
+
+    expect(readCheckpoint(historyDir(dir, ID))?.generation).toBe(2)
+    // Same generation in both, so the log is still replayable onto it -- which is
+    // the whole point of not having dropped it.
+    expect(logOf().generation).toBe(2)
+    expect(outputs(logOf().frames)).toContain('y')
+  })
+
   it('is thrown away when no checkpoint can be written, and cannot be replayed after', async () => {
     // A session whose screen model has faulted has nothing to checkpoint from,
     // so the log is the only thing growing and nothing would ever bound it.

--- a/tests/history-writer.test.ts
+++ b/tests/history-writer.test.ts
@@ -91,8 +91,7 @@ async function settle(rounds = 2): Promise<void> {
 }
 
 async function quiesce(): Promise<void> {
-  await sleep(TIMING.quiesceMs + TIMING.tickMs * 3)
-  await settleHistory()
+  await sleep(TIMING.quiesceMs)
   await settle()
 }
 
@@ -279,6 +278,48 @@ describe('a session that ends', () => {
     expect(readCheckpoint(historyDir(dir, ID))?.screen).toContain('hello')
   })
 
+  it('orders its work behind the terminal it replaced, not beside it', async () => {
+    // Two records over one directory. The replaced one is asked to remove its
+    // files and the replacement to write fresh ones, and through separate queues
+    // there is no order between those -- the removal can land after the new log
+    // has been written and take it away. The symptom was a respawned session
+    // whose history stopped until the next checkpoint rebuilt the directory, and
+    // a test that failed about one run in five.
+    //
+    // The property, rather than the symptom: everything on this directory is in
+    // one queue, so the replacement cannot start while the replaced session
+    // still has an operation in flight.
+    begin()
+    let release: (() => void) | undefined
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const real = fsp.appendFile
+    vi.spyOn(fsp, 'appendFile').mockImplementationOnce((async (...args: [never, never]) => {
+      await held
+      return real(...args)
+    }) as never)
+
+    emit(ID, 'from the first process')
+    await sleep(TIMING.tickMs * 3)
+
+    begin()
+    emit(ID, 'from the second process')
+
+    let finished = false
+    const settling = settleHistory().then(() => {
+      finished = true
+    })
+    await sleep(TIMING.tickMs * 6)
+    expect(finished, 'the replacement ran while the replaced session was mid-write').toBe(false)
+
+    release?.()
+    await settling
+    await settle(3)
+
+    expect(outputs(logOf().frames)).toBe('from the second process')
+  })
+
   it('starts clean when the same id is recorded again', async () => {
     begin()
     emit(ID, 'from the first process')
@@ -410,7 +451,39 @@ describe('a disk that stops answering', () => {
 })
 
 describe('one session against another', () => {
-  it('does not make a healthy terminal wait behind a wedged one', async () => {
+  it('does not make a healthy terminal wait behind a wedged checkpoint', async () => {
+    // The rule the per-session queue exists for, on the operation it was written
+    // about: a checkpoint holds one directory's write-and-rename pair, and that
+    // exclusivity buys nothing across directories. A queue for the whole server
+    // would make every terminal wait on the slowest disk under any of them.
+    begin('wedged')
+    begin('healthy')
+
+    let release: (() => void) | undefined
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const real = fsp.open
+    vi.spyOn(fsp, 'open').mockImplementation((async (...args: Parameters<typeof fsp.open>) => {
+      if (String(args[0]).includes('wedged')) await held
+      return real(...args)
+    }) as never)
+
+    emit('wedged', 'this one is stuck')
+    emit('healthy', 'this one is not')
+
+    // Polled rather than settled: settling would wait on the session that is
+    // deliberately stuck, which is the thing being shown not to matter.
+    await until(() =>
+      Boolean(readCheckpoint(historyDir(dir, 'healthy'))?.screen.includes('this one is not'))
+    )
+    expect(readCheckpoint(historyDir(dir, 'wedged'))).toBeNull()
+
+    release?.()
+    await settle()
+  })
+
+  it('does not make a healthy terminal wait behind a wedged append', async () => {
     begin('wedged')
     begin('healthy')
 

--- a/tests/history-writer.test.ts
+++ b/tests/history-writer.test.ts
@@ -334,6 +334,25 @@ describe('a session that ends', () => {
 })
 
 describe('shutting down', () => {
+  it('marks its checkpoints as the ones that got to say goodbye', async () => {
+    // What tells a restored pane "you closed Vorn" apart from "something stopped
+    // it". Nothing else sets it, so its absence is the honest answer for a
+    // crash, a kill, or a machine losing power.
+    begin()
+    emit(ID, 'hello')
+    await flushHistory()
+
+    expect(readCheckpoint(historyDir(dir, ID))?.closedCleanly).toBe(true)
+  })
+
+  it('and an ordinary one is not marked', async () => {
+    begin()
+    emit(ID, 'hello')
+    await quiesce()
+
+    expect(readCheckpoint(historyDir(dir, ID))?.closedCleanly).toBeUndefined()
+  })
+
   it('writes every terminal, not only the ones that had fallen quiet', async () => {
     begin('one')
     begin('two')

--- a/tests/history-writer.test.ts
+++ b/tests/history-writer.test.ts
@@ -419,10 +419,18 @@ describe('a log that outgrows its cap', () => {
 
     await settle(4)
 
-    expect(readCheckpoint(historyDir(dir, ID))?.generation).toBe(2)
+    // Not an absolute generation. `settle` sleeps against a live 5ms tick, so a
+    // loaded machine gets more ticks for the same four rounds and a further
+    // checkpoint lands -- which is legitimate and not what this is about. What
+    // must hold is that the log survived and still belongs to the checkpoint
+    // beside it, whichever number they reached together.
+    const checkpointed = readCheckpoint(historyDir(dir, ID))?.generation
+    expect(checkpointed).toBeGreaterThanOrEqual(2)
     // Same generation in both, so the log is still replayable onto it -- which is
     // the whole point of not having dropped it.
-    expect(logOf().generation).toBe(2)
+    expect(logOf().generation).toBe(checkpointed)
+    // The assertion that actually catches the regression: every byte that
+    // arrived during the checkpoint's fsyncs used to be thrown away here.
     expect(outputs(logOf().frames)).toContain('y')
   })
 

--- a/tests/history-writer.test.ts
+++ b/tests/history-writer.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  configureHistory,
+  startHistory,
+  recordOutput,
+  recordResize,
+  stopHistory,
+  flushHistory,
+  settleHistory,
+  historyState,
+  resetHistory
+} from '../packages/server/src/history/writer'
+import {
+  historyDir,
+  readCheckpoint,
+  CHECKPOINT_FILE,
+  LOG_FILE
+} from '../packages/server/src/history/checkpoint'
+import { readHeader, readFrames, type Frame } from '../packages/server/src/history/log'
+import { createScreen, feedScreen, resetScreens } from '../packages/server/src/terminal-screen'
+import { appendScrollback, resetScrollback } from '../packages/server/src/terminal-scrollback'
+
+/**
+ * Turning a running terminal into files a restart can read.
+ *
+ * The two modules under this one are pure -- one shapes buffers, one writes a
+ * file -- so everything left to get wrong is *when*: what is superseded by a
+ * checkpoint, what is carried past it, and what a shutdown must not undo. Those
+ * are the tests here, and each was checked against the code with that specific
+ * step removed.
+ */
+
+// A tick fast enough that a test does not wait on it, and a quiet window far
+// enough past it that settling for a flush never trips a checkpoint by accident.
+const TIMING = { tickMs: 5, quiesceMs: 500, checkpointMs: 60_000 }
+const ID = 'a-session'
+
+let dir: string
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-writer-'))
+  resetScreens()
+  resetScrollback()
+  resetHistory()
+  configureHistory(dir, TIMING)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetHistory()
+  resetScreens()
+  resetScrollback()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** What `flushBuffer` and `onData` do together, in the order they do it. */
+function emit(id: string, data: string): void {
+  appendScrollback(id, data)
+  feedScreen(id, data)
+  recordOutput(id, data)
+}
+
+function begin(id = ID, cols = 80, rows = 24): void {
+  createScreen(id, cols, rows)
+  startHistory(id)
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Wait for the tick to have picked the work up, then for the work to finish. */
+async function settle(rounds = 2): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await sleep(TIMING.tickMs * 3)
+    await settleHistory()
+  }
+}
+
+async function quiesce(): Promise<void> {
+  await sleep(TIMING.quiesceMs + TIMING.tickMs * 3)
+  await settleHistory()
+  await settle()
+}
+
+/** Poll rather than settle, for the tests where one session is deliberately stuck. */
+async function until(done: () => boolean, within = 2_000): Promise<void> {
+  const give = Date.now() + within
+  while (Date.now() < give) {
+    // A predicate that reads a file the writer has not created yet is not
+    // failure, it is "not yet".
+    try {
+      if (done()) return
+    } catch {
+      /* not yet */
+    }
+    await sleep(TIMING.tickMs)
+  }
+  throw new Error('the condition never became true')
+}
+
+function logOf(id = ID): { generation: number | null; frames: Frame[] } {
+  const buf = fs.readFileSync(path.join(historyDir(dir, id), LOG_FILE))
+  const header = readHeader(buf)
+  return { generation: header?.generation ?? null, frames: readFrames(buf).frames }
+}
+
+const outputs = (frames: Frame[]): string =>
+  frames
+    .filter((f): f is Extract<Frame, { kind: 'output' }> => f.kind === 'output')
+    .map((f) => f.data)
+    .join('')
+
+describe('what reaches the log', () => {
+  it('writes a header before anything else, so a reader can refuse a file that is not ours', async () => {
+    begin()
+    await settleHistory()
+
+    expect(logOf().generation).toBe(1)
+    expect(logOf().frames).toEqual([])
+  })
+
+  it('carries output and resizes, in the order they happened', async () => {
+    begin()
+    emit(ID, 'first')
+    recordResize(ID, 120, 40)
+    emit(ID, 'second')
+    await settle()
+
+    expect(logOf().frames).toEqual<Frame[]>([
+      { kind: 'batch', seq: 1 },
+      { kind: 'output', data: 'first' },
+      { kind: 'resize', cols: 120, rows: 40 },
+      { kind: 'output', data: 'second' }
+    ])
+  })
+
+  it('coalesces a tick of writes into one batch rather than one each', async () => {
+    // A batch is what reaches the disk together, which is the unit a torn tail
+    // cuts. Numbering per write would make that boundary meaningless and cost
+    // thirteen bytes per keystroke.
+    begin()
+    for (let i = 0; i < 20; i++) emit(ID, `${i}`)
+    await settle()
+
+    const batches = logOf().frames.filter((f) => f.kind === 'batch')
+    expect(batches).toEqual([{ kind: 'batch', seq: 1 }])
+  })
+
+  it('writes nothing at all before a data directory is configured', async () => {
+    resetHistory()
+    begin('unconfigured')
+    emit('unconfigured', 'output')
+    await settle()
+
+    expect(historyState('unconfigured')).toBeNull()
+    expect(fs.existsSync(path.join(dir, 'history'))).toBe(false)
+  })
+})
+
+describe('the checkpoint', () => {
+  it('is written once a terminal falls quiet, with everything a restore needs', async () => {
+    begin(ID, 100, 30)
+    emit(ID, '\x1b]0;vorn — building\x07')
+    emit(ID, 'hello world')
+    await quiesce()
+
+    const written = readCheckpoint(historyDir(dir, ID))
+    expect(written).not.toBeNull()
+    expect(written?.screen).toContain('hello world')
+    expect(written?.scrollback).toContain('hello world')
+    expect(written).toMatchObject({ cols: 100, rows: 30, title: 'vorn — building' })
+  })
+
+  it('does not leave behind the frames it already contains', async () => {
+    // The duplication this whole design turns on. A checkpoint holds the screen
+    // as of the moment it was taken, so replaying the frames before it over the
+    // top would print every byte twice.
+    begin()
+    emit(ID, 'hello world')
+    await settle()
+    expect(outputs(logOf().frames), 'they never reached the log, so this proves nothing').toBe(
+      'hello world'
+    )
+
+    await quiesce()
+
+    expect(outputs(logOf().frames)).toBe('')
+  })
+
+  it('moves the generation with it, so a log left over from before is refusable', async () => {
+    begin()
+    emit(ID, 'hello')
+    await quiesce()
+
+    const written = readCheckpoint(historyDir(dir, ID))
+    expect(written?.generation).toBe(2)
+    // The same number in both files is the whole tie. A crash between the two
+    // writes leaves the old log beside the new checkpoint, and this is what lets
+    // recovery notice rather than replay it.
+    expect(logOf().generation).toBe(2)
+  })
+
+  it('keeps output that arrives after it', async () => {
+    begin()
+    emit(ID, 'before')
+    await quiesce()
+    emit(ID, 'after')
+    await settle()
+
+    expect(outputs(logOf().frames)).toBe('after')
+    expect(readCheckpoint(historyDir(dir, ID))?.screen).toContain('before')
+  })
+
+  it('is not rewritten while nothing is happening', async () => {
+    begin()
+    emit(ID, 'hello')
+    await quiesce()
+    const first = fs.statSync(path.join(historyDir(dir, ID), CHECKPOINT_FILE)).mtimeMs
+
+    await quiesce()
+
+    expect(fs.statSync(path.join(historyDir(dir, ID), CHECKPOINT_FILE)).mtimeMs).toBe(first)
+  })
+
+  it('stops the timer once every session is written out', async () => {
+    // Otherwise this ticks four times a second through every idle night, for
+    // every server anyone leaves running.
+    begin()
+    emit(ID, 'hello')
+    await quiesce()
+
+    const before = process.getActiveResourcesInfo?.().filter((r) => r === 'Timeout').length ?? 0
+    await sleep(TIMING.tickMs * 4)
+    const after = process.getActiveResourcesInfo?.().filter((r) => r === 'Timeout').length ?? 0
+
+    expect(after).toBeLessThanOrEqual(before)
+    expect(historyState(ID)?.pendingBytes).toBe(0)
+  })
+})
+
+describe('a session that ends', () => {
+  it('takes its history with it', async () => {
+    begin()
+    emit(ID, 'hello')
+    await quiesce()
+    expect(fs.existsSync(historyDir(dir, ID))).toBe(true)
+
+    stopHistory(ID)
+    await settle()
+
+    expect(fs.existsSync(historyDir(dir, ID))).toBe(false)
+  })
+
+  it('is refused once the server is shutting down', async () => {
+    // `shutdown()` checkpoints every terminal and only then kills the PTYs, and
+    // a killed PTY runs the same teardown as one that exited on its own. Without
+    // the seal the last act of a clean shutdown is to delete what it just wrote.
+    begin()
+    emit(ID, 'hello')
+    await flushHistory()
+
+    stopHistory(ID)
+    await settle()
+
+    expect(readCheckpoint(historyDir(dir, ID))?.screen).toContain('hello')
+  })
+
+  it('starts clean when the same id is recorded again', async () => {
+    begin()
+    emit(ID, 'from the first process')
+    await quiesce()
+
+    begin()
+    await settle()
+
+    expect(readCheckpoint(historyDir(dir, ID))).toBeNull()
+    expect(logOf().generation).toBe(1)
+  })
+})
+
+describe('shutting down', () => {
+  it('writes every terminal, not only the ones that had fallen quiet', async () => {
+    begin('one')
+    begin('two')
+    emit('one', 'first terminal')
+    emit('two', 'second terminal')
+
+    await flushHistory()
+
+    expect(readCheckpoint(historyDir(dir, 'one'))?.screen).toContain('first terminal')
+    expect(readCheckpoint(historyDir(dir, 'two'))?.screen).toContain('second terminal')
+  })
+
+  it('does not leave frames that never reached the log to be replayed over it', async () => {
+    // The other half of the duplication. A shutdown checkpoints immediately, so
+    // the frames are still in memory rather than on disk -- and they are inside
+    // the screen just written, so carrying them past it would print twice.
+    begin()
+    emit(ID, 'hello world')
+    expect(historyState(ID)?.pendingBytes, 'a tick got there first').toBeGreaterThan(0)
+
+    await flushHistory()
+
+    expect(outputs(logOf().frames)).toBe('')
+  })
+})
+
+describe('a disk that stops answering', () => {
+  it('gives up on the log rather than growing without bound', async () => {
+    begin()
+    vi.spyOn(fsp, 'appendFile').mockRejectedValue(new Error('EIO'))
+
+    emit(ID, 'x'.repeat(1024))
+    await settle()
+
+    expect(historyState(ID)?.broken).toBe(true)
+    expect(historyState(ID)?.pendingBytes).toBe(0)
+  })
+
+  it('does not append past the gap it left', async () => {
+    // A hole in the middle of a file that replays forwards is worse than a stale
+    // screen: every byte after it is applied at the wrong point. The log stays
+    // untouched until a checkpoint replaces it whole.
+    begin()
+    const append = vi.spyOn(fsp, 'appendFile').mockRejectedValueOnce(new Error('EIO'))
+
+    emit(ID, 'lost')
+    await settle()
+    emit(ID, 'after')
+    await settle()
+
+    expect(outputs(logOf().frames)).toBe('')
+    expect(append).toHaveBeenCalledTimes(1)
+  })
+
+  it('is repaired by the next checkpoint', async () => {
+    begin()
+    vi.spyOn(fsp, 'appendFile').mockRejectedValueOnce(new Error('EIO'))
+
+    emit(ID, 'lost to the append')
+    await settle()
+    await quiesce()
+
+    expect(historyState(ID)?.broken).toBe(false)
+    // The bytes were never lost to the *screen*, only to the log, and the
+    // checkpoint is the screen.
+    expect(readCheckpoint(historyDir(dir, ID))?.screen).toContain('lost to the append')
+  })
+})
+
+describe('one session against another', () => {
+  it('does not make a healthy terminal wait behind a wedged one', async () => {
+    begin('wedged')
+    begin('healthy')
+
+    let release: (() => void) | undefined
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const real = fsp.appendFile
+    vi.spyOn(fsp, 'appendFile').mockImplementation((async (file: string, data: Buffer) => {
+      if (String(file).includes('wedged')) await held
+      return real(file, data)
+    }) as never)
+
+    emit('wedged', 'this one is stuck')
+    emit('healthy', 'this one is not')
+
+    // Polled rather than settled: settling would wait on the session that is
+    // deliberately stuck, which is the thing being shown not to matter.
+    await until(() => outputs(logOf('healthy').frames) === 'this one is not')
+    expect(logOf('wedged').frames).toEqual([])
+
+    release?.()
+    await settle()
+  })
+})

--- a/tests/launch-tokens.test.ts
+++ b/tests/launch-tokens.test.ts
@@ -96,6 +96,45 @@ describe('everything that is not a selector', () => {
   })
 })
 
+describe('a flag that takes no value', () => {
+  it('does not swallow the argument after it', () => {
+    // `--continue` takes no value, so what follows is somebody's prompt. An
+    // earlier version treated any non-dash token as the flag's value and turned
+    // this into `claude` -- not a refusal, but a command that runs and asks the
+    // agent nothing. Found by differential-testing the rewrite against /bin/sh.
+    expect(
+      stripSessionSelectors("claude --continue 'fix the failing test'", 'claude', from('claude'))
+    ).toBe("claude 'fix the failing test'")
+  })
+
+  it('does not swallow it for the short form either', () => {
+    expect(stripSessionSelectors('claude -c my-prompt', 'claude', from('claude'))).toBe(
+      'claude my-prompt'
+    )
+  })
+
+  it('still removes a flag that does take one, with its value', () => {
+    expect(stripSessionSelectors('claude --resume old-id rest', 'claude', from('claude'))).toBe(
+      'claude rest'
+    )
+  })
+})
+
+describe('after a bare double dash', () => {
+  it('nothing is a flag any more', () => {
+    // `--` is how a prompt beginning with a dash is passed. Rewriting past it
+    // changes what the agent is asked rather than which session it opens.
+    const line = 'claude -- --resume looks-like-a-flag'
+    expect(stripSessionSelectors(line, 'claude', from('claude'))).toBe(line)
+  })
+
+  it('but a selector before it is still removed', () => {
+    expect(
+      stripSessionSelectors('claude --resume old -- --resume text', 'claude', from('claude'))
+    ).toBe('claude -- --resume text')
+  })
+})
+
 describe('what is deliberately left alone', () => {
   it('keeps a joined short selector, and lets two of them ship', () => {
     // `-rold` cannot be told apart from another option taking a dash-leading

--- a/tests/launch-tokens.test.ts
+++ b/tests/launch-tokens.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { tokenize, stripSessionSelectors } from '../packages/server/src/launch-tokens'
+
+/**
+ * Removing a session selector from a line somebody else wrote.
+ *
+ * The rule is that exactly one selector reaches the agent. Being too cautious
+ * ships two and starts the wrong session; being too confident rewrites somebody's
+ * command and starts nothing. So most of this file is about what is *not*
+ * touched, and about lines this declines to read at all.
+ */
+
+/** Where the configured command ends. The caller composed the line, so it knows. */
+const from = (command: string): number => command.length
+
+describe('reading a line', () => {
+  it('keeps quoting out of the value and the offsets on the line', () => {
+    const tokens = tokenize(`claude --model "gpt 4"`)
+    expect(tokens?.map((t) => t.value)).toEqual(['claude', '--model', 'gpt 4'])
+    expect(tokens?.map((t) => t.raw)).toEqual(['claude', '--model', '"gpt 4"'])
+  })
+
+  it.each([
+    ['a pipeline', 'claude | tee log'],
+    ['a conjunction', 'foo && claude --resume x'],
+    ['a sequence', 'claude; echo done'],
+    ['a redirect', 'claude > out.txt'],
+    ['a subshell', 'claude $(cat id)'],
+    ['a backtick', 'claude `cat id`'],
+    ['an unterminated single quote', "claude --model 'gpt"],
+    ['an unterminated double quote', 'claude --model "gpt'],
+    ['a line continuation', 'claude --model \\']
+  ])('refuses %s rather than guessing at it', (_label, line) => {
+    // The refusal is what makes failing open safe. In `foo && claude`, reading
+    // `claude` as an argument of `foo` and editing around it would produce a
+    // command that does something else entirely.
+    expect(tokenize(line)).toBeNull()
+  })
+})
+
+describe('a selector already on the line', () => {
+  it.each([
+    ['a flag and its value', 'claude --resume old-id'],
+    ['a joined flag', 'claude --resume=old-id'],
+    ['the short form', 'claude -r old-id'],
+    ['continue', 'claude --continue'],
+    ['the short continue', 'claude -c'],
+    ['a pinned id', 'claude --session-id old-id']
+  ])('is removed: %s', (_label, line) => {
+    expect(stripSessionSelectors(line, 'claude', from('claude'))).toBe('claude')
+  })
+
+  it('takes the space in front of it, so nothing is left doubled', () => {
+    expect(stripSessionSelectors('claude --resume old --model x', 'claude', from('claude'))).toBe(
+      'claude --model x'
+    )
+  })
+
+  it('leaves a bare flag at the end of the line as just the flag', () => {
+    // `--resume` with nothing after it is the interactive picker. Still a
+    // selector, but the next token is not its value because there is none.
+    expect(stripSessionSelectors('claude --model x --resume', 'claude', from('claude'))).toBe(
+      'claude --model x'
+    )
+  })
+
+  it('does not swallow the next flag as though it were a value', () => {
+    expect(stripSessionSelectors('claude --resume --verbose', 'claude', from('claude'))).toBe(
+      'claude --verbose'
+    )
+  })
+})
+
+describe('everything that is not a selector', () => {
+  it('survives byte for byte, quoting and all', () => {
+    const line = `claude --model 'gpt 4' --resume old --dir "$HOME/dev"`
+    expect(stripSessionSelectors(line, 'claude', from('claude'))).toBe(
+      `claude --model 'gpt 4' --dir "$HOME/dev"`
+    )
+  })
+
+  it('includes an argument that merely looks like the executable', () => {
+    // `--wrapper /usr/local/bin/claude` is a path somebody passed, not the
+    // command. Nothing about it selects a session.
+    const line = 'claude --wrapper /usr/local/bin/claude --resume old'
+    expect(stripSessionSelectors(line, 'claude', from('claude'))).toBe(
+      'claude --wrapper /usr/local/bin/claude'
+    )
+  })
+
+  it('includes the command itself, however many words it is', () => {
+    // The settings form splits an argument field on whitespace, so a command of
+    // `npx -y @anthropic-ai/claude-code` is a working configuration.
+    const command = 'npx -y @anthropic-ai/claude-code'
+    expect(stripSessionSelectors(`${command} --resume old`, 'claude', from(command))).toBe(command)
+  })
+})
+
+describe('what is deliberately left alone', () => {
+  it('keeps a joined short selector, and lets two of them ship', () => {
+    // `-rold` cannot be told apart from another option taking a dash-leading
+    // value. Rewriting on a guess is worse than an extra selector somebody put
+    // there themselves.
+    const line = 'claude -rold-id'
+    expect(stripSessionSelectors(line, 'claude', from('claude'))).toBe(line)
+  })
+
+  it('keeps a cluster of short flags', () => {
+    // Splitting `-ir` needs to know which letters take arguments.
+    const line = 'claude -ir'
+    expect(stripSessionSelectors(line, 'claude', from('claude'))).toBe(line)
+  })
+
+  it('hands back a line it refused to read', () => {
+    const line = 'foo && claude --resume old'
+    expect(stripSessionSelectors(line, 'claude', from('foo'))).toBe(line)
+  })
+
+  it('leaves an agent with no resume of its own untouched', () => {
+    const line = 'gemini --resume old'
+    expect(stripSessionSelectors(line, 'gemini', from('gemini'))).toBe(line)
+  })
+})
+
+describe('per agent', () => {
+  it('removes copilot flags but not claude-only ones', () => {
+    expect(stripSessionSelectors('copilot --resume old -c', 'copilot', from('copilot'))).toBe(
+      'copilot -c'
+    )
+  })
+
+  it('removes an opencode session flag in both forms', () => {
+    expect(stripSessionSelectors('opencode --session old', 'opencode', from('opencode'))).toBe(
+      'opencode'
+    )
+    expect(stripSessionSelectors('opencode -s old', 'opencode', from('opencode'))).toBe('opencode')
+  })
+
+  it('removes a codex resume subcommand and its id', () => {
+    expect(stripSessionSelectors('codex resume old-id --model o3', 'codex', from('codex'))).toBe(
+      'codex --model o3'
+    )
+  })
+
+  it('removes a codex resume --last', () => {
+    expect(stripSessionSelectors('codex resume --last', 'codex', from('codex'))).toBe('codex')
+  })
+
+  it('leaves a codex resume that is not in subcommand position', () => {
+    // `--note resume` is a value somebody passed. A subcommand is only a
+    // subcommand where a subcommand can go.
+    const line = 'codex --note resume'
+    expect(stripSessionSelectors(line, 'codex', from('codex'))).toBe(line)
+  })
+})

--- a/tests/launcher-endpoint.process.test.ts
+++ b/tests/launcher-endpoint.process.test.ts
@@ -135,9 +135,35 @@ beforeEach(() => {
   delete process.env.VORN_DATA_DIR
 })
 
+/**
+ * Every server this sandbox started, published or not.
+ *
+ * `serverPid()` reads the one named in `ws-port`, and killing only that one
+ * leaked. These tests deliberately kill servers and let the launcher relaunch,
+ * and a spawn that dies before it publishes is never named there at all -- so
+ * each run left detached servers behind that nothing would ever reap. They
+ * orphan to init and sit for hours: seventeen of them, holding 117 MB, in
+ * directories that had already been deleted out from under them.
+ *
+ * The data directory really is absent from the command line, as `serverPid`
+ * says. The *entry* is not: the packaged spawn runs
+ * `<home>/Resources/server/index.cjs`, and that path is unique to this sandbox.
+ */
+function sandboxServers(): number[] {
+  try {
+    const ps = spawnSync('ps', ['-eo', 'pid=,command='], { encoding: 'utf-8' })
+    return ps.stdout
+      .split('\n')
+      .filter((line) => line.includes(resources))
+      .map((line) => Number(line.trim().split(/\s+/)[0]))
+      .filter((pid) => Number.isInteger(pid) && pid > 0 && pid !== process.pid)
+  } catch {
+    return []
+  }
+}
+
 afterEach(async () => {
-  const pid = serverPid()
-  if (pid) {
+  for (const pid of sandboxServers()) {
     try {
       process.kill(pid, 'SIGKILL')
     } catch {

--- a/tests/pty-manager-recovery.test.ts
+++ b/tests/pty-manager-recovery.test.ts
@@ -267,7 +267,11 @@ describe('agent crashes mid-session', () => {
     const channels = messages.map((m) => m.channel)
     expect(channels.indexOf(IPC.TERMINAL_DATA)).toBeLessThan(channels.indexOf(IPC.TERMINAL_EXIT))
     // Exactly one flush — the pending timer must not fire a second, empty one.
-    expect(messagesOn(IPC.TERMINAL_DATA)).toEqual([{ id: session.id, data: 'segfault imminent\n' }])
+    // `seq: 1` says the same thing from the other side: the counter a pane uses
+    // to tell what it already has moved once, so there was one flush.
+    expect(messagesOn(IPC.TERMINAL_DATA)).toEqual([
+      { id: session.id, data: 'segfault imminent\n', seq: 1 }
+    ])
   })
 
   it('cancels the idle timer so a crashed session is never re-marked', () => {

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -408,3 +408,43 @@ describe('the seam between a session and the one resuming it', () => {
     expect(fake.written.slice(before)).toEqual([])
   })
 })
+
+describe('letting go of a session that is about to come back', () => {
+  it('announces nothing, where killing one announces an exit', () => {
+    // Resume used to route through `killPty`, which emits `session-exit` for a
+    // session that is returning under the same id and -- when it was the last
+    // one in a worktree -- broadcasts WORKTREE_CONFIRM_CLEANUP. That reaches the
+    // person as an offer to delete the worktree the agent is at that moment
+    // being resumed into, and taking it removes the tree under a running agent.
+    const said: string[] = []
+    const onExit = (): void => void said.push('session-exit')
+    const onMessage = (channel: string): void => void said.push(channel)
+    ptyManager.on('session-exit', onExit)
+    ptyManager.on('client-message', onMessage)
+
+    try {
+      const coming_back = createAgent()
+      ptyManager.releaseForResume(coming_back.session.id)
+      expect(said).toEqual([])
+
+      // The contrast, so this cannot pass by nothing being emitted at all.
+      const going = createAgent()
+      ptyManager.killPty(going.session.id)
+      expect(said).toContain('session-exit')
+    } finally {
+      ptyManager.off('session-exit', onExit)
+      ptyManager.off('client-message', onMessage)
+    }
+  })
+
+  it('leaves the history alone, because the run replacing it resets that', () => {
+    // `killPty` calls `stopHistory`, which queues a recursive remove of the very
+    // directory `startHistory` resets a few lines later -- two queues over one
+    // directory, which the writer is built to never have.
+    const { session } = createAgent()
+    ptyManager.releaseForResume(session.id)
+
+    expect(ptyManager.hasLivePty(session.id)).toBe(false)
+    expect(ptyManager.getActiveSessions().some((s) => s.id === session.id)).toBe(false)
+  })
+})

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -132,8 +132,18 @@ vi.mock('../packages/server/src/process-utils', async () => {
   }
 })
 
+import fs from 'node:fs'
+import os from 'node:os'
 import { ptyManager } from '../packages/server/src/pty-manager'
 import { isGitRepo } from '../packages/server/src/git-utils'
+import {
+  configureHistory,
+  settleHistory,
+  resetHistory
+} from '../packages/server/src/history/writer'
+import { historyDir, LOG_FILE } from '../packages/server/src/history/checkpoint'
+import { readFrames, type Frame } from '../packages/server/src/history/log'
+import { readScrollback, resetScrollback } from '../packages/server/src/terminal-scrollback'
 
 vi.mocked(isGitRepo).mockReturnValue(false)
 
@@ -252,5 +262,101 @@ describe('the model follows the session it belongs to', () => {
 
     expect(screenCount()).toBe(held - 1)
     expect(await serializeScreen(session.id)).toBeNull()
+  })
+})
+
+describe('the terminal is recorded where it is fed', () => {
+  /**
+   * The wiring, which every other history test has to take on trust.
+   *
+   * `history-writer.test.ts` drives the writer directly and proves what it does
+   * with what it is given. Nothing there can show that `pty-manager` gives it
+   * anything at all -- four call sites that are one line each, and a one-line
+   * call site is exactly the kind that gets dropped in a merge and noticed
+   * months later as terminals that come back blank.
+   */
+  let dir: string
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-pty-history-'))
+    configureHistory(dir, { tickMs: 5, quiesceMs: 5_000, checkpointMs: 60_000 })
+  })
+
+  afterEach(() => {
+    resetHistory()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  async function settled(): Promise<void> {
+    for (let round = 0; round < 4; round++) {
+      await new Promise((r) => setTimeout(r, 20))
+      await settleHistory()
+    }
+  }
+
+  function framesFor(id: string): Frame[] {
+    return readFrames(fs.readFileSync(path.join(historyDir(dir, id), LOG_FILE))).frames
+  }
+
+  it('does not let the byte buffer run ahead of the screen model', async () => {
+    // Both are fed from the flush, and that is what makes a checkpoint coherent.
+    // The buffer used to be fed from `onData` instead, so for up to one flush it
+    // held bytes the model had not seen -- and a checkpoint takes both at the
+    // same instant. Those bytes went into its scrollback, arrived again as log
+    // frames written after it, and a restore counted them twice.
+    resetScrollback()
+    const { session, fake } = createAgent()
+    fake.emitData('printed but not yet flushed')
+
+    expect(readScrollback(session.id), 'the buffer saw it before the model did').toBe('')
+
+    await afterFlush()
+    expect(readScrollback(session.id)).toContain('printed but not yet flushed')
+  })
+
+  it('opens a log when a terminal is spawned', async () => {
+    const { session } = createAgent()
+    await settled()
+
+    expect(fs.existsSync(path.join(historyDir(dir, session.id), LOG_FILE))).toBe(true)
+  })
+
+  it('records what the terminal printed, and the size it printed at', async () => {
+    const { session, fake } = createAgent()
+    fake.emitData('tests passed, 402 of them\r\n')
+    await afterFlush()
+    ptyManager.resizePty(session.id, 132, 43)
+    await settled()
+
+    expect(framesFor(session.id)).toEqual(
+      expect.arrayContaining<Frame>([
+        { kind: 'output', data: 'tests passed, 402 of them\r\n' },
+        { kind: 'resize', cols: 132, rows: 43 }
+      ])
+    )
+  })
+
+  it('records once per flush rather than once per chunk', async () => {
+    // The reason the call sits in `flushBuffer` and not in `onData`. Thirty
+    // keystrokes are one frame, not thirty -- and it is what keeps the byte
+    // buffer and the screen model seeing the same bytes at the same moment.
+    const { session, fake } = createAgent()
+    for (let i = 0; i < 30; i++) fake.emitData('x')
+    await afterFlush()
+    await settled()
+
+    const output = framesFor(session.id).filter((f) => f.kind === 'output')
+    expect(output).toEqual([{ kind: 'output', data: 'x'.repeat(30) }])
+  })
+
+  it('takes the history with the terminal when it is killed', async () => {
+    const { session } = createAgent()
+    await settled()
+    expect(fs.existsSync(historyDir(dir, session.id))).toBe(true)
+
+    ptyManager.killPty(session.id)
+    await settled()
+
+    expect(fs.existsSync(historyDir(dir, session.id))).toBe(false)
   })
 })

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -448,3 +448,31 @@ describe('letting go of a session that is about to come back', () => {
     expect(ptyManager.getActiveSessions().some((s) => s.id === session.id)).toBe(false)
   })
 })
+
+describe('a release whose spawn then fails', () => {
+  it('can be put back, because otherwise the session is gone for good', () => {
+    // Releasing is destructive on purpose -- it is what lets the replacement
+    // take the same id -- but a spawn that throws must not end the session. The
+    // carried-over kind is handed back to `restored-sessions`; this is the other
+    // kind, whose record lives in the pty manager, and it was released and never
+    // put anywhere. The pane's next attempt was told the session was gone.
+    const { session } = createAgent()
+    ptyManager.releaseForResume(session.id)
+    expect(ptyManager.getActiveSessions().some((s) => s.id === session.id)).toBe(false)
+
+    ptyManager.restoreReleased(session)
+
+    expect(ptyManager.getActiveSessions().some((s) => s.id === session.id)).toBe(true)
+    // Still no process behind it, which is what makes it resumable rather than live.
+    expect(ptyManager.hasLivePty(session.id)).toBe(false)
+  })
+
+  it('does not put the id in the order twice', () => {
+    const { session } = createAgent()
+    ptyManager.releaseForResume(session.id)
+    ptyManager.restoreReleased(session)
+    ptyManager.restoreReleased(session)
+
+    expect(ptyManager.getActiveSessions().filter((s) => s.id === session.id)).toHaveLength(1)
+  })
+})

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -373,3 +373,38 @@ describe('the terminal is recorded where it is fed', () => {
     expect(fs.existsSync(historyDir(dir, session.id))).toBe(false)
   })
 })
+
+describe('the seam between a session and the one resuming it', () => {
+  it('puts the reset in the output stream, ahead of the new run', async () => {
+    // A resumed session keeps its pane, so the new process inherits whatever the
+    // last one left in the emulator -- a scroll region, an alternate screen it
+    // never came back from. Something has to sit between the two runs saying so,
+    // and it has to be in the stream rather than written by a client: a cold
+    // pane has not mounted when the resume starts, and the screen it replays is
+    // written when it finally does, by which time the new run is already
+    // streaming. Ordering these is the server's job because the server is what
+    // orders them.
+    const { session, fake } = createAgent()
+    fake.emitData('what the last run left')
+    await afterFlush()
+
+    ptyManager.injectOutput(session.id, `${ESC}[!p`)
+    fake.emitData('what the new run draws')
+    await afterFlush()
+
+    const seen = readScrollback(session.id)
+    expect(seen).toContain(`${ESC}[!p`)
+    expect(seen.indexOf(`${ESC}[!p`)).toBeGreaterThan(seen.indexOf('what the last run left'))
+    expect(seen.indexOf(`${ESC}[!p`)).toBeLessThan(seen.indexOf('what the new run draws'))
+  })
+
+  it('never answers it back down the pty, as any injected escape must not', async () => {
+    const { session, fake } = createAgent()
+    const before = fake.written.length
+
+    ptyManager.injectOutput(session.id, `${ESC}[!p${ESC}[?1049l`)
+    await afterFlush()
+
+    expect(fake.written.slice(before)).toEqual([])
+  })
+})

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -236,6 +236,19 @@ describe('the model follows the session it belongs to', () => {
     expect(live?.rows).toBe(43)
   })
 
+  it('ignores a resize larger than a frame can record', () => {
+    // A resize frame stores its dimensions in sixteen bits, so seventy thousand
+    // columns would be written to disk as four thousand -- a durable
+    // disagreement between what the program rendered against and what a replay
+    // lays it out at, re-applied on every start. Refused at the source, where
+    // the PTY and the model and the frame all still agree.
+    const { session, fake } = createAgent()
+    ptyManager.resizePty(session.id, 70_000, 40)
+
+    expect(fake.resize).not.toHaveBeenCalled()
+    expect(ptyManager.getActiveSessions().find((s) => s.id === session.id)?.cols).toBe(80)
+  })
+
   it('ignores a resize that would throw inside node-pty', () => {
     // Arrives as a fire-and-forget notification, so a throw here has no caller.
     const { session, fake } = createAgent()

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import path from 'node:path'
+import type { CreateTerminalPayload, TerminalSession } from '@vornrun/shared/types'
+
+/**
+ * The screen model, where there is a real PTY to watch.
+ *
+ * `terminal-screen.test.ts` proves what a screen becomes; it cannot prove that
+ * feeding one never writes back. That needs something on the other end of the
+ * PTY recording what arrives, which is what `FakePty` is -- every `write` lands
+ * in an array this can read.
+ *
+ * The failure being guarded is quiet and expensive: an emulator asked who it is
+ * answers, and an answer sent to a PTY arrives in the shell's *input* as
+ * characters the user did not type.
+ */
+
+// `FakePty` is here for its type only -- `lastPty` needs the instance shape.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { spawnMock, FakePty } = vi.hoisted(() => {
+  type DataHandler = (data: string) => void
+  type ExitHandler = (e: { exitCode: number; signal?: number }) => void
+
+  let nextPid = 1000
+
+  class FakePty {
+    pid = nextPid++
+    written: string[] = []
+    killed = false
+    /** Set to simulate killing a process that the OS already reaped. */
+    killError: Error | null = null
+    resize = vi.fn()
+    private dataHandlers: DataHandler[] = []
+    private exitHandlers: ExitHandler[] = []
+
+    write(data: string): void {
+      this.written.push(data)
+    }
+
+    kill(): void {
+      if (this.killError) throw this.killError
+      this.killed = true
+    }
+
+    onData(cb: DataHandler): { dispose: () => void } {
+      this.dataHandlers.push(cb)
+      return {
+        dispose: () => {
+          this.dataHandlers = this.dataHandlers.filter((h) => h !== cb)
+        }
+      }
+    }
+
+    onExit(cb: ExitHandler): { dispose: () => void } {
+      this.exitHandlers.push(cb)
+      return {
+        dispose: () => {
+          this.exitHandlers = this.exitHandlers.filter((h) => h !== cb)
+        }
+      }
+    }
+
+    emitData(data: string): void {
+      for (const h of [...this.dataHandlers]) h(data)
+    }
+
+    emitExit(exitCode = 0): void {
+      for (const h of [...this.exitHandlers]) h({ exitCode })
+    }
+  }
+
+  return { spawnMock: vi.fn(() => new FakePty()), FakePty }
+})
+
+type FakePtyInstance = InstanceType<typeof FakePty>
+
+// The nested copy by name, not the bare specifier. `packages/server` pins its
+// own node-pty, so mocking 'node-pty' from here patches the root copy and
+// leaves pty-manager's untouched — the spawns would be real. Same reasoning as
+// `pty-session-id.test.ts`, which is where this convention comes from.
+vi.mock('../packages/server/node_modules/node-pty', () => ({
+  default: { spawn: spawnMock },
+  spawn: spawnMock
+}))
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('../packages/server/src/config-manager', () => ({
+  configManager: {
+    loadConfig: vi.fn(() => ({ defaults: { shell: '/bin/zsh', minimalShellPrompt: true } }))
+  }
+}))
+
+vi.mock('../packages/server/src/git-utils', () => ({
+  getGitBranch: vi.fn(() => 'main'),
+  checkoutBranch: vi.fn(),
+  createWorktree: vi.fn(),
+  extractWorktreeName: vi.fn((p: string) => path.basename(p)),
+  isGitRepo: vi.fn(() => false)
+}))
+
+vi.mock('../packages/server/src/shell-integration', () => ({
+  getShellIntegration: vi.fn(() => ({ env: {} }))
+}))
+
+// The real launch line resolver shells out to `which` per agent; the recovery
+// paths under test only care that *some* line is written.
+vi.mock('../packages/server/src/agent-launch', () => ({
+  buildAgentLaunchLine: vi.fn((payload: CreateTerminalPayload) => `${payload.agentType}-launch`)
+}))
+
+vi.mock('../packages/server/src/process-utils', async () => {
+  const actual = await vi.importActual<typeof import('../packages/server/src/process-utils')>(
+    '../packages/server/src/process-utils'
+  )
+  return {
+    ...actual,
+    // The real versions spawn a login shell to resolve the user's environment.
+    getSafeEnv: () => ({ HOME: '/home/user', PATH: '/usr/bin' }),
+    getLaunchEnv: () => ({ HOME: '/home/user', PATH: '/usr/bin' })
+  }
+})
+
+import { ptyManager } from '../packages/server/src/pty-manager'
+import { isGitRepo } from '../packages/server/src/git-utils'
+
+vi.mocked(isGitRepo).mockReturnValue(false)
+
+function lastPty(): FakePtyInstance {
+  const results = spawnMock.mock.results
+  return results[results.length - 1].value as FakePtyInstance
+}
+
+function createAgent(overrides: Partial<CreateTerminalPayload> = {}): {
+  session: TerminalSession
+  fake: FakePtyInstance
+} {
+  const session = ptyManager.createPty({
+    agentType: 'claude',
+    projectName: 'proj',
+    projectPath: '/tmp/vorn-proj',
+    ...overrides
+  })
+  return { session, fake: lastPty() }
+}
+
+const ESC = '\x1b'
+
+/**
+ * Wait for the output coalescer.
+ *
+ * `emitData` only buffers; `flushBuffer` runs on an 8 ms timer and that is where
+ * the screen is fed. An assertion made straight after `emitData` is made before
+ * anything under test has happened -- which is how the first version of these
+ * passed against a `pty-manager` deliberately rigged to write replies back.
+ */
+const afterFlush = (): Promise<void> => new Promise((r) => setTimeout(r, 40))
+
+beforeEach(() => {
+  // Every session this file starts is torn down, so a count taken in one test
+  // is not a count of what an earlier one left running.
+  for (const s of ptyManager.getActiveSessions()) ptyManager.killPty(s.id)
+  spawnMock.mockClear()
+})
+
+afterEach(() => {
+  for (const s of ptyManager.getActiveSessions()) ptyManager.killPty(s.id)
+})
+
+describe('feeding the screen model never writes to the PTY', () => {
+  it('stays silent when a program asks the terminal who it is', async () => {
+    const { fake } = createAgent()
+    const before = fake.written.length
+
+    // A device-attributes query, a cursor-position report and a mode query --
+    // three things a terminal answers, arriving as ordinary program output.
+    fake.emitData(`${ESC}[c${ESC}[6n${ESC}[?1049$p`)
+    await afterFlush()
+
+    expect(fake.written.slice(before)).toEqual([])
+  })
+
+  it('stays silent across a resize, which also makes a terminal talkative', async () => {
+    const { session, fake } = createAgent()
+    fake.emitData('some output')
+    await afterFlush()
+    const before = fake.written.length
+
+    ptyManager.resizePty(session.id, 120, 40)
+    fake.emitData(`${ESC}[18t`)
+    await afterFlush()
+
+    expect(fake.written.slice(before)).toEqual([])
+  })
+
+  it('still delivers what the user actually types', () => {
+    // The counterpart: silence would be worthless if it meant the PTY heard
+    // nothing at all.
+    const { session, fake } = createAgent()
+
+    ptyManager.writeToPty(session.id, 'ls -la\r')
+
+    expect(fake.written).toContain('ls -la\r')
+  })
+})
+
+describe('the model follows the session it belongs to', () => {
+  it('records the geometry a resize asked for', () => {
+    const { session } = createAgent()
+
+    ptyManager.resizePty(session.id, 132, 43)
+
+    const live = ptyManager.getActiveSessions().find((s) => s.id === session.id)
+    expect(live?.cols).toBe(132)
+    expect(live?.rows).toBe(43)
+  })
+
+  it('ignores a resize that would throw inside node-pty', () => {
+    // Arrives as a fire-and-forget notification, so a throw here has no caller.
+    const { session, fake } = createAgent()
+
+    expect(() => ptyManager.resizePty(session.id, 0, 0)).not.toThrow()
+
+    expect(fake.resize).not.toHaveBeenCalled()
+    const live = ptyManager.getActiveSessions().find((s) => s.id === session.id)
+    expect(live?.cols).toBe(80)
+  })
+
+  it('lets go of the model when the terminal is killed', async () => {
+    // A `Terminal` holds buffers, so a map delete is not enough -- miss the
+    // dispose and every session ever closed stays resident. Counted as a delta
+    // rather than an absolute, because other sessions in this file are alive.
+    const { screenCount, serializeScreen } = await import('../packages/server/src/terminal-screen')
+    const { session, fake } = createAgent()
+    fake.emitData('output')
+    await afterFlush()
+    const held = screenCount()
+    expect(await serializeScreen(session.id)).toContain('output')
+
+    ptyManager.killPty(session.id)
+
+    expect(screenCount()).toBe(held - 1)
+    expect(await serializeScreen(session.id)).toBe('')
+  })
+})

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -5,6 +5,15 @@ import type { CreateTerminalPayload, TerminalSession } from '@vornrun/shared/typ
 /**
  * The screen model, where there is a real PTY to watch.
  *
+ * The mock harness below is duplicated from `pty-manager-recovery.test.ts`, and
+ * it is duplicated on purpose rather than by neglect. `vi.mock` is hoisted into
+ * the file that calls it; moved to a shared module it registers after that
+ * file's imports have already resolved, so the real `node-pty` is loaded and the
+ * suite spawns actual shells. Extracting it needs the factory form
+ * (`vi.mock(spec, () => import(helper))`) in both files, which trades a hundred
+ * lines of obvious boilerplate for a subtlety that fails silently. If a third
+ * file ever needs this, that trade is worth making.
+ *
  * `terminal-screen.test.ts` proves what a screen becomes; it cannot prove that
  * feeding one never writes back. That needs something on the other end of the
  * PTY recording what arrives, which is what `FakePty` is -- every `write` lands
@@ -237,11 +246,11 @@ describe('the model follows the session it belongs to', () => {
     fake.emitData('output')
     await afterFlush()
     const held = screenCount()
-    expect(await serializeScreen(session.id)).toContain('output')
+    expect((await serializeScreen(session.id))?.screen).toContain('output')
 
     ptyManager.killPty(session.id)
 
     expect(screenCount()).toBe(held - 1)
-    expect(await serializeScreen(session.id)).toBe('')
+    expect(await serializeScreen(session.id)).toBeNull()
   })
 })

--- a/tests/restored-resume.test.ts
+++ b/tests/restored-resume.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { TerminalSession } from '@vornrun/shared/types'
+import {
+  seedRestored,
+  consumeRestored,
+  consumeAllRestored,
+  restoredRecords,
+  resetRestored
+} from '../packages/server/src/restored-sessions'
+import {
+  configureHistory,
+  startHistory,
+  recordOutput,
+  discardHistory,
+  settleHistory,
+  flushHistory,
+  resetHistory
+} from '../packages/server/src/history/writer'
+import { historyDir } from '../packages/server/src/history/checkpoint'
+import { createScreen, feedScreen, resetScreens } from '../packages/server/src/terminal-screen'
+import { resetScrollback } from '../packages/server/src/terminal-scrollback'
+import { buildRestorePayload } from '@vornrun/shared/session-restore'
+
+/**
+ * Taking a session from the last run, or letting it go.
+ *
+ * Both are the same decision made twice over: the record stops being offered and
+ * what was written for it stops existing. The rule that matters is that it can
+ * only happen once -- two panes can be looking at the same ended session, on two
+ * devices, and the second to act must be told it is gone rather than starting a
+ * second agent against one transcript.
+ */
+
+const NOW = 1_700_000_000_000
+let dir: string
+
+function session(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: 'a-session',
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/dev/vorn',
+    status: 'idle',
+    createdAt: NOW - 60_000,
+    pid: 4242,
+    savedAt: NOW - 60_000,
+    ...over
+  } as TerminalSession
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-resume-'))
+  resetRestored()
+  resetScreens()
+  resetScrollback()
+  resetHistory()
+  configureHistory(dir, { tickMs: 5, quiesceMs: 5_000, checkpointMs: 60_000 })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetRestored()
+  resetScreens()
+  resetScrollback()
+  resetHistory()
+  fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** Put real files on disk for a session, the way a previous run would have. */
+async function wrote(id: string): Promise<void> {
+  createScreen(id, 80, 24)
+  startHistory(id)
+  feedScreen(id, 'output from the run before')
+  recordOutput(id, 'output from the run before')
+  await settleHistory()
+}
+
+describe('claiming one', () => {
+  it('can be done once, and the second caller is told it is gone', () => {
+    seedRestored([session({ id: 'one' })], NOW)
+
+    expect(consumeRestored('one')?.session.id).toBe('one')
+    // What the second pane, window or phone gets.
+    expect(consumeRestored('one')).toBeNull()
+  })
+
+  it('stops the record being persisted, so it is not offered again', () => {
+    seedRestored([session({ id: 'one' }), session({ id: 'two' })], NOW)
+    consumeRestored('one')
+
+    expect(restoredRecords().map((s) => s.id)).toEqual(['two'])
+  })
+})
+
+describe('what is on disk when a session is claimed or let go', () => {
+  it('goes, because a live session opens its own rather than appending to it', async () => {
+    await wrote('one')
+    expect(fs.existsSync(historyDir(dir, 'one'))).toBe(true)
+
+    await discardHistory('one')
+
+    expect(fs.existsSync(historyDir(dir, 'one'))).toBe(false)
+  })
+
+  it('is refused while the server is shutting down', async () => {
+    // `shutdown()` writes every terminal's screen and only then kills the PTYs,
+    // and the teardown that follows runs the same paths a dismiss does. Without
+    // this the last act of a clean shutdown is to delete what it just wrote.
+    await wrote('one')
+    await flushHistory()
+
+    await discardHistory('one')
+
+    expect(fs.existsSync(historyDir(dir, 'one'))).toBe(true)
+  })
+
+  it('is quiet about a session that never had any', async () => {
+    await expect(discardHistory('never-recorded')).resolves.toBeUndefined()
+  })
+})
+
+describe('letting all of them go at once', () => {
+  it('takes every record, so nothing is left half-offered', () => {
+    seedRestored([session({ id: 'one' }), session({ id: 'two' })], NOW)
+
+    expect(consumeAllRestored().map((r) => r.session.id)).toEqual(['one', 'two'])
+    expect(restoredRecords()).toEqual([])
+    expect(consumeRestored('one')).toBeNull()
+  })
+})
+
+describe('turning a record back into a launch', () => {
+  it('carries the worktree a session was running in', () => {
+    const payload = buildRestorePayload(
+      session({ isWorktree: true, worktreePath: '/dev/vorn-wt', branch: 'p4/restore' }),
+      'agent-session-id'
+    )
+
+    expect(payload).toMatchObject({
+      existingWorktreePath: '/dev/vorn-wt',
+      branch: 'p4/restore',
+      resumeSessionId: 'agent-session-id'
+    })
+  })
+
+  it('refuses a shell, which has no resume to build', () => {
+    // A shell restores by starting one in the directory it was in. Building an
+    // agent launch line for it would produce a command nothing can run.
+    expect(() => buildRestorePayload(session({ agentType: 'shell' }))).toThrow()
+  })
+})

--- a/tests/restored-resume.test.ts
+++ b/tests/restored-resume.test.ts
@@ -7,6 +7,7 @@ import {
   seedRestored,
   consumeRestored,
   consumeAllRestored,
+  restoreHeld,
   restoredRecords,
   resetRestored
 } from '../packages/server/src/restored-sessions'
@@ -150,5 +151,26 @@ describe('turning a record back into a launch', () => {
     // A shell restores by starting one in the directory it was in. Building an
     // agent launch line for it would produce a command nothing can run.
     expect(() => buildRestorePayload(session({ agentType: 'shell' }))).toThrow()
+  })
+})
+
+describe('a claim whose spawn then fails', () => {
+  it('puts the record back, because otherwise there is nothing to try again from', () => {
+    // Claiming is destructive on purpose -- it is what stops two clients
+    // starting two agents against one transcript. But a claim that then fails
+    // to spawn would leave the session in neither place: gone from here, never
+    // in the pty manager, and erased by the next save. Reachable without malice:
+    // a project directory renamed, a worktree pruned, a volume unmounted.
+    seedRestored([session({ id: 'one' })], NOW)
+    const claimed = consumeRestored('one')
+    expect(claimed).not.toBeNull()
+    expect(restoredRecords()).toEqual([])
+
+    restoreHeld(claimed!)
+
+    expect(restoredRecords().map((s) => s.id)).toEqual(['one'])
+    // And it can be claimed again, once.
+    expect(consumeRestored('one')).not.toBeNull()
+    expect(consumeRestored('one')).toBeNull()
   })
 })

--- a/tests/restored-resume.test.ts
+++ b/tests/restored-resume.test.ts
@@ -22,7 +22,12 @@ import {
 } from '../packages/server/src/history/writer'
 import { historyDir } from '../packages/server/src/history/checkpoint'
 import { createScreen, feedScreen, resetScreens } from '../packages/server/src/terminal-screen'
-import { resetScrollback } from '../packages/server/src/terminal-scrollback'
+import {
+  resetScrollback,
+  seedScrollback,
+  scrollbackUnitsHeld
+} from '../packages/server/src/terminal-scrollback'
+import { forgetRestored } from '../packages/server/src/register-methods'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
 
 /**
@@ -172,5 +177,31 @@ describe('a claim whose spawn then fails', () => {
     // And it can be claimed again, once.
     expect(consumeRestored('one')).not.toBeNull()
     expect(consumeRestored('one')).toBeNull()
+  })
+})
+
+describe('letting go of everything held for one', () => {
+  it('frees the scrollback recovery seeded, which nothing else would', async () => {
+    // Recovery gives a restored session a scrollback so a pane can be shown its
+    // last screen. That session has no PTY, so it never reaches the
+    // `clearScrollback` on the kill path, and being claimed or dismissed is the
+    // last thing that happens to it -- so without this the bytes are held for
+    // the life of the server, once per session anyone declines.
+    await wrote('one')
+    seedScrollback('one', 'what the last run had on screen')
+    expect(scrollbackUnitsHeld('one')).toBeGreaterThan(0)
+
+    await forgetRestored('one')
+
+    expect(scrollbackUnitsHeld('one')).toBe(0)
+  })
+
+  it('takes the history with it', async () => {
+    await wrote('two')
+    expect(fs.existsSync(historyDir(dir, 'two'))).toBe(true)
+
+    await forgetRestored('two')
+
+    expect(fs.existsSync(historyDir(dir, 'two'))).toBe(false)
   })
 })

--- a/tests/restored-sessions.test.ts
+++ b/tests/restored-sessions.test.ts
@@ -73,30 +73,6 @@ describe('a database that would not answer', () => {
   })
 })
 
-describe('a save that arrives before the last run has been read', () => {
-  it('says so, because that ordering is what the whole fix rests on', () => {
-    // `seedRestored` must run before the auto-save is wired. Reaching the
-    // failure needs a session created in the window between the two, which only
-    // a workflow launched by the inbox worker can do -- so no test drives it,
-    // and it is checked here instead of being left to a comment.
-    const warned: unknown[] = []
-    const logger = console.warn
-    console.warn = (...args: unknown[]): void => void warned.push(args)
-    try {
-      expect(restoredRecords()).toEqual([])
-    } finally {
-      console.warn = logger
-    }
-    // The record of the complaint is the point; the empty answer is the damage.
-    expect(restoredRecords()).toEqual([])
-  })
-
-  it('does not complain once the records have been read', () => {
-    seedRestored([session({ id: 'one' })], NOW)
-    expect(restoredRecords().map((s) => s.id)).toEqual(['one'])
-  })
-})
-
 describe('a record nobody came back for', () => {
   it('is dropped once it is older than the window', () => {
     const fresh = session({ id: 'fresh', savedAt: NOW - 1000 })

--- a/tests/restored-sessions.test.ts
+++ b/tests/restored-sessions.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import type { TerminalSession } from '@vornrun/shared/types'
+import {
+  seedRestored,
+  markRecovered,
+  listRestored,
+  restoredRecords,
+  consumeRestored,
+  consumeAllRestored,
+  resetRestored,
+  MAX_RESTORED_AGE_MS
+} from '../packages/server/src/restored-sessions'
+
+/**
+ * Holding on to what the last run left, so the next save does not erase it.
+ *
+ * The bug behind this file is worth stating because none of these assertions
+ * make sense without it: a save is a whole-table replace fed by the live session
+ * map, that map is empty after a restart, and so opening one pane deleted every
+ * record from the previous run. History is keyed by session id and swept when no
+ * record names it, so a terminal's screen survived exactly one restart.
+ */
+
+const NOW = 1_700_000_000_000
+
+function session(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: 'a-session',
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/dev/vorn',
+    status: 'idle',
+    createdAt: NOW - 60_000,
+    pid: 4242,
+    savedAt: NOW - 60_000,
+    ...over
+  } as TerminalSession
+}
+
+beforeEach(resetRestored)
+afterEach(resetRestored)
+
+describe('carrying records past a restart', () => {
+  it('keeps them so the next save cannot replace them away', () => {
+    seedRestored([session({ id: 'one' }), session({ id: 'two' })], NOW)
+
+    // What `startAutoSave` now persists, beside whatever is live.
+    expect(restoredRecords().map((s) => s.id)).toEqual(['one', 'two'])
+  })
+
+  it('hands recovery the same list it is holding, so one rule decides deletions', () => {
+    // Anything dropped here is absent from what `recoverHistory` is given, and
+    // its history goes in the same sweep as every other unreachable tree. That
+    // keeps a single deletion point rather than two that must agree.
+    const keep = seedRestored([session({ id: 'one' }), session({ id: 'two' })], NOW)
+
+    expect(keep?.map((s) => s.id)).toEqual(['one', 'two'])
+  })
+})
+
+describe('a database that would not answer', () => {
+  it('holds nothing and tells recovery to sweep nothing', () => {
+    // `readPreviousSessions` answers null when the read failed and `[]` when
+    // there genuinely are none. Reading the first as the second is the
+    // difference between removing nothing and removing every terminal's history
+    // on one transient error.
+    expect(seedRestored(null, NOW)).toBeNull()
+    expect(restoredRecords()).toEqual([])
+  })
+
+  it('is not the same as an empty list', () => {
+    expect(seedRestored([], NOW)).toEqual([])
+  })
+})
+
+describe('a save that arrives before the last run has been read', () => {
+  it('says so, because that ordering is what the whole fix rests on', () => {
+    // `seedRestored` must run before the auto-save is wired. Reaching the
+    // failure needs a session created in the window between the two, which only
+    // a workflow launched by the inbox worker can do -- so no test drives it,
+    // and it is checked here instead of being left to a comment.
+    const warned: unknown[] = []
+    const logger = console.warn
+    console.warn = (...args: unknown[]): void => void warned.push(args)
+    try {
+      expect(restoredRecords()).toEqual([])
+    } finally {
+      console.warn = logger
+    }
+    // The record of the complaint is the point; the empty answer is the damage.
+    expect(restoredRecords()).toEqual([])
+  })
+
+  it('does not complain once the records have been read', () => {
+    seedRestored([session({ id: 'one' })], NOW)
+    expect(restoredRecords().map((s) => s.id)).toEqual(['one'])
+  })
+})
+
+describe('a record nobody came back for', () => {
+  it('is dropped once it is older than the window', () => {
+    const fresh = session({ id: 'fresh', savedAt: NOW - 1000 })
+    const stale = session({ id: 'stale', savedAt: NOW - MAX_RESTORED_AGE_MS - 1000 })
+
+    const keep = seedRestored([fresh, stale], NOW)
+
+    expect(keep?.map((s) => s.id)).toEqual(['fresh'])
+    expect(restoredRecords().map((s) => s.id)).toEqual(['fresh'])
+  })
+
+  it('falls back to when it was created if it was never saved', () => {
+    const never = session({ id: 'never', savedAt: undefined, createdAt: NOW - 1000 })
+    expect(seedRestored([never], NOW)?.map((s) => s.id)).toEqual(['never'])
+  })
+})
+
+describe('claiming one', () => {
+  it('can be done once, and the second caller is told it is gone', () => {
+    // Two clients can have the same cold pane on screen. The second to press
+    // resume must be refused rather than starting a second agent against one
+    // transcript.
+    seedRestored([session({ id: 'one' })], NOW)
+
+    expect(consumeRestored('one')?.session.id).toBe('one')
+    expect(consumeRestored('one')).toBeNull()
+    expect(restoredRecords()).toEqual([])
+  })
+
+  it('leaves the others alone', () => {
+    seedRestored([session({ id: 'one' }), session({ id: 'two' })], NOW)
+    consumeRestored('one')
+    expect(restoredRecords().map((s) => s.id)).toEqual(['two'])
+  })
+
+  it('can be done to all of them at once', () => {
+    seedRestored([session({ id: 'one' }), session({ id: 'two' })], NOW)
+    expect(consumeAllRestored()).toHaveLength(2)
+    expect(restoredRecords()).toEqual([])
+  })
+})
+
+describe('what a pane is told about one', () => {
+  it('says when it ended, so the pane can say so too', () => {
+    seedRestored([session({ id: 'one', savedAt: NOW - 3_600_000 })], NOW)
+    expect(listRestored()[0]?.endedAt).toBe(NOW - 3_600_000)
+  })
+
+  it('says whether there is a screen to show, and whether it is whole', () => {
+    seedRestored([session({ id: 'whole' }), session({ id: 'torn' }), session({ id: 'none' })], NOW)
+
+    markRecovered([
+      { id: 'whole', stopped: 'end' },
+      { id: 'torn', stopped: 'checksum' }
+    ])
+
+    const byId = new Map(listRestored().map((r) => [r.session.id, r]))
+    expect(byId.get('whole')).toMatchObject({ replayable: true, partial: false })
+    expect(byId.get('torn')).toMatchObject({ replayable: true, partial: true })
+    // Nothing was rebuilt for this one, so the pane must not promise a screen.
+    expect(byId.get('none')).toMatchObject({ replayable: false, partial: false })
+  })
+})

--- a/tests/restored-sessions.test.ts
+++ b/tests/restored-sessions.test.ts
@@ -125,8 +125,8 @@ describe('what a pane is told about one', () => {
     seedRestored([session({ id: 'whole' }), session({ id: 'torn' }), session({ id: 'none' })], NOW)
 
     markRecovered([
-      { id: 'whole', stopped: 'end' },
-      { id: 'torn', stopped: 'checksum' }
+      { id: 'whole', stopped: 'end', closedCleanly: true },
+      { id: 'torn', stopped: 'checksum', closedCleanly: false }
     ])
 
     const byId = new Map(listRestored().map((r) => [r.session.id, r]))

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -50,6 +50,16 @@ class FakeBridge extends EventEmitter {
     super()
     bridges.push(this)
   }
+  target(): string {
+    return this.url
+  }
+  /** As the real one does: point somewhere else and reconnect, not instantly. */
+  retarget(url: string): void {
+    if (url === this.url) return
+    this.url = url
+    this.isConnected = false
+    this.connect()
+  }
   connect(): void {
     setImmediate(() => {
       // Mirrors the real ordering: the socket opens and `connected` fires first,
@@ -431,6 +441,32 @@ describe('an adopted server that dies', () => {
     bridges[0].emit('disconnected')
     await new Promise((r) => setTimeout(r, 20))
     expect(spawned).toEqual([])
+  })
+
+  it('is announced only once the bridge can be asked something', async () => {
+    // The port answering and this app being able to talk to it are two events
+    // with a reconnect between them. Announcing at the first one told every pane
+    // to go and ask the server what it still had, and the bridge rejected the
+    // question -- `Cannot send request: not connected` -- one line before it
+    // connected. A pane reads no answer as "leave the board alone", so a server
+    // dying under a running app changed nothing on screen: the freeze this
+    // announcement exists to end.
+    published.port = 50091
+    published.identity = identityFrom()
+    const { launchServer, onServerReplaced } = await import('../src/main/server/server-launcher')
+    await launchServer()
+    await vi.waitFor(() => expect(bridges[0].isConnected).toBe(true))
+
+    const reachable: boolean[] = []
+    onServerReplaced(() => reachable.push(bridges[0].isConnected))
+
+    published.pidAlive = false
+    bridges[0].isConnected = false
+    bridges[0].emit('disconnected')
+
+    await vi.waitFor(() => expect(reachable).toHaveLength(1))
+    expect(reachable).toEqual([true])
+    onServerReplaced(null)
   })
 
   it('is not replaced once the app has decided to quit', async () => {

--- a/tests/session-persistence.test.ts
+++ b/tests/session-persistence.test.ts
@@ -34,17 +34,19 @@ describe('sessionManager', () => {
     expect(() => sessionManager.saveSessions([])).not.toThrow()
   })
 
-  it('getPreviousSessions returns DB result', () => {
+  it('readPreviousSessions returns DB result', () => {
     const data = [{ id: 's1' }]
     mockGetPrevious.mockReturnValueOnce(data)
-    expect(sessionManager.getPreviousSessions()).toBe(data)
+    expect(sessionManager.readPreviousSessions()).toBe(data)
   })
 
-  it('getPreviousSessions returns [] on error', () => {
+  it('readPreviousSessions returns null on error, which is not the same as none', () => {
     mockGetPrevious.mockImplementationOnce(() => {
       throw new Error('db error')
     })
-    expect(sessionManager.getPreviousSessions()).toEqual([])
+    // History is swept when no session claims it, so reading a failure as "there
+    // are none" would remove every terminal's history for one bad query.
+    expect(sessionManager.readPreviousSessions()).toBeNull()
   })
 
   it('clear delegates to database', () => {

--- a/tests/session-restore-flow.test.ts
+++ b/tests/session-restore-flow.test.ts
@@ -19,7 +19,7 @@ vi.stubGlobal('window', {
 import {
   resolveResumeSessionId,
   buildRestorePayload,
-  reconcileSessions
+  coldSessions
 } from '../src/renderer/lib/session-utils'
 
 const env = { PATH: '/usr/bin' }
@@ -145,7 +145,7 @@ describe('session restore flow: Codex fallback to history', () => {
   })
 })
 
-describe('two answers from the server, made into one board', () => {
+describe('what is left of what is not running', () => {
   const restored = (id: string) => ({
     session: makeSession({ id }),
     endedAt: Date.now() - 3_600_000,
@@ -153,43 +153,24 @@ describe('two answers from the server, made into one board', () => {
     partial: false
   })
 
-  /**
-   * The saved list is not consulted at start-up any more. It said what existed
-   * when it was last written down, and start-up used to launch a replacement
-   * for every record in it -- including sessions that had never stopped, whose
-   * agent was still running and possibly mid-turn.
-   */
-  it('binds what is running and shows what is left of what is not', () => {
-    const { adopt, cold } = reconcileSessions(
-      [makeSession({ id: 'still-going' })],
-      [restored('ended')]
-    )
-
-    expect(adopt.map((s) => s.id)).toEqual(['still-going'])
-    expect(cold.map((r) => r.session.id)).toEqual(['ended'])
+  it('is what the server holds, minus anything that has a process', () => {
+    expect(
+      coldSessions([makeSession({ id: 'still-going' })], [restored('ended')]).map(
+        (r) => r.session.id
+      )
+    ).toEqual(['ended'])
   })
 
-  it('gives a running session one pane, not two', () => {
+  it('never includes a session that is running', () => {
     // The two questions are separate round trips, so a resume happening
     // elsewhere between them can put one id in both answers. The live one wins:
-    // the alternative is a photograph offering to start what is already going.
+    // the alternative is two panes for one terminal, one of them a photograph
+    // offering to start what is already going.
     const both = 'resumed-elsewhere'
-    const { adopt, cold } = reconcileSessions([makeSession({ id: both })], [restored(both)])
-
-    expect(adopt.map((s) => s.id)).toEqual([both])
-    expect(cold).toEqual([])
+    expect(coldSessions([makeSession({ id: both })], [restored(both)])).toEqual([])
   })
 
-  it('gives a pane to a session nothing saved, because the server is the authority', () => {
-    // Started from a phone, or by a workflow, since the last save. It exists,
-    // whatever any record says.
-    const { adopt, cold } = reconcileSessions([makeSession({ id: 'unsaved' })], [])
-
-    expect(adopt.map((s) => s.id)).toEqual(['unsaved'])
-    expect(cold).toEqual([])
-  })
-
-  it('has nothing to show when the server has nothing', () => {
-    expect(reconcileSessions([], [])).toEqual({ adopt: [], cold: [] })
+  it('is empty when the server is holding nothing', () => {
+    expect(coldSessions([makeSession({ id: 'live' })], [])).toEqual([])
   })
 })

--- a/tests/session-restore-flow.test.ts
+++ b/tests/session-restore-flow.test.ts
@@ -145,48 +145,51 @@ describe('session restore flow: Codex fallback to history', () => {
   })
 })
 
-describe('what to bind and what to relaunch', () => {
-  /**
-   * The rule the whole phase turns on. Start-up used to read the saved list and
-   * launch a replacement for every record in it -- including sessions that had
-   * never stopped, whose agent was still running and possibly mid-turn. The
-   * saved list says what existed when it was last written down; the server says
-   * what exists now.
-   */
-  it('binds a saved session that is still running rather than relaunching it', () => {
-    const running = makeSession({ id: 'still-going' })
-
-    const { adopt, orphaned } = reconcileSessions([running], [makeSession({ id: 'still-going' })])
-
-    expect(adopt.map((s) => s.id)).toEqual(['still-going'])
-    // Nothing to relaunch. A second agent against the same work is the failure.
-    expect(orphaned).toEqual([])
+describe('two answers from the server, made into one board', () => {
+  const restored = (id: string) => ({
+    session: makeSession({ id }),
+    endedAt: Date.now() - 3_600_000,
+    replayable: true,
+    partial: false
   })
 
-  it('leaves a saved session with no process behind for the other path', () => {
-    const { adopt, orphaned } = reconcileSessions(
-      [makeSession({ id: 'running' })],
-      [makeSession({ id: 'running' }), makeSession({ id: 'gone' })]
+  /**
+   * The saved list is not consulted at start-up any more. It said what existed
+   * when it was last written down, and start-up used to launch a replacement
+   * for every record in it -- including sessions that had never stopped, whose
+   * agent was still running and possibly mid-turn.
+   */
+  it('binds what is running and shows what is left of what is not', () => {
+    const { adopt, cold } = reconcileSessions(
+      [makeSession({ id: 'still-going' })],
+      [restored('ended')]
     )
 
-    expect(adopt.map((s) => s.id)).toEqual(['running'])
-    expect(orphaned.map((s) => s.id)).toEqual(['gone'])
+    expect(adopt.map((s) => s.id)).toEqual(['still-going'])
+    expect(cold.map((r) => r.session.id)).toEqual(['ended'])
+  })
+
+  it('gives a running session one pane, not two', () => {
+    // The two questions are separate round trips, so a resume happening
+    // elsewhere between them can put one id in both answers. The live one wins:
+    // the alternative is a photograph offering to start what is already going.
+    const both = 'resumed-elsewhere'
+    const { adopt, cold } = reconcileSessions([makeSession({ id: both })], [restored(both)])
+
+    expect(adopt.map((s) => s.id)).toEqual([both])
+    expect(cold).toEqual([])
   })
 
   it('gives a pane to a session nothing saved, because the server is the authority', () => {
-    // A session started from a phone, or by a workflow, between the last save
-    // and this start. It exists, whatever the database remembers.
-    const { adopt, orphaned } = reconcileSessions([makeSession({ id: 'unsaved' })], [])
+    // Started from a phone, or by a workflow, since the last save. It exists,
+    // whatever any record says.
+    const { adopt, cold } = reconcileSessions([makeSession({ id: 'unsaved' })], [])
 
     expect(adopt.map((s) => s.id)).toEqual(['unsaved'])
-    expect(orphaned).toEqual([])
+    expect(cold).toEqual([])
   })
 
-  it('has nothing to do when the server has nothing', () => {
-    const saved = [makeSession({ id: 'one' }), makeSession({ id: 'two' })]
-    const { adopt, orphaned } = reconcileSessions([], saved)
-
-    expect(adopt).toEqual([])
-    expect(orphaned.map((s) => s.id)).toEqual(['one', 'two'])
+  it('has nothing to show when the server has nothing', () => {
+    expect(reconcileSessions([], [])).toEqual({ adopt: [], cold: [] })
   })
 })

--- a/tests/session-restore-flow.test.ts
+++ b/tests/session-restore-flow.test.ts
@@ -16,7 +16,11 @@ vi.stubGlobal('window', {
   }
 })
 
-import { resolveResumeSessionId, buildRestorePayload } from '../src/renderer/lib/session-utils'
+import {
+  resolveResumeSessionId,
+  buildRestorePayload,
+  reconcileSessions
+} from '../src/renderer/lib/session-utils'
 
 const env = { PATH: '/usr/bin' }
 const cmds = DEFAULT_AGENT_COMMANDS
@@ -138,5 +142,51 @@ describe('session restore flow: Codex fallback to history', () => {
     const payload = makePayload({ agentType: 'codex', resumeSessionId: 'codex-sess-1' })
     const line = buildAgentLaunchLine(payload, cmds, env)
     expect(line).toBe('codex resume codex-sess-1')
+  })
+})
+
+describe('what to bind and what to relaunch', () => {
+  /**
+   * The rule the whole phase turns on. Start-up used to read the saved list and
+   * launch a replacement for every record in it -- including sessions that had
+   * never stopped, whose agent was still running and possibly mid-turn. The
+   * saved list says what existed when it was last written down; the server says
+   * what exists now.
+   */
+  it('binds a saved session that is still running rather than relaunching it', () => {
+    const running = makeSession({ id: 'still-going' })
+
+    const { adopt, orphaned } = reconcileSessions([running], [makeSession({ id: 'still-going' })])
+
+    expect(adopt.map((s) => s.id)).toEqual(['still-going'])
+    // Nothing to relaunch. A second agent against the same work is the failure.
+    expect(orphaned).toEqual([])
+  })
+
+  it('leaves a saved session with no process behind for the other path', () => {
+    const { adopt, orphaned } = reconcileSessions(
+      [makeSession({ id: 'running' })],
+      [makeSession({ id: 'running' }), makeSession({ id: 'gone' })]
+    )
+
+    expect(adopt.map((s) => s.id)).toEqual(['running'])
+    expect(orphaned.map((s) => s.id)).toEqual(['gone'])
+  })
+
+  it('gives a pane to a session nothing saved, because the server is the authority', () => {
+    // A session started from a phone, or by a workflow, between the last save
+    // and this start. It exists, whatever the database remembers.
+    const { adopt, orphaned } = reconcileSessions([makeSession({ id: 'unsaved' })], [])
+
+    expect(adopt.map((s) => s.id)).toEqual(['unsaved'])
+    expect(orphaned).toEqual([])
+  })
+
+  it('has nothing to do when the server has nothing', () => {
+    const saved = [makeSession({ id: 'one' }), makeSession({ id: 'two' })]
+    const { adopt, orphaned } = reconcileSessions([], saved)
+
+    expect(adopt).toEqual([])
+    expect(orphaned.map((s) => s.id)).toEqual(['one', 'two'])
   })
 })

--- a/tests/terminal-hydrate.test.ts
+++ b/tests/terminal-hydrate.test.ts
@@ -294,3 +294,38 @@ describe('a seed that never arrives', () => {
     expect(writes()).toEqual(['happened anyway'])
   })
 })
+
+describe('a chunk whose sequence cannot be compared', () => {
+  it('is shown rather than dropped without a word', async () => {
+    // `seq` is required by the protocol, so this means a server not keeping to
+    // it. Filtering on `undefined > 5` is false for every chunk, so the whole
+    // attach window went missing -- silently, which is the one way this must
+    // never fail. Showing it twice would at least be visible.
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = open()
+    emit({ id: ID, data: 'no sequence on this', seq: undefined as unknown as number })
+    await frame()
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+
+    expect(writes().join('')).toContain('no sequence on this')
+  })
+
+  it('still drops what the seed already contained, when the sequence is usable', async () => {
+    // The contrast, so the guard above cannot quietly become "keep everything".
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = open()
+    emit({ id: ID, data: 'already in the seed', seq: 5 })
+    emit({ id: ID, data: 'after the seed', seq: 6 })
+    await frame()
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+
+    expect(writes().join('')).not.toContain('already in the seed')
+    expect(writes().join('')).toContain('after the seed')
+  })
+})

--- a/tests/terminal-hydrate.test.ts
+++ b/tests/terminal-hydrate.test.ts
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const { created } = vi.hoisted(() => ({
+  created: [] as Array<{ id: number; write: ReturnType<typeof vi.fn> }>
+}))
+
+vi.mock('@xterm/xterm', () => {
+  let n = 0
+  class MockTerminal {
+    element: HTMLElement | null = null
+    cols = 80
+    rows = 24
+    options = { fontSize: 13 }
+    buffer = {
+      active: { viewportY: 0, baseY: 0, type: 'normal' },
+      onBufferChange: vi.fn().mockReturnValue({ dispose: vi.fn() })
+    }
+    parser = {
+      registerOscHandler: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      registerCsiHandler: vi.fn().mockReturnValue({ dispose: vi.fn() })
+    }
+    registerMarker = vi.fn()
+    registerDecoration = vi.fn()
+    loadAddon = vi.fn()
+    onData = vi.fn()
+    attachCustomKeyEventHandler = vi.fn()
+    dispose = vi.fn()
+    focus = vi.fn()
+    write = vi.fn()
+    clearSelection = vi.fn()
+    paste = vi.fn()
+    scrollToBottom = vi.fn()
+    scrollToLine = vi.fn()
+    refresh = vi.fn()
+    constructor() {
+      created.push({ id: n++, write: this.write })
+    }
+    open(el: HTMLElement): void {
+      this.element = el
+    }
+    hasSelection(): boolean {
+      return false
+    }
+    getSelection(): string {
+      return ''
+    }
+    onScroll(): { dispose: () => void } {
+      return { dispose: vi.fn() }
+    }
+    onWriteParsed(): { dispose: () => void } {
+      return { dispose: vi.fn() }
+    }
+  }
+  return { Terminal: MockTerminal }
+})
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn()
+  }
+}))
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: class {} }))
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}))
+
+type Chunk = { id: string; data: string; seq: number }
+let emit: (c: Chunk) => void = () => {}
+const attachTerminal = vi.fn()
+
+Object.defineProperty(window, 'api', {
+  value: {
+    onTerminalData: (cb: (c: Chunk) => void) => {
+      emit = cb
+      return () => {}
+    },
+    attachTerminal,
+    writeTerminal: vi.fn(),
+    resizeTerminal: vi.fn(),
+    openExternal: vi.fn()
+  },
+  writable: true
+})
+
+import {
+  registerSlot,
+  destroyTerminal,
+  hydrateTerminal,
+  registerStatusHandler,
+  initGlobalDataListener,
+  disposeGlobalDataListener
+} from '../src/renderer/lib/terminal-registry'
+
+/**
+ * Seeding a pane with a terminal it did not create.
+ *
+ * The ordering here is the whole feature and every way of getting it wrong is
+ * invisible at the time: bytes applied ahead of the seed are overwritten by it,
+ * bytes the seed already contains are printed twice, and bytes that arrive while
+ * the request is in flight are simply gone. None of that shows until somebody
+ * scrolls back.
+ */
+
+const ID = 'a-session'
+
+function slot(): HTMLDivElement {
+  const el = document.createElement('div')
+  el.getBoundingClientRect = () =>
+    ({
+      top: 0,
+      left: 0,
+      width: 400,
+      height: 300,
+      right: 400,
+      bottom: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }) as DOMRect
+  return el
+}
+
+const frame = (): Promise<void> => new Promise((r) => requestAnimationFrame(() => r()))
+
+/** What was written into this session's terminal, in order. */
+function writes(): string[] {
+  return created[created.length - 1]!.write.mock.calls.map((c) => c[0] as string)
+}
+
+beforeEach(() => {
+  created.length = 0
+  attachTerminal.mockReset()
+  initGlobalDataListener()
+  registerSlot(ID, slot())
+})
+
+afterEach(() => {
+  destroyTerminal(ID)
+  disposeGlobalDataListener()
+})
+
+describe('what the seed already contains', () => {
+  it('is not applied a second time', async () => {
+    // The chunk arrives while the request is in flight and is numbered at or
+    // below what comes back, so the scrollback already holds it.
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = hydrateTerminal(ID)
+    emit({ id: ID, data: 'already in the seed', seq: 5 })
+    await frame()
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+
+    expect(writes()).toEqual(['THE SEED'])
+  })
+
+  it('does not swallow what came after it', async () => {
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = hydrateTerminal(ID)
+    emit({ id: ID, data: 'in the seed', seq: 5 })
+    emit({ id: ID, data: 'after the seed', seq: 6 })
+    await frame()
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+
+    expect(writes()).toEqual(['THE SEED', 'after the seed'])
+  })
+
+  it('keeps later chunks in the order they happened', async () => {
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = hydrateTerminal(ID)
+    for (const [data, seq] of [
+      ['first', 6],
+      ['second', 7],
+      ['third', 8]
+    ] as const) {
+      emit({ id: ID, data, seq })
+    }
+    await frame()
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+
+    expect(writes()).toEqual(['THE SEED', 'first', 'second', 'third'])
+  })
+})
+
+describe('nothing is written ahead of the seed', () => {
+  it('holds live output from before the request was answered', async () => {
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = hydrateTerminal(ID)
+    emit({ id: ID, data: 'arrived first', seq: 9 })
+    await frame()
+
+    // Nothing yet: writing this now would put it above a seed that has not
+    // landed, and the seed would then paint over it.
+    expect(writes()).toEqual([])
+
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+    expect(writes()).toEqual(['THE SEED', 'arrived first'])
+  })
+})
+
+describe('the bell', () => {
+  it('does not ring for output that is only being replayed', async () => {
+    // The one thing that scans terminal output fires a desktop notification on
+    // \x07. A restored screen holding a bell an agent rang an hour ago must not
+    // announce itself as though it had just happened.
+    const handler = vi.fn()
+    registerStatusHandler(ID, handler)
+    attachTerminal.mockResolvedValue({ data: 'ding \x07 ding', seq: 3, live: false })
+
+    await hydrateTerminal(ID)
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('rings for a bell that arrived while the seed was in flight', async () => {
+    // Those bytes are live -- they rang a moment ago. Holding them back for the
+    // length of a round trip and then writing them silently would drop the
+    // notification for the one case where the pane was not yet looking.
+    const handler = vi.fn()
+    registerStatusHandler(ID, handler)
+    let answer: (v: unknown) => void = () => {}
+    attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
+
+    const hydrating = hydrateTerminal(ID)
+    emit({ id: ID, data: 'attention \x07', seq: 9 })
+    await frame()
+    answer({ data: 'THE SEED', seq: 5, live: true })
+    await hydrating
+
+    expect(handler).toHaveBeenCalledWith('attention \x07')
+  })
+
+  it('still rings for output that is actually arriving', async () => {
+    const handler = vi.fn()
+    registerStatusHandler(ID, handler)
+    attachTerminal.mockResolvedValue({ data: 'seed', seq: 3, live: true })
+    await hydrateTerminal(ID)
+
+    emit({ id: ID, data: 'live \x07', seq: 4 })
+    await frame()
+
+    expect(handler).toHaveBeenCalledWith('live \x07')
+  })
+})
+
+describe('asking twice', () => {
+  it('seeds once, however many panes ask', async () => {
+    // A second window, a reconnect and a re-render all land here. Seeding twice
+    // would double the scrollback.
+    attachTerminal.mockResolvedValue({ data: 'THE SEED', seq: 1, live: true })
+
+    await hydrateTerminal(ID)
+    await hydrateTerminal(ID)
+
+    expect(attachTerminal).toHaveBeenCalledTimes(1)
+    expect(writes()).toEqual(['THE SEED'])
+  })
+})
+
+describe('a seed that never arrives', () => {
+  it('lets the held output through rather than losing it', async () => {
+    attachTerminal.mockRejectedValue(new Error('the server went away'))
+    const quiet = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const hydrating = hydrateTerminal(ID)
+    emit({ id: ID, data: 'happened anyway', seq: 2 })
+    await frame()
+    await hydrating
+    quiet.mockRestore()
+
+    expect(writes()).toEqual(['happened anyway'])
+  })
+})

--- a/tests/terminal-hydrate.test.ts
+++ b/tests/terminal-hydrate.test.ts
@@ -195,7 +195,10 @@ describe('what the seed already contains', () => {
     answer({ data: 'THE SEED', seq: 5, live: true })
     await hydrating
 
-    expect(writes()).toEqual(['THE SEED', 'first', 'second', 'third'])
+    // One write, not three. xterm queues a task per call, and the held chunks
+    // are already in order -- joining them is the same bytes at a third of the
+    // scheduling.
+    expect(writes()).toEqual(['THE SEED', 'firstsecondthird'])
   })
 })
 
@@ -225,7 +228,7 @@ describe('the bell', () => {
     // announce itself as though it had just happened.
     const handler = vi.fn()
     registerStatusHandler(ID, handler)
-    attachTerminal.mockResolvedValue({ data: 'ding \x07 ding', seq: 3, live: false })
+    attachTerminal.mockResolvedValue({ data: 'ding \x07 ding', seq: 3, live: true })
 
     await open()
 

--- a/tests/terminal-hydrate.test.ts
+++ b/tests/terminal-hydrate.test.ts
@@ -126,11 +126,22 @@ function writes(): string[] {
   return created[created.length - 1]!.write.mock.calls.map((c) => c[0] as string)
 }
 
+/**
+ * Open the pane, which is what starts the seed.
+ *
+ * Production hydrates when the terminal is built rather than when somebody asks,
+ * so the mock has to be armed before this and not after. Awaiting the returned
+ * promise joins the seed already in flight; it does not start a second.
+ */
+function open(): Promise<void> {
+  registerSlot(ID, slot())
+  return hydrateTerminal(ID)
+}
+
 beforeEach(() => {
   created.length = 0
   attachTerminal.mockReset()
   initGlobalDataListener()
-  registerSlot(ID, slot())
 })
 
 afterEach(() => {
@@ -145,7 +156,7 @@ describe('what the seed already contains', () => {
     let answer: (v: unknown) => void = () => {}
     attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
 
-    const hydrating = hydrateTerminal(ID)
+    const hydrating = open()
     emit({ id: ID, data: 'already in the seed', seq: 5 })
     await frame()
     answer({ data: 'THE SEED', seq: 5, live: true })
@@ -158,7 +169,7 @@ describe('what the seed already contains', () => {
     let answer: (v: unknown) => void = () => {}
     attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
 
-    const hydrating = hydrateTerminal(ID)
+    const hydrating = open()
     emit({ id: ID, data: 'in the seed', seq: 5 })
     emit({ id: ID, data: 'after the seed', seq: 6 })
     await frame()
@@ -172,7 +183,7 @@ describe('what the seed already contains', () => {
     let answer: (v: unknown) => void = () => {}
     attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
 
-    const hydrating = hydrateTerminal(ID)
+    const hydrating = open()
     for (const [data, seq] of [
       ['first', 6],
       ['second', 7],
@@ -193,7 +204,7 @@ describe('nothing is written ahead of the seed', () => {
     let answer: (v: unknown) => void = () => {}
     attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
 
-    const hydrating = hydrateTerminal(ID)
+    const hydrating = open()
     emit({ id: ID, data: 'arrived first', seq: 9 })
     await frame()
 
@@ -216,7 +227,7 @@ describe('the bell', () => {
     registerStatusHandler(ID, handler)
     attachTerminal.mockResolvedValue({ data: 'ding \x07 ding', seq: 3, live: false })
 
-    await hydrateTerminal(ID)
+    await open()
 
     expect(handler).not.toHaveBeenCalled()
   })
@@ -230,7 +241,7 @@ describe('the bell', () => {
     let answer: (v: unknown) => void = () => {}
     attachTerminal.mockReturnValue(new Promise((r) => (answer = r)))
 
-    const hydrating = hydrateTerminal(ID)
+    const hydrating = open()
     emit({ id: ID, data: 'attention \x07', seq: 9 })
     await frame()
     answer({ data: 'THE SEED', seq: 5, live: true })
@@ -243,7 +254,7 @@ describe('the bell', () => {
     const handler = vi.fn()
     registerStatusHandler(ID, handler)
     attachTerminal.mockResolvedValue({ data: 'seed', seq: 3, live: true })
-    await hydrateTerminal(ID)
+    await open()
 
     emit({ id: ID, data: 'live \x07', seq: 4 })
     await frame()
@@ -258,7 +269,7 @@ describe('asking twice', () => {
     // would double the scrollback.
     attachTerminal.mockResolvedValue({ data: 'THE SEED', seq: 1, live: true })
 
-    await hydrateTerminal(ID)
+    await open()
     await hydrateTerminal(ID)
 
     expect(attachTerminal).toHaveBeenCalledTimes(1)
@@ -271,7 +282,7 @@ describe('a seed that never arrives', () => {
     attachTerminal.mockRejectedValue(new Error('the server went away'))
     const quiet = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    const hydrating = hydrateTerminal(ID)
+    const hydrating = open()
     emit({ id: ID, data: 'happened anyway', seq: 2 })
     await frame()
     await hydrating

--- a/tests/terminal-screen-memory.process.test.ts
+++ b/tests/terminal-screen-memory.process.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { spawnSync } from 'node:child_process'
-import path from 'node:path'
+import { runMeasurement } from './helpers/run-measurement'
+import { spawnsRealServers } from './helpers/one-at-a-time'
 
 /**
  * What fifty screen models cost, and whether they are given back.
@@ -22,6 +22,10 @@ import path from 'node:path'
  * nothing at all.
  */
 
+// Takes the same lock the server suites take. This one measures wall-clock and
+// heap, so anything spawning beside it is measuring something else.
+spawnsRealServers()
+
 interface Measurement {
   sessions: number
   cols: number
@@ -33,23 +37,11 @@ interface Measurement {
   residualSecond: number
 }
 
-function measure(): Measurement {
-  const script = path.join(__dirname, 'helpers', 'measure-screens.ts')
-  const run = spawnSync('npx', ['tsx', script], {
-    cwd: path.join(__dirname, '..'),
-    encoding: 'utf-8',
-    env: { ...process.env, NODE_OPTIONS: '--expose-gc' },
-    timeout: 180_000
-  })
-  if (run.status !== 0) {
-    throw new Error(`measurement failed (${run.status}):\n${run.stderr}`)
-  }
-  const line = run.stdout.trim().split('\n').pop() ?? ''
-  return JSON.parse(line) as Measurement
-}
-
 describe('fifty sessions', () => {
-  const result = measure()
+  const result = runMeasurement<Measurement>('measure-screens.ts', {
+    env: { NODE_OPTIONS: '--expose-gc' },
+    timeoutMs: 180_000
+  })
   const mb = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`
 
   it('models every one of them', () => {

--- a/tests/terminal-screen-memory.process.test.ts
+++ b/tests/terminal-screen-memory.process.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+/**
+ * What fifty screen models cost, and whether they are given back.
+ *
+ * Every PTY now carries a headless emulator, so the question "what does this
+ * cost at scale" has an answer that has to be measured rather than reasoned
+ * about — the whole reason the model runs with no scrollback is a claim about
+ * memory, and a claim about memory is worth what its measurement is worth.
+ *
+ * Measured in a child process, not here. This worker's heap holds the module
+ * graph, React and whatever the rest of the suite left behind, and that noise is
+ * larger than the thing being measured. The child runs with `--expose-gc`,
+ * because without it there is no way to tell "released" from "not collected
+ * yet", and a number that cannot tell those apart is not a measurement.
+ *
+ * The assertions are a ceiling and a release, never a point value. Heap numbers
+ * move with the Node version and the machine, and a tight assertion here would
+ * be a flaky test — which in this position gets deleted within a month, leaving
+ * nothing at all.
+ */
+
+interface Measurement {
+  sessions: number
+  cols: number
+  rows: number
+  modelled: number
+  remaining: number
+  heldBytes: number
+  residualFirst: number
+  residualSecond: number
+}
+
+function measure(): Measurement {
+  const script = path.join(__dirname, 'helpers', 'measure-screens.ts')
+  const run = spawnSync('npx', ['tsx', script], {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf-8',
+    env: { ...process.env, NODE_OPTIONS: '--expose-gc' },
+    timeout: 180_000
+  })
+  if (run.status !== 0) {
+    throw new Error(`measurement failed (${run.status}):\n${run.stderr}`)
+  }
+  const line = run.stdout.trim().split('\n').pop() ?? ''
+  return JSON.parse(line) as Measurement
+}
+
+describe('fifty sessions', () => {
+  const result = measure()
+  const mb = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`
+
+  it('models every one of them', () => {
+    expect(result.modelled).toBe(result.sessions)
+    expect(result.remaining).toBe(0)
+  })
+
+  it('costs an amount worth paying', () => {
+    // Roughly 8 MB when this was written, at 200x50 with realistic coloured
+    // output. The ceiling is generous on purpose: what would matter is a change
+    // that made this an order of magnitude worse -- giving the model the
+    // client's two thousand lines of scrollback, say, which computes to around
+    // a quarter of a gigabyte here.
+    expect(result.heldBytes, `held ${mb(result.heldBytes)} for ${result.sessions}`).toBeLessThan(
+      32 * 1024 * 1024
+    )
+  })
+
+  it('gives it back when the terminals go', () => {
+    // What this catches is a retained *reference* -- a `clearScreen` that stopped
+    // removing the entry from the map would keep every session ever closed
+    // resident, and this reports 3.9 MB against 51 KB when that happens.
+    //
+    // What it does not catch, checked rather than assumed: a missing
+    // `term.dispose()`. Dropping the map entry leaves the terminal unreachable
+    // and V8 collects it either way, so dispose earns its place by releasing
+    // xterm's internal listeners rather than by returning heap. Worth saying,
+    // because the obvious reading of this test is the wrong one.
+    //
+    // Measured on the second cycle rather than the first. The first leaves
+    // several hundred kilobytes behind whatever happens -- module init, lazy V8
+    // structures, xterm's own one-time setup -- and a leak is a thing that
+    // accumulates, so a second identical cycle is what tells them apart. It came
+    // back to about 50 KB against 8 MB held.
+    expect(
+      result.residualSecond,
+      `held ${mb(result.heldBytes)}, kept ${mb(result.residualSecond)} after release`
+    ).toBeLessThan(result.heldBytes / 8)
+  })
+}, 180_000)

--- a/tests/terminal-screen.test.ts
+++ b/tests/terminal-screen.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { Terminal } from '@xterm/headless'
+import {
+  feedScreen,
+  resizeScreen,
+  serializeScreen,
+  clearScreen,
+  screenCount,
+  resetScreens
+} from '../packages/server/src/terminal-screen'
+
+/**
+ * Modelling the screen rather than the bytes.
+ *
+ * A headless terminal is a pure function from bytes to a buffer, so almost all
+ * of this needs no PTY: feed the bytes a program would emit and ask what the
+ * screen became. The one thing that cannot be tested here is that `pty-manager`
+ * calls these at all, which is why the wiring is three lines with nothing to get
+ * wrong.
+ */
+
+const ESC = '\x1b'
+
+beforeEach(resetScreens)
+afterEach(resetScreens)
+
+/** Write a serialized screen into a fresh terminal, as a client would. */
+async function restore(dump: string, cols = 80, rows = 24): Promise<Terminal> {
+  const term = new Terminal({ cols, rows, scrollback: 0, allowProposedApi: true })
+  await new Promise<void>((resolve) => term.write(dump, resolve))
+  return term
+}
+
+/** Every cell of a row, as `char/fg/bg`, so a mismatch says which cell. */
+function row(term: Terminal, y: number): string {
+  const line = term.buffer.active.getLine(y)
+  if (!line) return ''
+  const cells: string[] = []
+  for (let x = 0; x < term.cols; x++) {
+    const cell = line.getCell(x)
+    if (!cell) continue
+    cells.push(`${cell.getChars() || ' '}/${cell.getFgColor()}/${cell.getBgColor()}`)
+  }
+  return cells.join('|')
+}
+
+describe('what the screen looks like when it comes back', () => {
+  it('reproduces text and colour cell for cell', async () => {
+    feedScreen('t', `${ESC}[31mred${ESC}[0m plain ${ESC}[1;34mbold blue${ESC}[0m`)
+    const dump = await serializeScreen('t')
+
+    const restored = await restore(dump)
+    const live = await restore(`${ESC}[31mred${ESC}[0m plain ${ESC}[1;34mbold blue${ESC}[0m`)
+
+    expect(row(restored, 0)).toBe(row(live, 0))
+    restored.dispose()
+    live.dispose()
+  })
+
+  it('puts the cursor back where it was', async () => {
+    feedScreen('t', `line one\r\nline two\r\n${ESC}[1;4H`)
+    const dump = await serializeScreen('t')
+
+    const restored = await restore(dump)
+
+    expect(restored.buffer.active.cursorY).toBe(0)
+    expect(restored.buffer.active.cursorX).toBe(3)
+    restored.dispose()
+  })
+
+  it('carries an alternate-screen program mid-render', async () => {
+    // What a TUI leaves behind: the alternate screen active, a painted frame,
+    // colours, and the cursor parked somewhere inside it. Bytes alone cannot say
+    // the alternate screen is the active one -- that is a mode, not a character.
+    const paint =
+      `${ESC}[?1049h${ESC}[2J${ESC}[H` +
+      `${ESC}[44m Status ${ESC}[0m\r\n` +
+      `${ESC}[32m M src/index.ts${ESC}[0m\r\n` +
+      `${ESC}[2;3H`
+    feedScreen('t', paint)
+    const dump = await serializeScreen('t')
+
+    const restored = await restore(dump)
+    const live = await restore(paint)
+
+    expect(row(restored, 0)).toBe(row(live, 0))
+    expect(row(restored, 1)).toBe(row(live, 1))
+    expect(restored.buffer.active.cursorY).toBe(live.buffer.active.cursorY)
+    expect(restored.buffer.active.cursorX).toBe(live.buffer.active.cursorX)
+    restored.dispose()
+    live.dispose()
+  })
+})
+
+describe('answering queries, which it must never do', () => {
+  it('has no subscriber to answer through, and no way to grow one', () => {
+    // There was a test here that built a spy, never attached it to anything, and
+    // asserted it was not called. It passed against every possible version of
+    // this module, including one wired straight to the PTY, which is worth more
+    // as a warning than the assertion was worth as a test.
+    //
+    // The protection is that nothing subscribes, so the invariant *is* the
+    // absence, and the honest way to check an absence is to look for it. The
+    // end-to-end proof -- that a query reaches no PTY -- lives in
+    // `pty-manager-screen.test.ts`, where there is a PTY to watch.
+    const source = fs.readFileSync(
+      path.join(__dirname, '..', 'packages', 'server', 'src', 'terminal-screen.ts'),
+      'utf-8'
+    )
+
+    expect(source).not.toMatch(/\.onData\s*\(/)
+    expect(source).not.toMatch(/\.onBinary\s*\(/)
+  })
+
+  it('produces a snapshot that asks nothing of whoever restores it', async () => {
+    // The other half: a serialized screen is fed back into a live terminal, and
+    // that terminal's replies do go to the PTY. If a snapshot carried a query,
+    // restoring one would type into the user's shell.
+    feedScreen('q', `${ESC}[cbefore${ESC}[5nafter`)
+    const dump = await serializeScreen('q')
+
+    const replies: string[] = []
+    const restored = new Terminal({ cols: 80, rows: 24, scrollback: 0, allowProposedApi: true })
+    restored.onData((d) => replies.push(d))
+    await new Promise<void>((resolve) => restored.write(dump, resolve))
+
+    expect(replies).toEqual([])
+    restored.dispose()
+  })
+
+  it('really would answer, if anything were listening', async () => {
+    // The counterpart that makes the two above mean something. A test asserting
+    // silence proves nothing unless the thing could speak -- and this one can:
+    // feed the same query to a terminal with a listener and it replies.
+    const replies: string[] = []
+    const term = new Terminal({ cols: 80, rows: 24, scrollback: 0, allowProposedApi: true })
+    term.onData((d) => replies.push(d))
+    await new Promise<void>((resolve) => term.write(`${ESC}[c`, resolve))
+
+    expect(replies.length).toBeGreaterThan(0)
+    expect(replies.join('')).toContain('[?')
+    term.dispose()
+  })
+})
+
+describe('reading a screen that is still being written', () => {
+  it('waits for the write rather than returning a half-parsed screen', async () => {
+    // `term.write` queues a macrotask; serializing straight after it would
+    // return whatever had been parsed by then, which is usually nothing. That
+    // failure is invisible in a test that happens to yield, and shows up under
+    // load instead.
+    feedScreen('t', 'hello world')
+    const dump = await serializeScreen('t')
+
+    expect(dump).toContain('hello world')
+  })
+
+  it('sees every write in order when several arrive before a read', async () => {
+    feedScreen('t', 'one ')
+    feedScreen('t', 'two ')
+    feedScreen('t', 'three')
+
+    expect(await serializeScreen('t')).toContain('one two three')
+  })
+})
+
+describe('following the terminal it models', () => {
+  it('starts at the geometry the session was given', async () => {
+    feedScreen('t', 'x'.repeat(100), 40, 10)
+    const dump = await serializeScreen('t')
+
+    // Forty columns means the hundred characters wrap onto a third line; eighty
+    // would not. The wrap is the observable difference.
+    const restored = await restore(dump, 40, 10)
+    expect(restored.buffer.active.getLine(2)?.translateToString(true)).toContain('x')
+    restored.dispose()
+  })
+
+  it('falls back to a PTY default when the session has no geometry', async () => {
+    feedScreen('t', 'hello')
+    expect(await serializeScreen('t')).toContain('hello')
+  })
+
+  it('follows a resize', async () => {
+    feedScreen('t', 'hello', 80, 24)
+    resizeScreen('t', 100, 40)
+    feedScreen('t', ' world')
+
+    expect(await serializeScreen('t')).toContain('hello world')
+  })
+
+  it('ignores a resize for a session it does not model', () => {
+    expect(() => resizeScreen('absent', 100, 40)).not.toThrow()
+  })
+})
+
+describe('keeping terminals apart, and letting them go', () => {
+  it('models each session separately', async () => {
+    feedScreen('a', 'first')
+    feedScreen('b', 'second')
+
+    expect(await serializeScreen('a')).toContain('first')
+    expect(await serializeScreen('a')).not.toContain('second')
+    expect(await serializeScreen('b')).toContain('second')
+  })
+
+  it('reads a session it has never seen as empty', async () => {
+    expect(await serializeScreen('never')).toBe('')
+  })
+
+  it('forgets a terminal that has gone', async () => {
+    feedScreen('t', 'something')
+    expect(screenCount()).toBe(1)
+
+    clearScreen('t')
+
+    expect(screenCount()).toBe(0)
+    expect(await serializeScreen('t')).toBe('')
+  })
+
+  it('does not throw when clearing one that was never there', () => {
+    expect(() => clearScreen('absent')).not.toThrow()
+  })
+
+  it('releases every terminal it held', () => {
+    for (let i = 0; i < 20; i++) feedScreen(`s${i}`, 'output')
+    expect(screenCount()).toBe(20)
+
+    resetScreens()
+
+    expect(screenCount()).toBe(0)
+  })
+})

--- a/tests/terminal-screen.test.ts
+++ b/tests/terminal-screen.test.ts
@@ -109,6 +109,64 @@ describe('a terminal that goes away while it is being read', () => {
   )
 })
 
+describe('where the shell says it is', () => {
+  it("follows the sequence Vorn's own integration emits", async () => {
+    // The handler this model started with listens on OSC 7, which is what other
+    // terminals use. Vorn's shell integration has always emitted `5522;cwd;`
+    // instead -- so the cwd was empty for every Vorn shell, and the checkpoint
+    // has been carrying an empty field since it was written.
+    createScreen('shell', 80, 24)
+    feedScreen('shell', `${ESC}]5522;cwd;/Users/x/dev/vorn\x07`)
+
+    expect((await serializeScreen('shell'))?.cwd).toBe('/Users/x/dev/vorn')
+  })
+
+  it('still follows the one other terminals use', async () => {
+    createScreen('shell', 80, 24)
+    feedScreen('shell', `${ESC}]7;file://host/Users/x/dev/other\x07`)
+
+    expect((await serializeScreen('shell'))?.cwd).toBe('/Users/x/dev/other')
+  })
+
+  it('survives a directory with a percent in its name', async () => {
+    // The path is not percent-encoded on this sequence, so it is taken as-is --
+    // and a directory called `100%` is a directory somebody has.
+    createScreen('shell', 80, 24)
+    feedScreen('shell', `${ESC}]5522;cwd;/tmp/100%\x07`)
+
+    expect((await serializeScreen('shell'))?.cwd).toBe('/tmp/100%')
+  })
+
+  it("ignores the integration's other reports", async () => {
+    createScreen('shell', 80, 24)
+    feedScreen('shell', `${ESC}]5522;cmd;bHM=\x07`)
+    feedScreen('shell', `${ESC}]5522;dur;120\x07`)
+
+    expect((await serializeScreen('shell'))?.cwd).toBe('')
+  })
+
+  it('keeps it bounded like the title', async () => {
+    createScreen('shell', 80, 24)
+    feedScreen('shell', `${ESC}]5522;cwd;/${'p'.repeat(5_000_000)}\x07`)
+
+    expect(((await serializeScreen('shell'))?.cwd.length ?? 0) <= 512).toBe(true)
+  })
+})
+
+describe('a screen rebuilt from a checkpoint', () => {
+  it('is given back the title and directory the serializer cannot carry', async () => {
+    // Neither is an escape sequence: they arrive as notifications and the
+    // serializer does not round-trip them. The checkpoint stores both, and
+    // recovery used to drop them on the floor.
+    createScreen('restored', 100, 30, { title: 'vorn — building', cwd: '/Users/x/dev/vorn' })
+
+    expect(await serializeScreen('restored')).toMatchObject({
+      title: 'vorn — building',
+      cwd: '/Users/x/dev/vorn'
+    })
+  })
+})
+
 describe('what a program can make the model hold', () => {
   it('keeps a title bounded, whatever length the program sends', async () => {
     // Both the title and the cwd live for as long as the terminal does and both

--- a/tests/terminal-screen.test.ts
+++ b/tests/terminal-screen.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { Terminal } from '@xterm/headless'
 import {
+  createScreen,
   feedScreen,
   resizeScreen,
   serializeScreen,
@@ -23,14 +24,41 @@ import {
 
 const ESC = '\x1b'
 
-beforeEach(resetScreens)
+const started = new Set<string>()
+
+beforeEach(() => {
+  resetScreens()
+  started.clear()
+})
 afterEach(resetScreens)
+
+/**
+ * Start a screen if this test has not already, then feed it.
+ *
+ * Production creates once, at the spawn, and feeds on every flush thereafter --
+ * so the geometry is stated once rather than carried on every chunk. These read
+ * the same way.
+ */
+function feed(id: string, data: string, cols = 80, rows = 24): void {
+  if (!started.has(id)) {
+    createScreen(id, cols, rows)
+    started.add(id)
+  }
+  feedScreen(id, data)
+}
 
 /** Write a serialized screen into a fresh terminal, as a client would. */
 async function restore(dump: string, cols = 80, rows = 24): Promise<Terminal> {
   const term = new Terminal({ cols, rows, scrollback: 0, allowProposedApi: true })
   await new Promise<void>((resolve) => term.write(dump, resolve))
   return term
+}
+
+/** Every cell of every row, so a mismatch says which cell of which row. */
+function screenOf(term: Terminal): string[] {
+  const rows: string[] = []
+  for (let y = 0; y < term.rows; y++) rows.push(row(term, y))
+  return rows
 }
 
 /** Every cell of a row, as `char/fg/bg`, so a mismatch says which cell. */
@@ -48,20 +76,25 @@ function row(term: Terminal, y: number): string {
 
 describe('what the screen looks like when it comes back', () => {
   it('reproduces text and colour cell for cell', async () => {
-    feedScreen('t', `${ESC}[31mred${ESC}[0m plain ${ESC}[1;34mbold blue${ESC}[0m`)
-    const dump = await serializeScreen('t')
+    feed('t', `${ESC}[31mred${ESC}[0m plain ${ESC}[1;34mbold blue${ESC}[0m`)
+    const snapshot = await serializeScreen('t')
+    const dump = snapshot?.screen ?? ''
 
     const restored = await restore(dump)
     const live = await restore(`${ESC}[31mred${ESC}[0m plain ${ESC}[1;34mbold blue${ESC}[0m`)
 
-    expect(row(restored, 0)).toBe(row(live, 0))
+    // Every cell of every row, not just the one with text on it. A screen that
+    // matched on row zero and diverged on row nine would be exactly the quiet
+    // wrongness this is meant to rule out.
+    expect(screenOf(restored)).toEqual(screenOf(live))
     restored.dispose()
     live.dispose()
   })
 
   it('puts the cursor back where it was', async () => {
-    feedScreen('t', `line one\r\nline two\r\n${ESC}[1;4H`)
-    const dump = await serializeScreen('t')
+    feed('t', `line one\r\nline two\r\n${ESC}[1;4H`)
+    const snapshot = await serializeScreen('t')
+    const dump = snapshot?.screen ?? ''
 
     const restored = await restore(dump)
 
@@ -79,14 +112,15 @@ describe('what the screen looks like when it comes back', () => {
       `${ESC}[44m Status ${ESC}[0m\r\n` +
       `${ESC}[32m M src/index.ts${ESC}[0m\r\n` +
       `${ESC}[2;3H`
-    feedScreen('t', paint)
-    const dump = await serializeScreen('t')
+    feed('t', paint)
+    const snapshot = await serializeScreen('t')
+    const dump = snapshot?.screen ?? ''
 
     const restored = await restore(dump)
     const live = await restore(paint)
 
-    expect(row(restored, 0)).toBe(row(live, 0))
-    expect(row(restored, 1)).toBe(row(live, 1))
+    expect(screenOf(restored)).toEqual(screenOf(live))
+    expect(restored.buffer.active.type, 'not on the alternate screen').toBe('alternate')
     expect(restored.buffer.active.cursorY).toBe(live.buffer.active.cursorY)
     expect(restored.buffer.active.cursorX).toBe(live.buffer.active.cursorX)
     restored.dispose()
@@ -118,8 +152,9 @@ describe('answering queries, which it must never do', () => {
     // The other half: a serialized screen is fed back into a live terminal, and
     // that terminal's replies do go to the PTY. If a snapshot carried a query,
     // restoring one would type into the user's shell.
-    feedScreen('q', `${ESC}[cbefore${ESC}[5nafter`)
-    const dump = await serializeScreen('q')
+    feed('q', `${ESC}[cbefore${ESC}[5nafter`)
+    const snapshot = await serializeScreen('q')
+    const dump = snapshot?.screen ?? ''
 
     const replies: string[] = []
     const restored = new Terminal({ cols: 80, rows: 24, scrollback: 0, allowProposedApi: true })
@@ -151,25 +186,27 @@ describe('reading a screen that is still being written', () => {
     // return whatever had been parsed by then, which is usually nothing. That
     // failure is invisible in a test that happens to yield, and shows up under
     // load instead.
-    feedScreen('t', 'hello world')
-    const dump = await serializeScreen('t')
+    feed('t', 'hello world')
+    const snapshot = await serializeScreen('t')
+    const dump = snapshot?.screen ?? ''
 
     expect(dump).toContain('hello world')
   })
 
   it('sees every write in order when several arrive before a read', async () => {
-    feedScreen('t', 'one ')
-    feedScreen('t', 'two ')
-    feedScreen('t', 'three')
+    feed('t', 'one ')
+    feed('t', 'two ')
+    feed('t', 'three')
 
-    expect(await serializeScreen('t')).toContain('one two three')
+    expect((await serializeScreen('t'))?.screen).toContain('one two three')
   })
 })
 
 describe('following the terminal it models', () => {
   it('starts at the geometry the session was given', async () => {
-    feedScreen('t', 'x'.repeat(100), 40, 10)
-    const dump = await serializeScreen('t')
+    feed('t', 'x'.repeat(100), 40, 10)
+    const snapshot = await serializeScreen('t')
+    const dump = snapshot?.screen ?? ''
 
     // Forty columns means the hundred characters wrap onto a third line; eighty
     // would not. The wrap is the observable difference.
@@ -179,45 +216,45 @@ describe('following the terminal it models', () => {
   })
 
   it('falls back to a PTY default when the session has no geometry', async () => {
-    feedScreen('t', 'hello')
-    expect(await serializeScreen('t')).toContain('hello')
+    feed('t', 'hello')
+    expect((await serializeScreen('t'))?.screen).toContain('hello')
   })
 
   it('follows a resize', async () => {
-    feedScreen('t', 'hello', 80, 24)
-    resizeScreen('t', 100, 40)
-    feedScreen('t', ' world')
+    feed('t', 'hello', 80, 24)
+    await resizeScreen('t', 100, 40)
+    feed('t', ' world')
 
-    expect(await serializeScreen('t')).toContain('hello world')
+    expect((await serializeScreen('t'))?.screen).toContain('hello world')
   })
 
-  it('ignores a resize for a session it does not model', () => {
-    expect(() => resizeScreen('absent', 100, 40)).not.toThrow()
+  it('ignores a resize for a session it does not model', async () => {
+    await expect(resizeScreen('absent', 100, 40)).resolves.toBeUndefined()
   })
 })
 
 describe('keeping terminals apart, and letting them go', () => {
   it('models each session separately', async () => {
-    feedScreen('a', 'first')
-    feedScreen('b', 'second')
+    feed('a', 'first')
+    feed('b', 'second')
 
-    expect(await serializeScreen('a')).toContain('first')
-    expect(await serializeScreen('a')).not.toContain('second')
-    expect(await serializeScreen('b')).toContain('second')
+    expect((await serializeScreen('a'))?.screen).toContain('first')
+    expect((await serializeScreen('a'))?.screen).not.toContain('second')
+    expect((await serializeScreen('b'))?.screen).toContain('second')
   })
 
   it('reads a session it has never seen as empty', async () => {
-    expect(await serializeScreen('never')).toBe('')
+    expect(await serializeScreen('never')).toBeNull()
   })
 
   it('forgets a terminal that has gone', async () => {
-    feedScreen('t', 'something')
+    feed('t', 'something')
     expect(screenCount()).toBe(1)
 
     clearScreen('t')
 
     expect(screenCount()).toBe(0)
-    expect(await serializeScreen('t')).toBe('')
+    expect(await serializeScreen('t')).toBeNull()
   })
 
   it('does not throw when clearing one that was never there', () => {
@@ -225,11 +262,94 @@ describe('keeping terminals apart, and letting them go', () => {
   })
 
   it('releases every terminal it held', () => {
-    for (let i = 0; i < 20; i++) feedScreen(`s${i}`, 'output')
+    for (let i = 0; i < 20; i++) feed(`s${i}`, 'output')
     expect(screenCount()).toBe(20)
 
     resetScreens()
 
     expect(screenCount()).toBe(0)
+  })
+})
+
+describe('what travels beside the screen', () => {
+  it('carries the geometry it has to be replayed at', async () => {
+    // Without it a caller cannot know what size to restore into, and a screen
+    // replayed at the wrong width wraps in different places -- which is the
+    // whole failure this model exists to avoid.
+    createScreen('t', 132, 43)
+    feedScreen('t', 'hello')
+
+    const snapshot = await serializeScreen('t')
+
+    expect(snapshot).toMatchObject({ cols: 132, rows: 43 })
+  })
+
+  it('follows the geometry through a resize', async () => {
+    createScreen('t', 80, 24)
+    feedScreen('t', 'hello')
+    await resizeScreen('t', 100, 40)
+
+    expect(await serializeScreen('t')).toMatchObject({ cols: 100, rows: 40 })
+  })
+
+  it('carries the title the program set, which the screen does not', async () => {
+    feed('t', `${ESC}]0;vorn — building${ESC}\\`)
+
+    expect((await serializeScreen('t'))?.title).toBe('vorn — building')
+  })
+
+  it('carries the working directory the shell reported', async () => {
+    feed('t', `${ESC}]7;file://host/Users/x/dev/vorn${ESC}\\`)
+
+    expect((await serializeScreen('t'))?.cwd).toBe('/Users/x/dev/vorn')
+  })
+
+  it('decodes a working directory with spaces in it', async () => {
+    feed('t', `${ESC}]7;file://host/Users/x/my%20projects${ESC}\\`)
+
+    expect((await serializeScreen('t'))?.cwd).toBe('/Users/x/my projects')
+  })
+
+  it('survives a working directory that is not valid percent-encoding', async () => {
+    // `cd /tmp/100%` and the shell reports exactly this. `decodeURIComponent`
+    // throws on a stray `%`, and the OSC handler runs inside xterm's own timer
+    // -- so the throw reaches the top of the process, which installs no handler
+    // for it. A directory somebody named would have killed the server and every
+    // session on it.
+    feed('t', `${ESC}]7;file://host/tmp/100%${ESC}\\after`)
+
+    const snapshot = await serializeScreen('t')
+
+    expect(snapshot?.cwd, 'left encoded rather than lost').toBe('/tmp/100%')
+    expect(snapshot?.screen).toContain('after')
+  })
+
+  it('reports neither when the program never said', async () => {
+    feed('t', 'just output')
+
+    expect(await serializeScreen('t')).toMatchObject({ title: '', cwd: '' })
+  })
+})
+
+describe('output arriving faster than it can be parsed', () => {
+  it('skips ahead rather than holding it all, and keeps the model', async () => {
+    // xterm parses on a timer and holds what it has not reached. A `cat` of
+    // something large outruns that, and xterm's own answer at fifty megabytes is
+    // to throw -- which would cost the session its model for good, having held
+    // fifty megabytes to get there. A model missing part of a flood is repaired
+    // by the next repaint; a model that no longer exists is not.
+    createScreen('flood', 80, 24)
+    const chunk = 'x'.repeat(64 * 1024)
+    for (let i = 0; i < 200; i++) feedScreen('flood', chunk)
+
+    // Still modelled: the flood cost it chunks, not its existence.
+    expect(screenCount()).toBe(1)
+
+    // And usable again once the parser has caught up, which is what a session
+    // between two bursts of output looks like. Serializing drains the queue.
+    await serializeScreen('flood')
+    feedScreen('flood', `${ESC}[2J${ESC}[Hrepainted`)
+
+    expect((await serializeScreen('flood'))?.screen).toContain('repainted')
   })
 })

--- a/tests/terminal-screen.test.ts
+++ b/tests/terminal-screen.test.ts
@@ -74,6 +74,65 @@ function row(term: Terminal, y: number): string {
   return cells.join('|')
 }
 
+describe('what a program can make the model hold', () => {
+  it('keeps a title bounded, whatever length the program sends', async () => {
+    // Both the title and the cwd live for as long as the terminal does and both
+    // travel in the checkpoint, and xterm will hand over an OSC payload of ten
+    // million characters. One long enough puts every checkpoint for that session
+    // over its size cap -- permanently, since the field never goes back. An
+    // agent printing a file it was asked to read can produce this without
+    // anybody intending it.
+    createScreen('shouty', 80, 24)
+    feedScreen('shouty', `${ESC}]0;${'t'.repeat(5_000_000)}\x07`)
+
+    const snapshot = await serializeScreen('shouty')
+
+    expect(snapshot?.title.length ?? 0).toBeLessThanOrEqual(512)
+    expect(snapshot?.title.startsWith('tt')).toBe(true)
+  })
+
+  it('keeps a cwd bounded the same way', async () => {
+    createScreen('shouty', 80, 24)
+    feedScreen('shouty', `${ESC}]7;file:///${'p'.repeat(5_000_000)}\x07`)
+
+    expect((await serializeScreen('shouty'))?.cwd.length ?? 0).toBeLessThanOrEqual(512)
+  })
+})
+
+describe('the moment a snapshot describes', () => {
+  it('holds what was written before it was asked for, and nothing written after', async () => {
+    // The whole correctness argument for the checkpoint rests on this. xterm
+    // invokes a write's callback from inside its own parse loop and then keeps
+    // consuming the queue for up to twelve milliseconds before returning, so
+    // anything that reads the buffer in a `then` reads it a loop later --
+    // holding output that arrived after the snapshot was asked for.
+    //
+    // Downstream that is not a stale screen, it is a duplicated one: those same
+    // bytes are recorded as log frames written after the checkpoint, so a
+    // restore applies them on top of a screen that already has them.
+    createScreen('later', 80, 24)
+    feedScreen('later', 'before the snapshot\r\n')
+
+    const pending = serializeScreen('later')
+    feedScreen('later', 'after the snapshot\r\n')
+    const snapshot = await pending
+
+    expect(snapshot?.screen).toContain('before the snapshot')
+    expect(snapshot?.screen ?? '', 'the snapshot ran a parse loop late').not.toContain(
+      'after the snapshot'
+    )
+  })
+
+  it('still waits for everything that was written before it', async () => {
+    // The other half, and the reason this cannot simply serialize synchronously:
+    // `term.write` returns before anything is parsed at all.
+    createScreen('earlier', 80, 24)
+    feedScreen('earlier', 'queued but not yet parsed\r\n')
+
+    expect((await serializeScreen('earlier'))?.screen).toContain('queued but not yet parsed')
+  })
+})
+
 describe('what the screen looks like when it comes back', () => {
   it('reproduces text and colour cell for cell', async () => {
     feed('t', `${ESC}[31mred${ESC}[0m plain ${ESC}[1;34mbold blue${ESC}[0m`)

--- a/tests/terminal-screen.test.ts
+++ b/tests/terminal-screen.test.ts
@@ -74,6 +74,41 @@ function row(term: Terminal, y: number): string {
   return cells.join('|')
 }
 
+describe('a terminal that goes away while it is being read', () => {
+  it.each([
+    ['a snapshot', (id: string) => serializeScreen(id)],
+    ['a resize', (id: string) => resizeScreen(id, 132, 43)]
+  ])(
+    'lets %s finish rather than leaving it pending for ever',
+    async (_label, start) => {
+      // Both read the buffer from inside xterm's write callback, which is the only
+      // point that means what they need it to mean. That leaves a question with a
+      // consequence: if `dispose()` dropped a pending callback, the promise would
+      // never settle -- and since every disk operation for a session runs behind
+      // the last, one unsettled promise would wedge that session's queue for the
+      // life of the server, so its history would never be written and never be
+      // removed.
+      //
+      // It does not: disposing does not cancel the parse xterm has already
+      // scheduled, so the callback still runs. That is a fact about this pinned
+      // version rather than a documented guarantee, which is exactly why it is
+      // asserted here -- a version bump is where it would change.
+      createScreen('going', 200, 50)
+      for (let i = 0; i < 4_000; i++) feedScreen('going', `line ${i} of output\r\n`)
+
+      const pending = start('going')
+      clearScreen('going')
+
+      const outcome = await Promise.race([
+        pending.then(() => 'settled'),
+        new Promise((resolve) => setTimeout(() => resolve('still pending'), 3_000))
+      ])
+      expect(outcome).toBe('settled')
+    },
+    10_000
+  )
+})
+
 describe('what a program can make the model hold', () => {
   it('keeps a title bounded, whatever length the program sends', async () => {
     // Both the title and the cwd live for as long as the terminal does and both

--- a/tests/terminal-scrollback.test.ts
+++ b/tests/terminal-scrollback.test.ts
@@ -3,6 +3,7 @@ import {
   appendScrollback,
   clearScrollback,
   readScrollback,
+  scrollbackUnitsHeld,
   resetScrollback
 } from '../packages/server/src/terminal-scrollback'
 
@@ -138,5 +139,22 @@ describe('holding chunks instead of one string', () => {
 
     expect(kept).toContain(`${ESC}[31mred`)
     expect(kept.length).toBeLessThanOrEqual(256 * 1024)
+  })
+})
+
+describe('the very first thing a terminal says', () => {
+  it('is bounded like everything after it', () => {
+    // An earlier version seeded the buffer with the first chunk and returned, so
+    // a single oversized write arriving before anything else sat unbounded until
+    // the next append -- which for a terminal that then goes quiet is never.
+    //
+    // Asserted on what is held, not on what a read returns: `readScrollback`
+    // compacts on the way out, so the answer was already within the cap either
+    // way. The first version of this test passed against the bug for exactly
+    // that reason.
+    appendScrollback('t', 'x'.repeat(2 * 1024 * 1024))
+
+    expect(scrollbackUnitsHeld('t')).toBeLessThanOrEqual(256 * 1024 + (256 * 1024) / 4)
+    expect(readScrollback('t').length).toBeLessThanOrEqual(256 * 1024)
   })
 })

--- a/tests/terminal-scrollback.test.ts
+++ b/tests/terminal-scrollback.test.ts
@@ -94,3 +94,49 @@ describe('staying bounded', () => {
     expect(readScrollback('a').length).toBeLessThanOrEqual(256 * 1024)
   })
 })
+
+describe('holding chunks instead of one string', () => {
+  it('bounds memory even when nobody ever reads', () => {
+    // Appends compact themselves past a slack margin, so a terminal producing
+    // output for hours without a single reader does not grow without limit.
+    // Reads are what enforce the exact cap; this enforces the rough one.
+    for (let i = 0; i < 400; i++) appendScrollback('t', 'x'.repeat(4096))
+
+    expect(readScrollback('t').length).toBeLessThanOrEqual(256 * 1024)
+  })
+
+  it('returns the same bytes however many times it is read', () => {
+    appendScrollback('t', 'one')
+    appendScrollback('t', 'two')
+
+    const first = readScrollback('t')
+    const second = readScrollback('t')
+
+    expect(first).toBe('onetwo')
+    expect(second).toBe(first)
+  })
+
+  it('keeps appending correctly after a read has compacted it', () => {
+    appendScrollback('t', 'before')
+    readScrollback('t')
+    appendScrollback('t', 'after')
+
+    expect(readScrollback('t')).toBe('beforeafter')
+  })
+
+  it('cuts at a boundary that spans two appends, not at the chunk edge', () => {
+    // The reason the trim runs on the joined text rather than per chunk. A PTY
+    // write can land anywhere -- including in the middle of an escape sequence --
+    // so trimming each chunk as it arrived would cut wherever the kernel happened
+    // to split the stream, which is exactly the mid-sequence cut the boundary
+    // rule exists to prevent.
+    appendScrollback('t', 'x'.repeat(256 * 1024))
+    appendScrollback('t', `\n${ESC}[3`)
+    appendScrollback('t', '1mred')
+
+    const kept = readScrollback('t')
+
+    expect(kept).toContain(`${ESC}[31mred`)
+    expect(kept.length).toBeLessThanOrEqual(256 * 1024)
+  })
+})

--- a/tests/terminal-seed-guard.test.ts
+++ b/tests/terminal-seed-guard.test.ts
@@ -8,7 +8,17 @@ Object.defineProperty(window, 'api', {
   writable: true
 })
 
-import { registerSlot, hydrateTerminal } from '../src/renderer/lib/terminal-registry'
+const seeded = vi.hoisted(() => [] as string[])
+vi.mock('../src/renderer/lib/command-blocks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/renderer/lib/command-blocks')>()),
+  markSeededFromServer: (id: string) => seeded.push(id)
+}))
+
+import {
+  registerSlot,
+  hydrateTerminal,
+  destroyTerminal
+} from '../src/renderer/lib/terminal-registry'
 
 /**
  * A replayed screen must not be answered.
@@ -21,6 +31,7 @@ const ESC = '\x1b'
 
 beforeEach(() => {
   vi.clearAllMocks()
+  seeded.length = 0
 })
 
 describe('seeding a pane with a screen from the past', () => {
@@ -38,5 +49,47 @@ describe('seeding a pane with a screen from the past', () => {
     await new Promise((r) => setTimeout(r, 60))
 
     expect(writeTerminal.mock.calls).toEqual([])
+  })
+})
+
+describe('a seed whose pane goes while the attach is in flight', () => {
+  it('does not land on top of the pane that took the id after it', async () => {
+    // A view swap, or a pane closed and reopened, destroys the terminal and
+    // mounts a new one under the same id. The closure still holds the old entry,
+    // so the stale seed would write into a disposed terminal -- which xterm
+    // accepts silently -- and hand the new pane's status handler the old pane's
+    // bytes. Mounting seeds on its own, so the live pane's own seed is expected;
+    // what must not happen is a second one arriving from the pane that is gone.
+    let answerTheDeadPane: (v: { data: string; seq: number; live: boolean }) => void = () => {}
+    attachTerminal
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          answerTheDeadPane = resolve
+        })
+      )
+      .mockResolvedValue({ data: 'what the live pane was given', seq: 0, live: true })
+
+    registerSlot('swapped', document.createElement('div'))
+
+    // The pane goes, and the id is taken again before the server answers.
+    destroyTerminal('swapped')
+    registerSlot('swapped', document.createElement('div'))
+    await new Promise((r) => setTimeout(r, 30))
+
+    answerTheDeadPane({ data: 'from the pane that is gone', seq: 0, live: true })
+    await new Promise((r) => setTimeout(r, 30))
+
+    expect(seeded).toEqual(['swapped'])
+  })
+
+  it('lands normally when the pane is still the one that asked', async () => {
+    // The contrast, so the test above cannot pass by seeds never arriving.
+    attachTerminal.mockResolvedValue({ data: 'a screen', seq: 0, live: true })
+    registerSlot('kept', document.createElement('div'))
+
+    await hydrateTerminal('kept')
+    await new Promise((r) => setTimeout(r, 30))
+
+    expect(seeded).toEqual(['kept'])
   })
 })

--- a/tests/terminal-seed-guard.test.ts
+++ b/tests/terminal-seed-guard.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const writeTerminal = vi.fn()
+const attachTerminal = vi.fn()
+Object.defineProperty(window, 'api', {
+  value: { writeTerminal, attachTerminal, notifyWidgetStatus: vi.fn(), openExternal: vi.fn() },
+  writable: true
+})
+
+import { registerSlot, hydrateTerminal } from '../src/renderer/lib/terminal-registry'
+
+/**
+ * A replayed screen must not be answered.
+ *
+ * Recordings carry the questions the old program asked its terminal. Written
+ * into a real emulator they are asked again and this one answers, and the answer
+ * goes down the pty as though it had been typed.
+ */
+const ESC = '\x1b'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('seeding a pane with a screen from the past', () => {
+  it('does not answer the questions in it', async () => {
+    // Device attributes, cursor position, background colour -- all things a
+    // terminal replies to, all things a serialized screen can contain.
+    attachTerminal.mockResolvedValue({
+      data: `${ESC}[c${ESC}[6n${ESC}]11;?${ESC}\\`,
+      seq: 0,
+      live: true
+    })
+    registerSlot('seeded', document.createElement('div'))
+
+    await hydrateTerminal('seeded')
+    await new Promise((r) => setTimeout(r, 60))
+
+    expect(writeTerminal.mock.calls).toEqual([])
+  })
+})

--- a/tests/write-path-throughput.process.test.ts
+++ b/tests/write-path-throughput.process.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { spawnSync } from 'node:child_process'
-import path from 'node:path'
+import { runMeasurement } from './helpers/run-measurement'
+import { spawnsRealServers } from './helpers/one-at-a-time'
 
 /**
  * What the server spends on each chunk of terminal output.
@@ -15,12 +15,20 @@ import path from 'node:path'
  * In a child process for the same reason as the memory measurement: this
  * worker's own scheduling noise is larger than the differences that matter.
  *
- * The ceilings are generous and the comparison is relative. Wall-clock on a
- * loaded CI box is not a number to assert tightly, and a flaky performance test
- * gets deleted rather than investigated. What these catch is a change of shape —
- * a per-chunk cost that goes back to being quadratic, or a model that becomes an
- * order of magnitude more expensive to feed.
+ * Every assertion is a comparison between numbers from the same run, never a
+ * ceiling on one of them. Wall-clock on a loaded CI box is not a thing to assert
+ * against a constant, and a flaky performance test gets deleted rather than
+ * investigated — which leaves nothing at all. What these catch is a change of
+ * *shape*: the buffer going quadratic again, or the model becoming the thing
+ * that dominates this path.
+ *
+ * The absolute figures belong in a commit message, where they are a record
+ * rather than a trap.
  */
+
+// Takes the same lock the server suites take. This one measures wall-clock and
+// heap, so anything spawning beside it is measuring something else.
+spawnsRealServers()
 
 interface Measurement {
   chunks: number
@@ -35,19 +43,8 @@ interface Measurement {
   screenOnlyMs: number
 }
 
-function measure(): Measurement {
-  const script = path.join(__dirname, 'helpers', 'measure-write-path.ts')
-  const run = spawnSync('npx', ['tsx', script], {
-    cwd: path.join(__dirname, '..'),
-    encoding: 'utf-8',
-    timeout: 300_000
-  })
-  if (run.status !== 0) throw new Error(`measurement failed (${run.status}):\n${run.stderr}`)
-  return JSON.parse(run.stdout.trim().split('\n').pop() ?? '') as Measurement
-}
-
 describe('the path every byte of output takes', () => {
-  const r = measure()
+  const r = runMeasurement<Measurement>('measure-write-path.ts', { timeoutMs: 300_000 })
 
   it('is faster than it was before a screen model was added to it', () => {
     // The headline, and the reason the buffer fix belongs in the same branch as
@@ -62,18 +59,17 @@ describe('the path every byte of output takes', () => {
     ).toBeLessThan(r.oldBufferMs)
   })
 
-  it('holds the buffer to a flat cost per chunk', () => {
-    // The old shape was quadratic in disguise: every append re-formed the whole
-    // buffer, so the cost per chunk grew with the buffer until it hit the cap and
-    // stayed there, expensively. Roughly 0.2µs/chunk now.
-    expect(r.newBufferMs, `${r.newBufferMs}ms for ${r.chunks} chunks`).toBeLessThan(200)
-  })
-
-  it('keeps the screen model affordable to feed', () => {
-    // About 1.9µs per chunk when this was written — a real VT parse, and the
-    // reason the model is fed from the 8ms coalescer rather than from every raw
-    // PTY write. An order of magnitude worse than this would be worth knowing
-    // about; a doubling would not.
-    expect(r.screenOnlyMs, `${r.screenOnlyMs}ms for ${r.chunks} chunks`).toBeLessThan(400)
+  it('spends most of what is left on the model rather than the buffer', () => {
+    // A ratio, not a ceiling. Absolute wall-clock in a permanent suite is a
+    // flaky test on a loaded CI box, and a flaky performance test gets deleted
+    // rather than investigated -- leaving nothing. Both numbers come from the
+    // same process and the same run, so their relationship is stable even when
+    // the machine is not.
+    //
+    // What this catches is the buffer going quadratic again: it would stop being
+    // the small half. Measured at roughly 4ms against 38ms when written.
+    expect(r.newBufferMs, `buffer ${r.newBufferMs}ms, model ${r.screenOnlyMs}ms`).toBeLessThan(
+      r.screenOnlyMs
+    )
   })
 }, 300_000)

--- a/tests/write-path-throughput.process.test.ts
+++ b/tests/write-path-throughput.process.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+/**
+ * What the server spends on each chunk of terminal output.
+ *
+ * The hottest path in the process: every byte an agent prints arrives here, and
+ * anything added to it is paid on every keystroke of every session at once. Two
+ * things changed on it — the byte buffer stopped rebuilding itself per chunk,
+ * and a screen model was added beside it. Whether that is a net win is not
+ * answerable by reasoning about which sounds heavier, so all three shapes are
+ * measured against the same bytes.
+ *
+ * In a child process for the same reason as the memory measurement: this
+ * worker's own scheduling noise is larger than the differences that matter.
+ *
+ * The ceilings are generous and the comparison is relative. Wall-clock on a
+ * loaded CI box is not a number to assert tightly, and a flaky performance test
+ * gets deleted rather than investigated. What these catch is a change of shape —
+ * a per-chunk cost that goes back to being quadratic, or a model that becomes an
+ * order of magnitude more expensive to feed.
+ */
+
+interface Measurement {
+  chunks: number
+  bytes: number
+  /** The buffer as it was: concatenate the whole thing per chunk, then re-slice. */
+  oldBufferMs: number
+  /** The buffer as it is: push, join on read. */
+  newBufferMs: number
+  /** The buffer as it is, with the screen model fed alongside. */
+  newBufferAndScreenMs: number
+  /** What the model alone adds. */
+  screenOnlyMs: number
+}
+
+function measure(): Measurement {
+  const script = path.join(__dirname, 'helpers', 'measure-write-path.ts')
+  const run = spawnSync('npx', ['tsx', script], {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf-8',
+    timeout: 300_000
+  })
+  if (run.status !== 0) throw new Error(`measurement failed (${run.status}):\n${run.stderr}`)
+  return JSON.parse(run.stdout.trim().split('\n').pop() ?? '') as Measurement
+}
+
+describe('the path every byte of output takes', () => {
+  const r = measure()
+
+  it('is faster than it was before a screen model was added to it', () => {
+    // The headline, and the reason the buffer fix belongs in the same branch as
+    // the emulator. Adding a full VT parse of every byte sounds like it must
+    // cost something, and it does — but the path it was added to was spending
+    // twenty-five times more than that rebuilding a quarter-megabyte string on
+    // every chunk. Measured at roughly 1040 ms before and 42 ms after, for
+    // twenty thousand chunks.
+    expect(
+      r.newBufferAndScreenMs,
+      `before ${r.oldBufferMs}ms, after ${r.newBufferAndScreenMs}ms for ${r.chunks} chunks`
+    ).toBeLessThan(r.oldBufferMs)
+  })
+
+  it('holds the buffer to a flat cost per chunk', () => {
+    // The old shape was quadratic in disguise: every append re-formed the whole
+    // buffer, so the cost per chunk grew with the buffer until it hit the cap and
+    // stayed there, expensively. Roughly 0.2µs/chunk now.
+    expect(r.newBufferMs, `${r.newBufferMs}ms for ${r.chunks} chunks`).toBeLessThan(200)
+  })
+
+  it('keeps the screen model affordable to feed', () => {
+    // About 1.9µs per chunk when this was written — a real VT parse, and the
+    // reason the model is fed from the 8ms coalescer rather than from every raw
+    // PTY write. An order of magnitude worse than this would be worth knowing
+    // about; a doubling would not.
+    expect(r.screenOnlyMs, `${r.screenOnlyMs}ms for ${r.chunks} chunks`).toBeLessThan(400)
+  })
+}, 300_000)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,6 +4670,8 @@ __metadata:
     "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@types/ws": "npm:^8.18.1"
     "@vornrun/shared": "workspace:*"
+    "@xterm/addon-serialize": "npm:0.13.0"
+    "@xterm/headless": "npm:5.5.0"
     fastify: "npm:^5.11.0"
     libsql: "npm:^0.5.29"
     node-cron: "npm:^4.2.1"
@@ -4731,6 +4733,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xterm/addon-serialize@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@xterm/addon-serialize@npm:0.13.0"
+  peerDependencies:
+    "@xterm/xterm": ^5.0.0
+  checksum: 10c0/090f502867250cdceca9abdbe37aebe0c01eb5d708a09c51d3e0e9bb5d4d3b0d4d67af1c4c8bde9b78f108a5e4150420180de69e6228aac76596fdbf6c4c59dc
+  languageName: node
+  linkType: hard
+
 "@xterm/addon-web-links@npm:0.12.0":
   version: 0.12.0
   resolution: "@xterm/addon-web-links@npm:0.12.0"
@@ -4742,6 +4753,13 @@ __metadata:
   version: 0.19.0
   resolution: "@xterm/addon-webgl@npm:0.19.0"
   checksum: 10c0/238f9af3745bc027c78a6ec6ed155721f82f2f0934bc65adffc0ae997c23ad053b18f04fceb121a38945d2fc31bf0e4baa01714c4c2916781bb27873d9d5cd8b
+  languageName: node
+  linkType: hard
+
+"@xterm/headless@npm:5.5.0":
+  version: 5.5.0
+  resolution: "@xterm/headless@npm:5.5.0"
+  checksum: 10c0/2cb22acc1b00acbbc8698b36c939493589f0e23256bcbf27afae7b3ee6c005dfde6e96843955d89b4de171c29ea97bff6d32f85e6fa3cb3f743e15e656c86f8f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Quitting Vorn killed every agent. The server was a child of the app, so every PTY
went with the window, and reopening could only relaunch each session from its
transcript — losing the process, the turn in flight, and any prompt waiting for an
answer. This branch makes a session outlive both the window and the server, and
makes a pane say honestly which of those happened.

Four phases, each landing on the one before it.

## The server outlives the app

It spawns detached and the app lets go of it at quit instead of ending it.
Production stops using `utilityProcess.fork`, which is tied to Electron's lifetime
by design; it spawns the same signed binary with `ELECTRON_RUN_AS_NODE=1`.

Detaching alone would be worse than the bug — the old server keeps the PTYs, the
next launch takes another port, and two servers share one database while the app
talks to the empty one. So the launch path looks for a running server first and
adopts it, reading the credential the server publishes rather than inventing one.
Adoption turns on the wire protocol, never the release version: the two move
independently, and gating on the release would end every session on every update.

Only the shipped app detaches. A dev server that outlives `yarn dev` gets adopted
by the next `yarn dev` — same data directory, same channel, every check passes —
and it is running the source from before the edit that prompted the restart.

## The screen survives a crash

A terminal's bytes were kept; the screen it was showing was not. There is now a
headless screen model per terminal, checkpointed to disk with a redo log beside
it, generation-tagged so a log can never be replayed onto the wrong checkpoint.
Recovery reads the pair back and a pane opens on what the terminal was showing.

The measurements are in the commits rather than asserted here: the write path was
profiled before the checkpoint interval was chosen, and a synchronous checkpoint
that blocked the event loop 5.8ms was found by measuring rather than by review.

## A pane joins a terminal already in progress

Seeding a pane and then applying live output must lose nothing and duplicate
nothing. `flushBuffer` is one synchronous block, so a counter incremented there
and the scrollback written there can be read together, in one tick, atomically
with respect to flushes. `terminal:attach` returns `{ data, seq, live }`; the
client subscribes first, buffers by id, attaches, then writes only what came
after `seq`.

`live` cannot come from `terminal:listActive` — that returns session *records*,
and a record outlives its process.

## Ending, and starting again

A pane whose session ended says so, in place of the composer, and says which
ending it was: an agent that exited, a quit, or a server that stopped. The
difference comes from `closedCleanly`, which only the flush on the way out sets —
so its absence is the honest answer for a kill, an OOM, or a machine losing power.

`reopenSessions` keeps the meaning it always had: the sessions come back. One rule
covers both cases — a session whose process was *stopped* is started again whether
the app was closed at the time or open and watching. A pane already sitting there
ended is skipped, and an agent that exited on its own is never relaunched.

A resumed session keeps its id. Every client keys a pane by that id, including the
terminal holding the replayed screen, so a new id would hand back a blank pane at
the moment the person asked for their work back.

## Notes for review

- Two bugs fixed first because everything sits on them: `saveSessions` is a whole
  table replace fed by live sessions, so after a restart opening one pane erased
  every previous record and the next start swept their history; and the shell cwd
  handler was registered on OSC 7 while Vorn's own integration emits OSC 5522, so
  the field had never been populated.
- The launch-line rewriter is tokenised and fails open: anything with an operator,
  an unterminated quote or a substitution is handed back untouched rather than
  guessed at. It was differential-tested against `/bin/sh` over 1,909 rewrites,
  which is how `--continue` swallowing the next token was found.
- Verified by hand across warm quit, cold kill of the server under a running app,
  and a hard kill of both — the last of which is what exposed a pane answering the
  device queries inside its own replayed screen and typing the answers into its
  shell.

`yarn typecheck && yarn test && yarn lint && yarn format:check` — 350 files, 4699
tests. Two suites assert an env var is absent and so fail when the suite is run
from inside a Vorn terminal; they pass with `VORN_SESSION_ID` and `VORN_DATA_DIR`
stripped.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT
