### PR TITLE
Draw workflows on a free canvas instead of the fixed rail

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "*.{json,css,md,html}": "prettier --write"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.1.1",
     "@grpc/grpc-js": "^1.14.4",
     "@grpc/proto-loader": "^0.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -66,6 +67,7 @@
     "@xterm/addon-web-links": "0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^5.5.0",
+    "@xyflow/react": "^12.11.3",
     "electron-log": "^5.4.4",
     "electron-updater": "^6.8.3",
     "framer-motion": "^12.38.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "*.{json,css,md,html}": "prettier --write"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^3.1.1",
     "@grpc/grpc-js": "^1.14.4",
     "@grpc/proto-loader": "^0.8.1",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -61,6 +61,8 @@ interface Props {
   ) => void
   /** Dragged nodes settled; write the new positions into the definition. */
   onPositionsCommit: (positions: Record<string, { x: number; y: number }>) => void
+  /** Delete-key removal of the selected step (never the trigger). */
+  onDeleteNode?: (nodeId: string) => void
   onTidyUp: () => void
   selectedNodeId: string | null
   /** What each node is doing in live runs; absent when nothing is running. */
@@ -346,11 +348,12 @@ function WorkflowCanvasInner({
   onConnectEdge,
   onPaletteInsert,
   onPositionsCommit,
+  onDeleteNode,
   onTidyUp,
   selectedNodeId,
   nodeStatus
 }: Props) {
-  const { screenToFlowPosition } = useReactFlow()
+  const { screenToFlowPosition, zoomIn, zoomOut, zoomTo, fitView } = useReactFlow()
   const wrapperRef = useRef<HTMLDivElement>(null)
 
   const elements = useMemo(() => toCanvasElements(nodes, edges), [nodes, edges])
@@ -471,16 +474,43 @@ function WorkflowCanvasInner({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key !== 'Tab' || palette) return
+      if (palette) return
       const target = e.target as HTMLElement
       if (target.closest('input, textarea, [contenteditable]')) return
-      const afterNodeId = leafForTabInsert()
-      const rect = wrapperRef.current?.getBoundingClientRect()
-      if (!afterNodeId || !rect) return
-      e.preventDefault()
-      openPaletteAt(rect.left + rect.width / 2 - 124, rect.top + rect.height / 3, afterNodeId)
+      if (e.key === 'Tab') {
+        const afterNodeId = leafForTabInsert()
+        const rect = wrapperRef.current?.getBoundingClientRect()
+        if (!afterNodeId || !rect) return
+        e.preventDefault()
+        openPaletteAt(rect.left + rect.width / 2 - 124, rect.top + rect.height / 3, afterNodeId)
+      } else if (e.key === '+' || e.key === '=') {
+        void zoomIn()
+      } else if (e.key === '-') {
+        void zoomOut()
+      } else if (e.key === '0') {
+        void zoomTo(1)
+      } else if (e.key === '1') {
+        void fitView({ padding: 0.2, maxZoom: 1 })
+      } else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedNodeId) {
+        const node = nodes.find((n) => n.id === selectedNodeId)
+        if (node && node.type !== 'trigger' && onDeleteNode) {
+          e.preventDefault()
+          onDeleteNode(selectedNodeId)
+        }
+      }
     },
-    [palette, leafForTabInsert, openPaletteAt]
+    [
+      palette,
+      leafForTabInsert,
+      openPaletteAt,
+      zoomIn,
+      zoomOut,
+      zoomTo,
+      fitView,
+      selectedNodeId,
+      nodes,
+      onDeleteNode
+    ]
   )
 
   const interactions = useMemo<CanvasInteractions>(
@@ -523,13 +553,17 @@ function WorkflowCanvasInner({
           fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
           minZoom={0.2}
           maxZoom={1.75}
+          snapToGrid
+          snapGrid={[8, 8]}
+          connectionRadius={60}
+          panOnScroll
           deleteKeyCode={null}
           selectionKeyCode={null}
           multiSelectionKeyCode={null}
           nodesFocusable={false}
           edgesFocusable={false}
           colorMode="dark"
-          className="bg-surface-base"
+          style={{ background: 'var(--color-surface-base)' }}
           defaultEdgeOptions={{ type: 'step' }}
           proOptions={{ hideAttribution: true }}
         >
@@ -538,6 +572,7 @@ function WorkflowCanvasInner({
             gap={20}
             size={1}
             color="rgba(255,255,255,0.05)"
+            bgColor="var(--color-surface-base)"
           />
           <MiniMap
             pannable

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -3,6 +3,7 @@ import {
   Background,
   BackgroundVariant,
   BaseEdge,
+  ControlButton,
   Controls,
   EdgeLabelRenderer,
   Handle,
@@ -21,7 +22,7 @@ import {
   type NodeProps
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { Repeat } from 'lucide-react'
+import { AlignVerticalSpaceAround, Repeat } from 'lucide-react'
 import { LoopConfig, NodeExecutionStatus, WorkflowEdge, WorkflowNode } from '../../../shared/types'
 import {
   AddStepNodeData,
@@ -204,7 +205,8 @@ function AddStepNode({ data }: NodeProps) {
   const { afterNodeId, insideBranch } = data as unknown as AddStepNodeData
 
   return (
-    <div className="relative">
+    // The wrapper of an unselectable, undraggable node gets pointer-events none.
+    <div className="relative pointer-events-auto">
       <Handle type="target" position={Position.Top} className="!opacity-0 !pointer-events-none" />
       <ConnectorButton
         onAddAction={() => onInsertNode(afterNodeId, null, 'agent')}
@@ -279,7 +281,11 @@ function StepEdge({
       <EdgeLabelRenderer>
         <div
           className="absolute flex flex-col items-center gap-1 pointer-events-auto"
-          style={{ transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)` }}
+          style={{
+            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+            // Hovered, the + and its menu must rise above the cards (selection elevates those to 1000).
+            zIndex: hovered ? 1300 : 'auto'
+          }}
           onMouseEnter={enter}
           onMouseLeave={leave}
         >
@@ -291,8 +297,8 @@ function StepEdge({
               {label}
             </div>
           ) : null}
-          {insertable && (hovered || !label) && (
-            <div className={hovered ? 'opacity-100' : 'opacity-0 hover:opacity-100'}>
+          {insertable && hovered && (
+            <div>
               <ConnectorButton
                 onAddAction={() =>
                   onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'agent')
@@ -525,6 +531,7 @@ function WorkflowCanvasInner({
           colorMode="dark"
           className="bg-surface-base"
           defaultEdgeOptions={{ type: 'step' }}
+          proOptions={{ hideAttribution: true }}
         >
           <Background
             variant={BackgroundVariant.Dots}
@@ -544,18 +551,12 @@ function WorkflowCanvasInner({
             showInteractive={false}
             className="!bg-surface-overlay !border !border-white/[0.12] !rounded-md !shadow-none
                        [&_button]:!bg-transparent [&_button]:!border-white/[0.08] [&_button]:!fill-gray-400"
-          />
-        </ReactFlow>
-
-        <div className="absolute top-2.5 right-2.5 z-10">
-          <button
-            onClick={onTidyUp}
-            className="text-[11px] text-gray-300 bg-surface-overlay border border-white/[0.12]
-                       rounded-md px-2.5 py-1 hover:text-white hover:border-white/[0.2] transition-colors"
           >
-            Tidy up
-          </button>
-        </div>
+            <ControlButton onClick={onTidyUp} title="Tidy up">
+              <AlignVerticalSpaceAround size={12} className="!fill-none stroke-gray-400" />
+            </ControlButton>
+          </Controls>
+        </ReactFlow>
 
         {palette && (
           <NodePalette

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -62,19 +62,11 @@ interface Props {
   onPositionsCommit: (positions: Record<string, { x: number; y: number }>) => void
   onTidyUp: () => void
   selectedNodeId: string | null
-  /**
-   * What each node is doing in the runs that are live right now, so the canvas
-   * reports a run rather than only describing a definition. Absent when nothing
-   * is running, which is most of the time.
-   */
+  /** What each node is doing in live runs; absent when nothing is running. */
   nodeStatus?: Record<string, NodeExecutionStatus>
 }
 
-/**
- * Everything a canvas node needs beyond its own id. Kept in context so the
- * node array only changes on structural edits — selection, status, and
- * callback identity churn re-render the cards without rebuilding the graph.
- */
+/** Kept in context so selection/status churn re-renders cards without rebuilding the node array. */
 interface CanvasInteractions {
   nodesById: Map<string, WorkflowNode>
   allNodes: WorkflowNode[]
@@ -117,12 +109,7 @@ function StepNode({ data }: NodeProps) {
   )
 }
 
-/**
- * A loop and the steps it repeats, drawn as one enclosure — the same composite
- * the rail drew. The body renders inside, so a repeated step can never be
- * mistaken for one that runs once, and membership stays the loop's own
- * `bodyNodeIds` rather than canvas geometry.
- */
+/** A loop and its body as one enclosure; membership stays `bodyNodeIds`, not canvas geometry. */
 function LoopNode({ data }: NodeProps) {
   const { nodesById, allNodes, selectedNodeId, nodeStatus, onNodeClick, onInsertNode } =
     useInteractions()
@@ -225,8 +212,7 @@ function AddStepNode({ data }: NodeProps) {
         onAddCondition={() => onInsertNode(afterNodeId, null, 'condition')}
         onAddApproval={() => onInsertNode(afterNodeId, null, 'approval')}
         onAddLoop={
-          // Gated like the rail: a loop lifts its body out of the trunk, and
-          // how that interacts with a fork's join is untested.
+          // Loop-inside-branch is untested against fork joins, same gate as the rail.
           !insideBranch ? () => onInsertNode(afterNodeId, null, 'loop') : undefined
         }
         onAddConnectorAction={() => onInsertNode(afterNodeId, null, 'connectorAction')}
@@ -238,12 +224,7 @@ function AddStepNode({ data }: NodeProps) {
   )
 }
 
-/**
- * A step edge: the connecting line, the True/False pill on condition branches,
- * and an insert button that appears while the pointer lingers. The generous
- * `interactionWidth` and the delayed leave exist so the mouse can travel from
- * the line to the button without the button vanishing under it.
- */
+/** The line, the branch pill, and a hover + whose delayed leave lets the mouse reach it. */
 function StepEdge({
   id,
   sourceX,
@@ -369,9 +350,7 @@ function WorkflowCanvasInner({
   const elements = useMemo(() => toCanvasElements(nodes, edges), [nodes, edges])
   const [rfNodes, setRfNodes] = useState<Node[]>(elements.nodes)
 
-  // The definition is the source of truth: rebuild whenever it changes.
-  // Interim drag positions live only in local state, so this is the
-  // adjust-state-while-rendering pattern rather than an effect.
+  // Adjust-state-while-rendering: rebuild from the definition; drag positions stay local.
   const [syncedElements, setSyncedElements] = useState(elements)
   if (syncedElements !== elements) {
     setSyncedElements(elements)
@@ -379,16 +358,13 @@ function WorkflowCanvasInner({
   }
 
   const handleNodesChange = useCallback((changes: NodeChange[]) => {
-    // Position is the only thing the canvas owns. Selection is driven by
-    // `selectedNodeId`, structure by the editor's own handlers.
+    // The canvas owns position only; selection and structure stay the editor's.
     const positional = changes.filter((c) => c.type === 'position' || c.type === 'dimensions')
     if (positional.length > 0) setRfNodes((prev) => applyNodeChanges(positional, prev))
   }, [])
 
   const handleDragStop = useCallback(() => {
-    // Commit every node's displayed position, not only the dragged one: the
-    // first drag on a never-arranged workflow materializes the computed
-    // layout, so the rest must not stay behind on the seed column.
+    // Committing every displayed position materializes the computed layout on first drag.
     const positions: Record<string, { x: number; y: number }> = {}
     for (const rfNode of rfNodes) {
       if (rfNode.type === 'addStep') continue
@@ -446,7 +422,7 @@ function WorkflowCanvasInner({
     return () => {
       cancelled = true
     }
-    // Loaded once per palette opening; the set of connections is stable within it.
+    // Loaded once per palette opening.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [palette !== null])
 
@@ -473,8 +449,7 @@ function WorkflowCanvasInner({
     (event: MouseEvent | TouchEvent, connectionState: { isValid: boolean | null }) => {
       const source = pendingConnectSource.current
       pendingConnectSource.current = null
-      // A drop on empty canvas means "add a step here": open the search where
-      // the edge was released, remembering what it should hang off.
+      // A drop on empty canvas opens the node search where the edge was released.
       if (connectionState.isValid === null && source && 'clientX' in event) {
         openPaletteAt(event.clientX, event.clientY, source)
       }

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -22,7 +22,7 @@ import {
   type NodeProps
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { AlignVerticalSpaceAround, Repeat } from 'lucide-react'
+import { AlignVerticalSpaceAround, Repeat, Trash2 } from 'lucide-react'
 import { LoopConfig, NodeExecutionStatus, WorkflowEdge, WorkflowNode } from '../../../shared/types'
 import {
   AddStepNodeData,
@@ -78,9 +78,34 @@ interface CanvasInteractions {
   onNodeClick: (nodeId: string) => void
   onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
   onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
+  onDeleteNode?: (nodeId: string) => void
 }
 
 const InteractionsContext = createContext<CanvasInteractions | null>(null)
+
+/** The strip that floats over a hovered card; the wrapper must carry `group`. */
+function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
+  const { onDeleteNode } = useInteractions()
+  if (!onDeleteNode) return null
+  return (
+    <div
+      className="absolute -top-8 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100
+                 transition-opacity duration-100 z-10"
+    >
+      <button
+        aria-label="Delete step"
+        onClick={(e) => {
+          e.stopPropagation()
+          onDeleteNode(nodeId)
+        }}
+        className="p-1.5 rounded-md bg-surface-overlay border border-white/[0.12] text-gray-400
+                   hover:text-white hover:border-white/[0.2] transition-colors"
+      >
+        <Trash2 size={12} />
+      </button>
+    </div>
+  )
+}
 
 function useInteractions(): CanvasInteractions {
   const ctx = useContext(InteractionsContext)
@@ -97,9 +122,12 @@ function StepNode({ data }: NodeProps) {
   if (!node) return null
 
   return (
-    <div className="relative">
+    <div className="relative group">
       {node.type !== 'trigger' && (
-        <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
+        <>
+          <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
+          <NodeHoverToolbar nodeId={node.id} />
+        </>
       )}
       <NodeCard
         node={node}
@@ -131,8 +159,9 @@ function LoopNode({ data }: NodeProps) {
   const loopStatus = nodeStatus?.[node.id]
 
   return (
-    <div className="relative">
+    <div className="relative group">
       <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
+      <NodeHoverToolbar nodeId={node.id} />
       <div
         data-loop-rail
         className={`w-[312px] rounded-lg border transition-all
@@ -521,9 +550,18 @@ function WorkflowCanvasInner({
       nodeStatus,
       onNodeClick,
       onInsertNode,
-      onAddParallelBranch
+      onAddParallelBranch,
+      onDeleteNode
     }),
-    [nodes, selectedNodeId, nodeStatus, onNodeClick, onInsertNode, onAddParallelBranch]
+    [
+      nodes,
+      selectedNodeId,
+      nodeStatus,
+      onNodeClick,
+      onInsertNode,
+      onAddParallelBranch,
+      onDeleteNode
+    ]
   )
 
   return (

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -1,32 +1,40 @@
-import { useMemo, Fragment } from 'react'
-import { TriggerNode } from './nodes/TriggerNode'
-import { LaunchAgentNode } from './nodes/LaunchAgentNode'
-import { ScriptNode } from './nodes/ScriptNode'
-import { ConditionNode } from './nodes/ConditionNode'
-import { ApprovalNode } from './nodes/ApprovalNode'
-import { Repeat } from 'lucide-react'
-// Fallback for a loop node that is not reachable from the trigger: orphans are
-// appended as plain node rows, so they never reach LoopRenderer.
-import { LoopNode } from './nodes/LoopNode'
-import { CreateTaskFromItemNode } from './nodes/CreateTaskFromItemNode'
-import { CallConnectorActionNode } from './nodes/CallConnectorActionNode'
-import { ConnectorButton } from './nodes/AddStepNode'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  WorkflowNode,
-  WorkflowEdge,
-  TriggerConfig,
-  LaunchAgentConfig,
-  ScriptConfig,
-  ConditionConfig,
-  ApprovalConfig,
-  LoopConfig,
-  CreateTaskFromItemConfig,
-  CallConnectorActionConfig,
-  NodeExecutionStatus
-} from '../../../shared/types'
-import { computeFlowLayout, FlowRow } from '../../lib/workflow-helpers'
-import { NODE_SELECTED, NODE_UNSELECTED, NODE_GLYPH } from './node-visuals'
+  Background,
+  BackgroundVariant,
+  BaseEdge,
+  Controls,
+  EdgeLabelRenderer,
+  Handle,
+  MiniMap,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  applyNodeChanges,
+  getBezierPath,
+  useReactFlow,
+  type Connection,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeChange,
+  type NodeProps
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import { Repeat } from 'lucide-react'
+import { LoopConfig, NodeExecutionStatus, WorkflowEdge, WorkflowNode } from '../../../shared/types'
+import {
+  AddStepNodeData,
+  CanvasEdgeData,
+  canConnect,
+  toCanvasElements
+} from '../../lib/workflow-canvas-layout'
+import { useConnections } from '../../lib/use-connections'
+import { NODE_GLYPH, NODE_SELECTED, NODE_UNSELECTED } from './node-visuals'
 import { WORKFLOW_STATUS_DOT_PULSE } from '../../lib/workflow-status'
+import { NodeCard } from './nodes/NodeCard'
+import { ConnectorButton } from './nodes/AddStepNode'
+import { NodePalette, PaletteConnectorItem, PalettePick } from './panels/NodePalette'
 
 export type AddableNodeType =
   | 'agent'
@@ -42,6 +50,17 @@ interface Props {
   onNodeClick: (nodeId: string) => void
   onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
   onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
+  /** A hand-drawn, validated connection between two existing steps. */
+  onConnectEdge: (sourceId: string, targetId: string) => void
+  /** A palette pick, appended after `afterNodeId` at `position` (flow coords). */
+  onPaletteInsert: (
+    pick: PalettePick,
+    afterNodeId: string,
+    position: { x: number; y: number }
+  ) => void
+  /** Dragged nodes settled; write the new positions into the definition. */
+  onPositionsCommit: (positions: Record<string, { x: number; y: number }>) => void
+  onTidyUp: () => void
   selectedNodeId: string | null
   /**
    * What each node is doing in the runs that are live right now, so the canvas
@@ -51,500 +70,539 @@ interface Props {
   nodeStatus?: Record<string, NodeExecutionStatus>
 }
 
-function VerticalLine({ dashed, height }: { dashed?: boolean; height?: number }) {
-  return (
-    <div
-      className={`w-px shrink-0 ${
-        dashed ? 'border-l border-dashed border-white/[0.08]' : 'bg-white/[0.08]'
-      }`}
-      style={{ height: height ?? 24 }}
-    />
-  )
-}
-
-function NodeCard({
-  node,
-  allNodes,
-  selected,
-  onClick,
-  executionStatus
-}: {
-  node: WorkflowNode
-  /** Every node in the workflow: a loop card lists the steps it repeats. */
+/**
+ * Everything a canvas node needs beyond its own id. Kept in context so the
+ * node array only changes on structural edits — selection, status, and
+ * callback identity churn re-render the cards without rebuilding the graph.
+ */
+interface CanvasInteractions {
+  nodesById: Map<string, WorkflowNode>
   allNodes: WorkflowNode[]
-  selected: boolean
-  onClick: () => void
-  executionStatus?: NodeExecutionStatus
-}) {
-  if (node.type === 'loop') {
-    return (
-      <LoopNode
-        label={node.label}
-        config={node.config as LoopConfig}
-        nodes={allNodes}
-        selected={selected}
-        onClick={onClick}
-        executionStatus={executionStatus}
-      />
-    )
-  }
-
-  if (node.type === 'trigger') {
-    return (
-      <TriggerNode
-        label={node.label}
-        config={node.config as TriggerConfig}
-        selected={selected}
-        onClick={onClick}
-      />
-    )
-  }
-
-  if (node.type === 'script') {
-    return (
-      <ScriptNode
-        label={node.label}
-        config={node.config as ScriptConfig}
-        selected={selected}
-        onClick={onClick}
-        executionStatus={executionStatus}
-      />
-    )
-  }
-
-  if (node.type === 'condition') {
-    return (
-      <ConditionNode
-        label={node.label}
-        config={node.config as ConditionConfig}
-        selected={selected}
-        onClick={onClick}
-        executionStatus={executionStatus}
-      />
-    )
-  }
-
-  if (node.type === 'approval') {
-    return (
-      <ApprovalNode
-        label={node.label}
-        config={node.config as ApprovalConfig}
-        selected={selected}
-        onClick={onClick}
-        executionStatus={executionStatus}
-      />
-    )
-  }
-
-  if (node.type === 'createTaskFromItem') {
-    return (
-      <CreateTaskFromItemNode
-        label={node.label}
-        config={node.config as CreateTaskFromItemConfig}
-        selected={selected}
-        onClick={onClick}
-        executionStatus={executionStatus}
-      />
-    )
-  }
-
-  if (node.type === 'callConnectorAction') {
-    return (
-      <CallConnectorActionNode
-        label={node.label}
-        config={node.config as CallConnectorActionConfig}
-        selected={selected}
-        onClick={onClick}
-        executionStatus={executionStatus}
-      />
-    )
-  }
-
-  return (
-    <LaunchAgentNode
-      label={node.label}
-      config={node.config as LaunchAgentConfig}
-      selected={selected}
-      onClick={onClick}
-      executionStatus={executionStatus}
-    />
-  )
-}
-
-function FlowRowRenderer({
-  rows,
-  edges,
-  nodes,
-  onNodeClick,
-  onInsertNode,
-  onAddParallelBranch,
-  selectedNodeId,
-  nodeStatus,
-  isInsideBranch
-}: {
-  rows: FlowRow[]
-  edges?: WorkflowEdge[]
-  nodes?: WorkflowNode[]
+  selectedNodeId: string | null
+  nodeStatus?: Record<string, NodeExecutionStatus>
   onNodeClick: (nodeId: string) => void
   onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
   onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
-  selectedNodeId: string | null
-  isInsideBranch?: boolean
-  nodeStatus?: Record<string, NodeExecutionStatus>
-}) {
-  return (
-    <>
-      {rows.map((row, i) => {
-        if (row.kind === 'node') {
-          const nextRow = rows[i + 1]
-          const isLast = i === rows.length - 1
-          const nextIsFork = nextRow?.kind === 'fork'
-
-          let beforeNodeId: string | null = null
-          if (nextIsFork) {
-            beforeNodeId = '__FORK__'
-          } else if (nextRow?.kind === 'node') {
-            beforeNodeId = nextRow.node.id
-          }
-
-          return (
-            <Fragment key={row.node.id}>
-              {i > 0 && <VerticalLine />}
-
-              <NodeCard
-                node={row.node}
-                allNodes={nodes ?? []}
-                selected={row.node.id === selectedNodeId}
-                onClick={() => onNodeClick(row.node.id)}
-                executionStatus={nodeStatus?.[row.node.id]}
-              />
-
-              {!isLast && (
-                <>
-                  <VerticalLine />
-                  <ConnectorButton
-                    onAddAction={() => onInsertNode(row.node.id, beforeNodeId, 'agent')}
-                    onAddScript={() => onInsertNode(row.node.id, beforeNodeId, 'script')}
-                    onAddCondition={() => onInsertNode(row.node.id, beforeNodeId, 'condition')}
-                    onAddApproval={() => onInsertNode(row.node.id, beforeNodeId, 'approval')}
-                    onAddLoop={
-                      // Gated like onAddParallelBranch: a loop lifts its body
-                      // out of the trunk, and how that interacts with a fork's
-                      // join is untested. Offering it inside a branch would be
-                      // promising something that has never been tried.
-                      !isInsideBranch
-                        ? () => onInsertNode(row.node.id, beforeNodeId, 'loop')
-                        : undefined
-                    }
-                    onAddConnectorAction={() =>
-                      onInsertNode(row.node.id, beforeNodeId, 'connectorAction')
-                    }
-                    onAddParallelBranch={() => onAddParallelBranch(row.node.id, 'agent')}
-                  />
-                </>
-              )}
-
-              {isLast && (
-                <>
-                  <VerticalLine dashed />
-                  <ConnectorButton
-                    onAddAction={() => onInsertNode(row.node.id, null, 'agent')}
-                    onAddScript={() => onInsertNode(row.node.id, null, 'script')}
-                    onAddCondition={() => onInsertNode(row.node.id, null, 'condition')}
-                    onAddApproval={() => onInsertNode(row.node.id, null, 'approval')}
-                    onAddLoop={
-                      !isInsideBranch ? () => onInsertNode(row.node.id, null, 'loop') : undefined
-                    }
-                    onAddConnectorAction={() => onInsertNode(row.node.id, null, 'connectorAction')}
-                    onAddParallelBranch={
-                      !isInsideBranch ? () => onAddParallelBranch(row.node.id, 'agent') : undefined
-                    }
-                  />
-                </>
-              )}
-            </Fragment>
-          )
-        }
-
-        if (row.kind === 'loop') {
-          return (
-            <LoopRenderer
-              key={`loop-${row.loopNode.id}`}
-              row={row}
-              onNodeClick={onNodeClick}
-              onInsertNode={onInsertNode}
-              selectedNodeId={selectedNodeId}
-              nodeStatus={nodeStatus}
-              nodes={nodes ?? []}
-            />
-          )
-        }
-
-        return (
-          <ForkRenderer
-            key={`fork-${row.forkNodeId}`}
-            row={row}
-            onNodeClick={onNodeClick}
-            onInsertNode={onInsertNode}
-            onAddParallelBranch={onAddParallelBranch}
-            selectedNodeId={selectedNodeId}
-            nodeStatus={nodeStatus}
-            edges={edges}
-            nodes={nodes}
-          />
-        )
-      })}
-    </>
-  )
 }
 
-function HorizontalBar({ branchCount }: { branchCount: number }) {
+const InteractionsContext = createContext<CanvasInteractions | null>(null)
+
+function useInteractions(): CanvasInteractions {
+  const ctx = useContext(InteractionsContext)
+  if (!ctx) throw new Error('Canvas node rendered outside the workflow canvas')
+  return ctx
+}
+
+const HANDLE_CLASS = '!w-[7px] !h-[7px] !bg-surface-base !border !border-white/[0.35] !rounded-full'
+
+/** A single step: the existing card, with ports above and below. */
+function StepNode({ data }: NodeProps) {
+  const { nodesById, selectedNodeId, nodeStatus, onNodeClick } = useInteractions()
+  const node = nodesById.get(data.nodeId as string)
+  if (!node) return null
+
   return (
-    <div className="flex w-full">
-      {Array.from({ length: branchCount }, (_, i) => (
-        <div key={i} className="flex-1 relative h-px">
-          {i > 0 && <div className="absolute left-0 right-1/2 top-0 h-px bg-white/[0.08]" />}
-          {i < branchCount - 1 && (
-            <div className="absolute left-1/2 right-0 top-0 h-px bg-white/[0.08]" />
-          )}
-        </div>
-      ))}
+    <div className="relative">
+      {node.type !== 'trigger' && (
+        <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
+      )}
+      <NodeCard
+        node={node}
+        selected={node.id === selectedNodeId}
+        onClick={() => onNodeClick(node.id)}
+        executionStatus={nodeStatus?.[node.id]}
+      />
+      <Handle type="source" position={Position.Bottom} className={HANDLE_CLASS} />
     </div>
   )
 }
 
 /**
- * A loop and the steps it repeats, drawn as one enclosure.
- *
- * The two questions a reader has — what repeats, and when does it stop — are
- * answered at the top and bottom edges of the rail, so neither requires
- * opening a panel. The body is inset, which is the whole point: a repeated
- * step must not look like a step that runs once.
+ * A loop and the steps it repeats, drawn as one enclosure — the same composite
+ * the rail drew. The body renders inside, so a repeated step can never be
+ * mistaken for one that runs once, and membership stays the loop's own
+ * `bodyNodeIds` rather than canvas geometry.
  */
-function LoopRenderer({
-  row,
-  onNodeClick,
-  onInsertNode,
-  selectedNodeId,
-  nodeStatus,
-  nodes
-}: {
-  row: Extract<FlowRow, { kind: 'loop' }>
-  onNodeClick: (nodeId: string) => void
-  onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
-  selectedNodeId: string | null
-  nodeStatus?: Record<string, NodeExecutionStatus>
-  nodes: WorkflowNode[]
-}) {
-  const config = row.loopNode.config as LoopConfig
-  const selected = row.loopNode.id === selectedNodeId
+function LoopNode({ data }: NodeProps) {
+  const { nodesById, allNodes, selectedNodeId, nodeStatus, onNodeClick, onInsertNode } =
+    useInteractions()
+  const node = nodesById.get(data.nodeId as string)
+  if (!node || node.type !== 'loop') return null
+
+  const config = node.config as LoopConfig
+  const selected = node.id === selectedNodeId
   const until = config.until?.variable
     ? `until ${config.until.variable} ${config.until.operator} ${config.until.value}`
     : 'runs every pass'
-  const lastBodyId = row.body.length > 0 ? row.body[row.body.length - 1] : null
-  // The rail draws its own header instead of going through NodeCard, so the
-  // loop is the one node whose status has to be read here. It has one: a loop
-  // runs while it iterates, and errors when it has no body steps or holds a
-  // gate — without this the rail sat plain while the run was inside it.
-  const loopStatus = nodeStatus?.[row.loopNode.id]
+  const body = (config.bodyNodeIds ?? [])
+    .map((id) => allNodes.find((n) => n.id === id))
+    .filter((n): n is WorkflowNode => !!n)
+  const lastBodyId = body.length > 0 ? body[body.length - 1].id : null
+  const loopStatus = nodeStatus?.[node.id]
 
   return (
-    <div
-      data-loop-rail
-      className={`w-[312px] rounded-lg border transition-all
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
-                  bg-surface-node`}
-    >
+    <div className="relative">
+      <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
       <div
-        onClick={(e) => {
-          e.stopPropagation()
-          onNodeClick(row.loopNode.id)
-        }}
-        className="flex items-center gap-2 px-4 py-2.5 border-b border-white/[0.06] cursor-pointer
-                   hover:bg-white/[0.02] rounded-t-lg"
+        data-loop-rail
+        className={`w-[312px] rounded-lg border transition-all
+                    ${selected ? NODE_SELECTED : NODE_UNSELECTED}
+                    bg-surface-node`}
       >
-        <Repeat size={13} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />
-        <span className="text-[12.5px] font-semibold text-white truncate flex-1">
-          {row.loopNode.label}
-        </span>
-        <span className="shrink-0 text-[10px] font-mono text-gray-400 bg-white/[0.06] rounded px-1.5 py-0.5">
-          max {config.maxIterations ?? 1}
-        </span>
-        {loopStatus && WORKFLOW_STATUS_DOT_PULSE[loopStatus] && (
-          <span
-            data-loop-status
-            className={`shrink-0 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[loopStatus]}`}
-          />
-        )}
-      </div>
+        <div
+          onClick={(e) => {
+            e.stopPropagation()
+            onNodeClick(node.id)
+          }}
+          className="flex items-center gap-2 px-4 py-2.5 border-b border-white/[0.06] cursor-pointer
+                     hover:bg-white/[0.02] rounded-t-lg"
+        >
+          <Repeat size={13} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />
+          <span className="text-[12.5px] font-semibold text-white truncate flex-1">
+            {node.label}
+          </span>
+          <span className="shrink-0 text-[10px] font-mono text-gray-400 bg-white/[0.06] rounded px-1.5 py-0.5">
+            max {config.maxIterations ?? 1}
+          </span>
+          {loopStatus && WORKFLOW_STATUS_DOT_PULSE[loopStatus] && (
+            <span
+              data-loop-status
+              className={`shrink-0 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[loopStatus]}`}
+            />
+          )}
+        </div>
 
-      <div className="px-4 pt-4 flex flex-col items-center">
-        {row.body.length === 0 ? (
-          <div
-            className="w-full rounded-md border border-dashed border-white/[0.12] px-3 py-4
-                       text-[11px] text-gray-500 text-center"
-          >
-            No steps yet — add one below
-          </div>
-        ) : (
-          row.body.map((bodyRow, i) => (
-            <Fragment key={bodyRow.kind === 'node' ? bodyRow.node.id : i}>
-              {i > 0 && <VerticalLine />}
-              {bodyRow.kind === 'node' && (
+        <div className="px-4 pt-4 flex flex-col items-center">
+          {body.length === 0 ? (
+            <div
+              className="w-full rounded-md border border-dashed border-white/[0.12] px-3 py-4
+                         text-[11px] text-gray-500 text-center"
+            >
+              No steps yet — add one below
+            </div>
+          ) : (
+            body.map((bodyNode, i) => (
+              <div key={bodyNode.id} className="flex flex-col items-center">
+                {i > 0 && <div className="w-px h-[18px] bg-white/[0.08]" />}
                 <NodeCard
-                  node={bodyRow.node}
-                  allNodes={nodes}
-                  selected={bodyRow.node.id === selectedNodeId}
-                  onClick={() => onNodeClick(bodyRow.node.id)}
-                  executionStatus={nodeStatus?.[bodyRow.node.id]}
+                  node={bodyNode}
+                  selected={bodyNode.id === selectedNodeId}
+                  onClick={() => onNodeClick(bodyNode.id)}
+                  executionStatus={nodeStatus?.[bodyNode.id]}
                 />
-              )}
-            </Fragment>
-          ))
-        )}
+              </div>
+            ))
+          )}
 
-        {/* Inside the rail, so position is what decides membership. */}
-        <VerticalLine />
-        <ConnectorButton
-          onAddAction={() =>
-            onInsertNode(
-              lastBodyId?.kind === 'node' ? lastBodyId.node.id : row.loopNode.id,
-              '__LOOP_BODY__',
-              'agent'
-            )
-          }
-          onAddScript={() =>
-            onInsertNode(
-              lastBodyId?.kind === 'node' ? lastBodyId.node.id : row.loopNode.id,
-              '__LOOP_BODY__',
-              'script'
-            )
-          }
-        />
-      </div>
+          {/* Inside the rail, so position is what decides membership. */}
+          <div className="w-px h-[18px] bg-white/[0.08]" />
+          <ConnectorButton
+            onAddAction={() => onInsertNode(lastBodyId ?? node.id, '__LOOP_BODY__', 'agent')}
+            onAddScript={() => onInsertNode(lastBodyId ?? node.id, '__LOOP_BODY__', 'script')}
+          />
+        </div>
 
-      <div className="px-4 pt-2.5 pb-3 text-[10px] font-mono text-gray-500 text-center truncate">
-        ↻ {until}
+        <div className="px-4 pt-2.5 pb-3 text-[10px] font-mono text-gray-500 text-center truncate">
+          ↻ {until}
+        </div>
       </div>
+      <Handle type="source" position={Position.Bottom} className={HANDLE_CLASS} />
     </div>
   )
 }
 
-function ForkRenderer({
-  row,
-  onNodeClick,
-  onInsertNode,
-  onAddParallelBranch,
-  selectedNodeId,
-  nodeStatus,
-  edges,
-  nodes
-}: {
-  row: Extract<FlowRow, { kind: 'fork' }>
-  onNodeClick: (nodeId: string) => void
-  onInsertNode: (afterNodeId: string, beforeNodeId: string | null, type: AddableNodeType) => void
-  onAddParallelBranch: (forkFromId: string, type: 'agent' | 'script') => void
-  selectedNodeId: string | null
-  nodeStatus?: Record<string, NodeExecutionStatus>
-  edges?: WorkflowEdge[]
-  nodes?: WorkflowNode[]
-}) {
-  const branchCount = row.branches.length
+/** The + that trails every leaf, carrying the same menu the rail ended with. */
+function AddStepNode({ data }: NodeProps) {
+  const { onInsertNode, onAddParallelBranch } = useInteractions()
+  const { afterNodeId, insideBranch } = data as unknown as AddStepNodeData
 
-  // Check if this fork is from a condition node
-  const forkNode = nodes?.find((n) => n.id === row.forkNodeId)
-  const isConditionFork = forkNode?.type === 'condition'
+  return (
+    <div className="relative">
+      <Handle type="target" position={Position.Top} className="!opacity-0 !pointer-events-none" />
+      <ConnectorButton
+        onAddAction={() => onInsertNode(afterNodeId, null, 'agent')}
+        onAddScript={() => onInsertNode(afterNodeId, null, 'script')}
+        onAddCondition={() => onInsertNode(afterNodeId, null, 'condition')}
+        onAddApproval={() => onInsertNode(afterNodeId, null, 'approval')}
+        onAddLoop={
+          // Gated like the rail: a loop lifts its body out of the trunk, and
+          // how that interacts with a fork's join is untested.
+          !insideBranch ? () => onInsertNode(afterNodeId, null, 'loop') : undefined
+        }
+        onAddConnectorAction={() => onInsertNode(afterNodeId, null, 'connectorAction')}
+        onAddParallelBranch={
+          !insideBranch ? () => onAddParallelBranch(afterNodeId, 'agent') : undefined
+        }
+      />
+    </div>
+  )
+}
 
-  // Determine branch labels for condition forks
-  const getBranchLabel = (branchIndex: number): string | null => {
-    if (!isConditionFork || !edges) return null
-    const branch = row.branches[branchIndex]
-    const firstNodeInBranch = branch?.[0]?.kind === 'node' ? branch[0].node.id : null
-    if (!firstNodeInBranch) return null
-    const edge = edges.find(
-      (e) => e.source === row.forkNodeId && e.target === firstNodeInBranch && e.conditionBranch
-    )
-    return edge?.conditionBranch === 'true'
-      ? 'True'
-      : edge?.conditionBranch === 'false'
-        ? 'False'
-        : null
+/**
+ * A step edge: the connecting line, the True/False pill on condition branches,
+ * and an insert button that appears while the pointer lingers. The generous
+ * `interactionWidth` and the delayed leave exist so the mouse can travel from
+ * the line to the button without the button vanishing under it.
+ */
+function StepEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  label,
+  style,
+  data
+}: EdgeProps) {
+  const { onInsertNode, onAddParallelBranch } = useInteractions()
+  const [hovered, setHovered] = useState(false)
+  const leaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (leaveTimer.current) clearTimeout(leaveTimer.current)
+    }
+  }, [])
+
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition
+  })
+
+  const edgeData = data as CanvasEdgeData | undefined
+  const insertable = !!edgeData?.afterNodeId && !!edgeData?.beforeNodeId
+
+  const enter = () => {
+    if (leaveTimer.current) clearTimeout(leaveTimer.current)
+    setHovered(true)
+  }
+  const leave = () => {
+    if (leaveTimer.current) clearTimeout(leaveTimer.current)
+    leaveTimer.current = setTimeout(() => setHovered(false), 600)
   }
 
   return (
-    <div className="flex flex-col items-center w-full">
-      <HorizontalBar branchCount={branchCount} />
-
-      <div className="flex w-full">
-        {row.branches.map((branch, bi) => {
-          const branchKey = branch[0]?.kind === 'node' ? branch[0].node.id : `branch-${bi}`
-          const label = getBranchLabel(bi)
-
-          return (
+    <g onMouseEnter={enter} onMouseLeave={leave}>
+      <BaseEdge
+        id={id}
+        path={path}
+        interactionWidth={40}
+        style={{ stroke: 'rgba(255,255,255,0.16)', strokeWidth: 1.5, ...style }}
+      />
+      <EdgeLabelRenderer>
+        <div
+          className="absolute flex flex-col items-center gap-1 pointer-events-auto"
+          style={{ transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)` }}
+          onMouseEnter={enter}
+          onMouseLeave={leave}
+        >
+          {label ? (
             <div
-              key={branchKey}
-              className="flex flex-col items-center flex-1"
-              style={{ minWidth: 310 }}
+              data-branch-label
+              className="px-2.5 py-0.5 rounded-full text-[10px] font-semibold border border-white/[0.08] text-ink-secondary bg-surface-base"
             >
-              {/* Both branches read the same. True was green and False red,
-                  which said one path is the good one and the other a failure —
-                  a condition is a fork, and the word already says which. */}
-              {label && (
-                <div className="px-2.5 py-0.5 rounded-full text-[10px] font-semibold mb-1 border border-white/[0.08] text-ink-secondary">
-                  {label}
-                </div>
-              )}
-
-              <VerticalLine />
-
-              <FlowRowRenderer
-                rows={branch}
-                edges={edges}
-                nodes={nodes}
-                onNodeClick={onNodeClick}
-                onInsertNode={onInsertNode}
-                onAddParallelBranch={onAddParallelBranch}
-                selectedNodeId={selectedNodeId}
-                nodeStatus={nodeStatus}
-                isInsideBranch
-              />
-
-              {row.joinNodeId && <VerticalLine />}
+              {label}
             </div>
-          )
-        })}
-      </div>
-
-      {row.joinNodeId && <HorizontalBar branchCount={branchCount} />}
-    </div>
+          ) : null}
+          {insertable && (hovered || !label) && (
+            <div className={hovered ? 'opacity-100' : 'opacity-0 hover:opacity-100'}>
+              <ConnectorButton
+                onAddAction={() =>
+                  onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'agent')
+                }
+                onAddScript={() =>
+                  onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'script')
+                }
+                onAddCondition={() =>
+                  onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'condition')
+                }
+                onAddApproval={() =>
+                  onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'approval')
+                }
+                onAddLoop={
+                  !edgeData!.insideBranch
+                    ? () => onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'loop')
+                    : undefined
+                }
+                onAddConnectorAction={() =>
+                  onInsertNode(edgeData!.afterNodeId, edgeData!.beforeNodeId, 'connectorAction')
+                }
+                onAddParallelBranch={
+                  !edgeData!.insideBranch
+                    ? () => onAddParallelBranch(edgeData!.afterNodeId, 'agent')
+                    : undefined
+                }
+              />
+            </div>
+          )}
+        </div>
+      </EdgeLabelRenderer>
+    </g>
   )
 }
 
-export function WorkflowCanvas({
+const NODE_TYPES = { step: StepNode, loop: LoopNode, addStep: AddStepNode }
+const EDGE_TYPES = { step: StepEdge }
+
+function WorkflowCanvasInner({
   nodes,
   edges,
   onNodeClick,
   onInsertNode,
   onAddParallelBranch,
+  onConnectEdge,
+  onPaletteInsert,
+  onPositionsCommit,
+  onTidyUp,
   selectedNodeId,
   nodeStatus
 }: Props) {
-  const flowLayout = useMemo(() => computeFlowLayout(nodes, edges), [nodes, edges])
+  const { screenToFlowPosition } = useReactFlow()
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
+  const elements = useMemo(() => toCanvasElements(nodes, edges), [nodes, edges])
+  const [rfNodes, setRfNodes] = useState<Node[]>(elements.nodes)
+
+  // The definition is the source of truth: rebuild whenever it changes.
+  // Interim drag positions live only in local state, so this is the
+  // adjust-state-while-rendering pattern rather than an effect.
+  const [syncedElements, setSyncedElements] = useState(elements)
+  if (syncedElements !== elements) {
+    setSyncedElements(elements)
+    setRfNodes(elements.nodes)
+  }
+
+  const handleNodesChange = useCallback((changes: NodeChange[]) => {
+    // Position is the only thing the canvas owns. Selection is driven by
+    // `selectedNodeId`, structure by the editor's own handlers.
+    const positional = changes.filter((c) => c.type === 'position' || c.type === 'dimensions')
+    if (positional.length > 0) setRfNodes((prev) => applyNodeChanges(positional, prev))
+  }, [])
+
+  const handleDragStop = useCallback(() => {
+    // Commit every node's displayed position, not only the dragged one: the
+    // first drag on a never-arranged workflow materializes the computed
+    // layout, so the rest must not stay behind on the seed column.
+    const positions: Record<string, { x: number; y: number }> = {}
+    for (const rfNode of rfNodes) {
+      if (rfNode.type === 'addStep') continue
+      positions[rfNode.id] = { x: rfNode.position.x, y: rfNode.position.y }
+    }
+    onPositionsCommit(positions)
+  }, [rfNodes, onPositionsCommit])
+
+  const isValidConnection = useCallback(
+    (connection: Connection | Edge) =>
+      !!connection.source &&
+      !!connection.target &&
+      canConnect(nodes, edges, connection.source, connection.target),
+    [nodes, edges]
+  )
+
+  const handleConnect = useCallback(
+    (connection: Connection) => {
+      if (connection.source && connection.target) {
+        onConnectEdge(connection.source, connection.target)
+      }
+    },
+    [onConnectEdge]
+  )
+
+  // --- Node search palette -------------------------------------------------
+  const [palette, setPalette] = useState<{
+    screen: { x: number; y: number }
+    flow: { x: number; y: number }
+    afterNodeId: string
+  } | null>(null)
+  const [connectorItems, setConnectorItems] = useState<PaletteConnectorItem[]>([])
+  const connections = useConnections()
+
+  useEffect(() => {
+    if (!palette) return
+    let cancelled = false
+    Promise.all(
+      connections.map(async (conn) => {
+        try {
+          const actions = await window.api.listConnectionActions(conn.id)
+          return actions.map((a) => ({
+            connectionId: conn.id,
+            action: a.type,
+            label: a.label || a.type,
+            source: conn.name
+          }))
+        } catch {
+          return []
+        }
+      })
+    ).then((lists) => {
+      if (!cancelled) setConnectorItems(lists.flat())
+    })
+    return () => {
+      cancelled = true
+    }
+    // Loaded once per palette opening; the set of connections is stable within it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [palette !== null])
+
+  const openPaletteAt = useCallback(
+    (clientX: number, clientY: number, afterNodeId: string) => {
+      const rect = wrapperRef.current?.getBoundingClientRect()
+      if (!rect) return
+      setPalette({
+        screen: { x: clientX - rect.left, y: clientY - rect.top },
+        flow: screenToFlowPosition({ x: clientX, y: clientY }),
+        afterNodeId
+      })
+    },
+    [screenToFlowPosition]
+  )
+
+  const pendingConnectSource = useRef<string | null>(null)
+
+  const handleConnectStart = useCallback((_: unknown, params: { nodeId: string | null }) => {
+    pendingConnectSource.current = params.nodeId
+  }, [])
+
+  const handleConnectEnd = useCallback(
+    (event: MouseEvent | TouchEvent, connectionState: { isValid: boolean | null }) => {
+      const source = pendingConnectSource.current
+      pendingConnectSource.current = null
+      // A drop on empty canvas means "add a step here": open the search where
+      // the edge was released, remembering what it should hang off.
+      if (connectionState.isValid === null && source && 'clientX' in event) {
+        openPaletteAt(event.clientX, event.clientY, source)
+      }
+    },
+    [openPaletteAt]
+  )
+
+  const leafForTabInsert = useCallback((): string | null => {
+    const hasOutgoing = new Set(edges.map((e) => e.source))
+    const leaf = [...nodes].reverse().find((n) => !hasOutgoing.has(n.id))
+    return leaf?.id ?? null
+  }, [nodes, edges])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== 'Tab' || palette) return
+      const target = e.target as HTMLElement
+      if (target.closest('input, textarea, [contenteditable]')) return
+      const afterNodeId = leafForTabInsert()
+      const rect = wrapperRef.current?.getBoundingClientRect()
+      if (!afterNodeId || !rect) return
+      e.preventDefault()
+      openPaletteAt(rect.left + rect.width / 2 - 124, rect.top + rect.height / 3, afterNodeId)
+    },
+    [palette, leafForTabInsert, openPaletteAt]
+  )
+
+  const interactions = useMemo<CanvasInteractions>(
+    () => ({
+      nodesById: new Map(nodes.map((n) => [n.id, n])),
+      allNodes: nodes,
+      selectedNodeId,
+      nodeStatus,
+      onNodeClick,
+      onInsertNode,
+      onAddParallelBranch
+    }),
+    [nodes, selectedNodeId, nodeStatus, onNodeClick, onInsertNode, onAddParallelBranch]
+  )
 
   return (
-    <div className="flex-1 h-full overflow-auto" onClick={() => onNodeClick('')}>
-      <div className="flex flex-col items-center py-8 min-h-full px-6">
-        <FlowRowRenderer
-          rows={flowLayout}
-          edges={edges}
-          nodes={nodes}
-          onNodeClick={onNodeClick}
-          onInsertNode={onInsertNode}
-          onAddParallelBranch={onAddParallelBranch}
-          selectedNodeId={selectedNodeId}
-          nodeStatus={nodeStatus}
-        />
+    <InteractionsContext.Provider value={interactions}>
+      <div
+        ref={wrapperRef}
+        className="flex-1 h-full relative outline-none"
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+      >
+        <ReactFlow
+          nodes={rfNodes}
+          edges={elements.edges}
+          nodeTypes={NODE_TYPES}
+          edgeTypes={EDGE_TYPES}
+          onNodesChange={handleNodesChange}
+          onNodeDragStop={handleDragStop}
+          onConnect={handleConnect}
+          onConnectStart={handleConnectStart}
+          onConnectEnd={handleConnectEnd}
+          isValidConnection={isValidConnection}
+          onPaneClick={() => {
+            setPalette(null)
+            onNodeClick('')
+          }}
+          fitView
+          fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
+          minZoom={0.2}
+          maxZoom={1.75}
+          deleteKeyCode={null}
+          selectionKeyCode={null}
+          multiSelectionKeyCode={null}
+          nodesFocusable={false}
+          edgesFocusable={false}
+          colorMode="dark"
+          className="bg-surface-base"
+          defaultEdgeOptions={{ type: 'step' }}
+        >
+          <Background
+            variant={BackgroundVariant.Dots}
+            gap={20}
+            size={1}
+            color="rgba(255,255,255,0.05)"
+          />
+          <MiniMap
+            pannable
+            zoomable
+            className="!bg-surface-panel !border !border-white/[0.12] !rounded"
+            maskColor="rgba(0,0,0,0.55)"
+            nodeColor="rgba(255,255,255,0.25)"
+            style={{ width: 96, height: 64 }}
+          />
+          <Controls
+            showInteractive={false}
+            className="!bg-surface-overlay !border !border-white/[0.12] !rounded-md !shadow-none
+                       [&_button]:!bg-transparent [&_button]:!border-white/[0.08] [&_button]:!fill-gray-400"
+          />
+        </ReactFlow>
+
+        <div className="absolute top-2.5 right-2.5 z-10">
+          <button
+            onClick={onTidyUp}
+            className="text-[11px] text-gray-300 bg-surface-overlay border border-white/[0.12]
+                       rounded-md px-2.5 py-1 hover:text-white hover:border-white/[0.2] transition-colors"
+          >
+            Tidy up
+          </button>
+        </div>
+
+        {palette && (
+          <NodePalette
+            position={palette.screen}
+            allowLoop={!elements.branchMembers.has(palette.afterNodeId)}
+            connectorItems={connectorItems}
+            onPick={(pick) => {
+              onPaletteInsert(pick, palette.afterNodeId, palette.flow)
+              setPalette(null)
+            }}
+            onClose={() => setPalette(null)}
+          />
+        )}
       </div>
-    </div>
+    </InteractionsContext.Provider>
+  )
+}
+
+export function WorkflowCanvas(props: Props) {
+  return (
+    <ReactFlowProvider>
+      <WorkflowCanvasInner {...props} />
+    </ReactFlowProvider>
   )
 }

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -89,7 +89,7 @@ function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
   if (!onDeleteNode) return null
   return (
     <div
-      className="absolute -top-8 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100
+      className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 opacity-0 group-hover:opacity-100
                  transition-opacity duration-100 z-10"
     >
       <button

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -496,12 +496,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     return () => window.removeEventListener('keydown', handler)
   }, [isActive, undo, redo])
 
-  const handleConnectEdge = useCallback(
-    (sourceId: string, targetId: string) => {
-      setEdges([...edges, { id: crypto.randomUUID(), source: sourceId, target: targetId }])
-    },
-    [edges]
-  )
+  const handleConnectEdge = useCallback((sourceId: string, targetId: string) => {
+    setEdges((eds) => [...eds, { id: crypto.randomUUID(), source: sourceId, target: targetId }])
+  }, [])
 
   const handlePositionsCommit = useCallback(
     (positions: Record<string, { x: number; y: number }>) => {

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -486,7 +486,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     const handler = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'z') return
       const target = e.target as HTMLElement
-      // Text fields keep their native undo; the shortcut is for the graph.
+      // Text fields keep their native undo.
       if (target.closest('input, textarea, [contenteditable="true"]')) return
       e.preventDefault()
       if (e.shiftKey) redo()
@@ -517,9 +517,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
 
   const handlePaletteInsert = useCallback(
     (pick: PalettePick, afterNodeId: string, position: { x: number; y: number }) => {
-      // A workflow nobody has arranged shows the computed layout; materialize
-      // it first so placing one node at the drop point doesn't strand the rest
-      // on the seed column.
+      // Materialize the computed layout first so the drop doesn't strand the rest on the seed column.
       const placeAll = (
         placed: WorkflowNode[],
         edgesForLayout: WorkflowEdge[],

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -879,6 +879,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           onConnectEdge={handleConnectEdge}
           onPaletteInsert={handlePaletteInsert}
           onPositionsCommit={handlePositionsCommit}
+          onDeleteNode={handleDeleteNode}
           onTidyUp={handleTidyUp}
           selectedNodeId={selectedNodeId}
           nodeStatus={nodeStatus}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -33,12 +33,16 @@ import {
   getProjectRemoteHostId
 } from '../../../shared/types'
 import { WorkflowCanvas, AddableNodeType } from './WorkflowCanvas'
+import type { PalettePick } from './panels/NodePalette'
+import { layoutPositions } from '../../lib/workflow-canvas-layout'
+import { useDefinitionHistory } from '../../lib/use-definition-history'
 import { NodeConfigPanel } from './panels/NodeConfigPanel'
 import { RunHistoryPanel } from './panels/RunHistoryPanel'
 import { WorkflowPropertiesPanel } from './panels/WorkflowPropertiesPanel'
 import {
   createTriggerNode,
   createLaunchAgentNode,
+  positionsAreSeed,
   createScriptNode,
   createConditionNode,
   createApprovalNode,
@@ -475,6 +479,97 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     if (!nodeId) setShowProperties(true)
   }, [])
 
+  const { undo, redo } = useDefinitionHistory(nodes, edges, setNodes, setEdges, editingId ?? 'new')
+
+  useEffect(() => {
+    if (!isActive) return
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== 'z') return
+      const target = e.target as HTMLElement
+      // Text fields keep their native undo; the shortcut is for the graph.
+      if (target.closest('input, textarea, [contenteditable="true"]')) return
+      e.preventDefault()
+      if (e.shiftKey) redo()
+      else undo()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [isActive, undo, redo])
+
+  const handleConnectEdge = useCallback(
+    (sourceId: string, targetId: string) => {
+      setEdges([...edges, { id: crypto.randomUUID(), source: sourceId, target: targetId }])
+    },
+    [edges]
+  )
+
+  const handlePositionsCommit = useCallback(
+    (positions: Record<string, { x: number; y: number }>) => {
+      setNodes((nds) => nds.map((n) => (positions[n.id] ? { ...n, position: positions[n.id] } : n)))
+    },
+    []
+  )
+
+  const handleTidyUp = useCallback(() => {
+    const { positions } = layoutPositions(nodes, edges)
+    setNodes(nodes.map((n) => (positions.has(n.id) ? { ...n, position: positions.get(n.id)! } : n)))
+  }, [nodes, edges])
+
+  const handlePaletteInsert = useCallback(
+    (pick: PalettePick, afterNodeId: string, position: { x: number; y: number }) => {
+      // A workflow nobody has arranged shows the computed layout; materialize
+      // it first so placing one node at the drop point doesn't strand the rest
+      // on the seed column.
+      const placeAll = (
+        placed: WorkflowNode[],
+        edgesForLayout: WorkflowEdge[],
+        newNodeId: string | undefined
+      ): WorkflowNode[] => {
+        const base = positionsAreSeed(nodes)
+          ? (() => {
+              const { positions } = layoutPositions(placed, edgesForLayout)
+              return placed.map((n) =>
+                positions.has(n.id) ? { ...n, position: positions.get(n.id)! } : n
+              )
+            })()
+          : placed
+        return base.map((n) => (n.id === newNodeId ? { ...n, position } : n))
+      }
+
+      if (pick.kind === 'type' && pick.type === 'condition') {
+        const result = insertConditionBetween(nodes, edges, afterNodeId, null)
+        const condNode = result.nodes.find(
+          (n) => n.type === 'condition' && !nodes.some((o) => o.id === n.id)
+        )
+        setNodes(placeAll(result.nodes, result.edges, condNode?.id))
+        setEdges(result.edges)
+        if (condNode) setSelectedNodeId(condNode.id)
+        return
+      }
+
+      const newNode =
+        pick.kind === 'connectorAction'
+          ? (() => {
+              const n = createNodeWithUniqueSlug('connectorAction')
+              return {
+                ...n,
+                config: {
+                  ...(n.config as CallConnectorActionConfig),
+                  connectionId: pick.connectionId,
+                  action: pick.action
+                }
+              }
+            })()
+          : createNodeWithUniqueSlug(pick.type)
+
+      const result = appendNodeAfter(nodes, edges, afterNodeId, newNode)
+      setNodes(placeAll(result.nodes, result.edges, newNode.id))
+      setEdges(result.edges)
+      setSelectedNodeId(newNode.id)
+    },
+    [nodes, edges, createNodeWithUniqueSlug]
+  )
+
   const handleNodeConfigChange = useCallback((nodeId: string, config: WorkflowNode['config']) => {
     setNodes((nds) => nds.map((n) => (n.id === nodeId ? { ...n, config } : n)))
   }, [])
@@ -783,6 +878,10 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           onNodeClick={handleNodeClick}
           onInsertNode={handleInsertNode}
           onAddParallelBranch={handleAddParallelBranch}
+          onConnectEdge={handleConnectEdge}
+          onPaletteInsert={handlePaletteInsert}
+          onPositionsCommit={handlePositionsCommit}
+          onTidyUp={handleTidyUp}
           selectedNodeId={selectedNodeId}
           nodeStatus={nodeStatus}
         />

--- a/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/AddStepNode.tsx
@@ -38,6 +38,7 @@ export function ConnectorButton({
   return (
     <div className="relative flex flex-col items-center" ref={menuRef}>
       <button
+        aria-label="Add a step"
         onClick={(e) => {
           e.stopPropagation()
           setOpen(!open)

--- a/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ApprovalNode.tsx
@@ -18,7 +18,7 @@ export function ApprovalNode({ label, config, selected, executionStatus, onClick
 
   return (
     <NodeShell
-      icon={<Hand size={14} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />}
+      icon={<Hand size={18} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />}
       label={label}
       subtitle={subtitle}
       selected={selected}

--- a/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
@@ -28,11 +28,12 @@ export function CallConnectorActionNode({
     <NodeShell
       icon={
         connectorId ? (
+          // A brand mark identifies the step; it gets full ink and a step up in size.
           <ConnectorIcon
             connectorId={connectorId}
             icon={icon}
-            size={14}
-            className={`${NODE_GLYPH} shrink-0`}
+            size={16}
+            className="text-ink shrink-0"
           />
         ) : (
           <Zap size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />

--- a/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CallConnectorActionNode.tsx
@@ -32,11 +32,11 @@ export function CallConnectorActionNode({
           <ConnectorIcon
             connectorId={connectorId}
             icon={icon}
-            size={16}
+            size={18}
             className="text-ink shrink-0"
           />
         ) : (
-          <Zap size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
+          <Zap size={18} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
         )
       }
       label={label}

--- a/src/renderer/components/workflow-editor/nodes/ConditionNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ConditionNode.tsx
@@ -37,7 +37,7 @@ export function ConditionNode({ label, config, selected, executionStatus, onClic
 
   return (
     <NodeShell
-      icon={<GitFork size={14} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />}
+      icon={<GitFork size={18} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />}
       label={label}
       subtitle={hasConfig ? OPERATOR_LABELS[config.operator] : 'Not configured'}
       selected={selected}

--- a/src/renderer/components/workflow-editor/nodes/CreateTaskFromItemNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/CreateTaskFromItemNode.tsx
@@ -23,7 +23,7 @@ export function CreateTaskFromItemNode({
 
   return (
     <NodeShell
-      icon={<ListPlus size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />}
+      icon={<ListPlus size={18} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />}
       label={label}
       subtitle={`${projectLabel} · initial: ${config.initialStatus}`}
       selected={selected}

--- a/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
@@ -33,9 +33,9 @@ export function LaunchAgentNode({ label, config, selected, executionStatus, onCl
       icon={
         <span className="shrink-0">
           {isFromTask ? (
-            <ClipboardList size={14} className={NODE_GLYPH} />
+            <ClipboardList size={18} className={NODE_GLYPH} />
           ) : (
-            <AgentIcon agentType={config.agentType as AiAgentType} size={14} />
+            <AgentIcon agentType={config.agentType as AiAgentType} size={18} />
           )}
         </span>
       }

--- a/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LoopNode.tsx
@@ -39,7 +39,7 @@ export function LoopNode({
 
   return (
     <NodeShell
-      icon={<Repeat size={14} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />}
+      icon={<Repeat size={18} className={`shrink-0 ${NODE_GLYPH}`} strokeWidth={2} />}
       label={label}
       subtitle={subtitle}
       selected={selected}

--- a/src/renderer/components/workflow-editor/nodes/NodeCard.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeCard.tsx
@@ -17,13 +17,7 @@ import { ApprovalNode } from './ApprovalNode'
 import { CreateTaskFromItemNode } from './CreateTaskFromItemNode'
 import { CallConnectorActionNode } from './CallConnectorActionNode'
 
-/**
- * The card for a single step, dispatched by type.
- *
- * Loops are not here on purpose: on the canvas a loop is a composite that
- * draws its own body, and a loop can never be another loop's body step, so a
- * card-shaped loop has no call site left.
- */
+/** The card for a single step, dispatched by type; loops render as composites, not cards. */
 export function NodeCard({
   node,
   selected,

--- a/src/renderer/components/workflow-editor/nodes/NodeCard.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeCard.tsx
@@ -1,0 +1,118 @@
+import {
+  WorkflowNode,
+  TriggerConfig,
+  LaunchAgentConfig,
+  ScriptConfig,
+  ConditionConfig,
+  ApprovalConfig,
+  CreateTaskFromItemConfig,
+  CallConnectorActionConfig,
+  NodeExecutionStatus
+} from '../../../../shared/types'
+import { TriggerNode } from './TriggerNode'
+import { LaunchAgentNode } from './LaunchAgentNode'
+import { ScriptNode } from './ScriptNode'
+import { ConditionNode } from './ConditionNode'
+import { ApprovalNode } from './ApprovalNode'
+import { CreateTaskFromItemNode } from './CreateTaskFromItemNode'
+import { CallConnectorActionNode } from './CallConnectorActionNode'
+
+/**
+ * The card for a single step, dispatched by type.
+ *
+ * Loops are not here on purpose: on the canvas a loop is a composite that
+ * draws its own body, and a loop can never be another loop's body step, so a
+ * card-shaped loop has no call site left.
+ */
+export function NodeCard({
+  node,
+  selected,
+  onClick,
+  executionStatus
+}: {
+  node: WorkflowNode
+  selected: boolean
+  onClick: () => void
+  executionStatus?: NodeExecutionStatus
+}) {
+  if (node.type === 'trigger') {
+    return (
+      <TriggerNode
+        label={node.label}
+        config={node.config as TriggerConfig}
+        selected={selected}
+        onClick={onClick}
+      />
+    )
+  }
+
+  if (node.type === 'script') {
+    return (
+      <ScriptNode
+        label={node.label}
+        config={node.config as ScriptConfig}
+        selected={selected}
+        onClick={onClick}
+        executionStatus={executionStatus}
+      />
+    )
+  }
+
+  if (node.type === 'condition') {
+    return (
+      <ConditionNode
+        label={node.label}
+        config={node.config as ConditionConfig}
+        selected={selected}
+        onClick={onClick}
+        executionStatus={executionStatus}
+      />
+    )
+  }
+
+  if (node.type === 'approval') {
+    return (
+      <ApprovalNode
+        label={node.label}
+        config={node.config as ApprovalConfig}
+        selected={selected}
+        onClick={onClick}
+        executionStatus={executionStatus}
+      />
+    )
+  }
+
+  if (node.type === 'createTaskFromItem') {
+    return (
+      <CreateTaskFromItemNode
+        label={node.label}
+        config={node.config as CreateTaskFromItemConfig}
+        selected={selected}
+        onClick={onClick}
+        executionStatus={executionStatus}
+      />
+    )
+  }
+
+  if (node.type === 'callConnectorAction') {
+    return (
+      <CallConnectorActionNode
+        label={node.label}
+        config={node.config as CallConnectorActionConfig}
+        selected={selected}
+        onClick={onClick}
+        executionStatus={executionStatus}
+      />
+    )
+  }
+
+  return (
+    <LaunchAgentNode
+      label={node.label}
+      config={node.config as LaunchAgentConfig}
+      selected={selected}
+      onClick={onClick}
+      executionStatus={executionStatus}
+    />
+  )
+}

--- a/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
@@ -68,12 +68,7 @@ export function NodeShell({
         />
       )}
       <div className="flex items-center gap-2">
-        <div
-          className="shrink-0 w-7 h-7 rounded-md border border-white/[0.08] bg-white/[0.04]
-                     flex items-center justify-center"
-        >
-          {icon}
-        </div>
+        {icon}
         <div className="min-w-0 flex-1">
           <div className="text-[13px] font-medium text-white truncate">{label}</div>
           <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>

--- a/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
@@ -67,7 +67,7 @@ export function NodeShell({
           className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}
         />
       )}
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
         {icon}
         <div className="min-w-0 flex-1">
           <div className="text-[13px] font-medium text-white truncate">{label}</div>

--- a/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
@@ -68,7 +68,12 @@ export function NodeShell({
         />
       )}
       <div className="flex items-center gap-2">
-        {icon}
+        <div
+          className="shrink-0 w-7 h-7 rounded-md border border-white/[0.08] bg-white/[0.04]
+                     flex items-center justify-center"
+        >
+          {icon}
+        </div>
         <div className="min-w-0 flex-1">
           <div className="text-[13px] font-medium text-white truncate">{label}</div>
           <div className="text-[11px] text-gray-500 truncate">{subtitle}</div>

--- a/src/renderer/components/workflow-editor/nodes/ScriptNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/ScriptNode.tsx
@@ -30,7 +30,7 @@ export function ScriptNode({ label, config, selected, executionStatus, onClick }
 
   return (
     <NodeShell
-      icon={<Icon size={14} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />}
+      icon={<Icon size={18} strokeWidth={2} className={`${NODE_GLYPH} shrink-0`} />}
       label={label}
       subtitle={
         <>

--- a/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
@@ -76,11 +76,11 @@ export function TriggerNode({ label, config, selected, onClick }: Props) {
           <ConnectorIcon
             connectorId={connectorId}
             icon={connectorGlyph}
-            size={16}
+            size={18}
             className="text-ink shrink-0"
           />
         ) : (
-          <Icon size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
+          <Icon size={18} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />
         )
       }
       label={label}

--- a/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
@@ -76,8 +76,8 @@ export function TriggerNode({ label, config, selected, onClick }: Props) {
           <ConnectorIcon
             connectorId={connectorId}
             icon={connectorGlyph}
-            size={14}
-            className={`${NODE_GLYPH} shrink-0`}
+            size={16}
+            className="text-ink shrink-0"
           />
         ) : (
           <Icon size={14} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />

--- a/src/renderer/components/workflow-editor/panels/NodePalette.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodePalette.tsx
@@ -1,96 +1,164 @@
-import { Zap, Clock, Play, ListPlus, ArrowRightLeft, Terminal } from 'lucide-react'
-import type { TriggerConfig } from '../../../../shared/types'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Play, Terminal, GitFork, Hand, Repeat, Zap, Search } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import { NODE_GLYPH } from '../node-visuals'
+import type { AddableNodeType } from '../WorkflowCanvas'
 
-interface Props {
-  onAddTrigger: (type: TriggerConfig['triggerType']) => void
-  onAddLaunchAgent: () => void
-  onAddScript: () => void
-  hasTrigger: boolean
+/**
+ * What picking a palette entry means: a bare step type, or a connector action
+ * with the connection and action already chosen.
+ */
+export type PalettePick =
+  | { kind: 'type'; type: AddableNodeType }
+  | { kind: 'connectorAction'; connectionId: string; action: string }
+
+export interface PaletteConnectorItem {
+  connectionId: string
+  action: string
+  label: string
+  /** Shown as the dimmed source column, e.g. the connector id. */
+  source: string
 }
 
-export function NodePalette({ onAddTrigger, onAddLaunchAgent, onAddScript, hasTrigger }: Props) {
+const TYPE_ITEMS: { type: AddableNodeType; label: string; icon: LucideIcon }[] = [
+  { type: 'agent', label: 'Add an agent', icon: Play },
+  { type: 'script', label: 'Add a script', icon: Terminal },
+  { type: 'condition', label: 'Add a condition', icon: GitFork },
+  { type: 'approval', label: 'Add an approval gate', icon: Hand },
+  { type: 'loop', label: 'Repeat steps until…', icon: Repeat },
+  { type: 'connectorAction', label: 'Call a connector action', icon: Zap }
+]
+
+/**
+ * The node search panel: opened by dropping a connection on empty canvas or
+ * pressing Tab. Lists the step types and every installed connector action,
+ * filtered as the user types; Enter picks the highlighted row.
+ */
+export function NodePalette({
+  position,
+  allowLoop,
+  connectorItems,
+  onPick,
+  onClose
+}: {
+  /** Where to place the panel, in the canvas container's coordinates. */
+  position: { x: number; y: number }
+  /** Loops lift their body out of the trunk; inside a branch that is untested. */
+  allowLoop: boolean
+  connectorItems: PaletteConnectorItem[]
+  onPick: (pick: PalettePick) => void
+  onClose: () => void
+}) {
+  const [query, setQuery] = useState('')
+  const [highlight, setHighlight] = useState(0)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    function handlePointer(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handlePointer)
+    return () => document.removeEventListener('mousedown', handlePointer)
+  }, [onClose])
+
+  const items = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    const types = TYPE_ITEMS.filter((t) => allowLoop || t.type !== 'loop')
+      .filter((t) => !q || t.label.toLowerCase().includes(q))
+      .map((t) => ({
+        key: `type:${t.type}`,
+        label: t.label,
+        source: '',
+        icon: t.icon,
+        pick: { kind: 'type', type: t.type } as PalettePick
+      }))
+    const actions = connectorItems
+      .filter((c) => !q || c.label.toLowerCase().includes(q) || c.source.toLowerCase().includes(q))
+      .map((c) => ({
+        key: `action:${c.connectionId}:${c.action}`,
+        label: c.label,
+        source: c.source,
+        icon: Zap,
+        pick: {
+          kind: 'connectorAction',
+          connectionId: c.connectionId,
+          action: c.action
+        } as PalettePick
+      }))
+    return [...types, ...actions]
+  }, [query, allowLoop, connectorItems])
+
+  const clampedHighlight = Math.min(highlight, Math.max(0, items.length - 1))
+
   return (
-    <div className="w-[180px] border-r border-white/[0.08] bg-surface-node flex flex-col h-full overflow-hidden titlebar-no-drag">
-      <div className="px-3 py-3 border-b border-white/[0.08]">
-        <span className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">
-          Add Nodes
-        </span>
+    <div
+      ref={rootRef}
+      data-node-palette
+      className="absolute z-50 w-[248px] bg-surface-overlay border border-white/[0.12]
+                 rounded-lg shadow-xl shadow-black/40 p-1.5
+                 animate-in fade-in-0 zoom-in-95 duration-100"
+      style={{ left: position.x, top: position.y }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation()
+          onClose()
+        } else if (e.key === 'ArrowDown') {
+          e.preventDefault()
+          setHighlight((h) => Math.min(h + 1, items.length - 1))
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault()
+          setHighlight((h) => Math.max(h - 1, 0))
+        } else if (e.key === 'Enter' && items[clampedHighlight]) {
+          e.preventDefault()
+          onPick(items[clampedHighlight].pick)
+        }
+      }}
+    >
+      <div className="flex items-center gap-1.5 border border-white/[0.08] rounded-md px-2 py-1.5 mb-1.5">
+        <Search size={12} className="shrink-0 text-gray-500" />
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setHighlight(0)
+          }}
+          placeholder="Search steps and actions"
+          className="w-full bg-transparent text-[12px] text-white placeholder:text-gray-600 outline-none"
+        />
       </div>
 
-      <div className="flex-1 overflow-y-auto p-2 space-y-4">
-        {/* Triggers */}
-        {!hasTrigger && (
-          <div>
-            <span className="text-[10px] text-gray-600 uppercase tracking-wider font-medium px-1.5 block mb-1.5">
-              Triggers
-            </span>
-            <div className="space-y-1">
-              <PaletteItem
-                icon={<Zap size={14} className={NODE_GLYPH} />}
-                label="Manual"
-                onClick={() => onAddTrigger('manual')}
-              />
-              <PaletteItem
-                icon={<Clock size={14} className={NODE_GLYPH} />}
-                label="Schedule"
-                onClick={() => onAddTrigger('recurring')}
-              />
-              <PaletteItem
-                icon={<ListPlus size={14} className={NODE_GLYPH} />}
-                label="Task Created"
-                onClick={() => onAddTrigger('taskCreated')}
-              />
-              <PaletteItem
-                icon={<ArrowRightLeft size={14} className={NODE_GLYPH} />}
-                label="Task Status Change"
-                onClick={() => onAddTrigger('taskStatusChanged')}
-              />
-            </div>
-          </div>
+      <div className="max-h-[264px] overflow-y-auto">
+        {items.length === 0 && (
+          <div className="px-2.5 py-3 text-[11px] text-gray-500">Nothing matches</div>
         )}
-
-        {/* Actions */}
-        <div>
-          <span className="text-[10px] text-gray-600 uppercase tracking-wider font-medium px-1.5 block mb-1.5">
-            Actions
-          </span>
-          <div className="space-y-1">
-            <PaletteItem
-              icon={<Play size={14} className={NODE_GLYPH} />}
-              label="Launch Agent"
-              onClick={onAddLaunchAgent}
-            />
-            <PaletteItem
-              icon={<Terminal size={14} className={NODE_GLYPH} />}
-              label="Run Script"
-              onClick={onAddScript}
-            />
-          </div>
-        </div>
+        {items.map((item, i) => {
+          const Icon = item.icon
+          return (
+            <button
+              key={item.key}
+              onClick={() => onPick(item.pick)}
+              onMouseEnter={() => setHighlight(i)}
+              className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-md text-[13px]
+                          text-left transition-colors
+                          ${i === clampedHighlight ? 'bg-white/[0.06] text-white' : 'text-gray-300'}`}
+            >
+              <Icon size={14} className={`${NODE_GLYPH} shrink-0`} />
+              <span className="truncate flex-1">{item.label}</span>
+              {item.source && (
+                <span className="shrink-0 text-[10px] font-mono text-gray-500 truncate max-w-[80px]">
+                  {item.source}
+                </span>
+              )}
+            </button>
+          )
+        })}
       </div>
     </div>
-  )
-}
-
-function PaletteItem({
-  icon,
-  label,
-  onClick
-}: {
-  icon: React.ReactNode
-  label: string
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className="w-full flex items-center gap-2 px-2.5 py-2 text-[12px] text-gray-300
-                 bg-white/[0.04] hover:bg-white/[0.08] border border-white/[0.08]
-                 rounded-md transition-colors text-left"
-    >
-      {icon}
-      {label}
-    </button>
   )
 }

--- a/src/renderer/components/workflow-editor/panels/NodePalette.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodePalette.tsx
@@ -4,10 +4,7 @@ import type { LucideIcon } from 'lucide-react'
 import { NODE_GLYPH } from '../node-visuals'
 import type { AddableNodeType } from '../WorkflowCanvas'
 
-/**
- * What picking a palette entry means: a bare step type, or a connector action
- * with the connection and action already chosen.
- */
+/** A bare step type, or a connector action with connection and action chosen. */
 export type PalettePick =
   | { kind: 'type'; type: AddableNodeType }
   | { kind: 'connectorAction'; connectionId: string; action: string }
@@ -29,11 +26,7 @@ const TYPE_ITEMS: { type: AddableNodeType; label: string; icon: LucideIcon }[] =
   { type: 'connectorAction', label: 'Call a connector action', icon: Zap }
 ]
 
-/**
- * The node search panel: opened by dropping a connection on empty canvas or
- * pressing Tab. Lists the step types and every installed connector action,
- * filtered as the user types; Enter picks the highlighted row.
- */
+/** The node search panel: step types and installed connector actions, filtered as you type. */
 export function NodePalette({
   position,
   allowLoop,
@@ -43,7 +36,7 @@ export function NodePalette({
 }: {
   /** Where to place the panel, in the canvas container's coordinates. */
   position: { x: number; y: number }
-  /** Loops lift their body out of the trunk; inside a branch that is untested. */
+  /** Loop-inside-branch is untested, so branches disallow it. */
   allowLoop: boolean
   connectorItems: PaletteConnectorItem[]
   onPick: (pick: PalettePick) => void

--- a/src/renderer/lib/use-definition-history.ts
+++ b/src/renderer/lib/use-definition-history.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { WorkflowEdge, WorkflowNode } from '../../shared/types'
+
+interface Snapshot {
+  nodes: WorkflowNode[]
+  edges: WorkflowEdge[]
+}
+
+const STACK_LIMIT = 100
+/** Edits landing this close together read as one gesture — typing a label,
+ *  nudging a node — and undo as one step. */
+const MERGE_WINDOW_MS = 500
+
+/**
+ * Undo/redo over the workflow definition, as snapshots.
+ *
+ * A definition is kilobytes, so whole-state snapshots buy the same UX as a
+ * command system for none of its machinery. The hook watches the definition
+ * the editor already owns; applying an undo sets the same state, flagged so
+ * the application itself is not recorded as a new edit.
+ */
+export function useDefinitionHistory(
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[],
+  setNodes: (nodes: WorkflowNode[]) => void,
+  setEdges: (edges: WorkflowEdge[]) => void,
+  /** Changes when a different workflow loads; history never crosses it. */
+  resetKey: string
+): { undo: () => void; redo: () => void } {
+  const past = useRef<Snapshot[]>([])
+  const future = useRef<Snapshot[]>([])
+  const current = useRef<Snapshot>({ nodes, edges })
+  const applying = useRef(false)
+  const lastPushAt = useRef(0)
+  const key = useRef(resetKey)
+
+  useEffect(() => {
+    if (key.current !== resetKey) {
+      key.current = resetKey
+      past.current = []
+      future.current = []
+      lastPushAt.current = 0
+      current.current = { nodes, edges }
+      return
+    }
+    if (nodes === current.current.nodes && edges === current.current.edges) return
+    if (applying.current) {
+      applying.current = false
+      current.current = { nodes, edges }
+      return
+    }
+    const now = Date.now()
+    if (now - lastPushAt.current > MERGE_WINDOW_MS || past.current.length === 0) {
+      past.current.push(current.current)
+      if (past.current.length > STACK_LIMIT) past.current.shift()
+    }
+    lastPushAt.current = now
+    future.current = []
+    current.current = { nodes, edges }
+  }, [nodes, edges, resetKey])
+
+  const undo = useCallback(() => {
+    const snapshot = past.current.pop()
+    if (!snapshot) return
+    future.current.push(current.current)
+    applying.current = true
+    lastPushAt.current = 0
+    setNodes(snapshot.nodes)
+    setEdges(snapshot.edges)
+  }, [setNodes, setEdges])
+
+  const redo = useCallback(() => {
+    const snapshot = future.current.pop()
+    if (!snapshot) return
+    past.current.push(current.current)
+    applying.current = true
+    lastPushAt.current = 0
+    setNodes(snapshot.nodes)
+    setEdges(snapshot.edges)
+  }, [setNodes, setEdges])
+
+  return { undo, redo }
+}

--- a/src/renderer/lib/use-definition-history.ts
+++ b/src/renderer/lib/use-definition-history.ts
@@ -7,18 +7,10 @@ interface Snapshot {
 }
 
 const STACK_LIMIT = 100
-/** Edits landing this close together read as one gesture — typing a label,
- *  nudging a node — and undo as one step. */
+/** Edits this close together read as one gesture and undo as one step. */
 const MERGE_WINDOW_MS = 500
 
-/**
- * Undo/redo over the workflow definition, as snapshots.
- *
- * A definition is kilobytes, so whole-state snapshots buy the same UX as a
- * command system for none of its machinery. The hook watches the definition
- * the editor already owns; applying an undo sets the same state, flagged so
- * the application itself is not recorded as a new edit.
- */
+/** Snapshot undo/redo over the definition; applying an undo is flagged so it isn't re-recorded. */
 export function useDefinitionHistory(
   nodes: WorkflowNode[],
   edges: WorkflowEdge[],
@@ -33,6 +25,8 @@ export function useDefinitionHistory(
   const applying = useRef(false)
   const lastPushAt = useRef(0)
   const key = useRef(resetKey)
+  // The first change after mount or a reset is the load landing, not an edit — undo must not reach past it.
+  const absorbingLoad = useRef(true)
 
   useEffect(() => {
     if (key.current !== resetKey) {
@@ -41,11 +35,17 @@ export function useDefinitionHistory(
       future.current = []
       lastPushAt.current = 0
       current.current = { nodes, edges }
+      absorbingLoad.current = true
       return
     }
     if (nodes === current.current.nodes && edges === current.current.edges) return
     if (applying.current) {
       applying.current = false
+      current.current = { nodes, edges }
+      return
+    }
+    if (absorbingLoad.current) {
+      absorbingLoad.current = false
       current.current = { nodes, edges }
       return
     }

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -201,7 +201,8 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
     })
   }
 
-  const hasOutgoing = new Set(edges.map((e) => e.source))
+  // Leaves are judged on the drawn graph: a terminal loop's body edges don't count.
+  const hasOutgoing = new Set(rfEdges.map((e) => e.source))
   for (const node of nodes) {
     if (bodySet.has(node.id)) continue
     if (hasOutgoing.has(node.id)) continue

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -1,0 +1,308 @@
+import { Position, type Edge, type Node } from '@xyflow/react'
+import { LoopConfig, WorkflowEdge, WorkflowNode } from '../../shared/types'
+import { stepPreview } from '../components/workflow-editor/node-visuals'
+import { computeFlowLayout, FlowRow } from './workflow-helpers'
+
+/**
+ * Everything the canvas derives from a workflow definition: which definition
+ * nodes become canvas nodes, where they sit, and which edges are drawn.
+ *
+ * The definition stays the source of truth. A loop and its body render as one
+ * composite canvas node — membership is the loop's own `bodyNodeIds`, so body
+ * steps never appear as free canvas nodes and an edge that leaves the body is
+ * drawn from the composite. The layout walks the same `FlowRow` tree the rail
+ * drew, so Tidy up reproduces exactly the order the rail showed.
+ */
+
+export const CARD_WIDTH = 280
+export const LOOP_WIDTH = 312
+/** Horizontal gap between fork branches. */
+const BRANCH_GAP = 56
+/** Vertical gap between consecutive steps (room for the edge). */
+const ROW_GAP = 56
+
+/** Data every canvas step/loop node carries: only the definition node's id.
+ *  Content, selection, and status come from context so the node array is
+ *  stable across selection and run-status changes. */
+export interface CanvasNodeData extends Record<string, unknown> {
+  nodeId: string
+}
+
+/** The + that trails every leaf, and what an insertion there means. */
+export interface AddStepNodeData extends Record<string, unknown> {
+  afterNodeId: string
+  insideBranch: boolean
+}
+
+export interface CanvasEdgeData extends Record<string, unknown> {
+  /** Arguments for the editor's insert path when the edge's + is used. */
+  afterNodeId: string
+  beforeNodeId: string
+  conditionBranch?: 'true' | 'false'
+  /** Loop and parallel insertion stay off edges inside a fork branch. */
+  insideBranch: boolean
+}
+
+/** Node ids that live inside some loop's body (only ids that still exist). */
+export function loopBodyMembers(nodes: WorkflowNode[]): Set<string> {
+  const ids = new Set(nodes.map((n) => n.id))
+  const members = new Set<string>()
+  for (const node of nodes) {
+    if (node.type !== 'loop') continue
+    for (const id of (node.config as LoopConfig).bodyNodeIds ?? []) {
+      if (ids.has(id)) members.add(id)
+    }
+  }
+  return members
+}
+
+/** The loop that owns a body node, if any. */
+function owningLoopId(nodes: WorkflowNode[], bodyNodeId: string): string | undefined {
+  return nodes.find(
+    (n) => n.type === 'loop' && ((n.config as LoopConfig).bodyNodeIds ?? []).includes(bodyNodeId)
+  )?.id
+}
+
+/**
+ * Rendered height of a step card, from the same facts the card renders:
+ * a header is two lines, a preview adds a footer. Only feeds the layout —
+ * a few points of drift just widens a gap.
+ */
+export function estimateNodeHeight(node: WorkflowNode, allNodes: WorkflowNode[]): number {
+  if (node.type === 'loop') {
+    const body = ((node.config as LoopConfig).bodyNodeIds ?? [])
+      .map((id) => allNodes.find((n) => n.id === id))
+      .filter((n): n is WorkflowNode => !!n)
+    const bodyHeights =
+      body.length === 0
+        ? 52 // the "no steps yet" placeholder
+        : body.reduce((sum, b) => sum + estimateNodeHeight(b, allNodes), 0) + (body.length - 1) * 18
+    // header + top padding + body + line + add button + footer
+    return 41 + 16 + bodyHeights + 18 + 22 + 40
+  }
+  return stepPreview(node) ? 90 : 58
+}
+
+interface Placed {
+  positions: Map<string, { x: number; y: number }>
+  /** Node ids drawn inside a fork branch — loop/parallel insertion stays off there. */
+  branchMembers: Set<string>
+}
+
+/**
+ * Positions for every top-level canvas node, derived from the FlowRow tree:
+ * a vertical trunk, fork branches side by side, a loop as one tall block.
+ * `xCenter` is the trunk's centerline in canvas coordinates.
+ */
+export function layoutPositions(nodes: WorkflowNode[], edges: WorkflowEdge[]): Placed {
+  const rows = computeFlowLayout(nodes, edges)
+  const positions = new Map<string, { x: number; y: number }>()
+  const branchMembers = new Set<string>()
+  const bodySet = loopBodyMembers(nodes)
+
+  const rowWidth = (row: FlowRow): number => {
+    if (row.kind === 'loop') return LOOP_WIDTH
+    if (row.kind === 'node') return CARD_WIDTH
+    const widths = row.branches.map(branchWidth)
+    return widths.reduce((a, b) => a + b, 0) + (widths.length - 1) * BRANCH_GAP
+  }
+  const branchWidth = (branch: FlowRow[]): number =>
+    branch.length === 0 ? CARD_WIDTH : Math.max(...branch.map(rowWidth))
+
+  const place = (rows: FlowRow[], xCenter: number, y: number, insideBranch: boolean): number => {
+    let cursor = y
+    for (const row of rows) {
+      if (row.kind === 'node') {
+        // Body members can appear as appended orphans; they draw inside their
+        // loop, so they take no space on the trunk.
+        if (bodySet.has(row.node.id)) continue
+        positions.set(row.node.id, { x: xCenter - CARD_WIDTH / 2, y: cursor })
+        if (insideBranch) branchMembers.add(row.node.id)
+        cursor += estimateNodeHeight(row.node, nodes) + ROW_GAP
+      } else if (row.kind === 'loop') {
+        positions.set(row.loopNode.id, { x: xCenter - LOOP_WIDTH / 2, y: cursor })
+        if (insideBranch) branchMembers.add(row.loopNode.id)
+        cursor += estimateNodeHeight(row.loopNode, nodes) + ROW_GAP
+      } else {
+        const widths = row.branches.map(branchWidth)
+        const total = widths.reduce((a, b) => a + b, 0) + (widths.length - 1) * BRANCH_GAP
+        let left = xCenter - total / 2
+        let deepest = cursor
+        row.branches.forEach((branch, i) => {
+          const center = left + widths[i] / 2
+          const bottom = place(branch, center, cursor, true)
+          deepest = Math.max(deepest, bottom)
+          left += widths[i] + BRANCH_GAP
+        })
+        cursor = deepest
+      }
+    }
+    return cursor
+  }
+
+  place(rows, 0, 0, false)
+  return { positions, branchMembers }
+}
+
+/** Whether every stored position is the untouched seed column (all x = 0). */
+export function positionsAreSeed(nodes: WorkflowNode[]): boolean {
+  return nodes.every((n) => !n.position || n.position.x === 0)
+}
+
+export interface CanvasElements {
+  nodes: Node[]
+  edges: Edge[]
+  branchMembers: Set<string>
+}
+
+/**
+ * Project the definition into canvas elements. Positions come from the
+ * definition when someone has arranged it, and from the layout walk when the
+ * stored positions are still the seeded single column.
+ */
+export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): CanvasElements {
+  const bodySet = loopBodyMembers(nodes)
+  const { positions: computed, branchMembers } = layoutPositions(nodes, edges)
+  const useComputed = positionsAreSeed(nodes)
+
+  const rfNodes: Node[] = []
+  for (const node of nodes) {
+    if (bodySet.has(node.id)) continue
+    const position = useComputed
+      ? (computed.get(node.id) ?? { x: 0, y: 0 })
+      : { x: node.position?.x ?? 0, y: node.position?.y ?? 0 }
+    const width = node.type === 'loop' ? LOOP_WIDTH : CARD_WIDTH
+    const height = estimateNodeHeight(node, nodes)
+    rfNodes.push({
+      id: node.id,
+      type: node.type === 'loop' ? 'loop' : 'step',
+      position,
+      data: { nodeId: node.id } satisfies CanvasNodeData,
+      // Explicit dimensions and declared handles let edges render before the
+      // first DOM measure — and at all in environments with no layout (tests).
+      width,
+      height,
+      handles: [
+        ...(node.type !== 'trigger'
+          ? [{ type: 'target' as const, position: Position.Top, x: width / 2, y: 0 }]
+          : []),
+        { type: 'source' as const, position: Position.Bottom, x: width / 2, y: height }
+      ]
+    })
+  }
+
+  const rfEdges: Edge[] = []
+  const seenEdgeIds = new Set<string>()
+  for (const edge of edges) {
+    const sourceInBody = bodySet.has(edge.source)
+    const targetInBody = bodySet.has(edge.target)
+    if (sourceInBody && targetInBody) continue
+    if (!sourceInBody && targetInBody) continue // the loop draws its own entry
+    if (seenEdgeIds.has(edge.id)) continue
+    seenEdgeIds.add(edge.id)
+
+    // An edge that leaves a loop body continues the trunk: draw it from the
+    // composite, but keep the real endpoints so insertion splices correctly.
+    const drawnSource = sourceInBody ? owningLoopId(nodes, edge.source) : edge.source
+    if (!drawnSource) continue
+
+    rfEdges.push({
+      id: edge.id,
+      source: drawnSource,
+      target: edge.target,
+      type: 'step',
+      label:
+        edge.conditionBranch === 'true'
+          ? 'True'
+          : edge.conditionBranch === 'false'
+            ? 'False'
+            : undefined,
+      data: {
+        afterNodeId: edge.source,
+        beforeNodeId: edge.target,
+        conditionBranch: edge.conditionBranch,
+        insideBranch:
+          branchMembers.has(edge.source) ||
+          branchMembers.has(edge.target) ||
+          edge.conditionBranch !== undefined
+      } satisfies CanvasEdgeData
+    })
+  }
+
+  // Every leaf gets a trailing +, matching the rail's end-of-chain button.
+  const hasOutgoing = new Set(edges.map((e) => e.source))
+  for (const node of nodes) {
+    if (bodySet.has(node.id)) continue
+    if (hasOutgoing.has(node.id)) continue
+    const anchor = rfNodes.find((n) => n.id === node.id)
+    if (!anchor) continue
+    const width = node.type === 'loop' ? LOOP_WIDTH : CARD_WIDTH
+    rfNodes.push({
+      id: `add:${node.id}`,
+      type: 'addStep',
+      position: {
+        x: anchor.position.x + width / 2 - 11,
+        y: anchor.position.y + estimateNodeHeight(node, nodes) + 26
+      },
+      data: {
+        afterNodeId: node.id,
+        insideBranch: branchMembers.has(node.id)
+      } satisfies AddStepNodeData,
+      width: 22,
+      height: 22,
+      handles: [{ type: 'target' as const, position: Position.Top, x: 11, y: 0 }],
+      draggable: false,
+      selectable: false
+    })
+    rfEdges.push({
+      id: `add-edge:${node.id}`,
+      source: node.id,
+      target: `add:${node.id}`,
+      type: 'step',
+      style: { strokeDasharray: '4 4' },
+      selectable: false
+    })
+  }
+
+  return { nodes: rfNodes, edges: rfEdges, branchMembers }
+}
+
+/**
+ * Would connecting `source` → `target` keep the definition a DAG with the
+ * shapes the engine understands? Used to validate hand-drawn connections.
+ */
+export function canConnect(
+  nodes: WorkflowNode[],
+  edges: WorkflowEdge[],
+  source: string,
+  target: string
+): boolean {
+  if (source === target) return false
+  const sourceNode = nodes.find((n) => n.id === source)
+  const targetNode = nodes.find((n) => n.id === target)
+  if (!sourceNode || !targetNode) return false
+  if (targetNode.type === 'trigger') return false
+  // A condition's branches carry true/false tags the panel manages; a loop
+  // drives its own body. Hand-drawn edges from either would bypass that.
+  if (sourceNode.type === 'condition') return false
+  const bodySet = loopBodyMembers(nodes)
+  if (bodySet.has(source) || bodySet.has(target)) return false
+  if (edges.some((e) => e.source === source && e.target === target)) return false
+  // No cycles: if source is reachable from target, this edge closes a loop.
+  const successors = new Map<string, string[]>()
+  for (const e of edges) {
+    const list = successors.get(e.source) ?? []
+    list.push(e.target)
+    successors.set(e.source, list)
+  }
+  const queue = [target]
+  const seen = new Set<string>()
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    if (current === source) return false
+    if (seen.has(current)) continue
+    seen.add(current)
+    queue.push(...(successors.get(current) ?? []))
+  }
+  return true
+}

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -213,7 +213,7 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
       type: 'addStep',
       position: {
         x: anchor.position.x + width / 2 - 11,
-        y: anchor.position.y + estimateNodeHeight(node, nodes) + 26
+        y: anchor.position.y + estimateNodeHeight(node, nodes) + 18
       },
       data: {
         afterNodeId: node.id,
@@ -232,7 +232,6 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
       source: node.id,
       target: `add:${node.id}`,
       type: 'step',
-      style: { strokeDasharray: '4 4' },
       selectable: false
     })
   }

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -223,7 +223,9 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
       height: 22,
       handles: [{ type: 'target' as const, position: Position.Top, x: 11, y: 0 }],
       draggable: false,
-      selectable: false
+      selectable: false,
+      // Its menu must open above neighbouring cards, and selection elevates those to 1000.
+      zIndex: 1200
     })
     rfEdges.push({
       id: `add-edge:${node.id}`,

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -3,16 +3,7 @@ import { LoopConfig, WorkflowEdge, WorkflowNode } from '../../shared/types'
 import { stepPreview } from '../components/workflow-editor/node-visuals'
 import { computeFlowLayout, FlowRow } from './workflow-helpers'
 
-/**
- * Everything the canvas derives from a workflow definition: which definition
- * nodes become canvas nodes, where they sit, and which edges are drawn.
- *
- * The definition stays the source of truth. A loop and its body render as one
- * composite canvas node — membership is the loop's own `bodyNodeIds`, so body
- * steps never appear as free canvas nodes and an edge that leaves the body is
- * drawn from the composite. The layout walks the same `FlowRow` tree the rail
- * drew, so Tidy up reproduces exactly the order the rail showed.
- */
+// Projects a workflow definition into canvas elements; the definition stays the source of truth.
 
 export const CARD_WIDTH = 280
 export const LOOP_WIDTH = 312
@@ -21,9 +12,7 @@ const BRANCH_GAP = 56
 /** Vertical gap between consecutive steps (room for the edge). */
 const ROW_GAP = 56
 
-/** Data every canvas step/loop node carries: only the definition node's id.
- *  Content, selection, and status come from context so the node array is
- *  stable across selection and run-status changes. */
+/** Only the id: content, selection, and status come from context, keeping the node array stable. */
 export interface CanvasNodeData extends Record<string, unknown> {
   nodeId: string
 }
@@ -35,11 +24,9 @@ export interface AddStepNodeData extends Record<string, unknown> {
 }
 
 export interface CanvasEdgeData extends Record<string, unknown> {
-  /** Arguments for the editor's insert path when the edge's + is used. */
   afterNodeId: string
   beforeNodeId: string
   conditionBranch?: 'true' | 'false'
-  /** Loop and parallel insertion stay off edges inside a fork branch. */
   insideBranch: boolean
 }
 
@@ -63,11 +50,7 @@ function owningLoopId(nodes: WorkflowNode[], bodyNodeId: string): string | undef
   )?.id
 }
 
-/**
- * Rendered height of a step card, from the same facts the card renders:
- * a header is two lines, a preview adds a footer. Only feeds the layout —
- * a few points of drift just widens a gap.
- */
+/** Estimated card height; only feeds the layout, so drift just widens a gap. */
 export function estimateNodeHeight(node: WorkflowNode, allNodes: WorkflowNode[]): number {
   if (node.type === 'loop') {
     const body = ((node.config as LoopConfig).bodyNodeIds ?? [])
@@ -75,9 +58,9 @@ export function estimateNodeHeight(node: WorkflowNode, allNodes: WorkflowNode[])
       .filter((n): n is WorkflowNode => !!n)
     const bodyHeights =
       body.length === 0
-        ? 52 // the "no steps yet" placeholder
+        ? 52
         : body.reduce((sum, b) => sum + estimateNodeHeight(b, allNodes), 0) + (body.length - 1) * 18
-    // header + top padding + body + line + add button + footer
+    // header + padding + body + line + add button + footer
     return 41 + 16 + bodyHeights + 18 + 22 + 40
   }
   return stepPreview(node) ? 90 : 58
@@ -85,15 +68,11 @@ export function estimateNodeHeight(node: WorkflowNode, allNodes: WorkflowNode[])
 
 interface Placed {
   positions: Map<string, { x: number; y: number }>
-  /** Node ids drawn inside a fork branch — loop/parallel insertion stays off there. */
+  /** Node ids drawn inside a fork branch, where loop/parallel insertion is off. */
   branchMembers: Set<string>
 }
 
-/**
- * Positions for every top-level canvas node, derived from the FlowRow tree:
- * a vertical trunk, fork branches side by side, a loop as one tall block.
- * `xCenter` is the trunk's centerline in canvas coordinates.
- */
+/** Positions from the FlowRow tree: vertical trunk, branches side by side, loops as one block. */
 export function layoutPositions(nodes: WorkflowNode[], edges: WorkflowEdge[]): Placed {
   const rows = computeFlowLayout(nodes, edges)
   const positions = new Map<string, { x: number; y: number }>()
@@ -113,8 +92,7 @@ export function layoutPositions(nodes: WorkflowNode[], edges: WorkflowEdge[]): P
     let cursor = y
     for (const row of rows) {
       if (row.kind === 'node') {
-        // Body members can appear as appended orphans; they draw inside their
-        // loop, so they take no space on the trunk.
+        // Orphaned body members draw inside their loop, not on the trunk.
         if (bodySet.has(row.node.id)) continue
         positions.set(row.node.id, { x: xCenter - CARD_WIDTH / 2, y: cursor })
         if (insideBranch) branchMembers.add(row.node.id)
@@ -155,11 +133,7 @@ export interface CanvasElements {
   branchMembers: Set<string>
 }
 
-/**
- * Project the definition into canvas elements. Positions come from the
- * definition when someone has arranged it, and from the layout walk when the
- * stored positions are still the seeded single column.
- */
+/** Stored positions when someone has arranged the workflow, the layout walk otherwise. */
 export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): CanvasElements {
   const bodySet = loopBodyMembers(nodes)
   const { positions: computed, branchMembers } = layoutPositions(nodes, edges)
@@ -178,8 +152,7 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
       type: node.type === 'loop' ? 'loop' : 'step',
       position,
       data: { nodeId: node.id } satisfies CanvasNodeData,
-      // Explicit dimensions and declared handles let edges render before the
-      // first DOM measure — and at all in environments with no layout (tests).
+      // Explicit dimensions and handles let edges render without a DOM measure.
       width,
       height,
       handles: [
@@ -197,12 +170,11 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
     const sourceInBody = bodySet.has(edge.source)
     const targetInBody = bodySet.has(edge.target)
     if (sourceInBody && targetInBody) continue
-    if (!sourceInBody && targetInBody) continue // the loop draws its own entry
+    if (!sourceInBody && targetInBody) continue
     if (seenEdgeIds.has(edge.id)) continue
     seenEdgeIds.add(edge.id)
 
-    // An edge that leaves a loop body continues the trunk: draw it from the
-    // composite, but keep the real endpoints so insertion splices correctly.
+    // Edges leaving a loop body draw from the composite; real endpoints stay for splicing.
     const drawnSource = sourceInBody ? owningLoopId(nodes, edge.source) : edge.source
     if (!drawnSource) continue
 
@@ -229,7 +201,6 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
     })
   }
 
-  // Every leaf gets a trailing +, matching the rail's end-of-chain button.
   const hasOutgoing = new Set(edges.map((e) => e.source))
   for (const node of nodes) {
     if (bodySet.has(node.id)) continue
@@ -267,10 +238,7 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
   return { nodes: rfNodes, edges: rfEdges, branchMembers }
 }
 
-/**
- * Would connecting `source` → `target` keep the definition a DAG with the
- * shapes the engine understands? Used to validate hand-drawn connections.
- */
+/** Whether a hand-drawn source → target edge keeps the graph a DAG the engine understands. */
 export function canConnect(
   nodes: WorkflowNode[],
   edges: WorkflowEdge[],
@@ -282,13 +250,11 @@ export function canConnect(
   const targetNode = nodes.find((n) => n.id === target)
   if (!sourceNode || !targetNode) return false
   if (targetNode.type === 'trigger') return false
-  // A condition's branches carry true/false tags the panel manages; a loop
-  // drives its own body. Hand-drawn edges from either would bypass that.
+  // Condition branches carry managed tags; hand-drawn edges would bypass them.
   if (sourceNode.type === 'condition') return false
   const bodySet = loopBodyMembers(nodes)
   if (bodySet.has(source) || bodySet.has(target)) return false
   if (edges.some((e) => e.source === source && e.target === target)) return false
-  // No cycles: if source is reachable from target, this edge closes a loop.
   const successors = new Map<string, string[]>()
   for (const e of edges) {
     const list = successors.get(e.source) ?? []

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -301,7 +301,7 @@ export function appendToLoopBody(
   // its default (0,0) position and the persisted layout drifts from what the
   // rest of the editor produces.
   const withNew = [...nextNodes, newNode]
-  return { nodes: autoLayoutNodes(withNew, nextEdges), edges: nextEdges }
+  return { nodes: placeNewNodes(nodes, withNew, nextEdges), edges: nextEdges }
 }
 
 /**
@@ -458,7 +458,41 @@ export function insertConditionBetween(
     newEdges.push({ id: crypto.randomUUID(), source: afterNodeId, target: conditionNode.id })
   }
 
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
+}
+
+/** Whether every stored position is still the untouched seed column (x = 0
+ *  everywhere). True for every definition that predates the canvas and for
+ *  anything authored over MCP with default positions. */
+export function positionsAreSeed(nodes: WorkflowNode[]): boolean {
+  return nodes.every((n) => !n.position || n.position.x === 0)
+}
+
+/**
+ * Position policy for every structural mutation.
+ *
+ * A definition nobody has arranged keeps the legacy single-column reflow, so
+ * its stored order stays meaningful. Once someone has dragged a node, the
+ * arrangement is theirs: existing positions are kept untouched and only the
+ * nodes this mutation created are placed — under their predecessor, offset
+ * enough to be visibly a new step rather than a stack.
+ */
+export function placeNewNodes(
+  prevNodes: WorkflowNode[],
+  nextNodes: WorkflowNode[],
+  edges: WorkflowEdge[]
+): WorkflowNode[] {
+  if (positionsAreSeed(prevNodes)) return autoLayoutNodes(nextNodes, edges)
+
+  const prevIds = new Set(prevNodes.map((n) => n.id))
+  const byId = new Map(nextNodes.map((n) => [n.id, n]))
+  return nextNodes.map((node) => {
+    if (prevIds.has(node.id)) return node
+    const incoming = edges.find((e) => e.target === node.id)
+    const pred = incoming ? byId.get(incoming.source) : undefined
+    const base = pred?.position ?? { x: 0, y: 0 }
+    return { ...node, position: { x: base.x, y: base.y + 140 } }
+  })
 }
 
 export function autoLayoutNodes(nodes: WorkflowNode[], edges: WorkflowEdge[]): WorkflowNode[] {
@@ -516,12 +550,19 @@ export function insertNodeBetween(
 
   const newEdges = edges.filter((e) => e.id !== edgeId)
   newEdges.push(
-    { id: crypto.randomUUID(), source: edge.source, target: newNode.id },
+    // A condition's branch tag rides the first half of the split: the new node
+    // still sits on that branch, so the fork must keep telling them apart.
+    {
+      id: crypto.randomUUID(),
+      source: edge.source,
+      target: newNode.id,
+      ...(edge.conditionBranch && { conditionBranch: edge.conditionBranch })
+    },
     { id: crypto.randomUUID(), source: newNode.id, target: edge.target }
   )
 
   const newNodes = [...nodes, newNode]
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
 export function appendNode(
@@ -538,7 +579,7 @@ export function appendNode(
   }
 
   const newNodes = [...nodes, newNode]
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
 export function removeNode(
@@ -569,7 +610,7 @@ export function removeNode(
       }
     }
     const remainingNodes = nodes.filter((n) => !toRemove.has(n.id))
-    return { nodes: autoLayoutNodes(remainingNodes, remainingEdges), edges: remainingEdges }
+    return { nodes: placeNewNodes(nodes, remainingNodes, remainingEdges), edges: remainingEdges }
   }
 
   const incomingEdges = edges.filter((e) => e.target === nodeId)
@@ -584,7 +625,7 @@ export function removeNode(
   }
 
   const newNodes = nodes.filter((n) => n.id !== nodeId)
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
 /**
@@ -739,7 +780,7 @@ export function appendNodeAfter(
 ): { nodes: WorkflowNode[]; edges: WorkflowEdge[] } {
   const newNodes = [...nodes, newNode]
   const newEdges = [...edges, { id: crypto.randomUUID(), source: afterNodeId, target: newNode.id }]
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
 export function insertBeforeFork(
@@ -754,7 +795,7 @@ export function insertBeforeFork(
   newEdges.push({ id: crypto.randomUUID(), source: forkNodeId, target: newNode.id })
 
   const newNodes = [...nodes, newNode]
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
 export function addParallelBranch(
@@ -803,5 +844,5 @@ export function addParallelBranch(
     }
   }
 
-  return { nodes: autoLayoutNodes(newNodes, newEdges), edges: newEdges }
+  return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -496,9 +496,31 @@ export function placeNewNodes(
     placed.set(node.id, { x: base.x + sibling * 320, y: base.y + 140 })
   }
 
-  return nextNodes.map((node) =>
-    prevIds.has(node.id) ? node : { ...node, position: placed.get(node.id)! }
-  )
+  // Inserting mid-chain must make room: downstream nodes sitting where a new
+  // node landed move down by one pitch instead of being covered.
+  const newIds = new Set(nextNodes.filter((n) => !prevIds.has(n.id)).map((n) => n.id))
+  const successors = buildSuccessorsMap(edges)
+  const shifted = new Set<string>()
+  for (const newId of newIds) {
+    const newPos = placed.get(newId)!
+    const queue = [...(successors.get(newId) ?? [])]
+    const seen = new Set<string>()
+    while (queue.length > 0) {
+      const id = queue.shift()!
+      if (seen.has(id) || newIds.has(id)) continue
+      seen.add(id)
+      const pos = placed.get(id)
+      if (pos && pos.y <= newPos.y + 100) shifted.add(id)
+      queue.push(...(successors.get(id) ?? []))
+    }
+  }
+
+  return nextNodes.map((node) => {
+    if (newIds.has(node.id)) return { ...node, position: placed.get(node.id)! }
+    if (shifted.has(node.id))
+      return { ...node, position: { x: node.position.x, y: node.position.y + 140 } }
+    return node
+  })
 }
 
 export function autoLayoutNodes(nodes: WorkflowNode[], edges: WorkflowEdge[]): WorkflowNode[] {

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -461,6 +461,20 @@ export function insertConditionBetween(
   return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
+/** Every node id reachable by following edges forward from `startId`. */
+function reachableFrom(startId: string, edges: WorkflowEdge[]): Set<string> {
+  const successors = buildSuccessorsMap(edges)
+  const seen = new Set<string>()
+  const queue = [...(successors.get(startId) ?? [])]
+  while (queue.length > 0) {
+    const id = queue.shift()!
+    if (seen.has(id)) continue
+    seen.add(id)
+    queue.push(...(successors.get(id) ?? []))
+  }
+  return seen
+}
+
 /** Whether every stored position is still the untouched seed column (x = 0 everywhere). */
 export function positionsAreSeed(nodes: WorkflowNode[]): boolean {
   return nodes.every((n) => !n.position || n.position.x === 0)
@@ -493,25 +507,30 @@ export function placeNewNodes(
     const base = (incoming && placed.get(incoming.source)) ?? { x: 0, y: 0 }
     const sibling = incoming ? (siblingCount.get(incoming.source) ?? 0) : 0
     if (incoming) siblingCount.set(incoming.source, sibling + 1)
-    placed.set(node.id, { x: base.x + sibling * 320, y: base.y + 140 })
+    let candidate = { x: base.x + sibling * 320, y: base.y + 140 }
+    // Probe downward until the spot is free, ignoring this node's own
+    // downstream — those get shifted out of the way below.
+    const downstream = reachableFrom(node.id, edges)
+    const occupied = (p: WorkflowNodePosition): boolean =>
+      [...placed.entries()].some(
+        ([id, o]) => !downstream.has(id) && Math.abs(o.x - p.x) < 300 && Math.abs(o.y - p.y) < 120
+      )
+    for (let tries = 0; occupied(candidate) && tries < 50; tries++) {
+      candidate = { x: candidate.x, y: candidate.y + 140 }
+    }
+    placed.set(node.id, candidate)
   }
 
   // Inserting mid-chain must make room: downstream nodes sitting where a new
   // node landed move down by one pitch instead of being covered.
   const newIds = new Set(nextNodes.filter((n) => !prevIds.has(n.id)).map((n) => n.id))
-  const successors = buildSuccessorsMap(edges)
   const shifted = new Set<string>()
   for (const newId of newIds) {
     const newPos = placed.get(newId)!
-    const queue = [...(successors.get(newId) ?? [])]
-    const seen = new Set<string>()
-    while (queue.length > 0) {
-      const id = queue.shift()!
-      if (seen.has(id) || newIds.has(id)) continue
-      seen.add(id)
+    for (const id of reachableFrom(newId, edges)) {
+      if (newIds.has(id)) continue
       const pos = placed.get(id)
       if (pos && pos.y <= newPos.y + 100) shifted.add(id)
-      queue.push(...(successors.get(id) ?? []))
     }
   }
 

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -461,22 +461,12 @@ export function insertConditionBetween(
   return { nodes: placeNewNodes(nodes, newNodes, newEdges), edges: newEdges }
 }
 
-/** Whether every stored position is still the untouched seed column (x = 0
- *  everywhere). True for every definition that predates the canvas and for
- *  anything authored over MCP with default positions. */
+/** Whether every stored position is still the untouched seed column (x = 0 everywhere). */
 export function positionsAreSeed(nodes: WorkflowNode[]): boolean {
   return nodes.every((n) => !n.position || n.position.x === 0)
 }
 
-/**
- * Position policy for every structural mutation.
- *
- * A definition nobody has arranged keeps the legacy single-column reflow, so
- * its stored order stays meaningful. Once someone has dragged a node, the
- * arrangement is theirs: existing positions are kept untouched and only the
- * nodes this mutation created are placed — under their predecessor, offset
- * enough to be visibly a new step rather than a stack.
- */
+/** Seed definitions reflow into the legacy column; arranged ones keep their positions and only new nodes are placed. */
 export function placeNewNodes(
   prevNodes: WorkflowNode[],
   nextNodes: WorkflowNode[],
@@ -485,14 +475,30 @@ export function placeNewNodes(
   if (positionsAreSeed(prevNodes)) return autoLayoutNodes(nextNodes, edges)
 
   const prevIds = new Set(prevNodes.map((n) => n.id))
-  const byId = new Map(nextNodes.map((n) => [n.id, n]))
-  return nextNodes.map((node) => {
-    if (prevIds.has(node.id)) return node
+  // Positions accumulate so chained new nodes hang off placed predecessors, siblings fanned apart.
+  const placed = new Map<string, WorkflowNodePosition>()
+  for (const node of nextNodes) {
+    if (prevIds.has(node.id)) placed.set(node.id, node.position)
+  }
+  const siblingCount = new Map<string, number>()
+  const remaining = nextNodes.filter((n) => !prevIds.has(n.id))
+  while (remaining.length > 0) {
+    const readyIndex = remaining.findIndex((n) => {
+      const incoming = edges.find((e) => e.target === n.id)
+      return !incoming || placed.has(incoming.source)
+    })
+    const index = readyIndex === -1 ? 0 : readyIndex
+    const node = remaining.splice(index, 1)[0]
     const incoming = edges.find((e) => e.target === node.id)
-    const pred = incoming ? byId.get(incoming.source) : undefined
-    const base = pred?.position ?? { x: 0, y: 0 }
-    return { ...node, position: { x: base.x, y: base.y + 140 } }
-  })
+    const base = (incoming && placed.get(incoming.source)) ?? { x: 0, y: 0 }
+    const sibling = incoming ? (siblingCount.get(incoming.source) ?? 0) : 0
+    if (incoming) siblingCount.set(incoming.source, sibling + 1)
+    placed.set(node.id, { x: base.x + sibling * 320, y: base.y + 140 })
+  }
+
+  return nextNodes.map((node) =>
+    prevIds.has(node.id) ? node : { ...node, position: placed.get(node.id)! }
+  )
 }
 
 export function autoLayoutNodes(nodes: WorkflowNode[], edges: WorkflowEdge[]): WorkflowNode[] {
@@ -550,8 +556,7 @@ export function insertNodeBetween(
 
   const newEdges = edges.filter((e) => e.id !== edgeId)
   newEdges.push(
-    // A condition's branch tag rides the first half of the split: the new node
-    // still sits on that branch, so the fork must keep telling them apart.
+    // The branch tag rides the first half of the split so the fork keeps telling branches apart.
     {
       id: crypto.randomUUID(),
       source: edge.source,

--- a/tests/canvas-interactions.test.tsx
+++ b/tests/canvas-interactions.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen, fireEvent, within } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.hoisted(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    writable: true
+  })
+  class NoopResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(window, 'ResizeObserver', { value: NoopResizeObserver, writable: true })
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = NoopResizeObserver
+})
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [{ id: 'conn1', name: 'GitHub' }],
+  useConnectorIdFor: () => undefined,
+  useConnectionIconFor: () => undefined
+}))
+
+import { WorkflowCanvas } from '../src/renderer/components/workflow-editor/WorkflowCanvas'
+import type { WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
+
+afterEach(cleanup)
+
+const node = (
+  id: string,
+  type: WorkflowNode['type'],
+  label: string,
+  config: Record<string, unknown> = {}
+): WorkflowNode => ({
+  id,
+  type,
+  label,
+  config: config as WorkflowNode['config'],
+  position: { x: 0, y: 0 }
+})
+
+const nodes = [
+  node('t', 'trigger', 'Manual', { triggerType: 'manual' }),
+  node('a', 'script', 'First step', { scriptType: 'bash', scriptContent: '' }),
+  node('b', 'script', 'Second step', { scriptType: 'bash', scriptContent: '' })
+]
+const edges: WorkflowEdge[] = [
+  { id: 'e1', source: 't', target: 'a' },
+  { id: 'e2', source: 'a', target: 'b' }
+]
+
+function renderCanvas(over: Partial<Parameters<typeof WorkflowCanvas>[0]> = {}) {
+  const handlers = {
+    onNodeClick: vi.fn(),
+    onInsertNode: vi.fn(),
+    onAddParallelBranch: vi.fn(),
+    onConnectEdge: vi.fn(),
+    onPaletteInsert: vi.fn(),
+    onPositionsCommit: vi.fn(),
+    onDeleteNode: vi.fn(),
+    onTidyUp: vi.fn()
+  }
+  const utils = render(
+    <WorkflowCanvas nodes={nodes} edges={edges} selectedNodeId={null} {...handlers} {...over} />
+  )
+  return { ...utils, ...handlers }
+}
+
+describe('inserting on an edge', () => {
+  it('offers the + while the edge is hovered and splices with the real endpoints', () => {
+    const { container, onInsertNode } = renderCanvas()
+    const edge = container.querySelector('.react-flow__edge') as SVGGElement
+    fireEvent.mouseEnter(edge.firstChild as Element)
+    const add = screen
+      .getAllByRole('button', { name: 'Add a step' })
+      .find((b) => b.closest('.react-flow__edgelabel-renderer'))!
+    fireEvent.click(add)
+    fireEvent.click(screen.getByText('Add a script'))
+    expect(onInsertNode).toHaveBeenCalledWith('t', 'a', 'script')
+  })
+})
+
+describe('the hover toolbar', () => {
+  it('deletes the hovered step, and never offers itself on the trigger', () => {
+    const { container, onDeleteNode } = renderCanvas()
+    const deletes = screen.getAllByRole('button', { name: 'Delete step' })
+    // One per non-trigger node: the trigger card carries none.
+    expect(deletes).toHaveLength(2)
+    fireEvent.click(deletes[0])
+    expect(onDeleteNode).toHaveBeenCalledTimes(1)
+    expect(container.querySelectorAll('.react-flow__node').length).toBeGreaterThan(2)
+  })
+})
+
+describe('the keyboard on the canvas', () => {
+  it('deletes the selected step with Backspace but spares the trigger', () => {
+    const { container, onDeleteNode } = renderCanvas({ selectedNodeId: 'b' })
+    const wrapper = container.querySelector('[tabindex="0"]') as HTMLElement
+    fireEvent.keyDown(wrapper, { key: 'Backspace' })
+    expect(onDeleteNode).toHaveBeenCalledWith('b')
+  })
+
+  it('never deletes the trigger', () => {
+    const { container, onDeleteNode } = renderCanvas({ selectedNodeId: 't' })
+    const wrapper = container.querySelector('[tabindex="0"]') as HTMLElement
+    fireEvent.keyDown(wrapper, { key: 'Delete' })
+    expect(onDeleteNode).not.toHaveBeenCalled()
+  })
+
+  it('opens the node search on Tab, anchored to the leaf', async () => {
+    const { container } = renderCanvas()
+    const wrapper = container.querySelector('[tabindex="0"]') as HTMLElement
+    wrapper.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600, x: 0, y: 0 }) as DOMRect
+    fireEvent.keyDown(wrapper, { key: 'Tab' })
+    expect(await screen.findByPlaceholderText('Search steps and actions')).toBeInTheDocument()
+  })
+})
+
+describe('picking from the palette', () => {
+  it('hands the pick and its anchor to the editor', async () => {
+    const { container, onPaletteInsert } = renderCanvas()
+    const wrapper = container.querySelector('[tabindex="0"]') as HTMLElement
+    wrapper.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600, x: 0, y: 0 }) as DOMRect
+    fireEvent.keyDown(wrapper, { key: 'Tab' })
+    const palette = (await screen.findByPlaceholderText('Search steps and actions')).closest(
+      '[data-node-palette]'
+    ) as HTMLElement
+    fireEvent.click(within(palette).getByText('Add an agent'))
+    expect(onPaletteInsert).toHaveBeenCalledWith(
+      { kind: 'type', type: 'agent' },
+      'b',
+      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number) })
+    )
+  })
+})
+
+describe('the tidy up control', () => {
+  it('sits with the zoom controls', () => {
+    const { onTidyUp } = renderCanvas()
+    fireEvent.click(screen.getByRole('button', { name: 'Tidy up' }))
+    expect(onTidyUp).toHaveBeenCalled()
+  })
+})

--- a/tests/loop-canvas.test.tsx
+++ b/tests/loop-canvas.test.tsx
@@ -8,6 +8,18 @@ vi.hoisted(() => {
     value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
     writable: true
   })
+  // The graph surface measures itself with ResizeObserver, which jsdom lacks.
+  // Nodes carry explicit dimensions, so a no-op observer is enough to render.
+  class NoopResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(window, 'ResizeObserver', {
+    value: NoopResizeObserver,
+    writable: true
+  })
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = NoopResizeObserver
 })
 
 vi.mock('../src/renderer/lib/use-connections', () => ({
@@ -74,6 +86,10 @@ function renderWith(
       onNodeClick={() => {}}
       onInsertNode={() => {}}
       onAddParallelBranch={() => {}}
+      onConnectEdge={() => {}}
+      onPaletteInsert={() => {}}
+      onPositionsCommit={() => {}}
+      onTidyUp={() => {}}
     />
   )
 }
@@ -149,6 +165,10 @@ describe('adding a step inside the rail', () => {
         onNodeClick={() => {}}
         onInsertNode={onInsertNode as never}
         onAddParallelBranch={() => {}}
+        onConnectEdge={() => {}}
+        onPaletteInsert={() => {}}
+        onPositionsCommit={() => {}}
+        onTidyUp={() => {}}
       />
     )
   }
@@ -160,7 +180,7 @@ describe('adding a step inside the rail', () => {
     const { container } = renderWithSpy(nodes, onInsertNode)
     const rail = container.querySelector('[data-loop-rail]') as HTMLElement
 
-    fireEvent.click(within(rail).getByRole('button', { name: '' }))
+    fireEvent.click(within(rail).getByRole('button', { name: 'Add a step' }))
     fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
 
     expect(onInsertNode).toHaveBeenCalledWith(expect.any(String), '__LOOP_BODY__', 'agent')
@@ -171,7 +191,7 @@ describe('adding a step inside the rail', () => {
     const { container } = renderWithSpy(nodes, onInsertNode)
     const rail = container.querySelector('[data-loop-rail]') as HTMLElement
 
-    fireEvent.click(within(rail).getByRole('button', { name: '' }))
+    fireEvent.click(within(rail).getByRole('button', { name: 'Add a step' }))
     fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
 
     expect(onInsertNode.mock.calls[0][0]).toBe('review')
@@ -185,7 +205,7 @@ describe('adding a step inside the rail', () => {
     )
     const rail = container.querySelector('[data-loop-rail]') as HTMLElement
 
-    fireEvent.click(within(rail).getByRole('button', { name: '' }))
+    fireEvent.click(within(rail).getByRole('button', { name: 'Add a step' }))
     fireEvent.click(screen.getByText(/Launch an agent|Add an agent|agent/i))
 
     expect(onInsertNode.mock.calls[0][0]).toBe('loop')
@@ -195,9 +215,13 @@ describe('adding a step inside the rail', () => {
 describe('where a loop can be added', () => {
   it('is offered on the trunk', () => {
     const { container } = renderWith(nodes)
-    // The + between trunk steps, outside the rail.
-    const buttons = container.querySelectorAll('button')
-    fireEvent.click(buttons[buttons.length - 1])
+    // The + that trails the leaf, outside the rail: the last add button in
+    // the document that does not sit inside the loop enclosure.
+    const rail = container.querySelector('[data-loop-rail]') as HTMLElement
+    const adds = screen
+      .getAllByRole('button', { name: 'Add a step' })
+      .filter((b) => !rail.contains(b))
+    fireEvent.click(adds[adds.length - 1])
     expect(screen.queryByText(/Repeat steps/)).not.toBeNull()
   })
 })
@@ -216,9 +240,7 @@ describe('the canvas reads in one colour', () => {
     // True was green and False red, which said one path is the good one and
     // the other a failure. A condition is a fork; the word says which way.
     const { container } = renderWith(forkNodes, null, forkEdges)
-    const labels = [...container.querySelectorAll('div')].filter(
-      (el) => el.textContent === 'True' || el.textContent === 'False'
-    )
+    const labels = [...container.querySelectorAll('[data-branch-label]')]
     expect(labels).toHaveLength(2)
     expect(labels[0].className).toBe(labels[1].className)
     for (const el of labels) {

--- a/tests/node-card-dispatch.test.tsx
+++ b/tests/node-card-dispatch.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [],
+  useConnectorIdFor: () => undefined,
+  useConnectionIconFor: () => undefined
+}))
+
+import { NodeCard } from '../src/renderer/components/workflow-editor/nodes/NodeCard'
+import type { WorkflowNode } from '../packages/shared/src/types'
+
+afterEach(cleanup)
+
+const card = (type: WorkflowNode['type'], label: string, config: Record<string, unknown>) =>
+  render(
+    <NodeCard
+      node={{
+        id: 'n',
+        type,
+        label,
+        config: config as WorkflowNode['config'],
+        position: { x: 0, y: 0 }
+      }}
+      selected={false}
+      onClick={() => {}}
+    />
+  )
+
+describe('the card for each step type', () => {
+  it.each([
+    ['trigger', 'When it starts', { triggerType: 'manual' }],
+    ['script', 'Run checks', { scriptType: 'bash', scriptContent: '' }],
+    ['condition', 'Ready?', { variable: 'x', operator: 'equals', value: '1' }],
+    ['approval', 'Sign off', { message: '' }],
+    ['createTaskFromItem', 'File it', { project: 'vorn' }],
+    ['callConnectorAction', 'Comment on issue', { connectionId: '', action: '', args: {} }],
+    ['launchAgent', 'Do the work', { agentType: 'claude', projectName: '', projectPath: '' }]
+  ] as const)('renders a %s card by its label', (type, label, config) => {
+    card(type, label, config as Record<string, unknown>)
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+})

--- a/tests/node-palette.test.tsx
+++ b/tests/node-palette.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import {
+  NodePalette,
+  PalettePick
+} from '../src/renderer/components/workflow-editor/panels/NodePalette'
+
+afterEach(cleanup)
+
+const connectorItems = [
+  { connectionId: 'c1', action: 'createIssue', label: 'Create issue', source: 'GitHub' },
+  { connectionId: 'c1', action: 'closeIssue', label: 'Close issue', source: 'GitHub' }
+]
+
+function renderPalette(over: Partial<Parameters<typeof NodePalette>[0]> = {}) {
+  const onPick = vi.fn()
+  const onClose = vi.fn()
+  const utils = render(
+    <NodePalette
+      position={{ x: 10, y: 20 }}
+      allowLoop
+      connectorItems={connectorItems}
+      onPick={onPick}
+      onClose={onClose}
+      {...over}
+    />
+  )
+  return { ...utils, onPick, onClose }
+}
+
+describe('the node search panel', () => {
+  it('lists every step type and every installed connector action', () => {
+    renderPalette()
+    for (const label of [
+      'Add an agent',
+      'Add a script',
+      'Add a condition',
+      'Add an approval gate',
+      'Repeat steps until…',
+      'Call a connector action',
+      'Create issue',
+      'Close issue'
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+    expect(screen.getAllByText('GitHub')).toHaveLength(2)
+  })
+
+  it('filters as you type, matching actions by label and source', () => {
+    renderPalette()
+    fireEvent.change(screen.getByPlaceholderText('Search steps and actions'), {
+      target: { value: 'issue' }
+    })
+    expect(screen.getByText('Create issue')).toBeInTheDocument()
+    expect(screen.queryByText('Add an agent')).toBeNull()
+    fireEvent.change(screen.getByPlaceholderText('Search steps and actions'), {
+      target: { value: 'github' }
+    })
+    expect(screen.getByText('Close issue')).toBeInTheDocument()
+  })
+
+  it('says so when nothing matches', () => {
+    renderPalette()
+    fireEvent.change(screen.getByPlaceholderText('Search steps and actions'), {
+      target: { value: 'zzz' }
+    })
+    expect(screen.getByText('Nothing matches')).toBeInTheDocument()
+  })
+
+  it('withholds the loop inside a branch', () => {
+    renderPalette({ allowLoop: false })
+    expect(screen.queryByText('Repeat steps until…')).toBeNull()
+  })
+
+  it('picks the highlighted row with Enter and moves the highlight with arrows', () => {
+    const { onPick, container } = renderPalette()
+    const root = container.querySelector('[data-node-palette]') as HTMLElement
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    fireEvent.keyDown(root, { key: 'ArrowUp' })
+    fireEvent.keyDown(root, { key: 'ArrowDown' })
+    fireEvent.keyDown(root, { key: 'Enter' })
+    expect(onPick).toHaveBeenCalledWith({ kind: 'type', type: 'script' } satisfies PalettePick)
+  })
+
+  it('reports a connector pick with its connection and action', () => {
+    const { onPick } = renderPalette()
+    fireEvent.click(screen.getByText('Create issue'))
+    expect(onPick).toHaveBeenCalledWith({
+      kind: 'connectorAction',
+      connectionId: 'c1',
+      action: 'createIssue'
+    } satisfies PalettePick)
+  })
+
+  it('closes on Escape and on a click outside', () => {
+    const { onClose, container } = renderPalette()
+    fireEvent.keyDown(container.querySelector('[data-node-palette]') as HTMLElement, {
+      key: 'Escape'
+    })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.mouseDown(document.body)
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/workflow-canvas-layout.test.ts
+++ b/tests/workflow-canvas-layout.test.ts
@@ -91,7 +91,7 @@ describe('the definition projected onto the canvas', () => {
     const { edges: rf } = toCanvasElements(loopNodes, loopEdges)
     const exit = rf.find((e) => e.id === 'e4')!
     expect(exit.source).toBe('loop')
-    // The real endpoints survive, so an insert there still splices correctly.
+    // Real endpoints survive so inserts still splice correctly.
     expect(exit.data).toMatchObject({ afterNodeId: 'r', beforeNodeId: 'after' })
     expect(rf.find((e) => e.id === 'e2')).toBeUndefined()
     expect(rf.find((e) => e.id === 'e3')).toBeUndefined()

--- a/tests/workflow-canvas-layout.test.ts
+++ b/tests/workflow-canvas-layout.test.ts
@@ -22,12 +22,12 @@ const node = (
   position
 })
 
-const linearNodes = [
+const chainNodes = [
   node('t', 'trigger', 'Manual', { triggerType: 'manual' }),
   node('a', 'script', 'One', { scriptType: 'bash', scriptContent: '' }),
   node('b', 'script', 'Two', { scriptType: 'bash', scriptContent: '' })
 ]
-const linearEdges: WorkflowEdge[] = [
+const chainEdges: WorkflowEdge[] = [
   { id: 'e1', source: 't', target: 'a' },
   { id: 'e2', source: 'a', target: 'b' }
 ]
@@ -62,8 +62,8 @@ const loopEdges: WorkflowEdge[] = [
 ]
 
 describe('the definition projected onto the canvas', () => {
-  it('keeps a linear chain in trigger order, top to bottom', () => {
-    const { positions } = layoutPositions(linearNodes, linearEdges)
+  it('keeps a straight chain in trigger order, top to bottom', () => {
+    const { positions } = layoutPositions(chainNodes, chainEdges)
     expect(positions.get('t')!.y).toBeLessThan(positions.get('a')!.y)
     expect(positions.get('a')!.y).toBeLessThan(positions.get('b')!.y)
     expect(positions.get('t')!.x).toBe(positions.get('a')!.x)
@@ -105,30 +105,30 @@ describe('the definition projected onto the canvas', () => {
   })
 
   it('trails every leaf with an add button and nothing else', () => {
-    const { nodes: rf } = toCanvasElements(linearNodes, linearEdges)
+    const { nodes: rf } = toCanvasElements(chainNodes, chainEdges)
     const adds = rf.filter((n) => n.type === 'addStep')
     expect(adds.map((n) => n.id)).toEqual(['add:b'])
   })
 
   it('uses stored positions once anyone has arranged the workflow', () => {
-    const arranged = linearNodes.map((n) =>
+    const arranged = chainNodes.map((n) =>
       n.id === 'a' ? { ...n, position: { x: 120, y: 300 } } : n
     )
     expect(positionsAreSeed(arranged)).toBe(false)
-    const { nodes: rf } = toCanvasElements(arranged, linearEdges)
+    const { nodes: rf } = toCanvasElements(arranged, chainEdges)
     expect(rf.find((n) => n.id === 'a')!.position).toEqual({ x: 120, y: 300 })
   })
 })
 
 describe('what a hand-drawn connection may do', () => {
   it('allows a forward edge between free steps', () => {
-    const open = [...linearNodes, node('c', 'script', 'Free', {})]
-    expect(canConnect(open, linearEdges, 'b', 'c')).toBe(true)
+    const open = [...chainNodes, node('c', 'script', 'Free', {})]
+    expect(canConnect(open, chainEdges, 'b', 'c')).toBe(true)
   })
 
   it('refuses a cycle', () => {
-    expect(canConnect(linearNodes, linearEdges, 'b', 't')).toBe(false)
-    expect(canConnect(linearNodes, linearEdges, 'b', 'a')).toBe(false)
+    expect(canConnect(chainNodes, chainEdges, 'b', 't')).toBe(false)
+    expect(canConnect(chainNodes, chainEdges, 'b', 'a')).toBe(false)
   })
 
   it('refuses edges into the trigger and out of a condition', () => {
@@ -142,6 +142,6 @@ describe('what a hand-drawn connection may do', () => {
   })
 
   it('refuses a duplicate of an existing edge', () => {
-    expect(canConnect(linearNodes, linearEdges, 'a', 'b')).toBe(false)
+    expect(canConnect(chainNodes, chainEdges, 'a', 'b')).toBe(false)
   })
 })

--- a/tests/workflow-canvas-layout.test.ts
+++ b/tests/workflow-canvas-layout.test.ts
@@ -110,6 +110,14 @@ describe('the definition projected onto the canvas', () => {
     expect(adds.map((n) => n.id)).toEqual(['add:b'])
   })
 
+  it('trails a workflow that ends in a loop', () => {
+    const terminal = loopNodes.filter((n) => n.id !== 'after')
+    const terminalEdges = loopEdges.filter((e) => e.id !== 'e4')
+    const { nodes: rf } = toCanvasElements(terminal, terminalEdges)
+    // The loop's body edges are not drawn, so the composite is the leaf.
+    expect(rf.some((n) => n.id === 'add:loop')).toBe(true)
+  })
+
   it('uses stored positions once anyone has arranged the workflow', () => {
     const arranged = chainNodes.map((n) =>
       n.id === 'a' ? { ...n, position: { x: 120, y: 300 } } : n

--- a/tests/workflow-canvas-layout.test.ts
+++ b/tests/workflow-canvas-layout.test.ts
@@ -120,6 +120,26 @@ describe('the definition projected onto the canvas', () => {
   })
 })
 
+describe('layout edge shapes', () => {
+  it('sizes an empty loop by its placeholder', () => {
+    const emptyLoop = [
+      node('t', 'trigger', 'Manual', { triggerType: 'manual' }),
+      node('loop', 'loop', 'Repeat', { nodeType: 'loop', bodyNodeIds: [], maxIterations: 2 })
+    ]
+    const { nodes: rf } = toCanvasElements(emptyLoop, [{ id: 'e1', source: 't', target: 'loop' }])
+    const loop = rf.find((n) => n.id === 'loop')!
+    expect(loop.height).toBeGreaterThan(120)
+  })
+
+  it('gives an empty fork branch a full column of width', () => {
+    const halfFork = forkNodes.filter((n) => n.id !== 'no' && n.id !== 'join')
+    const halfEdges = forkEdges.filter((e) => ['e1', 'e2', 'e3'].includes(e.id))
+    const { positions } = layoutPositions(halfFork, halfEdges)
+    // The dangling false edge points at a missing node; the true branch still lays out.
+    expect(positions.get('yes')).toBeDefined()
+  })
+})
+
 describe('what a hand-drawn connection may do', () => {
   it('allows a forward edge between free steps', () => {
     const open = [...chainNodes, node('c', 'script', 'Free', {})]

--- a/tests/workflow-canvas-layout.test.ts
+++ b/tests/workflow-canvas-layout.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest'
+import {
+  canConnect,
+  layoutPositions,
+  loopBodyMembers,
+  positionsAreSeed,
+  toCanvasElements
+} from '../src/renderer/lib/workflow-canvas-layout'
+import type { WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
+
+const node = (
+  id: string,
+  type: WorkflowNode['type'],
+  label: string,
+  config: Record<string, unknown> = {},
+  position = { x: 0, y: 0 }
+): WorkflowNode => ({
+  id,
+  type,
+  label,
+  config: config as WorkflowNode['config'],
+  position
+})
+
+const linearNodes = [
+  node('t', 'trigger', 'Manual', { triggerType: 'manual' }),
+  node('a', 'script', 'One', { scriptType: 'bash', scriptContent: '' }),
+  node('b', 'script', 'Two', { scriptType: 'bash', scriptContent: '' })
+]
+const linearEdges: WorkflowEdge[] = [
+  { id: 'e1', source: 't', target: 'a' },
+  { id: 'e2', source: 'a', target: 'b' }
+]
+
+const forkNodes = [
+  node('t', 'trigger', 'Manual', { triggerType: 'manual' }),
+  node('c', 'condition', 'Ready?', { variable: 'x', operator: 'equals', value: '1' }),
+  node('yes', 'script', 'Yes', { scriptType: 'bash', scriptContent: '' }),
+  node('no', 'script', 'No', { scriptType: 'bash', scriptContent: '' }),
+  node('join', 'script', 'Join', { scriptType: 'bash', scriptContent: '' })
+]
+const forkEdges: WorkflowEdge[] = [
+  { id: 'e1', source: 't', target: 'c' },
+  { id: 'e2', source: 'c', target: 'yes', conditionBranch: 'true' },
+  { id: 'e3', source: 'c', target: 'no', conditionBranch: 'false' },
+  { id: 'e4', source: 'yes', target: 'join' },
+  { id: 'e5', source: 'no', target: 'join' }
+]
+
+const loopNodes = [
+  node('t', 'trigger', 'Manual', { triggerType: 'manual' }),
+  node('loop', 'loop', 'Repeat', { nodeType: 'loop', bodyNodeIds: ['w', 'r'], maxIterations: 2 }),
+  node('w', 'script', 'Write', { scriptType: 'bash', scriptContent: '' }),
+  node('r', 'script', 'Review', { scriptType: 'bash', scriptContent: '' }),
+  node('after', 'script', 'After', { scriptType: 'bash', scriptContent: '' })
+]
+const loopEdges: WorkflowEdge[] = [
+  { id: 'e1', source: 't', target: 'loop' },
+  { id: 'e2', source: 'loop', target: 'w' },
+  { id: 'e3', source: 'w', target: 'r' },
+  { id: 'e4', source: 'r', target: 'after' }
+]
+
+describe('the definition projected onto the canvas', () => {
+  it('keeps a linear chain in trigger order, top to bottom', () => {
+    const { positions } = layoutPositions(linearNodes, linearEdges)
+    expect(positions.get('t')!.y).toBeLessThan(positions.get('a')!.y)
+    expect(positions.get('a')!.y).toBeLessThan(positions.get('b')!.y)
+    expect(positions.get('t')!.x).toBe(positions.get('a')!.x)
+  })
+
+  it('puts fork branches side by side and the join back on the trunk', () => {
+    const { positions, branchMembers } = layoutPositions(forkNodes, forkEdges)
+    expect(positions.get('yes')!.x).not.toBe(positions.get('no')!.x)
+    expect(positions.get('yes')!.y).toBe(positions.get('no')!.y)
+    expect(positions.get('join')!.x).toBe(positions.get('c')!.x)
+    expect(branchMembers.has('yes')).toBe(true)
+    expect(branchMembers.has('no')).toBe(true)
+    expect(branchMembers.has('join')).toBe(false)
+  })
+
+  it('draws no canvas nodes for loop body steps', () => {
+    const { nodes: rf } = toCanvasElements(loopNodes, loopEdges)
+    const ids = rf.map((n) => n.id)
+    expect(ids).toContain('loop')
+    expect(ids).not.toContain('w')
+    expect(ids).not.toContain('r')
+  })
+
+  it('redraws the edge that leaves a loop body from the composite', () => {
+    const { edges: rf } = toCanvasElements(loopNodes, loopEdges)
+    const exit = rf.find((e) => e.id === 'e4')!
+    expect(exit.source).toBe('loop')
+    // The real endpoints survive, so an insert there still splices correctly.
+    expect(exit.data).toMatchObject({ afterNodeId: 'r', beforeNodeId: 'after' })
+    expect(rf.find((e) => e.id === 'e2')).toBeUndefined()
+    expect(rf.find((e) => e.id === 'e3')).toBeUndefined()
+  })
+
+  it('labels condition branches and keeps the tag on the edge data', () => {
+    const { edges: rf } = toCanvasElements(forkNodes, forkEdges)
+    const yes = rf.find((e) => e.id === 'e2')!
+    expect(yes.label).toBe('True')
+    expect(yes.data).toMatchObject({ conditionBranch: 'true', insideBranch: true })
+  })
+
+  it('trails every leaf with an add button and nothing else', () => {
+    const { nodes: rf } = toCanvasElements(linearNodes, linearEdges)
+    const adds = rf.filter((n) => n.type === 'addStep')
+    expect(adds.map((n) => n.id)).toEqual(['add:b'])
+  })
+
+  it('uses stored positions once anyone has arranged the workflow', () => {
+    const arranged = linearNodes.map((n) =>
+      n.id === 'a' ? { ...n, position: { x: 120, y: 300 } } : n
+    )
+    expect(positionsAreSeed(arranged)).toBe(false)
+    const { nodes: rf } = toCanvasElements(arranged, linearEdges)
+    expect(rf.find((n) => n.id === 'a')!.position).toEqual({ x: 120, y: 300 })
+  })
+})
+
+describe('what a hand-drawn connection may do', () => {
+  it('allows a forward edge between free steps', () => {
+    const open = [...linearNodes, node('c', 'script', 'Free', {})]
+    expect(canConnect(open, linearEdges, 'b', 'c')).toBe(true)
+  })
+
+  it('refuses a cycle', () => {
+    expect(canConnect(linearNodes, linearEdges, 'b', 't')).toBe(false)
+    expect(canConnect(linearNodes, linearEdges, 'b', 'a')).toBe(false)
+  })
+
+  it('refuses edges into the trigger and out of a condition', () => {
+    expect(canConnect(forkNodes, forkEdges, 'join', 't')).toBe(false)
+    expect(canConnect(forkNodes, forkEdges, 'c', 'join')).toBe(false)
+  })
+
+  it('refuses edges touching a loop body', () => {
+    expect(canConnect(loopNodes, loopEdges, 'after', 'w')).toBe(false)
+    expect(loopBodyMembers(loopNodes)).toEqual(new Set(['w', 'r']))
+  })
+
+  it('refuses a duplicate of an existing edge', () => {
+    expect(canConnect(linearNodes, linearEdges, 'a', 'b')).toBe(false)
+  })
+})

--- a/tests/workflow-editor-error-policy.test.tsx
+++ b/tests/workflow-editor-error-policy.test.tsx
@@ -115,6 +115,8 @@ vi.mock('../src/renderer/stores', () => {
   return { useAppStore }
 })
 ;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
   api: {
     listWorkflowRuns: vi.fn().mockResolvedValue([]),
     createTerminal: vi.fn(),

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -65,6 +65,8 @@ vi.mock('../src/renderer/stores', () => {
   return { useAppStore }
 })
 ;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
   api: {
     listWorkflowRuns: vi.fn().mockResolvedValue([]),
     createTerminal: vi.fn(),

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
 vi.mock('framer-motion', () => ({
@@ -21,8 +21,12 @@ vi.mock('../src/renderer/components/Tooltip', () => ({
   Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
 }))
 
+const captured = vi.hoisted(() => ({ canvasProps: null as Record<string, unknown> | null }))
 vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', () => ({
-  WorkflowCanvas: () => <div data-testid="canvas" />
+  WorkflowCanvas: (props: Record<string, unknown>) => {
+    captured.canvasProps = props
+    return <div data-testid="canvas" />
+  }
 }))
 
 vi.mock('../src/renderer/components/workflow-editor/panels/NodeConfigPanel', () => ({
@@ -301,5 +305,106 @@ describe('WorkflowEditor', () => {
     )
     mockState.editingWorkflowId = null
     mockState.config = { workflows: [], tasks: [], projects: [], defaults: {} }
+  })
+})
+
+describe('the handlers the canvas drives', () => {
+  const canvas = () =>
+    captured.canvasProps as unknown as {
+      nodes: { id: string; type: string; position: { x: number; y: number } }[]
+      onConnectEdge: (s: string, t: string) => void
+      onPositionsCommit: (p: Record<string, { x: number; y: number }>) => void
+      onTidyUp: () => void
+      onPaletteInsert: (
+        pick: { kind: string; type?: string; connectionId?: string; action?: string },
+        after: string,
+        pos: { x: number; y: number }
+      ) => void
+    }
+  const save = (container: HTMLElement) => {
+    const saveButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Save')
+    )!
+    fireEvent.click(saveButton)
+    return mockState.addWorkflow.mock.lastCall![0] as {
+      nodes: { id: string; type: string; position: { x: number; y: number }; config: unknown }[]
+      edges: { source: string; target: string }[]
+    }
+  }
+
+  it('writes a hand-drawn connection into the definition', () => {
+    mockState.addWorkflow.mockClear()
+    const { container } = render(<WorkflowEditor />)
+    const trigger = canvas().nodes?.[0] ?? { id: '' }
+    void trigger
+    const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
+    act(() => canvas().onConnectEdge(triggerId, 'ghost-target'))
+    expect(save(container).edges.some((e) => e.target === 'ghost-target')).toBe(true)
+  })
+
+  it('persists committed drag positions', () => {
+    mockState.addWorkflow.mockClear()
+    const { container } = render(<WorkflowEditor />)
+    const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
+    act(() => canvas().onPositionsCommit({ [triggerId]: { x: 48, y: 96 } }))
+    expect(save(container).nodes[0].position).toEqual({ x: 48, y: 96 })
+  })
+
+  it('tidy up writes the computed layout into the definition', () => {
+    mockState.addWorkflow.mockClear()
+    const { container } = render(<WorkflowEditor />)
+    act(() => canvas().onTidyUp())
+    expect(save(container).nodes[0].position.x).toBe(-140)
+  })
+
+  it('a palette pick appends after its anchor at the drop point', () => {
+    mockState.addWorkflow.mockClear()
+    const { container } = render(<WorkflowEditor />)
+    const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
+    act(() =>
+      canvas().onPaletteInsert({ kind: 'type', type: 'script' }, triggerId, { x: 24, y: 480 })
+    )
+    const saved = save(container)
+    const script = saved.nodes.find((n) => n.type === 'script')!
+    expect(script.position).toEqual({ x: 24, y: 480 })
+    expect(saved.edges.some((e) => e.target === script.id)).toBe(true)
+  })
+
+  it('a connector pick lands preconfigured', () => {
+    mockState.addWorkflow.mockClear()
+    const { container } = render(<WorkflowEditor />)
+    const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
+    act(() =>
+      canvas().onPaletteInsert(
+        { kind: 'connectorAction', connectionId: 'c9', action: 'createIssue' },
+        triggerId,
+        { x: 0, y: 200 }
+      )
+    )
+    const saved = save(container)
+    const step = saved.nodes.find((n) => n.type === 'callConnectorAction')!
+    expect(step.config).toMatchObject({ connectionId: 'c9', action: 'createIssue' })
+  })
+
+  it('cmd+z walks an edit back', () => {
+    mockState.addWorkflow.mockClear()
+    const winAdd = (window.addEventListener as ReturnType<typeof vi.fn>).mock
+    const { container } = render(<WorkflowEditor />)
+    const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
+    act(() => canvas().onConnectEdge(triggerId, 'ghost-target'))
+    const keydown = winAdd.calls.filter((c) => c[0] === 'keydown').at(-1)![1] as (
+      e: unknown
+    ) => void
+    act(() =>
+      keydown({
+        metaKey: true,
+        ctrlKey: false,
+        shiftKey: false,
+        key: 'z',
+        target: document.createElement('div'),
+        preventDefault: () => {}
+      })
+    )
+    expect(save(container).edges).toHaveLength(0)
   })
 })

--- a/tests/workflow-panel-surface.test.ts
+++ b/tests/workflow-panel-surface.test.ts
@@ -6,12 +6,13 @@ const root = join(__dirname, '..')
 const panels = join(root, 'src/renderer/components/workflow-editor/panels')
 const read = (name: string): string => readFileSync(join(panels, name), 'utf8')
 
-/** The panels docked to an edge of the editor, each a permanent region of it. */
+/** The panels docked to an edge of the editor, each a permanent region of it.
+ *  NodePalette left this list when it became the floating node search — it
+ *  floats over the canvas now, so the overlay rung is the correct one for it. */
 const DOCKED = [
   'NodeConfigPanel.tsx',
   'WorkflowPropertiesPanel.tsx',
-  'RunHistoryPanel.tsx',
-  'NodePalette.tsx'
+  'RunHistoryPanel.tsx'
 ] as const
 
 /** The one panel element in each file: the root, which carries the edge border. */

--- a/tests/workflow-position-policy.test.tsx
+++ b/tests/workflow-position-policy.test.tsx
@@ -3,7 +3,10 @@ import { describe, it, expect } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useState } from 'react'
 import {
+  appendNodeAfter,
+  insertBeforeFork,
   insertConditionBetween,
+  insertNodeBetween,
   placeNewNodes,
   createScriptNode
 } from '../src/renderer/lib/workflow-helpers'
@@ -57,6 +60,50 @@ describe('placing the nodes a mutation creates', () => {
   })
 })
 
+describe('more placement paths', () => {
+  it('probes past an occupied spot instead of covering it', () => {
+    const crowd = [
+      ...arrangedNodes,
+      node('c', 'script', 'Crowder', { x: -140, y: 340 }, { scriptType: 'bash', scriptContent: '' })
+    ]
+    const newNode = createScriptNode()
+    const next = [...crowd, newNode]
+    const nextEdges = [...arrangedEdges, { id: 'e2', source: 'a', target: newNode.id }]
+    const placed = placeNewNodes(crowd, next, nextEdges)
+    const landed = placed.find((n) => n.id === newNode.id)!.position
+    // a's slot below is taken by Crowder; the new node keeps moving down.
+    expect(landed.y).toBeGreaterThan(340)
+  })
+
+  it('keeps a branch tag on the first half of a spliced edge', () => {
+    const tagged = [
+      node(
+        'cond',
+        'condition',
+        'Ready?',
+        { x: 0, y: 0 },
+        { variable: 'x', operator: 'equals', value: '1' }
+      ),
+      node('yes', 'script', 'Yes', { x: 0, y: 200 }, { scriptType: 'bash', scriptContent: '' })
+    ]
+    const taggedEdges: WorkflowEdge[] = [
+      { id: 't1', source: 'cond', target: 'yes', conditionBranch: 'true' }
+    ]
+    const result = insertNodeBetween(tagged, taggedEdges, 't1', createScriptNode())
+    const first = result.edges.find((e) => e.source === 'cond')!
+    expect(first.conditionBranch).toBe('true')
+  })
+
+  it('appends after a step and inserts before a fork without reflowing the rest', () => {
+    const appended = appendNodeAfter(arrangedNodes, arrangedEdges, 'a', createScriptNode())
+    expect(appended.nodes.find((n) => n.id === 't')!.position).toEqual({ x: -140, y: 0 })
+
+    const beforeFork = insertBeforeFork(arrangedNodes, arrangedEdges, 't', createScriptNode())
+    expect(beforeFork.edges.some((e) => e.source === 't')).toBe(true)
+    expect(beforeFork.nodes.find((n) => n.id === 'a')!.position.x).toBe(-140)
+  })
+})
+
 describe('what undo may reach', () => {
   function useEditorLike() {
     const [nodes, setNodes] = useState<WorkflowNode[]>([])
@@ -77,6 +124,24 @@ describe('what undo may reach', () => {
 
     // A wipe here would let a save persist an emptied workflow.
     expect(result.current.nodes).toEqual(arrangedNodes)
+  })
+
+  it('starts a fresh history when a different workflow loads', () => {
+    const { result, rerender } = renderHook(
+      ({ resetKey }: { resetKey: string }) => {
+        const [nodes, setNodes] = useState<WorkflowNode[]>([])
+        const [edges, setEdges] = useState<WorkflowEdge[]>([])
+        const history = useDefinitionHistory(nodes, edges, setNodes, setEdges, resetKey)
+        return { nodes, setNodes, setEdges, history }
+      },
+      { initialProps: { resetKey: 'wf-1' } }
+    )
+    act(() => result.current.setNodes(arrangedNodes))
+    act(() => result.current.setNodes([...arrangedNodes, createScriptNode()]))
+    rerender({ resetKey: 'wf-2' })
+    act(() => result.current.history.undo())
+    // The old workflow's edits are unreachable across the switch.
+    expect(result.current.nodes).toHaveLength(3)
   })
 
   it('still undoes a real edit back to the loaded definition', () => {

--- a/tests/workflow-position-policy.test.tsx
+++ b/tests/workflow-position-policy.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useState } from 'react'
+import {
+  insertConditionBetween,
+  placeNewNodes,
+  createScriptNode
+} from '../src/renderer/lib/workflow-helpers'
+import { useDefinitionHistory } from '../src/renderer/lib/use-definition-history'
+import type { WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
+
+const node = (
+  id: string,
+  type: WorkflowNode['type'],
+  label: string,
+  position: { x: number; y: number },
+  config: Record<string, unknown> = {}
+): WorkflowNode => ({
+  id,
+  type,
+  label,
+  config: config as WorkflowNode['config'],
+  position
+})
+
+/** An arranged workflow: someone has dragged it, so positions are theirs. */
+const arrangedNodes = [
+  node('t', 'trigger', 'Manual', { x: -140, y: 0 }, { triggerType: 'manual' }),
+  node('a', 'script', 'After', { x: -140, y: 200 }, { scriptType: 'bash', scriptContent: '' })
+]
+const arrangedEdges: WorkflowEdge[] = [{ id: 'e1', source: 't', target: 'a' }]
+
+describe('placing the nodes a mutation creates', () => {
+  it('hangs a chain of new nodes off where each predecessor actually landed', () => {
+    // A condition insert creates three nodes at once, chained through the new condition.
+    const result = insertConditionBetween(arrangedNodes, arrangedEdges, 't', 'a')
+    const cond = result.nodes.find((n) => n.type === 'condition')!
+    const trueBranch = result.nodes.find((n) => n.label === 'True Branch')!
+    const falseBranch = result.nodes.find((n) => n.label === 'False Branch')!
+
+    expect(cond.position.y).toBeGreaterThan(0)
+    expect(trueBranch.position.y).toBeGreaterThan(cond.position.y)
+    expect(falseBranch.position.y).toBeGreaterThan(cond.position.y)
+    // Two cards on one coordinate cannot both be seen.
+    expect(trueBranch.position).not.toEqual(falseBranch.position)
+  })
+
+  it('leaves every pre-existing node exactly where it was', () => {
+    const newNode = createScriptNode()
+    const nextNodes = [...arrangedNodes, newNode]
+    const nextEdges = [...arrangedEdges, { id: 'e2', source: 'a', target: newNode.id }]
+    const placed = placeNewNodes(arrangedNodes, nextNodes, nextEdges)
+    expect(placed.find((n) => n.id === 't')!.position).toEqual({ x: -140, y: 0 })
+    expect(placed.find((n) => n.id === 'a')!.position).toEqual({ x: -140, y: 200 })
+    expect(placed.find((n) => n.id === newNode.id)!.position).toEqual({ x: -140, y: 340 })
+  })
+})
+
+describe('what undo may reach', () => {
+  function useEditorLike() {
+    const [nodes, setNodes] = useState<WorkflowNode[]>([])
+    const [edges, setEdges] = useState<WorkflowEdge[]>([])
+    const history = useDefinitionHistory(nodes, edges, setNodes, setEdges, 'wf-1')
+    return { nodes, edges, setNodes, setEdges, history }
+  }
+
+  it('never undoes past the loaded definition', () => {
+    const { result } = renderHook(useEditorLike)
+
+    // The load effect lands one commit after mount, exactly like the editor.
+    act(() => {
+      result.current.setNodes(arrangedNodes)
+      result.current.setEdges(arrangedEdges)
+    })
+    act(() => result.current.history.undo())
+
+    // A wipe here would let a save persist an emptied workflow.
+    expect(result.current.nodes).toEqual(arrangedNodes)
+  })
+
+  it('still undoes a real edit back to the loaded definition', () => {
+    const { result } = renderHook(useEditorLike)
+    act(() => {
+      result.current.setNodes(arrangedNodes)
+      result.current.setEdges(arrangedEdges)
+    })
+
+    const edited = [...arrangedNodes, createScriptNode()]
+    act(() => result.current.setNodes(edited))
+    expect(result.current.nodes).toHaveLength(3)
+
+    act(() => result.current.history.undo())
+    expect(result.current.nodes).toEqual(arrangedNodes)
+
+    act(() => result.current.history.redo())
+    expect(result.current.nodes).toEqual(edited)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,22 +1417,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dagrejs/dagre@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "@dagrejs/dagre@npm:3.1.1"
-  dependencies:
-    "@dagrejs/graphlib": "npm:4.0.5"
-  checksum: 10c0/e2607e941e54407d07650c13b7c4c6aca1466e12d56fd7d1e704eab686837b049700f05ca9a723aa34f027ec71bee61914594339a0e74b1f4ad7b69c5fa55242
-  languageName: node
-  linkType: hard
-
-"@dagrejs/graphlib@npm:4.0.5":
-  version: 4.0.5
-  resolution: "@dagrejs/graphlib@npm:4.0.5"
-  checksum: 10c0/698c9ceb996bc1da3a4a141858db57b8380854d412fcd5c9daa48f159f385fc0fb07ef84967409c224d3a82fb8460018d871657c90175bffd9b34ef9c538c1f7
-  languageName: node
-  linkType: hard
-
 "@electron-internal/extract-zip@npm:^1.0.1":
   version: 1.0.4
   resolution: "@electron-internal/extract-zip@npm:1.0.4"
@@ -12480,7 +12464,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vorn@workspace:."
   dependencies:
-    "@dagrejs/dagre": "npm:^3.1.1"
     "@electron/rebuild": "npm:^4.0.4"
     "@eslint/js": "npm:^10.0.1"
     "@grpc/grpc-js": "npm:^1.14.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,6 +1417,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dagrejs/dagre@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@dagrejs/dagre@npm:3.1.1"
+  dependencies:
+    "@dagrejs/graphlib": "npm:4.0.5"
+  checksum: 10c0/e2607e941e54407d07650c13b7c4c6aca1466e12d56fd7d1e704eab686837b049700f05ca9a723aa34f027ec71bee61914594339a0e74b1f4ad7b69c5fa55242
+  languageName: node
+  linkType: hard
+
+"@dagrejs/graphlib@npm:4.0.5":
+  version: 4.0.5
+  resolution: "@dagrejs/graphlib@npm:4.0.5"
+  checksum: 10c0/698c9ceb996bc1da3a4a141858db57b8380854d412fcd5c9daa48f159f385fc0fb07ef84967409c224d3a82fb8460018d871657c90175bffd9b34ef9c538c1f7
+  languageName: node
+  linkType: hard
+
 "@electron-internal/extract-zip@npm:^1.0.1":
   version: 1.0.4
   resolution: "@electron-internal/extract-zip@npm:1.0.4"
@@ -4025,10 +4041,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-color@npm:*":
+  version: 3.1.3
+  resolution: "@types/d3-color@npm:3.1.3"
+  checksum: 10c0/65eb0487de606eb5ad81735a9a5b3142d30bc5ea801ed9b14b77cb14c9b909f718c059f13af341264ee189acf171508053342142bdf99338667cea26a2d8d6ae
+  languageName: node
+  linkType: hard
+
+"@types/d3-drag@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@types/d3-drag@npm:3.0.7"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10c0/65e29fa32a87c72d26c44b5e2df3bf15af21cd128386bcc05bcacca255927c0397d0cd7e6062aed5f0abd623490544a9d061c195f5ed9f018fe0b698d99c079d
+  languageName: node
+  linkType: hard
+
 "@types/d3-hierarchy@npm:^3.1.7":
   version: 3.1.7
   resolution: "@types/d3-hierarchy@npm:3.1.7"
   checksum: 10c0/873711737d6b8e7b6f1dda0bcd21294a48f75024909ae510c5d2c21fad2e72032e0958def4d9f68319d3aaac298ad09c49807f8bfc87a145a82693b5208613c7
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:*, @types/d3-interpolate@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "npm:*"
+  checksum: 10c0/066ebb8da570b518dd332df6b12ae3b1eaa0a7f4f0c702e3c57f812cf529cc3500ec2aac8dc094f31897790346c6b1ebd8cd7a077176727f4860c2b181a65ca4
+  languageName: node
+  linkType: hard
+
+"@types/d3-selection@npm:*, @types/d3-selection@npm:^3.0.10":
+  version: 3.0.11
+  resolution: "@types/d3-selection@npm:3.0.11"
+  checksum: 10c0/0c512956c7503ff5def4bb32e0c568cc757b9a2cc400a104fc0f4cfe5e56d83ebde2a97821b6f2cb26a7148079d3b86a2f28e11d68324ed311cf35c2ed980d1d
+  languageName: node
+  linkType: hard
+
+"@types/d3-transition@npm:^3.0.8":
+  version: 3.0.9
+  resolution: "@types/d3-transition@npm:3.0.9"
+  dependencies:
+    "@types/d3-selection": "npm:*"
+  checksum: 10c0/4f68b9df7ac745b3491216c54203cbbfa0f117ae4c60e2609cdef2db963582152035407fdff995b10ee383bae2f05b7743493f48e1b8e46df54faa836a8fb7b5
+  languageName: node
+  linkType: hard
+
+"@types/d3-zoom@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@types/d3-zoom@npm:3.0.8"
+  dependencies:
+    "@types/d3-interpolate": "npm:*"
+    "@types/d3-selection": "npm:*"
+  checksum: 10c0/1dbdbcafddcae12efb5beb6948546963f29599e18bc7f2a91fb69cc617c2299a65354f2d47e282dfb86fec0968406cd4fb7f76ba2d2fb67baa8e8d146eb4a547
   languageName: node
   linkType: hard
 
@@ -4749,6 +4816,44 @@ __metadata:
   version: 5.5.0
   resolution: "@xterm/xterm@npm:5.5.0"
   checksum: 10c0/358801feece58617d777b2783bec68dac1f52f736da3b0317f71a34f4e25431fb0b1920244f678b8d673f797145b4858c2a5ccb463a4a6df7c10c9093f1c9267
+  languageName: node
+  linkType: hard
+
+"@xyflow/react@npm:^12.11.3":
+  version: 12.11.3
+  resolution: "@xyflow/react@npm:12.11.3"
+  dependencies:
+    "@xyflow/system": "npm:0.0.80"
+    classcat: "npm:^5.0.3"
+    zustand: "npm:^4.4.0"
+  peerDependencies:
+    "@types/react": ">=17"
+    "@types/react-dom": ">=17"
+    react: ">=17"
+    react-dom: ">=17"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/56ce5c4608568e326d5e2d07532e4ba5f0abc5f774284e9039202c01e8ecbf9fdd56744eaadef0886406172a5323e6fbca1889cc65a036b90bda7a0ad2c2fe93
+  languageName: node
+  linkType: hard
+
+"@xyflow/system@npm:0.0.80":
+  version: 0.0.80
+  resolution: "@xyflow/system@npm:0.0.80"
+  dependencies:
+    "@types/d3-drag": "npm:^3.0.7"
+    "@types/d3-interpolate": "npm:^3.0.4"
+    "@types/d3-selection": "npm:^3.0.10"
+    "@types/d3-transition": "npm:^3.0.8"
+    "@types/d3-zoom": "npm:^3.0.8"
+    d3-drag: "npm:^3.0.0"
+    d3-interpolate: "npm:^3.0.1"
+    d3-selection: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+  checksum: 10c0/e8df5712c9eba4eeee29476686b416d24e014ccb95ebdcb46b7f60707ba5150ec51ff1e8b5d3983c4739a9b890e7458813d802149340e615fa1b528a88268539
   languageName: node
   linkType: hard
 
@@ -5474,6 +5579,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"classcat@npm:^5.0.3":
+  version: 5.0.5
+  resolution: "classcat@npm:5.0.5"
+  checksum: 10c0/ff8d273055ef9b518529cfe80fd0486f7057a9917373807ff802d75ceb46e8f8e148f41fa094ee7625c8f34642cfaa98395ff182d9519898da7cbf383d4a210d
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^6.0.0":
   version: 6.0.0
   resolution: "cliui@npm:6.0.0"
@@ -5721,6 +5833,88 @@ __metadata:
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 10c0/a4e20e1115fa696fce041fbe13fbc80dc4c19150fa72027a7c128ade980bc0eeeba4bcf28c9e21f0bce0e0dbfe7ca5869ef67746541dcfda053e4802ad19783c
+  languageName: node
+  linkType: hard
+
+"d3-dispatch@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-dispatch@npm:3.0.1"
+  checksum: 10c0/6eca77008ce2dc33380e45d4410c67d150941df7ab45b91d116dbe6d0a3092c0f6ac184dd4602c796dc9e790222bad3ff7142025f5fd22694efe088d1d941753
+  languageName: node
+  linkType: hard
+
+"d3-drag@npm:2 - 3, d3-drag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-drag@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-selection: "npm:3"
+  checksum: 10c0/d2556e8dc720741a443b595a30af403dd60642dfd938d44d6e9bfc4c71a962142f9a028c56b61f8b4790b65a34acad177d1263d66f103c3c527767b0926ef5aa
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: 10c0/fec8ef826c0cc35cda3092c6841e07672868b1839fcaf556e19266a3a37e6bc7977d8298c0fcb9885e7799bfdcef7db1baaba9cd4dcf4bc5e952cf78574a88b0
+  languageName: node
+  linkType: hard
+
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+  checksum: 10c0/19f4b4daa8d733906671afff7767c19488f51a43d251f8b7f484d5d3cfc36c663f0a66c38fe91eee30f40327443d799be17169f55a293a3ba949e84e57a33e6a
+  languageName: node
+  linkType: hard
+
+"d3-selection@npm:2 - 3, d3-selection@npm:3, d3-selection@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-selection@npm:3.0.0"
+  checksum: 10c0/e59096bbe8f0cb0daa1001d9bdd6dbc93a688019abc97d1d8b37f85cd3c286a6875b22adea0931b0c88410d025563e1643019161a883c516acf50c190a11b56b
+  languageName: node
+  linkType: hard
+
+"d3-timer@npm:1 - 3":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 10c0/d4c63cb4bb5461d7038aac561b097cd1c5673969b27cbdd0e87fa48d9300a538b9e6f39b4a7f0e3592ef4f963d858c8a9f0e92754db73116770856f2fc04561a
+  languageName: node
+  linkType: hard
+
+"d3-transition@npm:2 - 3":
+  version: 3.0.1
+  resolution: "d3-transition@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+    d3-dispatch: "npm:1 - 3"
+    d3-ease: "npm:1 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-timer: "npm:1 - 3"
+  peerDependencies:
+    d3-selection: 2 - 3
+  checksum: 10c0/4e74535dda7024aa43e141635b7522bb70cf9d3dfefed975eb643b36b864762eca67f88fafc2ca798174f83ca7c8a65e892624f824b3f65b8145c6a1a88dbbad
+  languageName: node
+  linkType: hard
+
+"d3-zoom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "d3-zoom@npm:3.0.0"
+  dependencies:
+    d3-dispatch: "npm:1 - 3"
+    d3-drag: "npm:2 - 3"
+    d3-interpolate: "npm:1 - 3"
+    d3-selection: "npm:2 - 3"
+    d3-transition: "npm:2 - 3"
+  checksum: 10c0/ee2036479049e70d8c783d594c444fe00e398246048e3f11a59755cd0e21de62ece3126181b0d7a31bf37bcf32fd726f83ae7dea4495ff86ec7736ce5ad36fd3
   languageName: node
   linkType: hard
 
@@ -12086,7 +12280,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.4.0":
+"use-sync-external-store@npm:^1.2.2, use-sync-external-store@npm:^1.4.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:
@@ -12286,6 +12480,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vorn@workspace:."
   dependencies:
+    "@dagrejs/dagre": "npm:^3.1.1"
     "@electron/rebuild": "npm:^4.0.4"
     "@eslint/js": "npm:^10.0.1"
     "@grpc/grpc-js": "npm:^1.14.4"
@@ -12321,6 +12516,7 @@ __metadata:
     "@xterm/addon-web-links": "npm:0.12.0"
     "@xterm/addon-webgl": "npm:^0.19.0"
     "@xterm/xterm": "npm:^5.5.0"
+    "@xyflow/react": "npm:^12.11.3"
     electron: "npm:^41.10.3"
     electron-builder: "npm:^26.10.0"
     electron-log: "npm:^5.4.4"
@@ -12962,6 +13158,26 @@ __metadata:
   version: 4.4.3
   resolution: "zod@npm:4.4.3"
   checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.4.0":
+  version: 4.5.7
+  resolution: "zustand@npm:4.5.7"
+  dependencies:
+    use-sync-external-store: "npm:^1.2.2"
+  peerDependencies:
+    "@types/react": ">=16.8"
+    immer: ">=9.0.6"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/55559e37a82f0c06cadc61cb08f08314c0fe05d6a93815e41e3376130c13db22a5017cbb0cd1f018c82f2dad0051afe3592561d40f980bd4082e32005e8a950c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The workflow editor's auto-laid-out rail becomes a real node canvas: nodes drag, edges connect from ports, the viewport pans and zooms with a minimap, and every workflow keeps rendering exactly as before until someone rearranges it.

## What changed
- **Canvas surface** on `@xyflow/react`, controlled: the definition stays the single source of truth; the canvas owns position and selection only. All structure mutations keep flowing through the existing insert/delete helpers.
- **Mapping layer** (`workflow-canvas-layout.ts`): definition ↔ canvas elements. A loop and its body render as one enclosure (membership stays `bodyNodeIds`); fork branches sit side by side with True/False pills; fork/join stays derived from edges.
- **Positions go live.** The persisted per-node position is finally read. Structural edits keep an arranged layout and only place the new nodes (with room-making and overlap probing); never-arranged workflows keep the legacy column and Tidy up reproduces the rail's exact order.
- **Adding steps**: trailing + under every leaf, + on edge hover with splice, drag-from-port onto empty canvas opens a searchable node palette (step types + installed connector actions), also on Tab.
- **Undo/redo** as definition snapshots (⌘Z/⌘⇧Z), safe against the workflow-load itself.
- **Feel**: scroll pans, ctrl/pinch zooms, 8px grid snap, 60px connection snapping, zoom keys, Delete key, hover delete on cards, larger card glyphs with full-ink connector brand marks.
- Insert helpers now preserve a condition edge's branch tag when splicing onto a branch.

## Testing
- New unit suites for the mapping layer and position policy; loop/fork/selection/status behavior suites ported to the canvas and passing (full run: 4,440 passing; the only failures are the three known environment-dependent tests unrelated to this diff).
- Local review ran with a verification pass; both confirmed findings (chained-insert overlap, undo wiping a fresh load) fixed with regression tests.
- Hands-on pass in the isolated dev app: dragging, tidy up, palette insert, edge splice, undo, live run dots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc