### PR TITLE
chore(release): 0.7.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump only. `scripts/sync-versions.sh` carried it to the six workspace packages.