### PR TITLE
Claim the conversation, not the pane

### DIFF
--- a/packages/server/src/agent-history.ts
+++ b/packages/server/src/agent-history.ts
@@ -471,13 +471,15 @@ const opencodeProvider: AgentHistoryProvider = {
 // Registry
 // ---------------------------------------------------------------------------
 
-const providers: AgentHistoryProvider[] = [
-  claudeProvider,
-  geminiProvider,
-  codexProvider,
-  copilotProvider,
-  opencodeProvider
-]
+const providerByAgent: Record<AiAgentType, AgentHistoryProvider> = {
+  claude: claudeProvider,
+  gemini: geminiProvider,
+  codex: codexProvider,
+  copilot: copilotProvider,
+  opencode: opencodeProvider
+}
+
+const providers = Object.values(providerByAgent)
 
 export function getRecentSessions(projectPath?: string, limit = 20): RecentSession[] {
   const allSessions: RecentSession[] = []
@@ -488,4 +490,17 @@ export function getRecentSessions(projectPath?: string, limit = 20): RecentSessi
   }
 
   return allSessions.sort((a, b) => b.timestamp - a.timestamp).slice(0, limit)
+}
+
+/** One agent's sessions, unmerged, so a busy agent cannot crowd out a quiet one. */
+export function getRecentSessionsFor(
+  agentType: AiAgentType,
+  projectPath?: string,
+  limit = 20
+): RecentSession[] {
+  const provider = providerByAgent[agentType]
+  if (!provider) return []
+  return provider
+    .getRecentSessions(createProjectScope(projectPath), limit)
+    .sort((a, b) => b.timestamp - a.timestamp)
 }

--- a/packages/server/src/agent-history.ts
+++ b/packages/server/src/agent-history.ts
@@ -45,9 +45,14 @@ function escapeSqlString(value: string): string {
   return value.replace(/'/g, "''")
 }
 
+/** One form for comparing a Vorn path against a path an agent recorded. */
+export function comparablePath(value: string): string {
+  return normalizePath(value).replace(/\\/g, '/').toLowerCase()
+}
+
 function buildPathWhereClause(column: string, scope: ProjectScope): string {
   const clauses = scope.rawPaths.map((projectPath) => {
-    const normalized = normalizePath(projectPath).replace(/\\/g, '/').toLowerCase()
+    const normalized = comparablePath(projectPath)
     return `lower(rtrim(replace(${column}, char(92), '/'), '/')) = '${escapeSqlString(normalized)}'`
   })
   return clauses.length === 1 ? clauses[0] : `(${clauses.join(' OR ')})`

--- a/packages/server/src/agent-transcript.ts
+++ b/packages/server/src/agent-transcript.ts
@@ -1,6 +1,7 @@
 import type { AiAgentType, RecentSession, TerminalSession } from '@vornrun/shared/types'
 import { supportsExactSessionResume } from '@vornrun/shared/types'
 import { getRecentSessionsFor } from './agent-history'
+import { claimSpawningTranscript, spawningTranscripts } from './transcript-claims'
 import { normalizePath } from './process-utils'
 
 function comparablePath(value: string): string {
@@ -68,4 +69,18 @@ export function transcriptHolder(
   live: TerminalSession[]
 ): TerminalSession | undefined {
   return live.find((session) => session.agentSessionId === transcriptId)
+}
+
+/**
+ * The conversation a resume should continue, claimed against everything in flight.
+ */
+export function claimTranscriptFor(
+  session: TerminalSession,
+  live: TerminalSession[],
+  sessionId: string
+): string | undefined {
+  const held = new Set([...heldTranscripts(live), ...spawningTranscripts()])
+  const transcriptId = resolveTranscriptId(session, held)
+  if (transcriptId) claimSpawningTranscript(transcriptId, sessionId)
+  return transcriptId
 }

--- a/packages/server/src/agent-transcript.ts
+++ b/packages/server/src/agent-transcript.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentType,
   AiAgentType,
   HeadlessSession,
   RecentSession,
@@ -70,6 +71,21 @@ export function transcriptHolder(
   live: TerminalSession[]
 ): TerminalSession | undefined {
   return live.find((session) => session.agentSessionId === transcriptId)
+}
+
+/**
+ * The conversation a fresh launch is really naming.
+ *
+ * Nothing for an agent that cannot be sent back to one: `agent-launch` drops the
+ * id there, so binding on it would answer with an unrelated session and claiming
+ * it would hold a transcript nobody is going to open.
+ */
+export function transcriptNamedOnCreate(
+  agentType: AgentType,
+  resumeSessionId: string | undefined
+): string | undefined {
+  if (!resumeSessionId || !supportsExactSessionResume(agentType)) return undefined
+  return resumeSessionId
 }
 
 /** The session a fresh launch should show instead, when it names one already running. */

--- a/packages/server/src/agent-transcript.ts
+++ b/packages/server/src/agent-transcript.ts
@@ -1,0 +1,71 @@
+import type { AiAgentType, RecentSession, TerminalSession } from '@vornrun/shared/types'
+import { supportsExactSessionResume } from '@vornrun/shared/types'
+import { getRecentSessionsFor } from './agent-history'
+import { normalizePath } from './process-utils'
+
+function comparablePath(value: string): string {
+  return normalizePath(value).toLowerCase()
+}
+
+function preferredPaths(session: TerminalSession): string[] {
+  return [session.worktreePath, session.projectPath]
+    .filter((value): value is string => value !== undefined)
+    .map(comparablePath)
+}
+
+function read(sessions: () => RecentSession[]): RecentSession[] {
+  try {
+    return sessions()
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Which agent conversation a session continues, or undefined to let the agent choose.
+ */
+export function resolveTranscriptId(
+  session: TerminalSession,
+  held: ReadonlySet<string> = new Set()
+): string | undefined {
+  if (!supportsExactSessionResume(session.agentType)) return undefined
+
+  // Not hookSessionId: that is Vorn's own routing id, which the agent has never seen.
+  const pinned = session.agentSessionId
+  if (pinned && !held.has(pinned)) return pinned
+
+  const agentType = session.agentType as AiAgentType
+  const available = (candidate: RecentSession): boolean =>
+    candidate.agentType === agentType && candidate.canResumeExact && !held.has(candidate.sessionId)
+
+  const wanted = preferredPaths(session)
+  const atPreferredPath = (candidates: RecentSession[]): RecentSession | undefined => {
+    for (const path of wanted) {
+      const match = candidates.find(
+        (candidate) => available(candidate) && comparablePath(candidate.projectPath) === path
+      )
+      if (match) return match
+    }
+    return undefined
+  }
+
+  const scoped = read(() => getRecentSessionsFor(agentType, session.projectPath))
+  const scopedMatch = atPreferredPath(scoped) ?? scoped.find(available)
+  if (scopedMatch) return scopedMatch.sessionId
+
+  // Unscoped matches by path only: a loose match here would cross projects.
+  return atPreferredPath(read(() => getRecentSessionsFor(agentType)))?.sessionId
+}
+
+/** The transcripts processes are writing right now. */
+export function heldTranscripts(live: TerminalSession[]): Set<string> {
+  const ids = live.map((session) => session.agentSessionId)
+  return new Set(ids.filter((id): id is string => id !== undefined))
+}
+
+export function transcriptHolder(
+  transcriptId: string,
+  live: TerminalSession[]
+): TerminalSession | undefined {
+  return live.find((session) => session.agentSessionId === transcriptId)
+}

--- a/packages/server/src/agent-transcript.ts
+++ b/packages/server/src/agent-transcript.ts
@@ -1,12 +1,7 @@
 import type { AiAgentType, RecentSession, TerminalSession } from '@vornrun/shared/types'
 import { supportsExactSessionResume } from '@vornrun/shared/types'
-import { getRecentSessionsFor } from './agent-history'
+import { comparablePath, getRecentSessionsFor } from './agent-history'
 import { claimSpawningTranscript, spawningTranscripts } from './transcript-claims'
-import { normalizePath } from './process-utils'
-
-function comparablePath(value: string): string {
-  return normalizePath(value).toLowerCase()
-}
 
 function preferredPaths(session: TerminalSession): string[] {
   return [session.worktreePath, session.projectPath]
@@ -14,17 +9,7 @@ function preferredPaths(session: TerminalSession): string[] {
     .map(comparablePath)
 }
 
-function read(sessions: () => RecentSession[]): RecentSession[] {
-  try {
-    return sessions()
-  } catch {
-    return []
-  }
-}
-
-/**
- * Which agent conversation a session continues, or undefined to let the agent choose.
- */
+/** Which agent conversation a session continues, or undefined to let the agent choose. */
 export function resolveTranscriptId(
   session: TerminalSession,
   held: ReadonlySet<string> = new Set()
@@ -50,15 +35,15 @@ export function resolveTranscriptId(
     return undefined
   }
 
-  const scoped = read(() => getRecentSessionsFor(agentType, session.projectPath))
+  const scoped = getRecentSessionsFor(agentType, session.projectPath)
   const scopedMatch = atPreferredPath(scoped) ?? scoped.find(available)
   if (scopedMatch) return scopedMatch.sessionId
 
   // Unscoped matches by path only: a loose match here would cross projects.
-  return atPreferredPath(read(() => getRecentSessionsFor(agentType)))?.sessionId
+  return atPreferredPath(getRecentSessionsFor(agentType))?.sessionId
 }
 
-/** The transcripts processes are writing right now. */
+/** The conversations processes are writing right now. */
 export function heldTranscripts(live: TerminalSession[]): Set<string> {
   const ids = live.map((session) => session.agentSessionId)
   return new Set(ids.filter((id): id is string => id !== undefined))
@@ -71,9 +56,7 @@ export function transcriptHolder(
   return live.find((session) => session.agentSessionId === transcriptId)
 }
 
-/**
- * The conversation a resume should continue, claimed against everything in flight.
- */
+/** The conversation a resume should continue, claimed against everything in flight. */
 export function claimTranscriptFor(
   session: TerminalSession,
   live: TerminalSession[],

--- a/packages/server/src/agent-transcript.ts
+++ b/packages/server/src/agent-transcript.ts
@@ -1,4 +1,9 @@
-import type { AiAgentType, RecentSession, TerminalSession } from '@vornrun/shared/types'
+import type {
+  AiAgentType,
+  HeadlessSession,
+  RecentSession,
+  TerminalSession
+} from '@vornrun/shared/types'
 import { supportsExactSessionResume } from '@vornrun/shared/types'
 import { comparablePath, getRecentSessionsFor } from './agent-history'
 import { claimSpawningTranscript, spawningTranscripts } from './transcript-claims'
@@ -43,12 +48,23 @@ export function resolveTranscriptId(
   return atPreferredPath(getRecentSessionsFor(agentType))?.sessionId
 }
 
-/** The conversations processes are writing right now. */
-export function heldTranscripts(live: TerminalSession[]): Set<string> {
-  const ids = live.map((session) => session.agentSessionId)
+/**
+ * The conversations processes are writing right now.
+ *
+ * A workflow step runs in its own manager rather than the pty one, and it can be
+ * launched naming a conversation. Left out, its transcript reads as free and a
+ * resume beside it starts a second agent on the run in progress.
+ */
+export function heldTranscripts(
+  live: TerminalSession[],
+  headless: HeadlessSession[] = []
+): Set<string> {
+  const running = headless.filter((session) => session.status === 'running')
+  const ids = [...live, ...running].map((session) => session.agentSessionId)
   return new Set(ids.filter((id): id is string => id !== undefined))
 }
 
+/** Only a pane can be handed back, so a headless run holds without being a holder. */
 export function transcriptHolder(
   transcriptId: string,
   live: TerminalSession[]
@@ -56,14 +72,25 @@ export function transcriptHolder(
   return live.find((session) => session.agentSessionId === transcriptId)
 }
 
+/** The session a fresh launch should show instead, when it names one already running. */
+export function sessionToBindOnCreate(
+  resumeSessionId: string | undefined,
+  live: TerminalSession[]
+): TerminalSession | undefined {
+  return resumeSessionId ? transcriptHolder(resumeSessionId, live) : undefined
+}
+
 /** The conversation a resume should continue, claimed against everything in flight. */
 export function claimTranscriptFor(
   session: TerminalSession,
   live: TerminalSession[],
-  sessionId: string
+  sessionId: string,
+  headless: HeadlessSession[] = []
 ): string | undefined {
-  const held = new Set([...heldTranscripts(live), ...spawningTranscripts()])
+  const held = new Set([...heldTranscripts(live, headless), ...spawningTranscripts()])
   const transcriptId = resolveTranscriptId(session, held)
-  if (transcriptId) claimSpawningTranscript(transcriptId, sessionId)
-  return transcriptId
+  if (!transcriptId) return undefined
+  // Taken between resolving and claiming: let the agent choose rather than double up.
+  const taken = claimSpawningTranscript(transcriptId, sessionId)
+  return taken === undefined ? transcriptId : undefined
 }

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -1032,6 +1032,11 @@ class PtyManager extends EventEmitter {
     return this.ptys.has(id)
   }
 
+  /** Records with a process behind them, which `getActiveSessions` alone cannot say. */
+  getLiveSessions(): TerminalSession[] {
+    return this.getActiveSessions().filter((session) => this.hasLivePty(session.id))
+  }
+
   getActiveSessions(): TerminalSession[] {
     if (this.sessionOrder.length === 0) {
       return Array.from(this.sessions.values())

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -24,8 +24,12 @@ import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
 import { clearScrollback, readScrollback } from './terminal-scrollback'
-import { claimTranscriptFor, transcriptHolder } from './agent-transcript'
-import { releaseSpawningTranscript } from './transcript-claims'
+import { claimTranscriptFor, sessionToBindOnCreate, transcriptHolder } from './agent-transcript'
+import {
+  claimSpawningTranscript,
+  releaseSpawningTranscript,
+  releaseSpawningTranscriptsFor
+} from './transcript-claims'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
 import { hookStatusMapper } from './hook-status-mapper'
@@ -359,7 +363,14 @@ export function registerAllMethods(): void {
 
   // Terminal
   registerMethod('terminal:create', (payload) => {
-    return ptyManager.createPty(payload)
+    // Naming a conversation that is already running: show what is writing it
+    // rather than starting a second agent on it, as a resume does.
+    const running = sessionToBindOnCreate(payload.resumeSessionId, ptyManager.getLiveSessions())
+    if (running) return running
+    const session = ptyManager.createPty(payload)
+    // Agents that cannot be told an id report theirs seconds later; hold it meanwhile.
+    if (payload.resumeSessionId) claimSpawningTranscript(payload.resumeSessionId, session.id)
+    return session
   })
   /**
    * Let go of what was kept for a session from the last run.
@@ -761,7 +772,7 @@ export function registerAllMethods(): void {
         return { ok: true as const, session }
       }
 
-      transcriptId = claimTranscriptFor(previous, live, id)
+      transcriptId = claimTranscriptFor(previous, live, id, headlessManager.getActiveSessions())
 
       // Same id, same reasons as the shell branch above.
       const session = ptyManager.createPty(buildRestorePayload(previous, transcriptId), id)
@@ -1777,19 +1788,33 @@ export function registerAllMethods(): void {
       !supportsSessionIdPinning(payload.agentType)
     ) {
       const captureSessionId = session.id
-      setTimeout(() => {
-        const s = ptyManager.getActiveSessions().find((t) => t.id === captureSessionId)
-        if (!s || s.agentSessionId) return
-        const cwd = s.worktreePath || s.projectPath
-        const capturedId = captureAgentSessionId(s.agentType, cwd)
-        if (capturedId) {
+      // Asked more than once: an agent slow to write its own history used to be
+      // read at five seconds, come up empty, and never be asked again -- leaving
+      // the session holding a conversation it could not name, which a later
+      // resume was then free to take.
+      const attempt = (remaining: number[]): void => {
+        const [delay, ...rest] = remaining
+        if (delay === undefined) return
+        setTimeout(() => {
+          const s = ptyManager.getActiveSessions().find((t) => t.id === captureSessionId)
+          if (!s) {
+            releaseSpawningTranscriptsFor(captureSessionId)
+            return
+          }
+          if (s.agentSessionId) return
+          const cwd = s.worktreePath || s.projectPath
+          const capturedId = captureAgentSessionId(s.agentType, cwd)
+          if (!capturedId) return attempt(rest)
           s.agentSessionId = capturedId
+          // Its own record names the conversation now, so the spawn claim is spent.
+          releaseSpawningTranscriptsFor(captureSessionId)
           sessionManager.scheduleSave()
           clientRegistry.broadcast(IPC.SESSION_UPDATED, s)
           broadcastWidgetUpdate()
           log.info(`[session] captured ${s.agentType} session ID: ${capturedId}`)
-        }
-      }, 5000)
+        }, delay)
+      }
+      attempt([5000, 5000, 10_000, 20_000])
     }
 
     sessionManager.scheduleSave()
@@ -1805,6 +1830,9 @@ export function registerAllMethods(): void {
 
   // Clean up Copilot hooks on session exit
   ptyManager.on('session-exit', (session) => {
+    // A session that died early holds nothing; without this its conversation
+    // stays unreachable for the rest of the spawn window.
+    releaseSpawningTranscriptsFor(session.id)
     const inst = copilotInstallations.get(session.id)
     if (inst) {
       uninstallCopilotHooks(inst)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -24,12 +24,8 @@ import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
 import { clearScrollback, readScrollback } from './terminal-scrollback'
-import { heldTranscripts, resolveTranscriptId, transcriptHolder } from './agent-transcript'
-import {
-  claimSpawningTranscript,
-  releaseSpawningTranscript,
-  spawningTranscripts
-} from './transcript-claims'
+import { claimTranscriptFor, transcriptHolder } from './agent-transcript'
+import { releaseSpawningTranscript } from './transcript-claims'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
 import { hookStatusMapper } from './hook-status-mapper'
@@ -764,9 +760,7 @@ export function registerAllMethods(): void {
         return { ok: true as const, session }
       }
 
-      const held = new Set([...heldTranscripts(live), ...spawningTranscripts()])
-      const transcriptId = resolveTranscriptId(previous, held)
-      if (transcriptId) claimSpawningTranscript(transcriptId, id)
+      const transcriptId = claimTranscriptFor(previous, live, id)
 
       // Same id, same reasons as the shell branch above.
       const session = ptyManager.createPty(buildRestorePayload(previous, transcriptId), id)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -24,6 +24,12 @@ import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
 import { clearScrollback, readScrollback } from './terminal-scrollback'
+import { heldTranscripts, resolveTranscriptId, transcriptHolder } from './agent-transcript'
+import {
+  claimSpawningTranscript,
+  releaseSpawningTranscript,
+  spawningTranscripts
+} from './transcript-claims'
 import { browserBridge } from './browser-bridge'
 import { hookServer } from './hook-server'
 import { hookStatusMapper } from './hook-status-mapper'
@@ -681,7 +687,7 @@ export function registerAllMethods(): void {
    */
   const BETWEEN_RUNS = '\x1b[?1049l\x1b[!p\x1b[0m\x1b[?25h\r\n'
 
-  registerMethod('sessions:resume', async ({ id, resumeSessionId }) => {
+  registerMethod('sessions:resume', async ({ id }) => {
     // Claimed before anything is started, and that ordering is the point. Two
     // clients can be looking at the same cold pane; the second must be told it
     // is gone rather than launching a second agent against one transcript.
@@ -699,6 +705,17 @@ export function registerAllMethods(): void {
       : ptyManager.getActiveSessions().find((s) => s.id === id && !ptyManager.hasLivePty(id))
     const previous = restored?.session ?? dead
     if (!previous) return { ok: false as const, reason: 'gone' as const }
+
+    const live = ptyManager.getActiveSessions().filter((s) => ptyManager.hasLivePty(s.id))
+    const pinned = previous.agentSessionId
+    const holder = pinned ? transcriptHolder(pinned, live) : undefined
+    if (holder) {
+      // Its conversation is already running; hand back what is writing it.
+      if (dead) ptyManager.releaseForResume(id)
+      await forgetRestored(id)
+      sessionManager.scheduleSave()
+      return { ok: true as const, session: holder, boundTo: holder.id }
+    }
 
     try {
       // Claimed, for the second kind. Not `killPty`: that announces an exit for
@@ -747,8 +764,12 @@ export function registerAllMethods(): void {
         return { ok: true as const, session }
       }
 
+      const held = new Set([...heldTranscripts(live), ...spawningTranscripts()])
+      const transcriptId = resolveTranscriptId(previous, held)
+      if (transcriptId) claimSpawningTranscript(transcriptId, id)
+
       // Same id, same reasons as the shell branch above.
-      const session = ptyManager.createPty(buildRestorePayload(previous, resumeSessionId), id)
+      const session = ptyManager.createPty(buildRestorePayload(previous, transcriptId), id)
       ptyManager.injectOutput(session.id, BETWEEN_RUNS)
       sessionManager.scheduleSave()
       return { ok: true as const, session }
@@ -760,6 +781,7 @@ export function registerAllMethods(): void {
       // one that ended during this run goes back to the pty manager it came from.
       if (restored) restoreHeld(restored)
       else if (dead) ptyManager.restoreReleased(dead)
+      releaseSpawningTranscript(previous.agentSessionId ?? '', id)
       return {
         ok: false as const,
         reason: 'failed' as const,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -359,13 +359,6 @@ export function registerAllMethods(): void {
 
   // Terminal
   registerMethod('terminal:create', (payload) => {
-    // A conversation picked by hand -- the palette, a task -- may already be open.
-    const wanted = payload.resumeSessionId
-    if (wanted) {
-      const live = ptyManager.getActiveSessions().filter((s) => ptyManager.hasLivePty(s.id))
-      const holder = transcriptHolder(wanted, live)
-      if (holder) return holder
-    }
     return ptyManager.createPty(payload)
   })
   /**
@@ -709,7 +702,8 @@ export function registerAllMethods(): void {
     const previous = restored?.session ?? dead
     if (!previous) return { ok: false as const, reason: 'gone' as const }
 
-    const live = ptyManager.getActiveSessions().filter((s) => ptyManager.hasLivePty(s.id))
+    const live = ptyManager.getLiveSessions()
+    let transcriptId: string | undefined
     const pinned = previous.agentSessionId
     const holder = pinned ? transcriptHolder(pinned, live) : undefined
     if (holder) {
@@ -767,7 +761,7 @@ export function registerAllMethods(): void {
         return { ok: true as const, session }
       }
 
-      const transcriptId = claimTranscriptFor(previous, live, id)
+      transcriptId = claimTranscriptFor(previous, live, id)
 
       // Same id, same reasons as the shell branch above.
       const session = ptyManager.createPty(buildRestorePayload(previous, transcriptId), id)
@@ -782,7 +776,7 @@ export function registerAllMethods(): void {
       // one that ended during this run goes back to the pty manager it came from.
       if (restored) restoreHeld(restored)
       else if (dead) ptyManager.restoreReleased(dead)
-      releaseSpawningTranscript(previous.agentSessionId ?? '', id)
+      if (transcriptId) releaseSpawningTranscript(transcriptId, id)
       return {
         ok: false as const,
         reason: 'failed' as const,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -359,6 +359,13 @@ export function registerAllMethods(): void {
 
   // Terminal
   registerMethod('terminal:create', (payload) => {
+    // A conversation picked by hand -- the palette, a task -- may already be open.
+    const wanted = payload.resumeSessionId
+    if (wanted) {
+      const live = ptyManager.getActiveSessions().filter((s) => ptyManager.hasLivePty(s.id))
+      const holder = transcriptHolder(wanted, live)
+      if (holder) return holder
+    }
     return ptyManager.createPty(payload)
   })
   /**

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -24,7 +24,12 @@ import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
 import { clearScrollback, readScrollback } from './terminal-scrollback'
-import { claimTranscriptFor, sessionToBindOnCreate, transcriptHolder } from './agent-transcript'
+import {
+  claimTranscriptFor,
+  sessionToBindOnCreate,
+  transcriptHolder,
+  transcriptNamedOnCreate
+} from './agent-transcript'
 import {
   claimSpawningTranscript,
   releaseSpawningTranscript,
@@ -363,13 +368,15 @@ export function registerAllMethods(): void {
 
   // Terminal
   registerMethod('terminal:create', (payload) => {
+    const named = transcriptNamedOnCreate(payload.agentType, payload.resumeSessionId)
     // Naming a conversation that is already running: show what is writing it
     // rather than starting a second agent on it, as a resume does.
-    const running = sessionToBindOnCreate(payload.resumeSessionId, ptyManager.getLiveSessions())
+    const running = sessionToBindOnCreate(named, ptyManager.getLiveSessions())
     if (running) return running
     const session = ptyManager.createPty(payload)
-    // Agents that cannot be told an id report theirs seconds later; hold it meanwhile.
-    if (payload.resumeSessionId) claimSpawningTranscript(payload.resumeSessionId, session.id)
+    // Only until the session names the conversation itself: an agent that can be
+    // told an id already carries it, and one that cannot reports seconds later.
+    if (named && !session.agentSessionId) claimSpawningTranscript(named, session.id)
     return session
   })
   /**
@@ -776,6 +783,9 @@ export function registerAllMethods(): void {
 
       // Same id, same reasons as the shell branch above.
       const session = ptyManager.createPty(buildRestorePayload(previous, transcriptId), id)
+      // The record names the conversation now, so the claim standing in for it is
+      // spent; leaving it would hold an id the session already reports.
+      if (session.agentSessionId) releaseSpawningTranscriptsFor(id)
       ptyManager.injectOutput(session.id, BETWEEN_RUNS)
       sessionManager.scheduleSave()
       return { ok: true as const, session }

--- a/packages/server/src/transcript-claims.ts
+++ b/packages/server/src/transcript-claims.ts
@@ -1,6 +1,9 @@
 // Held while a process starts, before it can report which conversation it took.
 
-const SPAWN_WINDOW_MS = 15_000
+// Longer than the capture ladder that sets `agentSessionId`, so a claim outlives
+// the reporting it waits for; still lapsing, so a spawn that dies never wedges a
+// transcript.
+const SPAWN_WINDOW_MS = 60_000
 
 interface Spawning {
   sessionId: string
@@ -30,6 +33,13 @@ export function claimSpawningTranscript(
 
 export function releaseSpawningTranscript(transcriptId: string, sessionId: string): void {
   if (spawning.get(transcriptId)?.sessionId === sessionId) spawning.delete(transcriptId)
+}
+
+/** Everything a session was holding, for when it reports its conversation or exits. */
+export function releaseSpawningTranscriptsFor(sessionId: string): void {
+  for (const [transcriptId, held] of spawning) {
+    if (held.sessionId === sessionId) spawning.delete(transcriptId)
+  }
 }
 
 export function spawningTranscripts(): Set<string> {

--- a/packages/server/src/transcript-claims.ts
+++ b/packages/server/src/transcript-claims.ts
@@ -1,11 +1,4 @@
-/**
- * A transcript is spoken for while its process starts, before it reports its own id.
- *
- * codex and opencode cannot be told an id at launch, so `agentSessionId` only
- * arrives from the capture five seconds later. Until then a live session does not
- * know which conversation it is writing, and two resumes would both resolve to it.
- * Claims lapse rather than lock, so a spawn that dies never wedges the transcript.
- */
+// Held while a process starts, before it can report which conversation it took.
 
 const SPAWN_WINDOW_MS = 15_000
 

--- a/packages/server/src/transcript-claims.ts
+++ b/packages/server/src/transcript-claims.ts
@@ -1,0 +1,49 @@
+/**
+ * A transcript is spoken for while its process starts, before it reports its own id.
+ *
+ * codex and opencode cannot be told an id at launch, so `agentSessionId` only
+ * arrives from the capture five seconds later. Until then a live session does not
+ * know which conversation it is writing, and two resumes would both resolve to it.
+ * Claims lapse rather than lock, so a spawn that dies never wedges the transcript.
+ */
+
+const SPAWN_WINDOW_MS = 15_000
+
+interface Spawning {
+  sessionId: string
+  claimedAt: number
+}
+
+const spawning = new Map<string, Spawning>()
+
+function evictLapsed(now: number): void {
+  for (const [transcriptId, held] of spawning) {
+    if (now - held.claimedAt >= SPAWN_WINDOW_MS) spawning.delete(transcriptId)
+  }
+}
+
+/** The session already starting on this transcript, or undefined when the claim is taken. */
+export function claimSpawningTranscript(
+  transcriptId: string,
+  sessionId: string
+): string | undefined {
+  const now = Date.now()
+  evictLapsed(now)
+  const held = spawning.get(transcriptId)
+  if (held) return held.sessionId
+  spawning.set(transcriptId, { sessionId, claimedAt: now })
+  return undefined
+}
+
+export function releaseSpawningTranscript(transcriptId: string, sessionId: string): void {
+  if (spawning.get(transcriptId)?.sessionId === sessionId) spawning.delete(transcriptId)
+}
+
+export function spawningTranscripts(): Set<string> {
+  evictLapsed(Date.now())
+  return new Set(spawning.keys())
+}
+
+export function resetTranscriptClaims(): void {
+  spawning.clear()
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -541,9 +541,9 @@ export interface RequestMethods {
    * one transcript is the failure this prevents.
    */
   'sessions:resume': {
-    params: { id: string; resumeSessionId?: string }
-    result:
-      | { ok: true; session: TerminalSession }
+    params: { id: string }
+    result: /** `boundTo` names the session already writing this conversation, when one was. */
+      | { ok: true; session: TerminalSession; boundTo?: string }
       | { ok: false; reason: 'gone' | 'failed'; message?: string }
   }
   'sessions:clear': { params: void; result: void }

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -436,8 +436,7 @@ export function createApiShim(wsUrl: string) {
     // so the surface matches, and so a caller does not have to know which client
     // it is running in.
     onServerReplaced: (_callback: () => void) => () => {},
-    resumeSession: (params: { id: string; resumeSessionId?: string }) =>
-      rpc.invoke('sessions:resume', params),
+    resumeSession: (params: { id: string }) => rpc.invoke('sessions:resume', params),
     clearPreviousSessions: () => rpc.invoke('sessions:clear'),
     getRecentSessions: (projectPath?: string) => rpc.invoke('sessions:getRecent', projectPath),
     renameSession: (id: string, displayName: string) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -166,12 +166,12 @@ const api = {
   /** Sessions from the last run that no pane has taken yet. */
   getRestoredSessions: (): Promise<RestoredSession[]> => ipcRenderer.invoke(IPC.SESSIONS_RESTORED),
 
-  /** Claim one and start it. `gone` means another pane took it first. */
+  /** Claim one and start it. `boundTo` names the session already writing it. */
   resumeSession: (params: {
     id: string
-    resumeSessionId?: string
   }): Promise<
-    { ok: true; session: TerminalSession } | { ok: false; reason: string; message?: string }
+    | { ok: true; session: TerminalSession; boundTo?: string }
+    | { ok: false; reason: string; message?: string }
   > => ipcRenderer.invoke(IPC.SESSIONS_RESUME, params),
 
   clearPreviousSessions: () => ipcRenderer.invoke(IPC.SESSIONS_CLEAR),

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -121,8 +121,6 @@ async function reconcile(options: { showCold: boolean; resume: boolean }): Promi
  * back in the order they were in.
  */
 async function resumeAll(ids: string[]): Promise<void> {
-  // One set for the pass, not one per pane. See `resumeEndedSession`.
-  const claimed = new Set<string>()
   for (const id of ids) {
     // Read again rather than carried: each resume above it awaited a spawn, and
     // an exit or a close for this pane could have arrived in that gap.
@@ -130,6 +128,6 @@ async function resumeAll(ids: string[]): Promise<void> {
     if (!term?.ended) continue
     // A failure leaves the pane ended and its strip on screen, which is already
     // the offer to try again by hand. Nothing is said twice.
-    await resumeEndedSession(id, { automatic: true, claimed })
+    await resumeEndedSession(id, { automatic: true })
   }
 }

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -66,7 +66,20 @@ export async function resumeEndedSession(
     return
   }
 
-  useAppStore.getState().replaceTerminal(terminalId, result.session)
+  const state = useAppStore.getState()
+  // Bound to a session this client already draws: the ended pane goes and the
+  // running one is brought forward. Replacing in place would key two panes by
+  // one id -- and closing either would then close both.
+  if (
+    result.boundTo &&
+    result.session.id !== terminalId &&
+    state.terminals.has(result.session.id)
+  ) {
+    state.removeTerminal(terminalId)
+    state.setFocusedTerminal(result.session.id)
+  } else {
+    state.replaceTerminal(terminalId, result.session)
+  }
   // Said even for an automatic resume: a pane quietly becoming a second view of
   // a session open elsewhere is the one surprise worth a line.
   if (result.boundTo) toast('That conversation was already running. This pane shows it.')

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -67,9 +67,9 @@ export async function resumeEndedSession(
   }
 
   useAppStore.getState().replaceTerminal(terminalId, result.session)
-  if (result.boundTo && !options.automatic) {
-    toast('That conversation was already running. This pane is showing it.')
-  }
+  // Said even for an automatic resume: a pane quietly becoming a second view of
+  // a session open elsewhere is the one surprise worth a line.
+  if (result.boundTo) toast('That conversation was already running. This pane shows it.')
 }
 
 /**

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -1,6 +1,5 @@
 import { useAppStore } from '../stores'
 import { toast } from '../components/Toast'
-import { resolveResumeSessionId } from './session-utils'
 
 /**
  * Taking a session from a previous run, or letting it go.
@@ -46,31 +45,11 @@ export async function showEndedSession(id: string): Promise<void> {
  */
 export async function resumeEndedSession(
   terminalId: string,
-  options: { automatic?: boolean; claimed?: Set<string> } = {}
+  options: { automatic?: boolean } = {}
 ): Promise<void> {
-  const state = useAppStore.getState()
-  const previous = state.terminals.get(terminalId)?.session
-  if (!previous) return
+  if (!useAppStore.getState().terminals.has(terminalId)) return
 
-  // Which agent-side conversation to continue. Resolved here rather than on the
-  // server because it fans out to the agent history, which is a client concern
-  // and already lives here; the server is given the answer, not the search.
-  let resumeSessionId: string | undefined
-  try {
-    // `claimed` carries across a whole pass. Where an agent cannot be asked for
-    // an exact id -- codex and opencode support resuming but not pinning, so
-    // there is never an `agentSessionId` to use -- this falls back to scanning
-    // the agent's own history and taking the first match for the project. Two
-    // panes resolved independently would take the same one, and the pass would
-    // start two agents against a single transcript: the thing the record's own
-    // claim exists to prevent, undone one layer down.
-    resumeSessionId = await resolveResumeSessionId(previous, options.claimed)
-    if (resumeSessionId) options.claimed?.add(resumeSessionId)
-  } catch {
-    // No exact match found. The agent's own picker is better than refusing.
-  }
-
-  const result = await window.api.resumeSession({ id: terminalId, resumeSessionId })
+  const result = await window.api.resumeSession({ id: terminalId })
   if (!result.ok) {
     if (result.reason === 'gone') {
       // Another pane, window or device took it first. Nothing to resume and
@@ -88,6 +67,9 @@ export async function resumeEndedSession(
   }
 
   useAppStore.getState().replaceTerminal(terminalId, result.session)
+  if (result.boundTo && !options.automatic) {
+    toast('That conversation was already running. This pane is showing it.')
+  }
 }
 
 /**

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -1,5 +1,4 @@
 import {
-  supportsExactSessionResume,
   getProjectRemoteHostId,
   type TerminalSession,
   type RecentSession,
@@ -71,68 +70,6 @@ export function countSessionsByWorktree(
     if (wtPath) counts.set(wtPath, (counts.get(wtPath) ?? 0) + 1)
   }
   return counts
-}
-
-function isDefined<T>(value: T | undefined): value is T {
-  return value !== undefined
-}
-
-/**
- * Resolve the agent session ID to pass as --resume when restoring a session.
- * Falls back through progressively looser matching strategies.
- *
- * @param claimed - session IDs already assigned to other terminals in this
- *   restore batch; prevents multiple terminals from resuming the same session.
- */
-export async function resolveResumeSessionId(
-  s: TerminalSession,
-  claimed: Set<string> = new Set()
-): Promise<string | undefined> {
-  if (!supportsExactSessionResume(s.agentType)) return undefined
-  // Only use agentSessionId for resume — it's the real agent session ID passed
-  // via --session-id on fresh launch. hookSessionId is a Vorn-internal UUID
-  // for hook event routing; the agent CLI doesn't know about it. For agents
-  // without pinning support, fall through to the history-based scan.
-  const resumeId = s.agentSessionId
-  if (resumeId && !claimed.has(resumeId)) return resumeId
-
-  const isAvailable = (r: RecentSession): boolean =>
-    r.agentType === s.agentType && r.canResumeExact && !claimed.has(r.sessionId)
-
-  // Fallback for agents without hookSessionId: progressively looser matching
-  const targetPaths = [s.worktreePath, s.projectPath].filter(isDefined).map(normalizeComparablePath)
-  const findPreferredPathMatch = (sessions: RecentSession[]): RecentSession | undefined => {
-    for (const targetPath of targetPaths) {
-      const match = sessions.find(
-        (session) =>
-          isAvailable(session) && normalizeComparablePath(session.projectPath) === targetPath
-      )
-      if (match) return match
-    }
-    return undefined
-  }
-
-  // Scoped fetch first — the global unscoped list has a default limit of 20,
-  // so a project's sessions may not appear in the global results.
-  try {
-    const scopedRecent = await window.api.getRecentSessions(s.projectPath)
-    const scopedExact = findPreferredPathMatch(scopedRecent)
-    if (scopedExact) return scopedExact.sessionId
-
-    const scopedMatch = scopedRecent.find(isAvailable)
-    if (scopedMatch) return scopedMatch.sessionId
-  } catch {
-    // Scoped fetch failed — fall through to unscoped lookup
-  }
-
-  // Unscoped fallback for looser matching (path normalization mismatches)
-  const allRecent = await window.api.getRecentSessions()
-
-  // Exact project path match
-  const exact = findPreferredPathMatch(allRecent)
-  if (exact) return exact.sessionId
-
-  return undefined
 }
 
 /**

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -181,7 +181,10 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
         lastOutputTimestamp: Date.now()
       })
       // In place, so a resumed card keeps the slot it was already occupying.
-      const order = state.terminalOrder.map((id) => (id === previousId ? session.id : id))
+      const mapped = state.terminalOrder.map((id) => (id === previousId ? session.id : id))
+      // Once, even when the session was already on the board: two slots under one
+      // id draw the same pane twice and close together.
+      const order = mapped.filter((id, at) => mapped.indexOf(id) === at)
       window.api.notifyWidgetStatus()
       return {
         terminals: next,

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -184,11 +184,12 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       const mapped = state.terminalOrder.map((id) => (id === previousId ? session.id : id))
       // Once, even when the session was already on the board: two slots under one
       // id draw the same pane twice and close together.
-      const order = mapped.filter((id, at) => mapped.indexOf(id) === at)
+      const seen = new Set<string>()
+      const order = mapped.filter((id) => !seen.has(id) && seen.add(id))
       window.api.notifyWidgetStatus()
       return {
         terminals: next,
-        terminalOrder: order.includes(session.id) ? order : [...order, session.id]
+        terminalOrder: seen.has(session.id) ? order : [...order, session.id]
       }
     }),
 

--- a/tests/agent-transcript.test.ts
+++ b/tests/agent-transcript.test.ts
@@ -191,3 +191,24 @@ describe('two cold panes resumed one after the other', () => {
     expect(claimTranscriptFor(session({ id: 'two' }), live, 'two')).toBeUndefined()
   })
 })
+
+describe('a launch that names no conversation', () => {
+  /**
+   * A workflow step launches through `terminal:create` with no transcript, and
+   * keeps its own claim over the worktree in `workflow-run-claims`. The two stay
+   * separate on purpose; this pins that rather than leaving it implied.
+   */
+  it('claims nothing, so a workflow step and a resume never contend', () => {
+    getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'transcript-a' })])
+    const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
+
+    expect(transcriptHolder('', live)).toBeUndefined()
+    // The resume beside it still resolves normally.
+    expect(claimTranscriptFor(session({ id: 'two' }), live, 'two')).toBeUndefined()
+  })
+
+  it('does not treat a session with no reported conversation as holding one', () => {
+    const live = [session({ id: 'one' }), session({ id: 'two' })]
+    expect(heldTranscripts(live).size).toBe(0)
+  })
+})

--- a/tests/agent-transcript.test.ts
+++ b/tests/agent-transcript.test.ts
@@ -12,6 +12,7 @@ import {
   heldTranscripts,
   transcriptHolder,
   sessionToBindOnCreate,
+  transcriptNamedOnCreate,
   claimTranscriptFor
 } from '../packages/server/src/agent-transcript'
 import {
@@ -244,6 +245,18 @@ describe('a launch that names a conversation already running', () => {
   it('starts normally when it names no conversation at all', () => {
     const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
     expect(sessionToBindOnCreate(undefined, live)).toBeUndefined()
+  })
+
+  it('names one only for an agent that can be sent back to it', () => {
+    expect(transcriptNamedOnCreate('claude', 'transcript-a')).toBe('transcript-a')
+    expect(transcriptNamedOnCreate('codex', 'transcript-a')).toBe('transcript-a')
+    // The launch line drops the id for these, so nothing should be held on it.
+    expect(transcriptNamedOnCreate('gemini', 'transcript-a')).toBeUndefined()
+    expect(transcriptNamedOnCreate('shell', 'transcript-a')).toBeUndefined()
+  })
+
+  it('names nothing when the launch carried no id', () => {
+    expect(transcriptNamedOnCreate('claude', undefined)).toBeUndefined()
   })
 })
 

--- a/tests/agent-transcript.test.ts
+++ b/tests/agent-transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { RecentSession, TerminalSession } from '../packages/shared/src/types'
+import type { HeadlessSession, RecentSession, TerminalSession } from '../packages/shared/src/types'
 
 const getRecentSessionsFor = vi.fn()
 vi.mock('../packages/server/src/agent-history', async (importOriginal) => ({
@@ -11,6 +11,7 @@ import {
   resolveTranscriptId,
   heldTranscripts,
   transcriptHolder,
+  sessionToBindOnCreate,
   claimTranscriptFor
 } from '../packages/server/src/agent-transcript'
 import {
@@ -188,6 +189,61 @@ describe('a launch that names no conversation', () => {
   it('does not treat a session with no reported conversation as holding one', () => {
     const live = [session({ id: 'one' }), session({ id: 'two' })]
     expect(heldTranscripts(live).size).toBe(0)
+  })
+})
+
+describe('a workflow step running beside the panes', () => {
+  const headless = (overrides: Partial<HeadlessSession> = {}): HeadlessSession =>
+    ({
+      id: 'headless-1',
+      pid: 99,
+      agentType: 'claude',
+      projectName: 'my-app',
+      projectPath: '/home/user/my-app',
+      status: 'running',
+      startedAt: Date.now(),
+      ...overrides
+    }) as HeadlessSession
+
+  it('holds the conversation it was launched on, though no pane is drawing it', () => {
+    expect(heldTranscripts([], [headless({ agentSessionId: 'transcript-a' })])).toEqual(
+      new Set(['transcript-a'])
+    )
+  })
+
+  it('is let go of once it has exited', () => {
+    const done = headless({ agentSessionId: 'transcript-a', status: 'exited' })
+    expect(heldTranscripts([], [done]).size).toBe(0)
+  })
+
+  it('is not resumed onto, even by the pane that pinned that conversation', () => {
+    getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'transcript-b' })])
+    const resumed = session({ id: 'pane', agentSessionId: 'transcript-a' })
+    const running = [headless({ agentSessionId: 'transcript-a' })]
+    expect(claimTranscriptFor(resumed, [], 'pane', running)).toBe('transcript-b')
+  })
+
+  it('leaves the agent to choose when its conversation is the only one', () => {
+    getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'transcript-a' })])
+    const running = [headless({ agentSessionId: 'transcript-a' })]
+    expect(claimTranscriptFor(session({ id: 'pane' }), [], 'pane', running)).toBeUndefined()
+  })
+})
+
+describe('a launch that names a conversation already running', () => {
+  it('is handed the session writing it rather than starting beside it', () => {
+    const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
+    expect(sessionToBindOnCreate('transcript-a', live)?.id).toBe('one')
+  })
+
+  it('starts normally when nothing is writing that conversation', () => {
+    const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
+    expect(sessionToBindOnCreate('transcript-b', live)).toBeUndefined()
+  })
+
+  it('starts normally when it names no conversation at all', () => {
+    const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
+    expect(sessionToBindOnCreate(undefined, live)).toBeUndefined()
   })
 })
 

--- a/tests/agent-transcript.test.ts
+++ b/tests/agent-transcript.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { RecentSession, TerminalSession } from '../packages/shared/src/types'
+
+const getRecentSessionsFor = vi.fn()
+vi.mock('../packages/server/src/agent-history', () => ({
+  getRecentSessionsFor: (...args: unknown[]) => getRecentSessionsFor(...args)
+}))
+
+import {
+  resolveTranscriptId,
+  heldTranscripts,
+  transcriptHolder
+} from '../packages/server/src/agent-transcript'
+
+/**
+ * Which conversation a session continues.
+ *
+ * Moved here from the renderer: every input was already on this side, and the
+ * renderer could only dedupe within one window's restore pass, which is why two
+ * devices could take one transcript.
+ */
+
+function session(overrides: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: 'term-1',
+    agentType: 'claude',
+    projectName: 'my-app',
+    projectPath: '/home/user/my-app',
+    status: 'running',
+    createdAt: Date.now(),
+    pid: 1234,
+    ...overrides
+  } as TerminalSession
+}
+
+function recent(overrides: Partial<RecentSession> = {}): RecentSession {
+  return {
+    sessionId: 'sess-1',
+    agentType: 'claude',
+    display: 'Fix bug',
+    projectPath: '/home/user/my-app',
+    timestamp: Date.now(),
+    activityCount: 5,
+    activityLabel: 'message',
+    canResumeExact: true,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getRecentSessionsFor.mockReturnValue([])
+})
+
+describe('resolving which conversation a session continues', () => {
+  it('takes the id the agent was launched with, without reading any history', () => {
+    expect(resolveTranscriptId(session({ agentSessionId: 'claude-abc' }))).toBe('claude-abc')
+    expect(getRecentSessionsFor).not.toHaveBeenCalled()
+  })
+
+  it('never uses hookSessionId, which the agent has never seen', () => {
+    expect(resolveTranscriptId(session({ hookSessionId: 'hook-abc' }))).toBeUndefined()
+  })
+
+  it('matches a conversation by the directory it ran in', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'sess-match', projectPath: '/home/user/my-app' })
+    ])
+    expect(resolveTranscriptId(session({ projectPath: '/home/user/my-app' }))).toBe('sess-match')
+  })
+
+  it('prefers the worktree it was in over the project root', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'sess-root', projectPath: '/home/user/my-app' }),
+      recent({
+        sessionId: 'sess-worktree',
+        projectPath: '/home/user/.vorn-worktrees/my-app/feature-a'
+      })
+    ])
+    const resumed = session({
+      projectPath: '/home/user/my-app',
+      worktreePath: '/home/user/.vorn-worktrees/my-app/feature-a'
+    })
+    expect(resolveTranscriptId(resumed)).toBe('sess-worktree')
+  })
+
+  it('will not match on a basename, which would cross projects', () => {
+    getRecentSessionsFor.mockImplementation((_agent: string, projectPath?: string) =>
+      projectPath ? [] : [recent({ sessionId: 'sess-fuzzy', projectPath: '/private/var/my-app' })]
+    )
+    expect(resolveTranscriptId(session({ projectPath: '/var/my-app' }))).toBeUndefined()
+  })
+
+  it('asks the project first, then everywhere', () => {
+    const resumed = session()
+    resolveTranscriptId(resumed)
+    expect(getRecentSessionsFor).toHaveBeenCalledTimes(2)
+    expect(getRecentSessionsFor).toHaveBeenNthCalledWith(1, 'claude', resumed.projectPath)
+    expect(getRecentSessionsFor).toHaveBeenNthCalledWith(2, 'claude')
+  })
+
+  it('asks for one agent, not the merged list of five', () => {
+    resolveTranscriptId(session({ agentType: 'codex' }))
+    expect(getRecentSessionsFor).toHaveBeenCalledWith('codex', '/home/user/my-app')
+  })
+
+  it('answers nothing for an agent that cannot resume an exact conversation', () => {
+    expect(resolveTranscriptId(session({ agentType: 'gemini' }))).toBeUndefined()
+    expect(getRecentSessionsFor).not.toHaveBeenCalled()
+  })
+
+  it('leaves a conversation someone else is already writing', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'sess-1' }),
+      recent({ sessionId: 'sess-2' })
+    ])
+    expect(resolveTranscriptId(session())).toBe('sess-1')
+    expect(resolveTranscriptId(session(), new Set(['sess-1']))).toBe('sess-2')
+  })
+
+  it('leaves its own pinned conversation when that is the one being written', () => {
+    // Falls through to the scan rather than handing back an id already in use.
+    getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'sess-2' })])
+    const resumed = session({ agentSessionId: 'sess-1' })
+    expect(resolveTranscriptId(resumed, new Set(['sess-1']))).toBe('sess-2')
+  })
+
+  it('survives an agent whose history cannot be read', () => {
+    getRecentSessionsFor.mockImplementation(() => {
+      throw new Error('database is locked')
+    })
+    expect(resolveTranscriptId(session())).toBeUndefined()
+  })
+})
+
+describe('who is writing a conversation right now', () => {
+  it('is whichever live session carries its id', () => {
+    const live = [session({ id: 'a' }), session({ id: 'b', agentSessionId: 'sess-9' })]
+    expect(transcriptHolder('sess-9', live)?.id).toBe('b')
+    expect(transcriptHolder('sess-1', live)).toBeUndefined()
+  })
+
+  it('is nobody once the processes are gone, which is what a restart leaves', () => {
+    expect(heldTranscripts([])).toEqual(new Set())
+  })
+
+  it('counts only sessions that know which conversation they took', () => {
+    const live = [session({ id: 'a' }), session({ id: 'b', agentSessionId: 'sess-9' })]
+    expect(heldTranscripts(live)).toEqual(new Set(['sess-9']))
+  })
+})

--- a/tests/agent-transcript.test.ts
+++ b/tests/agent-transcript.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { RecentSession, TerminalSession } from '../packages/shared/src/types'
 
 const getRecentSessionsFor = vi.fn()
-vi.mock('../packages/server/src/agent-history', () => ({
+vi.mock('../packages/server/src/agent-history', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../packages/server/src/agent-history')>()),
   getRecentSessionsFor: (...args: unknown[]) => getRecentSessionsFor(...args)
 }))
 
@@ -12,15 +13,10 @@ import {
   transcriptHolder,
   claimTranscriptFor
 } from '../packages/server/src/agent-transcript'
-import { resetTranscriptClaims } from '../packages/server/src/transcript-claims'
-
-/**
- * Which conversation a session continues.
- *
- * Moved here from the renderer: every input was already on this side, and the
- * renderer could only dedupe within one window's restore pass, which is why two
- * devices could take one transcript.
- */
+import {
+  resetTranscriptClaims,
+  releaseSpawningTranscript
+} from '../packages/server/src/transcript-claims'
 
 function session(overrides: Partial<TerminalSession> = {}): TerminalSession {
   return {
@@ -122,17 +118,9 @@ describe('resolving which conversation a session continues', () => {
   })
 
   it('leaves its own pinned conversation when that is the one being written', () => {
-    // Falls through to the scan rather than handing back an id already in use.
     getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'sess-2' })])
     const resumed = session({ agentSessionId: 'sess-1' })
     expect(resolveTranscriptId(resumed, new Set(['sess-1']))).toBe('sess-2')
-  })
-
-  it('survives an agent whose history cannot be read', () => {
-    getRecentSessionsFor.mockImplementation(() => {
-      throw new Error('database is locked')
-    })
-    expect(resolveTranscriptId(session())).toBeUndefined()
   })
 })
 
@@ -154,11 +142,6 @@ describe('who is writing a conversation right now', () => {
 })
 
 describe('two cold panes resumed one after the other', () => {
-  /**
-   * The case the whole change exists for. codex reports which conversation it
-   * took seconds after it starts, so the first resume is still nameless when the
-   * second asks -- and both would take the newest thread.
-   */
   it('take different conversations, because the first claims while it starts', () => {
     getRecentSessionsFor.mockReturnValue([
       recent({ sessionId: 'transcript-a', agentType: 'codex' }),
@@ -193,11 +176,6 @@ describe('two cold panes resumed one after the other', () => {
 })
 
 describe('a launch that names no conversation', () => {
-  /**
-   * A workflow step launches through `terminal:create` with no transcript, and
-   * keeps its own claim over the worktree in `workflow-run-claims`. The two stay
-   * separate on purpose; this pins that rather than leaving it implied.
-   */
   it('claims nothing, so a workflow step and a resume never contend', () => {
     getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'transcript-a' })])
     const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
@@ -210,5 +188,34 @@ describe('a launch that names no conversation', () => {
   it('does not treat a session with no reported conversation as holding one', () => {
     const live = [session({ id: 'one' }), session({ id: 'two' })]
     expect(heldTranscripts(live).size).toBe(0)
+  })
+})
+
+describe('a spawn that fails', () => {
+  it('can release exactly what it claimed, so a retry gets the same conversation', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'transcript-a', agentType: 'codex' })
+    ])
+    const cold = session({ id: 'one', agentType: 'codex' })
+
+    const claimed = claimTranscriptFor(cold, [], 'one')
+    expect(claimed).toBe('transcript-a')
+
+    releaseSpawningTranscript(claimed!, 'one')
+
+    expect(claimTranscriptFor(cold, [], 'one')).toBe('transcript-a')
+  })
+
+  it('leaves the conversation unreachable when the claim is released under another key', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'transcript-a', agentType: 'codex' }),
+      recent({ sessionId: 'transcript-b', agentType: 'codex' })
+    ])
+    const cold = session({ id: 'one', agentType: 'codex' })
+    claimTranscriptFor(cold, [], 'one')
+
+    releaseSpawningTranscript('', 'one')
+
+    expect(claimTranscriptFor(cold, [], 'one')).toBe('transcript-b')
   })
 })

--- a/tests/agent-transcript.test.ts
+++ b/tests/agent-transcript.test.ts
@@ -9,8 +9,10 @@ vi.mock('../packages/server/src/agent-history', () => ({
 import {
   resolveTranscriptId,
   heldTranscripts,
-  transcriptHolder
+  transcriptHolder,
+  claimTranscriptFor
 } from '../packages/server/src/agent-transcript'
+import { resetTranscriptClaims } from '../packages/server/src/transcript-claims'
 
 /**
  * Which conversation a session continues.
@@ -49,6 +51,7 @@ function recent(overrides: Partial<RecentSession> = {}): RecentSession {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  resetTranscriptClaims()
   getRecentSessionsFor.mockReturnValue([])
 })
 
@@ -147,5 +150,44 @@ describe('who is writing a conversation right now', () => {
   it('counts only sessions that know which conversation they took', () => {
     const live = [session({ id: 'a' }), session({ id: 'b', agentSessionId: 'sess-9' })]
     expect(heldTranscripts(live)).toEqual(new Set(['sess-9']))
+  })
+})
+
+describe('two cold panes resumed one after the other', () => {
+  /**
+   * The case the whole change exists for. codex reports which conversation it
+   * took seconds after it starts, so the first resume is still nameless when the
+   * second asks -- and both would take the newest thread.
+   */
+  it('take different conversations, because the first claims while it starts', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'transcript-a', agentType: 'codex' }),
+      recent({ sessionId: 'transcript-b', agentType: 'codex' })
+    ])
+    const first = session({ id: 'one', agentType: 'codex' })
+    const second = session({ id: 'two', agentType: 'codex' })
+
+    const firstTranscript = claimTranscriptFor(first, [], 'one')
+    // Started, but has not yet reported what it took.
+    const live = [{ ...first, agentSessionId: undefined }]
+    const secondTranscript = claimTranscriptFor(second, live, 'two')
+
+    expect(firstTranscript).toBe('transcript-a')
+    expect(secondTranscript).toBe('transcript-b')
+  })
+
+  it('skip a conversation a live session has already reported', () => {
+    getRecentSessionsFor.mockReturnValue([
+      recent({ sessionId: 'transcript-a' }),
+      recent({ sessionId: 'transcript-b' })
+    ])
+    const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
+    expect(claimTranscriptFor(session({ id: 'two' }), live, 'two')).toBe('transcript-b')
+  })
+
+  it('leave the agent to choose when every conversation is taken', () => {
+    getRecentSessionsFor.mockReturnValue([recent({ sessionId: 'transcript-a' })])
+    const live = [session({ id: 'one', agentSessionId: 'transcript-a' })]
+    expect(claimTranscriptFor(session({ id: 'two' }), live, 'two')).toBeUndefined()
   })
 })

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -5,13 +5,11 @@ import type { RestoredSession, TerminalSession } from '../packages/shared/src/ty
 const listActiveSessions = vi.fn()
 const getRestoredSessions = vi.fn()
 const resumeSession = vi.fn()
-const getRecentSessions = vi.fn()
 Object.defineProperty(window, 'api', {
   value: {
     listActiveSessions,
     getRestoredSessions,
     resumeSession,
-    getRecentSessions,
     notifyWidgetStatus: vi.fn()
   },
   writable: true
@@ -60,7 +58,6 @@ beforeEach(() => {
   useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
   vi.clearAllMocks()
   live.length = 0
-  getRecentSessions.mockResolvedValue([])
   listActiveSessions.mockImplementation(async () => [...live])
   getRestoredSessions.mockResolvedValue([])
   // As the server does: a resumed session keeps its id -- that is what makes it
@@ -273,41 +270,6 @@ describe('two reconciliations at once', () => {
     await syncBoard({ showCold: true, resume: true })
 
     expect(useAppStore.getState().terminals.has('contested')).toBe(true)
-  })
-})
-
-describe('two panes resumed in one pass', () => {
-  it('do not both take the same agent transcript', async () => {
-    // codex and opencode can resume an exact session but cannot have an id
-    // pinned on a fresh launch, so there is never an `agentSessionId` and both
-    // fall back to scanning the agent's own history -- which returns the first
-    // match for the project. Resolved independently, two panes get the same id
-    // and the pass starts two agents against one conversation, which is the
-    // thing the record's own claim exists to prevent.
-    getRestoredSessions.mockResolvedValue([
-      held('one', { session: session({ id: 'one', agentType: 'codex' }) }),
-      held('two', { session: session({ id: 'two', agentType: 'codex' }) })
-    ])
-    getRecentSessions.mockResolvedValue([
-      {
-        sessionId: 'transcript-a',
-        agentType: 'codex',
-        canResumeExact: true,
-        projectPath: '/dev/vorn'
-      },
-      {
-        sessionId: 'transcript-b',
-        agentType: 'codex',
-        canResumeExact: true,
-        projectPath: '/dev/vorn'
-      }
-    ])
-
-    await syncBoard({ showCold: true, resume: true })
-
-    const taken = resumeSession.mock.calls.map((c) => c[0].resumeSessionId)
-    expect(taken).toHaveLength(2)
-    expect(new Set(taken).size).toBe(2)
   })
 })
 

--- a/tests/session-bind.test.ts
+++ b/tests/session-bind.test.ts
@@ -95,6 +95,19 @@ describe('a resume bound to a session this client has never drawn', () => {
   })
 })
 
+describe('replacing a pane with a session already on the board', () => {
+  it('leaves one slot, in the place the running session already had', () => {
+    const store = useAppStore.getState()
+    store.addTerminal(session({ id: 'first' }))
+    store.addTerminal(session({ id: 'running' }))
+    store.addTerminal(session({ id: 'cold' }), { reason: 'app-closed', at: 1, replayed: true })
+
+    useAppStore.getState().replaceTerminal('cold', session({ id: 'running' }))
+
+    expect(useAppStore.getState().terminalOrder).toEqual(['first', 'running'])
+  })
+})
+
 describe('an ordinary resume', () => {
   it('keeps replacing in place, with the same id', async () => {
     const store = useAppStore.getState()

--- a/tests/session-bind.test.ts
+++ b/tests/session-bind.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { TerminalSession } from '../packages/shared/src/types'
+
+const resumeSession = vi.fn()
+Object.defineProperty(window, 'api', {
+  value: { resumeSession, notifyWidgetStatus: vi.fn() },
+  writable: true
+})
+
+vi.mock('../src/renderer/components/Toast', () => {
+  const toast = Object.assign(vi.fn(), { error: vi.fn() })
+  return { toast }
+})
+
+import { useAppStore } from '../src/renderer/stores'
+import { resumeEndedSession } from '../src/renderer/lib/session-resume'
+import { toast } from '../src/renderer/components/Toast'
+
+/**
+ * Resuming a pane whose conversation is already open somewhere else.
+ *
+ * The server hands back the session writing it rather than starting a second
+ * agent. What the board must not do with that answer is key two panes by one id:
+ * they draw the same terminal twice, and closing either closes both.
+ */
+
+function session(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: 'cold',
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/dev/vorn',
+    status: 'running',
+    createdAt: 1,
+    ...over
+  } as TerminalSession
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
+})
+
+describe('a resume bound to a session already on the board', () => {
+  beforeEach(() => {
+    const store = useAppStore.getState()
+    store.addTerminal(session({ id: 'running', agentSessionId: 'transcript-a' }))
+    store.addTerminal(session({ id: 'cold', agentSessionId: 'transcript-a' }), {
+      reason: 'app-closed',
+      at: 1,
+      replayed: true
+    })
+    resumeSession.mockResolvedValue({
+      ok: true,
+      session: session({ id: 'running', agentSessionId: 'transcript-a' }),
+      boundTo: 'running'
+    })
+  })
+
+  it('leaves one slot per session, not two under one id', async () => {
+    await resumeEndedSession('cold')
+    const { terminalOrder } = useAppStore.getState()
+    expect(terminalOrder).toEqual(['running'])
+  })
+
+  it('lets the ended pane go and brings the running one forward', async () => {
+    await resumeEndedSession('cold')
+    const state = useAppStore.getState()
+    expect(state.terminals.has('cold')).toBe(false)
+    expect(state.focusedTerminalId).toBe('running')
+  })
+
+  it('says so, because nobody asked for the pane to change what it shows', async () => {
+    await resumeEndedSession('cold')
+    expect(toast).toHaveBeenCalledWith('That conversation was already running. This pane shows it.')
+  })
+})
+
+describe('a resume bound to a session this client has never drawn', () => {
+  it('adopts it into the slot the ended pane was in', async () => {
+    const store = useAppStore.getState()
+    store.addTerminal(session({ id: 'cold' }), { reason: 'app-closed', at: 1, replayed: true })
+    resumeSession.mockResolvedValue({
+      ok: true,
+      session: session({ id: 'elsewhere' }),
+      boundTo: 'elsewhere'
+    })
+
+    await resumeEndedSession('cold')
+
+    const state = useAppStore.getState()
+    expect(state.terminalOrder).toEqual(['elsewhere'])
+    expect(state.terminals.has('cold')).toBe(false)
+  })
+})
+
+describe('an ordinary resume', () => {
+  it('keeps replacing in place, with the same id', async () => {
+    const store = useAppStore.getState()
+    store.addTerminal(session({ id: 'cold' }), { reason: 'app-closed', at: 1, replayed: true })
+    resumeSession.mockResolvedValue({ ok: true, session: session({ id: 'cold' }) })
+
+    await resumeEndedSession('cold')
+
+    expect(useAppStore.getState().terminalOrder).toEqual(['cold'])
+    expect(toast).not.toHaveBeenCalled()
+  })
+})

--- a/tests/session-restore-flow.test.ts
+++ b/tests/session-restore-flow.test.ts
@@ -9,7 +9,8 @@ import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import type { CreateTerminalPayload, TerminalSession } from '@vornrun/shared/types'
 
 const mockGetRecentSessions = vi.fn()
-vi.mock('../packages/server/src/agent-history', () => ({
+vi.mock('../packages/server/src/agent-history', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../packages/server/src/agent-history')>()),
   getRecentSessionsFor: (...args: unknown[]) => mockGetRecentSessions(...args)
 }))
 

--- a/tests/session-restore-flow.test.ts
+++ b/tests/session-restore-flow.test.ts
@@ -8,19 +8,13 @@ import { buildAgentLaunchLine } from '../packages/server/src/agent-launch'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import type { CreateTerminalPayload, TerminalSession } from '@vornrun/shared/types'
 
-// Mock the renderer API for resolveResumeSessionId
 const mockGetRecentSessions = vi.fn()
-vi.stubGlobal('window', {
-  api: {
-    getRecentSessions: mockGetRecentSessions
-  }
-})
+vi.mock('../packages/server/src/agent-history', () => ({
+  getRecentSessionsFor: (...args: unknown[]) => mockGetRecentSessions(...args)
+}))
 
-import {
-  resolveResumeSessionId,
-  buildRestorePayload,
-  coldSessions
-} from '../src/renderer/lib/session-utils'
+import { resolveTranscriptId } from '../packages/server/src/agent-transcript'
+import { buildRestorePayload, coldSessions } from '../src/renderer/lib/session-utils'
 
 const env = { PATH: '/usr/bin' }
 const cmds = DEFAULT_AGENT_COMMANDS
@@ -49,13 +43,13 @@ function makePayload(overrides: Partial<CreateTerminalPayload> = {}): CreateTerm
 
 beforeEach(() => {
   vi.clearAllMocks()
-  mockGetRecentSessions.mockResolvedValue([])
+  mockGetRecentSessions.mockReturnValue([])
 })
 
 describe('session restore flow: Claude with agentSessionId', () => {
   it('agentSessionId is used as resumeSessionId without scanning history', async () => {
     const session = makeSession({ agentSessionId: 'exact-uuid-123' })
-    const resumeId = await resolveResumeSessionId(session)
+    const resumeId = resolveTranscriptId(session)
     expect(resumeId).toBe('exact-uuid-123')
     // Should NOT have called getRecentSessions — agentSessionId was sufficient
     expect(mockGetRecentSessions).not.toHaveBeenCalled()
@@ -63,7 +57,7 @@ describe('session restore flow: Claude with agentSessionId', () => {
 
   it('hookSessionId alone is NOT used for resume (VibeGrid-internal UUID)', async () => {
     const session = makeSession({ hookSessionId: 'hook-only-uuid' })
-    const resumeId = await resolveResumeSessionId(session)
+    const resumeId = resolveTranscriptId(session)
     // hookSessionId is a VibeGrid routing UUID, not a real agent session ID
     expect(resumeId).toBeUndefined()
   })
@@ -93,7 +87,7 @@ describe('session restore flow: Claude with agentSessionId', () => {
     const session = makeSession({ agentSessionId: 'chain-uuid' })
 
     // Step 1: resolve
-    const resumeId = await resolveResumeSessionId(session)
+    const resumeId = resolveTranscriptId(session)
     expect(resumeId).toBe('chain-uuid')
 
     // Step 2: build payload
@@ -107,9 +101,9 @@ describe('session restore flow: Claude with agentSessionId', () => {
 })
 
 describe('session restore flow: Gemini (no resume support)', () => {
-  it('resolveResumeSessionId returns undefined for gemini', async () => {
+  it('resolveTranscriptId returns undefined for gemini', async () => {
     const session = makeSession({ agentType: 'gemini' })
-    const resumeId = await resolveResumeSessionId(session)
+    const resumeId = resolveTranscriptId(session)
     expect(resumeId).toBeUndefined()
   })
 
@@ -123,7 +117,7 @@ describe('session restore flow: Gemini (no resume support)', () => {
 
 describe('session restore flow: Codex fallback to history', () => {
   it('codex without hookSessionId falls back to getRecentSessions', async () => {
-    mockGetRecentSessions.mockResolvedValue([
+    mockGetRecentSessions.mockReturnValue([
       {
         sessionId: 'codex-sess-1',
         agentType: 'codex',
@@ -133,7 +127,7 @@ describe('session restore flow: Codex fallback to history', () => {
       }
     ])
     const session = makeSession({ agentType: 'codex' })
-    const resumeId = await resolveResumeSessionId(session)
+    const resumeId = resolveTranscriptId(session)
     expect(resumeId).toBe('codex-sess-1')
     expect(mockGetRecentSessions).toHaveBeenCalled()
   })

--- a/tests/session-utils.test.ts
+++ b/tests/session-utils.test.ts
@@ -1,20 +1,8 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import type { TerminalSession, RecentSession, AgentType } from '../packages/shared/src/types'
 
-const mockGetRecentSessions = vi.fn()
-
-// Mock window.api
-Object.defineProperty(window, 'api', {
-  value: { getRecentSessions: (...args: unknown[]) => mockGetRecentSessions(...args) },
-  writable: true
-})
-
-import {
-  resolveResumeSessionId,
-  resolveProjectName,
-  buildRestorePayload
-} from '../src/renderer/lib/session-utils'
+import { resolveProjectName, buildRestorePayload } from '../src/renderer/lib/session-utils'
 
 function makeSession(overrides: Partial<TerminalSession> = {}): TerminalSession {
   return {
@@ -42,129 +30,6 @@ function makeRecent(overrides: Partial<RecentSession> = {}): RecentSession {
     ...overrides
   }
 }
-
-beforeEach(() => {
-  vi.clearAllMocks()
-  mockGetRecentSessions.mockResolvedValue([])
-})
-
-describe('resolveResumeSessionId', () => {
-  it('returns agentSessionId immediately when present', async () => {
-    const session = makeSession({ agentSessionId: 'claude-abc' })
-    const result = await resolveResumeSessionId(session)
-    expect(result).toBe('claude-abc')
-    expect(mockGetRecentSessions).not.toHaveBeenCalled()
-  })
-
-  it('ignores hookSessionId for resume (VibeGrid-internal, not a real agent session ID)', async () => {
-    const session = makeSession({ hookSessionId: 'hook-abc' })
-    const result = await resolveResumeSessionId(session)
-    // hookSessionId alone should NOT be used — falls through to history scan
-    expect(result).toBeUndefined()
-  })
-
-  it('returns exact-match sessionId from recent sessions', async () => {
-    mockGetRecentSessions.mockResolvedValue([
-      makeRecent({ sessionId: 'sess-match', projectPath: '/home/user/my-app' })
-    ])
-    const session = makeSession({ projectPath: '/home/user/my-app' })
-    const result = await resolveResumeSessionId(session)
-    expect(result).toBe('sess-match')
-  })
-
-  it('prefers worktree path matches over project root matches', async () => {
-    mockGetRecentSessions.mockResolvedValue([
-      makeRecent({ sessionId: 'sess-root', projectPath: '/home/user/my-app' }),
-      makeRecent({
-        sessionId: 'sess-worktree',
-        projectPath: '/home/user/.vorn-worktrees/my-app/feature-a'
-      })
-    ])
-    const session = makeSession({
-      projectPath: '/home/user/my-app',
-      worktreePath: '/home/user/.vorn-worktrees/my-app/feature-a'
-    })
-
-    const result = await resolveResumeSessionId(session)
-    expect(result).toBe('sess-worktree')
-  })
-
-  it('does not fall back to basename match (prevents cross-project confusion)', async () => {
-    mockGetRecentSessions.mockImplementation((projectPath?: string) => {
-      if (projectPath) return Promise.resolve([])
-      return Promise.resolve([
-        makeRecent({ sessionId: 'sess-fuzzy', projectPath: '/private/var/folders/my-app' })
-      ])
-    })
-    const session = makeSession({ projectPath: '/var/folders/my-app' })
-    const result = await resolveResumeSessionId(session)
-    expect(result).toBeUndefined()
-  })
-
-  it('returns undefined when no match found', async () => {
-    // Scoped call returns nothing; unscoped returns non-matching session
-    mockGetRecentSessions.mockImplementation((projectPath?: string) => {
-      if (projectPath) return Promise.resolve([])
-      return Promise.resolve([
-        makeRecent({
-          sessionId: 'sess-other',
-          agentType: 'copilot',
-          projectPath: '/completely/different'
-        })
-      ])
-    })
-    const session = makeSession({ projectPath: '/home/user/my-app' })
-    const result = await resolveResumeSessionId(session)
-    expect(result).toBeUndefined()
-  })
-
-  it('tries scoped fetch first, then unscoped fallback', async () => {
-    mockGetRecentSessions.mockResolvedValue([])
-    const session = makeSession()
-    await resolveResumeSessionId(session)
-    expect(mockGetRecentSessions).toHaveBeenCalledTimes(2)
-    expect(mockGetRecentSessions).toHaveBeenNthCalledWith(1, session.projectPath)
-    expect(mockGetRecentSessions).toHaveBeenNthCalledWith(2)
-  })
-
-  it('skips already-claimed session IDs', async () => {
-    mockGetRecentSessions.mockResolvedValue([
-      makeRecent({ sessionId: 'sess-1', projectPath: '/home/user/my-app' }),
-      makeRecent({ sessionId: 'sess-2', projectPath: '/home/user/my-app' })
-    ])
-    const session = makeSession({ projectPath: '/home/user/my-app' })
-
-    // First call claims sess-1
-    const claimed = new Set<string>()
-    const first = await resolveResumeSessionId(session, claimed)
-    expect(first).toBe('sess-1')
-    claimed.add(first!)
-
-    // Second call with same session skips sess-1, returns sess-2
-    const second = await resolveResumeSessionId(session, claimed)
-    expect(second).toBe('sess-2')
-  })
-
-  it('skips claimed hookSessionId', async () => {
-    const claimed = new Set(['hook-abc'])
-    const session = makeSession({ hookSessionId: 'hook-abc' })
-    mockGetRecentSessions.mockResolvedValue([
-      makeRecent({ sessionId: 'sess-fallback', projectPath: '/home/user/my-app' })
-    ])
-    const result = await resolveResumeSessionId(session, claimed)
-    expect(result).toBe('sess-fallback')
-  })
-
-  it('does not attempt exact resume for gemini sessions', async () => {
-    const session = makeSession({
-      agentType: 'gemini',
-      hookSessionId: 'gemini-hook'
-    })
-    const result = await resolveResumeSessionId(session)
-    expect(result).toBeUndefined()
-    expect(mockGetRecentSessions).not.toHaveBeenCalled()
-  })
-})
 
 describe('resolveProjectName', () => {
   const projects = [

--- a/tests/transcript-claims.test.ts
+++ b/tests/transcript-claims.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import {
   claimSpawningTranscript,
   releaseSpawningTranscript,
+  releaseSpawningTranscriptsFor,
   spawningTranscripts,
   resetTranscriptClaims
 } from '../packages/server/src/transcript-claims'
@@ -40,15 +41,23 @@ describe('a transcript being started', () => {
   it('lapses rather than locks, so a spawn that died never wedges it', () => {
     vi.useFakeTimers()
     claimSpawningTranscript('transcript-a', 'term-1')
-    vi.advanceTimersByTime(15_001)
+    vi.advanceTimersByTime(60_001)
     expect(spawningTranscripts()).toEqual(new Set())
     expect(claimSpawningTranscript('transcript-a', 'term-2')).toBeUndefined()
   })
 
-  it('still holds inside the window', () => {
+  it('outlasts the capture that asks an agent which conversation it took', () => {
     vi.useFakeTimers()
     claimSpawningTranscript('transcript-a', 'term-1')
-    vi.advanceTimersByTime(14_000)
+    // The last attempt lands at forty seconds; a claim gone by then is the bug.
+    vi.advanceTimersByTime(40_000)
     expect(claimSpawningTranscript('transcript-a', 'term-2')).toBe('term-1')
+  })
+
+  it('lets go of everything one session was holding', () => {
+    claimSpawningTranscript('transcript-a', 'term-1')
+    claimSpawningTranscript('transcript-b', 'term-2')
+    releaseSpawningTranscriptsFor('term-1')
+    expect(spawningTranscripts()).toEqual(new Set(['transcript-b']))
   })
 })

--- a/tests/transcript-claims.test.ts
+++ b/tests/transcript-claims.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  claimSpawningTranscript,
+  releaseSpawningTranscript,
+  spawningTranscripts,
+  resetTranscriptClaims
+} from '../packages/server/src/transcript-claims'
+
+/**
+ * The window where a session has started but cannot yet say what it is writing.
+ *
+ * codex and opencode take no id at launch, so `agentSessionId` only arrives from
+ * the capture seconds later. Resuming two cold panes in that gap is the case
+ * this covers: the first spawn holds its transcript, so the second resolves to a
+ * different one instead of starting a second agent on one conversation.
+ */
+
+beforeEach(() => resetTranscriptClaims())
+afterEach(() => vi.useRealTimers())
+
+describe('a transcript being started', () => {
+  it('is granted once, and names the holder to whoever asks next', () => {
+    expect(claimSpawningTranscript('transcript-a', 'term-1')).toBeUndefined()
+    expect(claimSpawningTranscript('transcript-a', 'term-2')).toBe('term-1')
+  })
+
+  it('is counted as held while it starts, so a resolve skips it', () => {
+    claimSpawningTranscript('transcript-a', 'term-1')
+    expect(spawningTranscripts()).toEqual(new Set(['transcript-a']))
+  })
+
+  it('leaves other transcripts alone', () => {
+    claimSpawningTranscript('transcript-a', 'term-1')
+    expect(claimSpawningTranscript('transcript-b', 'term-2')).toBeUndefined()
+  })
+
+  it('is free again once the spawn that took it releases', () => {
+    claimSpawningTranscript('transcript-a', 'term-1')
+    releaseSpawningTranscript('transcript-a', 'term-1')
+    expect(claimSpawningTranscript('transcript-a', 'term-2')).toBeUndefined()
+  })
+
+  it('ignores a release from a session that does not hold it', () => {
+    claimSpawningTranscript('transcript-a', 'term-1')
+    releaseSpawningTranscript('transcript-a', 'term-2')
+    expect(claimSpawningTranscript('transcript-a', 'term-3')).toBe('term-1')
+  })
+
+  it('lapses rather than locks, so a spawn that died never wedges it', () => {
+    vi.useFakeTimers()
+    claimSpawningTranscript('transcript-a', 'term-1')
+    vi.advanceTimersByTime(15_001)
+    expect(spawningTranscripts()).toEqual(new Set())
+    expect(claimSpawningTranscript('transcript-a', 'term-2')).toBeUndefined()
+  })
+
+  it('still holds inside the window', () => {
+    vi.useFakeTimers()
+    claimSpawningTranscript('transcript-a', 'term-1')
+    vi.advanceTimersByTime(14_000)
+    expect(claimSpawningTranscript('transcript-a', 'term-2')).toBe('term-1')
+  })
+})

--- a/tests/transcript-claims.test.ts
+++ b/tests/transcript-claims.test.ts
@@ -60,4 +60,19 @@ describe('a transcript being started', () => {
     releaseSpawningTranscriptsFor('term-1')
     expect(spawningTranscripts()).toEqual(new Set(['transcript-b']))
   })
+
+  it('lets go by session, so a resume given an alternate conversation still clears', () => {
+    // A pane pinned to `transcript-a` whose resume resolved `transcript-b`
+    // instead: the release names the session, never the id it hoped for.
+    claimSpawningTranscript('transcript-b', 'term-1')
+    releaseSpawningTranscriptsFor('term-1')
+    expect(spawningTranscripts()).toEqual(new Set())
+    expect(claimSpawningTranscript('transcript-b', 'term-2')).toBeUndefined()
+  })
+
+  it('ignores a release naming a conversation the session never took', () => {
+    claimSpawningTranscript('transcript-b', 'term-1')
+    releaseSpawningTranscript('transcript-a', 'term-1')
+    expect(spawningTranscripts()).toEqual(new Set(['transcript-b']))
+  })
 })

--- a/tests/transcript-claims.test.ts
+++ b/tests/transcript-claims.test.ts
@@ -6,15 +6,6 @@ import {
   resetTranscriptClaims
 } from '../packages/server/src/transcript-claims'
 
-/**
- * The window where a session has started but cannot yet say what it is writing.
- *
- * codex and opencode take no id at launch, so `agentSessionId` only arrives from
- * the capture seconds later. Resuming two cold panes in that gap is the case
- * this covers: the first spawn holds its transcript, so the second resolves to a
- * different one instead of starting a second agent on one conversation.
- */
-
 beforeEach(() => resetTranscriptClaims())
 afterEach(() => vi.useRealTimers())
 


### PR DESCRIPTION
Resume could start two agents on one conversation. The task this came from blamed a race between two clients and asked for an ownership registry with fencing tokens. **That race does not exist** — `sessions:resume` runs its claim and `createPty` in one synchronous block with no `await` between them, on a single-threaded server, so a second caller for the same id already gets `gone`. Attaching was never the problem either; that is P4 and it is idempotent.

The real fault was that **the claim was on the wrong key.**

## What was wrong

`resolveResumeSessionId` ran in the renderer. It scanned the agent's own history and handed the server a transcript id, which went into the launch line unchecked. The server claims **Vorn session ids**; what must not be doubled is the **conversation**. Two legitimate sessions in one project could resolve to the same transcript and both be granted, because the server saw two different ids and no conflict at all.

codex and opencode hit this every time — neither can be told an id at launch, so there is never an `agentSessionId` and both always fall to the history scan. The renderer deduped with a set built per restore pass, in one window: a second window, a phone, or the Resume button on a card (which passed no set at all) each resolved on their own.

## What this does

**Resolution moves to the server.** Every input was already there — `getRecentSessions` was a pure pass-through, and the session record is in hand at the resume site. Two things come free with the move: it asks **one agent's provider** instead of the merged list of five (where a busy agent crowds out a quiet one after the 20-row slice), and it uses the project scope that expands into **all worktrees**, which the renderer's two-path list did not.

**The claim is derived, not stored.** A conversation is taken if a live session is writing it — `agentSessionId` on the session, `hasLivePty` for what is running. No registry, no table, no generation counter. After a restart nothing is running, so nothing is held, which is exactly right.

**A lapsing claim covers the one real gap.** codex and opencode only learn which conversation they took seconds after they start, so a resume in that window is nameless. A spawning claim holds it meanwhile, lapsing rather than locking so a spawn that dies never wedges the transcript. Same shape as `workflow-run-claims`.

**Binding, not refusing.** When the conversation asked for is already running, the session writing it is handed back and the pane shows it. Announced even when nobody clicked: a pane quietly becoming a second view is the surprise worth a line. The ended pane is then let go rather than replaced in place — replacing it with an id already on the board keyed two panes to one session, which drew the same terminal twice and closed both at once.

`terminal:create` asks the same question. The palette, a task's detail panel, the recent-sessions popover and the editor's run panel all name a conversation explicitly, and picking one already open started a second agent on it. A launch that names a conversation nothing is writing takes a spawning claim on it, as a resume does.

**A workflow step is separate but not invisible.** It keeps its own claim over the worktree, and a step launched naming a conversation now counts as writing it: headless sessions live in their own manager, so leaving them out made a run in progress look like a free transcript to the resume beside it.

**The claim outlasts what it waits for.** codex and opencode are asked for their conversation five seconds in; an agent slower than that used to be asked once, come up empty, and stay nameless — free for a later resume to take. It is asked again up to forty seconds, the window is longer than that ladder, and the claim is released the moment the session reports its conversation or exits.

## Tests

40 across `agent-transcript.test.ts`, `transcript-claims.test.ts` and `session-bind.test.ts`, each checked against the unfixed code first. The later ones cover what a review found: a headless run holding its conversation against a pane that pinned it, a launch handed the session already writing what it named, a claim that survives the whole capture ladder and is released by session, and the bound pane leaving one slot on the board rather than two under one id. The seven cases that covered resolution moved from the renderer rather than being rewritten, and gained what the renderer could not reach: one agent asked rather than five, a pinned id already in use falling through to the scan, an unreadable history resolving to nothing.

The case the change exists for is covered directly — two cold codex panes, the first still nameless when the second asks. Without the spawning claim the test finds both on `transcript-a`.

That join was briefly untestable because I had composed it inline in the RPC handler; `claimTranscriptFor` exists so it is a unit test rather than a socket harness. The harness is avoided on purpose: it replaces the database module wholesale, and three suites doing that were until last week asserting against default config because their mocks named exports the module does not have.

## Verification

Types clean over both the test and server projects · lint clean on every touched file · **4829 tests across 360 files**, two failing only for the ambient environment they were run in (`pty-session-id`, `process-utils`), which pass with `VORN_SESSION_ID` and `VORN_DATA_DIR` unset.

Still to check by hand: two cold codex sessions in one project resumed together, then the same from a phone and a desktop at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT

