### PR TITLE
Put the last run's data at every node and answer the run click instantly

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -877,6 +877,8 @@ export type NodeExecutionStatus =
 export interface NodeExecutionState {
   nodeId: string
   status: NodeExecutionStatus
+  /** Why a skipped node was skipped: a condition branch or a partial run's target slice. */
+  skipReason?: 'branch' | 'target'
   startedAt?: string
   completedAt?: string
   sessionId?: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -984,6 +984,10 @@ export interface WorkflowExecution {
   connectorInboxLeaseToken?: string
   /** Durable terminal handling for restart recovery. */
   connectorInboxDisposition?: 'processed' | 'retry'
+  /** True when the run executed only a target step and its upstream slice. */
+  partial?: boolean
+  /** The failed run this one resumed, reusing its completed step outputs. */
+  retryOfRunId?: string
 }
 
 /** Stable identity for a run row, tolerating history written before `runId`. */

--- a/src/renderer/components/SourcePromptDialog.tsx
+++ b/src/renderer/components/SourcePromptDialog.tsx
@@ -153,7 +153,14 @@ export function SourcePromptDialog() {
             } satisfies TerminalSession
           }
         : null
-    void executeWorkflow(workflow, { ...base, inputs }, { source: 'manual' })
+    void executeWorkflow(
+      workflow,
+      { ...base, inputs },
+      {
+        source: 'manual',
+        targetNodeId: pendingRun?.targetNodeId
+      }
+    )
     close()
   }
 

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { GATE_APPROVE, GATE_REJECT } from '../../lib/gate-affordance'
 import { ChevronDown, ChevronRight, Maximize2, Play, RotateCcw, Check, X } from 'lucide-react'
 import {
@@ -93,6 +93,8 @@ interface RunStepsListProps {
   includeTrigger?: boolean
   onViewFullOutput?: (logs: string) => void
   onClickTask?: (taskId: string) => void
+  /** Auto-expand whichever step is running and keep it scrolled into view. */
+  followActive?: boolean
   onResumeSession?: (
     agentSessionId: string,
     agentType: AiAgentType,
@@ -121,9 +123,23 @@ export function RunStepsList({
   includeTrigger = false,
   onViewFullOutput,
   onClickTask,
+  followActive,
   onResumeSession
 }: RunStepsListProps) {
   const [expandedNodeId, setExpandedNodeId] = useState<string | null>(null)
+  const activeNodeId = followActive
+    ? (execution.nodeStates.find((ns) => ns.status === 'running')?.nodeId ?? null)
+    : null
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (activeNodeId) setExpandedNodeId(activeNodeId)
+  }, [activeNodeId])
+  const expandedRowRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (followActive && expandedNodeId) {
+      expandedRowRef.current?.scrollIntoView?.({ block: 'nearest' })
+    }
+  }, [followActive, expandedNodeId])
   const connections = useConnections()
 
   const actionStates = includeTrigger
@@ -224,7 +240,7 @@ export function RunStepsList({
             node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
 
           return (
-            <div key={ns.nodeId}>
+            <div key={ns.nodeId} ref={isExpanded ? expandedRowRef : undefined}>
               {/* Line linking the previous step to this one so the cards read
                   as one continuous flow. Neutral on purpose: the status dots
                   carry the colour, and tinting the connectors too turns the
@@ -434,6 +450,8 @@ interface RunEntryProps {
   onRerunRun?: (execution: WorkflowExecution) => void
   /** Resume this failed run from its failed step, reusing completed outputs. */
   onRetryRun?: (execution: WorkflowExecution) => void
+  /** Keep this run expanded and its active step in view while it streams. */
+  follow?: boolean
   onResumeSession?: (
     agentSessionId: string,
     agentType: AiAgentType,
@@ -453,15 +471,16 @@ export function RunEntry({
   onClickTask,
   onRerunRun,
   onRetryRun,
+  follow,
   onResumeSession
 }: RunEntryProps) {
   const hasWaitingGate = execution.nodeStates.some((ns) => ns.status === 'waiting')
-  const [expanded, setExpanded] = useState(hasWaitingGate)
+  const [expanded, setExpanded] = useState(hasWaitingGate || !!follow)
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (hasWaitingGate) setExpanded(true)
-  }, [hasWaitingGate])
+    if (hasWaitingGate || follow) setExpanded(true)
+  }, [hasWaitingGate, follow])
 
   const triggerTask =
     execution.triggerTaskId && tasks
@@ -547,6 +566,7 @@ export function RunEntry({
           onViewFullOutput={onViewFullOutput}
           onClickTask={onClickTask}
           onResumeSession={onResumeSession}
+          followActive={follow}
         />
       )}
     </div>

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { GATE_APPROVE, GATE_REJECT } from '../../lib/gate-affordance'
-import { ChevronDown, ChevronRight, Maximize2, RotateCcw, Check, X } from 'lucide-react'
+import { ChevronDown, ChevronRight, Maximize2, Play, RotateCcw, Check, X } from 'lucide-react'
 import {
   WorkflowExecution,
   WorkflowNode,
@@ -430,6 +430,10 @@ interface RunEntryProps {
   tasks?: TaskConfig[]
   onViewFullOutput?: (logs: string) => void
   onClickTask?: (taskId: string) => void
+  /** Start a fresh run with this run's launch context. */
+  onRerunRun?: (execution: WorkflowExecution) => void
+  /** Resume this failed run from its failed step, reusing completed outputs. */
+  onRetryRun?: (execution: WorkflowExecution) => void
   onResumeSession?: (
     agentSessionId: string,
     agentType: AiAgentType,
@@ -447,6 +451,8 @@ export function RunEntry({
   tasks,
   onViewFullOutput,
   onClickTask,
+  onRerunRun,
+  onRetryRun,
   onResumeSession
 }: RunEntryProps) {
   const hasWaitingGate = execution.nodeStates.some((ns) => ns.status === 'waiting')
@@ -493,10 +499,41 @@ export function RunEntry({
               {triggerTask.title}
             </span>
           )}
+          {execution.partial && (
+            <span className="text-[9px] font-mono uppercase tracking-wider text-gray-500 border border-white/[0.08] rounded px-1 shrink-0">
+              partial
+            </span>
+          )}
           <span className="text-[11px] text-gray-500 shrink-0">
             {formatRunDuration(execution.startedAt, execution.completedAt)}
           </span>
         </button>
+        {execution.status === 'error' && onRetryRun && (
+          <span className="shrink-0">
+            <Tooltip label="Retry from failed step" position="top">
+              <button
+                aria-label="Retry from failed step"
+                onClick={() => onRetryRun(execution)}
+                className="p-1 rounded text-gray-500 hover:text-white transition-colors"
+              >
+                <RotateCcw size={12} strokeWidth={2} />
+              </button>
+            </Tooltip>
+          </span>
+        )}
+        {execution.status !== 'running' && onRerunRun && (
+          <span className="shrink-0">
+            <Tooltip label="Run again" position="top">
+              <button
+                aria-label="Run again"
+                onClick={() => onRerunRun(execution)}
+                className="p-1 rounded text-gray-500 hover:text-white transition-colors"
+              >
+                <Play size={12} strokeWidth={2} />
+              </button>
+            </Tooltip>
+          </span>
+        )}
         <span className="pr-2 shrink-0">
           <StopRunButton execution={execution} stopPropagation={false} />
         </span>

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -22,7 +22,7 @@ import {
   type NodeProps
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { AlignVerticalSpaceAround, Repeat, Trash2 } from 'lucide-react'
+import { AlignVerticalSpaceAround, Repeat, StepForward, Trash2 } from 'lucide-react'
 import { LoopConfig, NodeExecutionStatus, WorkflowEdge, WorkflowNode } from '../../../shared/types'
 import {
   AddStepNodeData,
@@ -32,6 +32,7 @@ import {
 } from '../../lib/workflow-canvas-layout'
 import { NODE_GLYPH, NODE_SELECTED, NODE_UNSELECTED } from './node-visuals'
 import { WORKFLOW_STATUS_DOT_PULSE } from '../../lib/workflow-status'
+import { Tooltip } from '../Tooltip'
 import { NodeCard } from './nodes/NodeCard'
 import { ConnectorButton } from './nodes/AddStepNode'
 
@@ -72,6 +73,8 @@ interface Props {
   onPositionsCommit: (positions: Record<string, { x: number; y: number }>) => void
   /** Delete-key removal of the selected step (never the trigger). */
   onDeleteNode?: (nodeId: string) => void
+  /** Hover-toolbar shortcut into the editor's run-to-step path. */
+  onRunToStep?: (nodeId: string) => void
   onTidyUp: () => void
   selectedNodeId: string | null
   /** What each node is doing in live runs; absent when nothing is running. */
@@ -88,6 +91,7 @@ interface CanvasInteractions {
   onOpenLibrary: (anchor: InsertAnchor) => void
   libraryAnchor: InsertAnchor | null
   onDeleteNode?: (nodeId: string) => void
+  onRunToStep?: (nodeId: string) => void
 }
 
 const InteractionsContext = createContext<CanvasInteractions | null>(null)
@@ -99,25 +103,45 @@ function useInteractions(): CanvasInteractions {
 }
 
 /** The strip that floats over a hovered card; the wrapper must carry `group`. */
+const TOOLBAR_BUTTON = `p-1.5 rounded-md bg-surface-overlay border border-white/[0.12] text-gray-400
+                        hover:text-white hover:border-white/[0.2] transition-colors`
+
 function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
-  const { onDeleteNode } = useInteractions()
-  if (!onDeleteNode) return null
+  const { onDeleteNode, onRunToStep } = useInteractions()
+  if (!onDeleteNode && !onRunToStep) return null
   return (
     <div
-      className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 opacity-0 group-hover:opacity-100
-                 transition-opacity duration-100 z-10"
+      className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 flex flex-col gap-1 opacity-0
+                 group-hover:opacity-100 transition-opacity duration-100 z-10"
     >
-      <button
-        aria-label="Delete step"
-        onClick={(e) => {
-          e.stopPropagation()
-          onDeleteNode(nodeId)
-        }}
-        className="p-1.5 rounded-md bg-surface-overlay border border-white/[0.12] text-gray-400
-                   hover:text-white hover:border-white/[0.2] transition-colors"
-      >
-        <Trash2 size={12} />
-      </button>
+      {onRunToStep && (
+        <Tooltip label="Run to this step" position="right">
+          <button
+            aria-label="Run to this step"
+            onClick={(e) => {
+              e.stopPropagation()
+              onRunToStep(nodeId)
+            }}
+            className={TOOLBAR_BUTTON}
+          >
+            <StepForward size={12} />
+          </button>
+        </Tooltip>
+      )}
+      {onDeleteNode && (
+        <Tooltip label="Delete step" position="right">
+          <button
+            aria-label="Delete step"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDeleteNode(nodeId)
+            }}
+            className={TOOLBAR_BUTTON}
+          >
+            <Trash2 size={12} />
+          </button>
+        </Tooltip>
+      )}
     </div>
   )
 }
@@ -383,6 +407,7 @@ function WorkflowCanvasInner({
   onConnectEdge,
   onPositionsCommit,
   onDeleteNode,
+  onRunToStep,
   onTidyUp,
   selectedNodeId,
   nodeStatus
@@ -517,9 +542,19 @@ function WorkflowCanvasInner({
       onNodeClick,
       onOpenLibrary,
       libraryAnchor,
-      onDeleteNode
+      onDeleteNode,
+      onRunToStep
     }),
-    [nodes, selectedNodeId, nodeStatus, onNodeClick, onOpenLibrary, libraryAnchor, onDeleteNode]
+    [
+      nodes,
+      selectedNodeId,
+      nodeStatus,
+      onNodeClick,
+      onOpenLibrary,
+      libraryAnchor,
+      onDeleteNode,
+      onRunToStep
+    ]
   )
 
   return (

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -181,10 +181,16 @@ function LoopNode({ data }: NodeProps) {
       <NodeHoverToolbar nodeId={node.id} />
       <div
         data-loop-rail
-        className={`w-[312px] rounded-lg border transition-all
-                    ${selected ? NODE_SELECTED : NODE_UNSELECTED}
+        className={`w-[312px] rounded-lg border transition-all relative
+                    ${selected ? NODE_SELECTED : loopStatus === 'error' ? 'border-danger/60' : NODE_UNSELECTED}
                     bg-surface-node`}
       >
+        {loopStatus === 'running' && (
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-lg border border-white/[0.35] animate-pulse pointer-events-none"
+          />
+        )}
         <div
           onClick={(e) => {
             e.stopPropagation()

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -63,7 +63,6 @@ import {
 import { startManualRun } from '../../lib/workflow-menu-items'
 import {
   buildStepOutputsMap,
-  executeWorkflow,
   retryRunFromFailure,
   rerunWorkflowRun
 } from '../../lib/workflow-execution'
@@ -404,9 +403,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     (nodeId: string) => {
       const workflow = persistWorkflow()
       setShowRunHistory(false)
-      executeWorkflow(workflow, undefined, { source: 'manual', targetNodeId: nodeId }).catch(
-        (err) => toast.error(err instanceof Error ? err.message : String(err))
-      )
+      startManualRun(workflow, undefined, { targetNodeId: nodeId })
     },
     [persistWorkflow]
   )

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -8,14 +8,16 @@ import {
   History,
   Workflow,
   MoreHorizontal,
-  Settings
+  Settings,
+  Loader2,
+  Square
 } from 'lucide-react'
 import { ICON_MAP } from '../project-sidebar/icon-map'
 import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../../lib/project-icons'
 import { Tooltip } from '../Tooltip'
 import { useAppStore } from '../../stores'
 import { useShallow } from 'zustand/react/shallow'
-import { liveNodeStatus } from '../../lib/run-presentation'
+import { liveNodeStatus, runCompletionToast } from '../../lib/run-presentation'
 import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from '../../lib/platform'
 import { SidebarToggleButton } from '../SidebarToggleButton'
 import { MainViewPills } from '../MainViewPills'
@@ -58,13 +60,15 @@ import {
   loopOwningInsertPoint,
   addParallelBranch,
   removeNode,
-  getWorktreeMode
+  getWorktreeMode,
+  needsRunPrompt
 } from '../../lib/workflow-helpers'
 import { startManualRun } from '../../lib/workflow-menu-items'
 import {
   buildStepOutputsMap,
   retryRunFromFailure,
-  rerunWorkflowRun
+  rerunWorkflowRun,
+  stopWorkflowRun
 } from '../../lib/workflow-execution'
 import { loopBodyMembers } from '../../lib/workflow-canvas-layout'
 import { toast } from '../Toast'
@@ -107,6 +111,10 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [pendingInsert, setPendingInsert] = useState<InsertAnchor | null>(null)
   const [showRunHistory, setShowRunHistory] = useState(false)
+  const [launchingSince, setLaunchingSince] = useState<number | null>(null)
+  const [followRunId, setFollowRunId] = useState<string | null>(null)
+  const followArmRef = useRef(false)
+  const trackedRunsRef = useRef(new Map<string, WorkflowExecution['status']>())
   const [showProperties, setShowProperties] = useState(true)
   const [showIconPicker, setShowIconPicker] = useState(false)
   const [showOverflowMenu, setShowOverflowMenu] = useState(false)
@@ -284,6 +292,44 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     )
   )
 
+  const runningRun = useAppStore(
+    useShallow((s) => {
+      if (!editingId) return null
+      for (const exec of s.workflowExecutions.values()) {
+        if (exec.workflowId === editingId && exec.status === 'running') {
+          return { runId: exec.runId, startedAt: exec.startedAt }
+        }
+      }
+      return null
+    })
+  )
+
+  const [nowTick, setNowTick] = useState(() => Date.now())
+  useEffect(() => {
+    if (!runningRun && launchingSince === null) return
+    const timer = setInterval(() => setNowTick(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [runningRun, launchingSince])
+
+  // The click answered before the server did; the real run takes over here.
+  useEffect(() => {
+    if (!runningRun) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLaunchingSince(null)
+    if (followArmRef.current) {
+      followArmRef.current = false
+      setFollowRunId(runningRun.runId)
+      trackedRunsRef.current.set(runningRun.runId, 'running')
+    }
+  }, [runningRun])
+
+  // A cancelled prompt or refused claim must not leave the button spinning.
+  useEffect(() => {
+    if (launchingSince === null) return
+    const timer = setTimeout(() => setLaunchingSince(null), 8000)
+    return () => clearTimeout(timer)
+  }, [launchingSince])
+
   // Load existing workflow when editing (with slug migration)
   useEffect(() => {
     if (existingWorkflow) {
@@ -399,13 +445,19 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     setEditingId
   ])
 
+  const beginEditorRun = useCallback((workflow: WorkflowDefinition, targetNodeId?: string) => {
+    if (!needsRunPrompt(workflow)) setLaunchingSince(Date.now())
+    followArmRef.current = true
+    setShowRunHistory(true)
+    setSelectedNodeId(null)
+    startManualRun(workflow, undefined, targetNodeId ? { targetNodeId } : undefined)
+  }, [])
+
   const handleRunToStep = useCallback(
     (nodeId: string) => {
-      const workflow = persistWorkflow()
-      setShowRunHistory(false)
-      startManualRun(workflow, undefined, { targetNodeId: nodeId })
+      beginEditorRun(persistWorkflow(), nodeId)
     },
-    [persistWorkflow]
+    [persistWorkflow, beginEditorRun]
   )
 
   const handleRetryRun = useCallback(
@@ -417,6 +469,37 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     },
     [persistWorkflow]
   )
+
+  // Terminal transitions of editor-launched runs land as toasts.
+  useEffect(() => {
+    if (!editingId) return
+    const execs = useAppStore.getState().workflowExecutions
+    for (const [runId, prev] of trackedRunsRef.current) {
+      const exec = execs.get(runId)
+      if (!exec || exec.status === prev) continue
+      trackedRunsRef.current.set(runId, exec.status)
+      if (exec.status === 'running') continue
+      trackedRunsRef.current.delete(runId)
+      const note = runCompletionToast(exec, nodes)
+      if (note.kind === 'success') {
+        toast.success(note.message)
+      } else if (note.kind === 'error') {
+        toast(note.message, 'error', {
+          duration: Number.POSITIVE_INFINITY,
+          actions: [
+            {
+              label: 'Retry',
+              onClick: (toastId) => {
+                toast.dismiss(toastId)
+                const latest = useAppStore.getState().workflowExecutions.get(runId) ?? exec
+                handleRetryRun(latest)
+              }
+            }
+          ]
+        })
+      }
+    }
+  }, [editingId, liveExecSignature, nodes, handleRetryRun])
 
   const handleRerunRun = useCallback(
     (run: WorkflowExecution) => {
@@ -445,9 +528,13 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
 
   const handleRun = useCallback(() => {
     const workflow = persistWorkflow()
-    if (!inline) handleClose()
-    startManualRun(workflow)
-  }, [persistWorkflow, inline, handleClose])
+    if (!inline) {
+      handleClose()
+      startManualRun(workflow)
+      return
+    }
+    beginEditorRun(workflow)
+  }, [persistWorkflow, inline, handleClose, beginEditorRun])
 
   const handleDelete = useCallback(() => {
     if (editingId) {
@@ -875,15 +962,43 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         </div>
 
         <div className="flex items-center gap-1 titlebar-no-drag">
-          <Tooltip label="Run workflow" position="bottom">
-            <button
-              onClick={handleRun}
-              aria-label="Run workflow"
-              className="text-gray-400 hover:text-white p-1.5 rounded-md hover:bg-white/[0.06] transition-colors"
-            >
-              <Play size={15} />
-            </button>
-          </Tooltip>
+          {runningRun || launchingSince !== null ? (
+            <div className="flex items-center gap-0.5">
+              <span className="flex items-center gap-1.5 px-1.5 text-gray-300">
+                <Loader2 size={13} className="animate-spin" />
+                <span className="text-[11px] font-mono tabular-nums">
+                  {(() => {
+                    const startMs = runningRun
+                      ? Date.parse(runningRun.startedAt)
+                      : (launchingSince ?? nowTick)
+                    const total = Math.max(0, Math.floor((nowTick - startMs) / 1000))
+                    return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`
+                  })()}
+                </span>
+              </span>
+              <Tooltip label="Stop run" position="bottom">
+                <button
+                  onClick={() => runningRun && void stopWorkflowRun(runningRun.runId)}
+                  aria-label="Stop run"
+                  disabled={!runningRun}
+                  className="text-gray-400 hover:text-danger p-1.5 rounded-md hover:bg-white/[0.06]
+                             transition-colors disabled:opacity-50"
+                >
+                  <Square size={13} />
+                </button>
+              </Tooltip>
+            </div>
+          ) : (
+            <Tooltip label="Run workflow" position="bottom">
+              <button
+                onClick={handleRun}
+                aria-label="Run workflow"
+                className="text-gray-400 hover:text-white p-1.5 rounded-md hover:bg-white/[0.06] transition-colors"
+              >
+                <Play size={15} />
+              </button>
+            </Tooltip>
+          )}
 
           {editingId && (
             <Tooltip
@@ -1004,11 +1119,15 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             executions={executionHistory}
             nodes={nodes}
             tasks={tasks}
-            onClose={() => setShowRunHistory(false)}
+            onClose={() => {
+              setShowRunHistory(false)
+              setFollowRunId(null)
+            }}
             onClickTask={handleClickTask}
             onResumeSession={handleResumeSession}
             onRetryRun={handleRetryRun}
             onRerunRun={handleRerunRun}
+            followRunId={followRunId}
           />
         )}
 

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -376,6 +376,11 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setSelectedNodeId(null)
       setPendingInsert(null)
       setShowRunHistory(false)
+      // Run feedback belongs to the workflow that launched it.
+      setFollowRunId(null)
+      setLaunchingSince(null)
+      followArmRef.current = false
+      trackedRunsRef.current.clear()
     }
   }, [existingWorkflow, editingId, isActive])
 
@@ -468,6 +473,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const handleRetryRun = useCallback(
     (run: WorkflowExecution) => {
       const workflow = persistWorkflow()
+      // A stale toast or row must never replay another workflow's run here.
+      if (run.workflowId !== workflow.id) return
       retryRunFromFailure(workflow, run).catch((err) =>
         toast.error(err instanceof Error ? err.message : String(err))
       )

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -1106,6 +1106,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           onConnectEdge={handleConnectEdge}
           onPositionsCommit={handlePositionsCommit}
           onDeleteNode={handleDeleteNode}
+          onRunToStep={handleRunToStep}
           onTidyUp={handleTidyUp}
           selectedNodeId={selectedNodeId}
           nodeStatus={nodeStatus}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -25,6 +25,8 @@ import {
   WorkflowNode,
   WorkflowNodeErrorPolicy,
   WorkflowEdge,
+  NodeExecutionStatus,
+  WorkflowExecution,
   TriggerConfig,
   AiAgentType,
   CallConnectorActionConfig,
@@ -59,6 +61,13 @@ import {
   getWorktreeMode
 } from '../../lib/workflow-helpers'
 import { startManualRun } from '../../lib/workflow-menu-items'
+import {
+  buildStepOutputsMap,
+  executeWorkflow,
+  retryRunFromFailure,
+  rerunWorkflowRun
+} from '../../lib/workflow-execution'
+import { loopBodyMembers } from '../../lib/workflow-canvas-layout'
 import { toast } from '../Toast'
 import {
   slugify,
@@ -196,11 +205,27 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     [connectionActions]
   )
 
+  // The freshest run, live or finished, feeds values into the {} picker.
+  const latestRun = useMemo(() => {
+    const sorted = [...executionHistory].sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+    return sorted[0]
+  }, [executionHistory])
+
+  const lastRunData = useMemo(() => {
+    if (!latestRun) return undefined
+    const nodeMap = new Map(nodes.map((n) => [n.id, n]))
+    const states: Record<string, { status: NodeExecutionStatus; completedAt?: string }> = {}
+    for (const ns of latestRun.nodeStates) {
+      states[ns.nodeId] = { status: ns.status, completedAt: ns.completedAt }
+    }
+    return { outputs: buildStepOutputsMap(latestRun, nodeMap), states }
+  }, [latestRun, nodes])
+
   const stepGroups = useMemo(() => {
     if (!selectedNodeId) return []
     const ancestors = getAncestorNodes(nodes, edges, selectedNodeId)
-    return buildStepGroups(ancestors, lookupAction)
-  }, [nodes, edges, selectedNodeId, lookupAction])
+    return buildStepGroups(ancestors, lookupAction, lastRunData)
+  }, [nodes, edges, selectedNodeId, lookupAction, lastRunData])
 
   // Load execution history from database
   useEffect(() => {
@@ -374,6 +399,46 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     inline,
     setEditingId
   ])
+
+  const handleRunToStep = useCallback(
+    (nodeId: string) => {
+      const workflow = persistWorkflow()
+      setShowRunHistory(false)
+      executeWorkflow(workflow, undefined, { source: 'manual', targetNodeId: nodeId }).catch(
+        (err) => toast.error(err instanceof Error ? err.message : String(err))
+      )
+    },
+    [persistWorkflow]
+  )
+
+  const handleRetryRun = useCallback(
+    (run: WorkflowExecution) => {
+      const workflow = persistWorkflow()
+      retryRunFromFailure(workflow, run).catch((err) =>
+        toast.error(err instanceof Error ? err.message : String(err))
+      )
+    },
+    [persistWorkflow]
+  )
+
+  const handleRerunRun = useCallback(
+    (run: WorkflowExecution) => {
+      const workflow = persistWorkflow()
+      rerunWorkflowRun(workflow, run).catch((err) =>
+        toast.error(err instanceof Error ? err.message : String(err))
+      )
+    },
+    [persistWorkflow]
+  )
+
+  // Loop bodies are driven by their loop, so a body step cannot be a run target.
+  const runToStepEligible = useMemo(() => {
+    const body = loopBodyMembers(nodes)
+    return (nodeId: string): boolean => {
+      const node = nodes.find((n) => n.id === nodeId)
+      return !!node && node.type !== 'trigger' && !body.has(nodeId)
+    }
+  }, [nodes])
 
   const handleSave = useCallback(() => {
     persistWorkflow()
@@ -945,6 +1010,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             onClose={() => setShowRunHistory(false)}
             onClickTask={handleClickTask}
             onResumeSession={handleResumeSession}
+            onRetryRun={handleRetryRun}
+            onRerunRun={handleRerunRun}
           />
         )}
 
@@ -961,6 +1028,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             isContextualTrigger={isContextualTrigger}
             inputVars={inputVars}
             stepGroups={stepGroups}
+            onRunToStep={runToStepEligible(selectedNode.id) ? handleRunToStep : undefined}
           />
         )}
 

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -124,6 +124,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     import('../../../shared/types').WorkflowExecution[]
   >([])
   const loadedRunsForId = useRef<string | null>(null)
+  const loadedEditorIdRef = useRef<string | null | undefined>(undefined)
 
   const selectedNode = useMemo(
     () => nodes.find((n) => n.id === selectedNodeId) || null,
@@ -369,9 +370,13 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setEnabled(true)
       setStaggerDelayMs(undefined)
     }
-    setSelectedNodeId(null)
-    setPendingInsert(null)
-    setShowRunHistory(false)
+    // Saving hands back a new workflow object; only an actual switch resets the panels.
+    if (loadedEditorIdRef.current !== editingId) {
+      loadedEditorIdRef.current = editingId
+      setSelectedNodeId(null)
+      setPendingInsert(null)
+      setShowRunHistory(false)
+    }
   }, [existingWorkflow, editingId, isActive])
 
   useEffect(() => {

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -331,6 +331,21 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     return () => clearTimeout(timer)
   }, [launchingSince])
 
+  // A dismissed run prompt must also drop the arm, or the next background run
+  // of this workflow would be adopted and toasted as editor-launched.
+  const promptOpenFor = useAppStore((s) => s.pendingWorkflowRun?.workflowId ?? null)
+  const prevPromptRef = useRef<string | null>(null)
+  useEffect(() => {
+    const prev = prevPromptRef.current
+    prevPromptRef.current = promptOpenFor
+    if (!editingId || prev !== editingId || promptOpenFor !== null) return
+    // A confirm launches within moments; a cancel never does.
+    const timer = setTimeout(() => {
+      followArmRef.current = false
+    }, 2000)
+    return () => clearTimeout(timer)
+  }, [promptOpenFor, editingId])
+
   // Load existing workflow when editing (with slug migration)
   useEffect(() => {
     if (existingWorkflow) {

--- a/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeShell.tsx
@@ -58,10 +58,16 @@ export function NodeShell({
         onClick()
       }}
       className={`relative px-3 py-2.5 rounded-md border w-[280px] transition-all cursor-pointer
-                  ${selected ? NODE_SELECTED : NODE_UNSELECTED}
+                  ${selected ? NODE_SELECTED : executionStatus === 'error' ? 'border-danger/60' : NODE_UNSELECTED}
                   ${dashed ? 'border-dashed' : ''}
                   bg-surface-node hover:bg-white/[0.02]`}
     >
+      {executionStatus === 'running' && (
+        <span
+          aria-hidden
+          className="absolute inset-0 rounded-md border border-white/[0.35] animate-pulse pointer-events-none"
+        />
+      )}
       {executionStatus && WORKFLOW_STATUS_DOT_PULSE[executionStatus] && (
         <span
           className={`absolute top-2 right-2 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT_PULSE[executionStatus]}`}

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -147,12 +147,6 @@ export function NodeConfigPanel({
       </div>
 
       <div className="flex-1 overflow-y-auto p-5 space-y-5">
-        {node.slug && node.type !== 'trigger' && (
-          <p className="text-[10px] text-gray-600 font-mono -mt-2 mb-3">
-            Ref: {`{{steps.${node.slug}.output}}`}
-          </p>
-        )}
-
         {node.type === 'trigger' && (
           <TriggerConfigForm
             config={node.config as TriggerConfig}

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { X, MoreHorizontal, Trash2 } from 'lucide-react'
+import { X, MoreHorizontal, Trash2, StepForward } from 'lucide-react'
 import {
   WorkflowNode,
   LoopConfig,
@@ -38,10 +38,13 @@ interface Props {
   /** Autocomplete entries for the workflow's declared manual-run inputs. */
   inputVars?: TemplateVariable[]
   stepGroups?: StepVariableGroup[]
+  /** Run only this step and its upstream slice; absent when the step is not a valid target. */
+  onRunToStep?: (nodeId: string) => void
 }
 
 export function NodeConfigPanel({
   node,
+  onRunToStep,
   allNodes,
   onChange,
   onLabelChange,
@@ -252,6 +255,20 @@ export function NodeConfigPanel({
           </div>
         )}
       </div>
+
+      {onRunToStep && (
+        <div className="shrink-0 border-t border-white/[0.08] p-3">
+          <button
+            onClick={() => onRunToStep(node.id)}
+            className="w-full flex items-center justify-center gap-2 border border-white/[0.12] rounded-md
+                       px-3 py-1.5 text-[12px] text-gray-300 hover:text-white hover:border-white/[0.2]
+                       transition-colors"
+          >
+            <StepForward size={12} strokeWidth={2} />
+            Run to this step
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
@@ -16,6 +16,8 @@ interface Props {
   tasks?: TaskConfig[]
   onClose: () => void
   onClickTask?: (taskId: string) => void
+  onRetryRun?: (execution: WorkflowExecution) => void
+  onRerunRun?: (execution: WorkflowExecution) => void
   onResumeSession?: (
     agentSessionId: string,
     agentType: AiAgentType,
@@ -32,6 +34,8 @@ export function RunHistoryPanel({
   tasks,
   onClose,
   onClickTask,
+  onRetryRun,
+  onRerunRun,
   onResumeSession
 }: Props) {
   const [fullOutputLogs, setFullOutputLogs] = useState<string | null>(null)
@@ -61,6 +65,8 @@ export function RunHistoryPanel({
                 tasks={tasks}
                 onViewFullOutput={setFullOutputLogs}
                 onClickTask={onClickTask}
+                onRetryRun={onRetryRun}
+                onRerunRun={onRerunRun}
                 onResumeSession={onResumeSession}
               />
             ))

--- a/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/RunHistoryPanel.tsx
@@ -18,6 +18,8 @@ interface Props {
   onClickTask?: (taskId: string) => void
   onRetryRun?: (execution: WorkflowExecution) => void
   onRerunRun?: (execution: WorkflowExecution) => void
+  /** Run to keep expanded and following its live steps; set by editor launches. */
+  followRunId?: string | null
   onResumeSession?: (
     agentSessionId: string,
     agentType: AiAgentType,
@@ -36,7 +38,8 @@ export function RunHistoryPanel({
   onClickTask,
   onRetryRun,
   onRerunRun,
-  onResumeSession
+  onResumeSession,
+  followRunId
 }: Props) {
   const [fullOutputLogs, setFullOutputLogs] = useState<string | null>(null)
 
@@ -68,6 +71,7 @@ export function RunHistoryPanel({
                 onRetryRun={onRetryRun}
                 onRerunRun={onRerunRun}
                 onResumeSession={onResumeSession}
+                follow={workflowRunId(exec) === followRunId}
               />
             ))
           )}

--- a/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
+++ b/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
@@ -9,6 +9,12 @@ import {
 } from 'react'
 import { Braces, ChevronDown, ChevronRight } from 'lucide-react'
 import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
+import { previewStepTokens } from '../../../lib/template-vars'
+import { NODE_TYPE_ICON } from '../node-visuals'
+import { WORKFLOW_STATUS_DOT } from '../../../lib/workflow-status'
+import { ConnectorIcon } from '../../ConnectorIcon'
+import { useConnectorIdFor, useConnectionIconFor } from '../../../lib/use-connections'
+import type { WorkflowNode } from '../../../../shared/types'
 
 interface Props {
   value: string
@@ -52,6 +58,33 @@ interface DropdownItem {
   description: string
   pattern: string
   disabled?: boolean
+  value?: string
+}
+
+/** The step's own glyph — its connector's brand mark when it has one. */
+function StepGroupIcon({ group }: { group: StepVariableGroup }) {
+  const connectorId = useConnectorIdFor(group.connectionId ?? null)
+  const icon = useConnectionIconFor(group.connectionId ?? null)
+  if (connectorId) {
+    return (
+      <ConnectorIcon
+        connectorId={connectorId}
+        icon={icon}
+        size={12}
+        className="text-ink-secondary shrink-0"
+      />
+    )
+  }
+  const Icon = NODE_TYPE_ICON[group.nodeType as WorkflowNode['type']]
+  return Icon ? <Icon size={12} className="text-ink-secondary shrink-0" strokeWidth={2} /> : null
+}
+
+function ranAtLabel(iso: string | undefined): string | undefined {
+  if (!iso) return undefined
+  const date = new Date(iso)
+  return isNaN(date.getTime())
+    ? undefined
+    : date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
 }
 
 export function VariableAutocomplete({
@@ -84,7 +117,8 @@ export function VariableAutocomplete({
           label: k.label,
           description: k.description,
           pattern: `{{steps.${group.slug}.${k.key}}}`,
-          disabled: group.disabled
+          disabled: group.disabled,
+          value: k.value
         })
       }
     }
@@ -261,6 +295,13 @@ export function VariableAutocomplete({
 
   const hasVariables = allItems.length > 0
 
+  const groupsBySlug = useMemo(() => new Map(stepGroups.map((g) => [g.slug, g])), [stepGroups])
+
+  const preview = useMemo(
+    () => (value.includes('{{') ? previewStepTokens(value, stepGroups) : undefined),
+    [value, stepGroups]
+  )
+
   return (
     <div className="relative">
       <div className="relative">
@@ -300,6 +341,18 @@ export function VariableAutocomplete({
         )}
       </div>
 
+      {preview?.broken && (
+        <p className="text-[10.5px] font-mono text-danger/90 mt-1 truncate">
+          {preview.broken.token} not found
+          {preview.broken.suggestion ? ` — did you mean ${preview.broken.suggestion}?` : ''}
+        </p>
+      )}
+      {preview?.resolved && (
+        <p className="text-[10.5px] font-mono text-ink-faint mt-1 truncate">
+          → {preview.resolved.replace(/\s+/g, ' ').slice(0, 160)}
+        </p>
+      )}
+
       {showDropdown && hasVariables && (
         <div
           ref={dropdownRef}
@@ -332,22 +385,49 @@ export function VariableAutocomplete({
               const isCollapsed = collapsedGroups.has(group.id)
               const Chevron = isCollapsed ? ChevronRight : ChevronDown
 
+              const stepGroup = groupsBySlug.get(group.id)
+              const ranAt = ranAtLabel(stepGroup?.runCompletedAt)
+
               return (
                 <div key={group.id}>
-                  <button
-                    onClick={() => toggleGroup(group.id)}
-                    className={`w-full flex items-center gap-1.5 px-2.5 py-1.5 text-[10px] font-semibold
-                               uppercase tracking-wider transition-colors
-                               ${group.disabled ? 'text-gray-600' : 'text-gray-500 hover:text-gray-400 hover:bg-white/[0.03]'}`}
-                  >
-                    <Chevron size={11} />
-                    {group.name}
-                    {group.disabled && (
-                      <span className="text-[9px] font-normal normal-case tracking-normal text-gray-600 ml-1">
-                        (no output)
+                  {stepGroup ? (
+                    <button
+                      onClick={() => toggleGroup(group.id)}
+                      className="w-full flex items-center gap-2 px-2.5 py-1.5 transition-colors
+                                 text-gray-400 hover:text-gray-300 hover:bg-white/[0.03]"
+                    >
+                      <Chevron size={11} className="shrink-0" />
+                      <StepGroupIcon group={stepGroup} />
+                      <span className="text-[11.5px] font-semibold text-ink-secondary truncate">
+                        {group.name}
                       </span>
-                    )}
-                  </button>
+                      {stepGroup.runStatus && WORKFLOW_STATUS_DOT[stepGroup.runStatus] && (
+                        <span
+                          className={`shrink-0 w-1.5 h-1.5 rounded-full ${WORKFLOW_STATUS_DOT[stepGroup.runStatus]}`}
+                        />
+                      )}
+                      {ranAt && (
+                        <span className="ml-auto text-[9.5px] font-mono text-gray-600 shrink-0">
+                          {ranAt}
+                        </span>
+                      )}
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => toggleGroup(group.id)}
+                      className={`w-full flex items-center gap-1.5 px-2.5 py-1.5 text-[10px] font-semibold
+                                 uppercase tracking-wider transition-colors
+                                 ${group.disabled ? 'text-gray-600' : 'text-gray-500 hover:text-gray-400 hover:bg-white/[0.03]'}`}
+                    >
+                      <Chevron size={11} />
+                      {group.name}
+                      {group.disabled && (
+                        <span className="text-[9px] font-normal normal-case tracking-normal text-gray-600 ml-1">
+                          (no output)
+                        </span>
+                      )}
+                    </button>
+                  )}
 
                   {!isCollapsed &&
                     group.items.map((item) => {
@@ -366,10 +446,16 @@ export function VariableAutocomplete({
                           <span className="text-[12px] text-ink-secondary font-mono min-w-[50px]">
                             {item.key === item.pattern ? item.label : item.key}
                           </span>
-                          {item.description && (
-                            <span className="text-[11px] text-gray-600 truncate">
-                              {item.description}
+                          {item.value ? (
+                            <span className="ml-auto text-[10.5px] font-mono text-gray-500 truncate max-w-[45%]">
+                              {item.value}
                             </span>
+                          ) : (
+                            item.description && (
+                              <span className="text-[11px] text-gray-600 truncate">
+                                {item.description}
+                              </span>
+                            )
                           )}
                         </button>
                       )

--- a/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
+++ b/src/renderer/components/workflow-editor/panels/VariableAutocomplete.tsx
@@ -436,7 +436,7 @@ export function VariableAutocomplete({
 
                       return (
                         <button
-                          key={item.pattern}
+                          key={`${item.groupId}:${item.key}`}
                           onClick={() => !item.disabled && insertPattern(item.pattern)}
                           disabled={item.disabled}
                           className={`w-full flex items-center gap-2 px-3 pl-6 py-1.5 text-left transition-colors

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -105,6 +105,11 @@ export function RunDetailPane({
           <span className="text-[10px] px-1.5 py-0.5 rounded border border-white/[0.08] text-gray-400 shrink-0">
             {presentation.sourceLabel}
           </span>
+          {run.partial && (
+            <span className="text-[9px] font-mono uppercase tracking-wider text-gray-500 border border-white/[0.08] rounded px-1 shrink-0">
+              partial
+            </span>
+          )}
           <span className="flex-1" />
           {run.status === 'error' && fullWorkflow && (
             <button

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react'
-import { Check, X, Inbox } from 'lucide-react'
+import { useAppStore } from '../../stores'
+import { toast } from '../Toast'
+import { Check, X, Inbox, Play, RotateCcw } from 'lucide-react'
 import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import {
   completedStageCount,
@@ -10,7 +12,12 @@ import {
   runSummaryText,
   type RunWorkflowRef
 } from '../../lib/run-presentation'
-import { approveWorkflowGate, rejectWorkflowGate } from '../../lib/workflow-execution'
+import {
+  approveWorkflowGate,
+  rejectWorkflowGate,
+  retryRunFromFailure,
+  rerunWorkflowRun
+} from '../../lib/workflow-execution'
 import { RunStepsList, StatusDot } from '../workflow-editor/RunEntry'
 import { RunIcon } from './RunIcon'
 import { StopRunButton } from './StopRunButton'
@@ -51,6 +58,11 @@ export function RunDetailPane({
 }: Props) {
   const nodes = workflow?.nodes ?? []
   const workflowName = workflow?.name?.trim() || undefined
+  // Retry and re-run need the full definition, not the render-only ref.
+  const fullWorkflow = useAppStore((s) => s.config?.workflows?.find((w) => w.id === run.workflowId))
+  const onLaunchError = (err: unknown): void => {
+    toast.error(err instanceof Error ? err.message : String(err))
+  }
   const presentation = describeRun(run, workflow)
   const outcome = describeOutcome(run, nodes)
   const stages = runStages(run, nodes)
@@ -94,6 +106,26 @@ export function RunDetailPane({
             {presentation.sourceLabel}
           </span>
           <span className="flex-1" />
+          {run.status === 'error' && fullWorkflow && (
+            <button
+              aria-label="Retry from failed step"
+              title="Retry from failed step"
+              onClick={() => retryRunFromFailure(fullWorkflow, run).catch(onLaunchError)}
+              className="p-1 rounded text-gray-500 hover:text-white transition-colors shrink-0"
+            >
+              <RotateCcw size={13} strokeWidth={2} />
+            </button>
+          )}
+          {run.status !== 'running' && fullWorkflow && (
+            <button
+              aria-label="Run again"
+              title="Run again"
+              onClick={() => rerunWorkflowRun(fullWorkflow, run).catch(onLaunchError)}
+              className="p-1 rounded text-gray-500 hover:text-white transition-colors shrink-0"
+            >
+              <Play size={13} strokeWidth={2} />
+            </button>
+          )}
           <StopRunButton execution={run} stopPropagation={false} />
         </div>
         <p className="mt-1.5 flex items-center gap-1.5 text-[11px] text-gray-500 font-mono truncate">

--- a/src/renderer/components/workflow-runs/RunListRow.tsx
+++ b/src/renderer/components/workflow-runs/RunListRow.tsx
@@ -81,6 +81,11 @@ function RunListRowImpl({
         >
           {presentation.title}
         </span>
+        {run.partial && (
+          <span className="text-[9px] font-mono uppercase tracking-wider text-gray-500 border border-white/[0.08] rounded px-1 shrink-0">
+            partial
+          </span>
+        )}
         {workflowDeleted && (
           <span className="text-[10px] uppercase tracking-wide text-gray-600 shrink-0">
             deleted

--- a/src/renderer/lib/run-presentation.ts
+++ b/src/renderer/lib/run-presentation.ts
@@ -9,6 +9,38 @@ import type {
 } from '../../shared/types'
 import { WORKFLOW_STATUS_DOT, type WorkflowStatusKey, type RunOutcomeTone } from './workflow-status'
 import type { RunBucket } from '../stores/types'
+import { formatRunDuration } from './format-time'
+
+/** What the editor toasts when a run it launched reaches a terminal state. */
+export function runCompletionToast(
+  execution: WorkflowExecution,
+  nodes: WorkflowNode[]
+): { kind: 'success' | 'error' | 'quiet'; message: string; failedNodeId?: string } {
+  const triggerIds = new Set(nodes.filter((n) => n.type === 'trigger').map((n) => n.id))
+  if (execution.status === 'success') {
+    const steps = execution.nodeStates.filter(
+      (ns) => ns.status === 'success' && !triggerIds.has(ns.nodeId)
+    ).length
+    const duration = formatRunDuration(execution.startedAt, execution.completedAt)
+    return {
+      kind: 'success',
+      message: `Run finished — ${steps} step${steps === 1 ? '' : 's'} in ${duration}`
+    }
+  }
+  if (execution.status === 'error') {
+    // The true failure is the errored step that was not skipped by another one.
+    const failed = execution.nodeStates.find(
+      (ns) => ns.status === 'error' && !ns.error?.startsWith('Skipped:')
+    )
+    const failedNode = failed ? nodes.find((n) => n.id === failed.nodeId) : undefined
+    return {
+      kind: 'error',
+      message: failedNode ? `Run failed at "${failedNode.label}"` : 'Run failed',
+      failedNodeId: failedNode?.id
+    }
+  }
+  return { kind: 'quiet', message: '' }
+}
 
 /**
  * Which filter bucket a run belongs to. A paused run is `waiting` rather than

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -7,7 +7,8 @@ import {
   CallConnectorActionConfig,
   LaunchAgentConfig,
   ConnectorActionDef,
-  WorkflowInputDef
+  WorkflowInputDef,
+  NodeExecutionStatus
 } from '../../shared/types'
 import { schemaProperties, schemaTypeHint } from '../../shared/json-schema-utils'
 
@@ -53,7 +54,20 @@ export interface StepVariableGroup {
   slug: string
   nodeType: string
   disabled?: boolean
-  keys: { key: string; label: string; description: string }[]
+  keys: { key: string; label: string; description: string; value?: string }[]
+  /** The connection behind a connector step, so the picker can show its brand mark. */
+  connectionId?: string
+  /** How this step ended in the run whose values the picker shows. */
+  runStatus?: NodeExecutionStatus
+  runCompletedAt?: string
+  /** The step's raw last-run output object, for resolved previews. */
+  runOutputs?: Record<string, unknown>
+}
+
+/** What buildStepGroups reads from the workflow's most recent run. */
+export interface LastRunData {
+  outputs: StepOutputs
+  states: Record<string, { status: NodeExecutionStatus; completedAt?: string }>
 }
 
 // --- Template Variable Types ---
@@ -204,9 +218,26 @@ function schemaTopLevelKeys(
   })
 }
 
+/** Compact single-line rendering of a run value for the picker's value column. */
+export function formatRunValue(val: unknown): string {
+  if (val === undefined) return ''
+  if (typeof val === 'string') {
+    const flat = val.replace(/\s+/g, ' ').trim()
+    const clipped = flat.length > 60 ? `${flat.slice(0, 60)}…` : flat
+    return JSON.stringify(clipped)
+  }
+  try {
+    const text = JSON.stringify(val) ?? String(val)
+    return text.length > 60 ? `${text.slice(0, 60)}…` : text
+  } catch {
+    return String(val)
+  }
+}
+
 export function buildStepGroups(
   ancestorNodes: WorkflowNode[],
-  lookupAction?: ConnectorActionLookup
+  lookupAction?: ConnectorActionLookup,
+  lastRun?: LastRunData
 ): StepVariableGroup[] {
   return ancestorNodes
     .filter((n) => n.slug)
@@ -237,14 +268,104 @@ export function buildStepGroups(
           keys = [...schemaKeys, ...defaultKeys]
         }
       }
+      const runOutputs = lastRun?.outputs[n.slug!]
+      const runState = lastRun?.states[n.id]
+      if (runOutputs) {
+        keys = keys.map((k) => ({ ...k, value: formatRunValue(runOutputs[k.key]) || undefined }))
+      }
+      const cfg = n.config as { connectionId?: string } | undefined
       return {
         nodeId: n.id,
         label: n.label,
         slug: n.slug!,
         nodeType: n.type,
-        keys
+        keys,
+        connectionId: n.type === 'callConnectorAction' ? cfg?.connectionId : undefined,
+        runStatus: runState?.status,
+        runCompletedAt: runState?.completedAt,
+        runOutputs
       }
     })
+}
+
+// --- Template Preview ---
+
+export interface TemplatePreview {
+  /** The template with every steps.* token resolved, when data allows it. */
+  resolved?: string
+  /** The first steps.* token that resolves nowhere, with the closest real path. */
+  broken?: { token: string; suggestion?: string }
+}
+
+function editDistance(a: string, b: string): number {
+  const rows = Array.from({ length: a.length + 1 }, (_, i) => [i, ...Array(b.length).fill(0)])
+  for (let j = 1; j <= b.length; j++) rows[0][j] = j
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      rows[i][j] = Math.min(
+        rows[i - 1][j] + 1,
+        rows[i][j - 1] + 1,
+        rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      )
+    }
+  }
+  return rows[a.length][b.length]
+}
+
+export function suggestNearestPath(path: string, candidates: string[]): string | undefined {
+  let best: string | undefined
+  let bestScore = Infinity
+  for (const candidate of candidates) {
+    const score = editDistance(path, candidate)
+    if (score < bestScore) {
+      bestScore = score
+      best = candidate
+    }
+  }
+  return bestScore <= Math.max(3, Math.floor(path.length / 3)) ? best : undefined
+}
+
+/**
+ * Preview a template's steps.* tokens against the picker's own groups: known
+ * paths resolve to their last-run text, unknown ones come back as broken.
+ */
+export function previewStepTokens(template: string, groups: StepVariableGroup[]): TemplatePreview {
+  const tokens = [...template.matchAll(/\{\{\s*steps\.([\w.]+)\s*\}\}/g)]
+  if (tokens.length === 0) return {}
+
+  const bySlug = new Map(groups.map((g) => [g.slug, g]))
+  const knownPaths = groups.flatMap((g) => g.keys.map((k) => `steps.${g.slug}.${k.key}`))
+
+  let broken: TemplatePreview['broken']
+  let anyData = false
+  const resolved = template.replace(
+    /\{\{\s*steps\.([\w.]+)\s*\}\}/g,
+    (match, path: string): string => {
+      const [slug, ...rest] = path.split('.')
+      const group = bySlug.get(slug)
+      if (!group || rest.length === 0) {
+        broken ??= {
+          token: `steps.${path}`,
+          suggestion: suggestNearestPath(`steps.${path}`, knownPaths)
+        }
+        return match
+      }
+      if (!group.runOutputs) return match
+      const value = walkPath(group.runOutputs, rest)
+      if (value === undefined) {
+        broken ??= {
+          token: `steps.${path}`,
+          suggestion: suggestNearestPath(`steps.${path}`, knownPaths)
+        }
+        return match
+      }
+      anyData = true
+      return stringifyResolved(value)
+    }
+  )
+
+  if (broken) return { broken }
+  return anyData ? { resolved } : {}
 }
 
 // --- Template Variable Resolution ---

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -324,6 +324,7 @@ export function suggestNearestPath(path: string, candidates: string[]): string |
   let best: string | undefined
   let bestScore = Infinity
   for (const candidate of candidates) {
+    if (candidate === path) continue
     const score = editDistance(path, candidate)
     if (score < bestScore) {
       bestScore = score
@@ -343,6 +344,7 @@ export function previewStepTokens(template: string, groups: StepVariableGroup[])
 
   const bySlug = new Map(groups.map((g) => [g.slug, g]))
   const knownPaths = groups.flatMap((g) => g.keys.map((k) => `steps.${g.slug}.${k.key}`))
+  const knownSet = new Set(knownPaths)
 
   let broken: TemplatePreview['broken']
   let anyData = false
@@ -351,6 +353,8 @@ export function previewStepTokens(template: string, groups: StepVariableGroup[])
     (match, path: string): string => {
       const [slug, ...rest] = path.split('.')
       const group = bySlug.get(slug)
+      // A declared path is never broken; without run data it just shows nothing.
+      const declared = rest.length > 0 && knownSet.has(`steps.${slug}.${rest[0]}`)
       if (!group || rest.length === 0) {
         broken ??= {
           token: `steps.${path}`,
@@ -361,9 +365,11 @@ export function previewStepTokens(template: string, groups: StepVariableGroup[])
       if (!group.runOutputs) return match
       const value = walkPath(group.runOutputs, rest)
       if (value === undefined) {
-        broken ??= {
-          token: `steps.${path}`,
-          suggestion: suggestNearestPath(`steps.${path}`, knownPaths)
+        if (!declared) {
+          broken ??= {
+            token: `steps.${path}`,
+            suggestion: suggestNearestPath(`steps.${path}`, knownPaths)
+          }
         }
         return match
       }

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -353,8 +353,6 @@ export function previewStepTokens(template: string, groups: StepVariableGroup[])
     (match, path: string): string => {
       const [slug, ...rest] = path.split('.')
       const group = bySlug.get(slug)
-      // A declared path is never broken; without run data it just shows nothing.
-      const declared = rest.length > 0 && knownSet.has(`steps.${slug}.${rest[0]}`)
       if (!group || rest.length === 0) {
         broken ??= {
           token: `steps.${path}`,
@@ -365,7 +363,13 @@ export function previewStepTokens(template: string, groups: StepVariableGroup[])
       if (!group.runOutputs) return match
       const value = walkPath(group.runOutputs, rest)
       if (value === undefined) {
-        if (!declared) {
+        // Trusted while unverifiable: the exact token is declared, or its key
+        // is declared and this run did not emit it. A deeper walk failing on
+        // an emitted key is a real mistake and gets flagged.
+        const exactKnown = knownSet.has(`steps.${path}`)
+        const keyDeclared = knownSet.has(`steps.${slug}.${rest[0]}`)
+        const keyEmitted = Object.prototype.hasOwnProperty.call(group.runOutputs, rest[0])
+        if (!exactKnown && !(keyDeclared && !keyEmitted)) {
           broken ??= {
             token: `steps.${path}`,
             suggestion: suggestNearestPath(`steps.${path}`, knownPaths)

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -271,7 +271,15 @@ export function buildStepGroups(
       const runOutputs = lastRun?.outputs[n.slug!]
       const runState = lastRun?.states[n.id]
       if (runOutputs) {
-        keys = keys.map((k) => ({ ...k, value: formatRunValue(runOutputs[k.key]) || undefined }))
+        // Fields the run actually produced count as known even without a schema.
+        const declared = new Set(keys.map((k) => k.key))
+        const discovered = Object.keys(runOutputs)
+          .filter((key) => !declared.has(key))
+          .map((key) => ({ key, label: key, description: 'From the last run' }))
+        keys = [...discovered, ...keys].map((k) => ({
+          ...k,
+          value: formatRunValue(runOutputs[k.key]) || undefined
+        }))
       }
       const cfg = n.config as { connectionId?: string } | undefined
       return {

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -63,6 +63,10 @@ export function estimateNodeHeight(node: WorkflowNode, allNodes: WorkflowNode[])
     // header + padding + body + line + add button + footer
     return 41 + 16 + bodyHeights + 18 + 22 + 40
   }
+  if (node.type === 'condition') {
+    const cfg = node.config as { variable?: string }
+    return cfg.variable ? 90 : 58
+  }
   return stepPreview(node) ? 90 : 58
 }
 
@@ -152,9 +156,10 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
       type: node.type === 'loop' ? 'loop' : 'step',
       position,
       data: { nodeId: node.id } satisfies CanvasNodeData,
-      // Explicit dimensions and handles let edges render without a DOM measure.
-      width,
-      height,
+      // Initial dimensions and handles anchor edges before (and without) a DOM
+      // measure; once mounted, measured card bounds take over.
+      initialWidth: width,
+      initialHeight: height,
       handles: [
         ...(node.type !== 'trigger'
           ? [{ type: 'target' as const, position: Position.Top, x: width / 2, y: 0 }]
@@ -220,8 +225,8 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
         afterNodeId: node.id,
         insideBranch: branchMembers.has(node.id)
       } satisfies AddStepNodeData,
-      width: 22,
-      height: 22,
+      initialWidth: 22,
+      initialHeight: 22,
       handles: [{ type: 'target' as const, position: Position.Top, x: 11, y: 0 }],
       draggable: false,
       selectable: false,

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -1486,15 +1486,13 @@ export async function executeWorkflow(
     workflowId: workflow.id,
     startedAt: new Date().toISOString(),
     status: 'running',
-    nodeStates: workflow.nodes.map((n) => ({
-      nodeId: n.id,
-      status:
-        n.type === 'trigger'
-          ? 'success'
-          : targetSlice && !targetSlice.has(n.id)
-            ? 'skipped'
-            : 'pending'
-    })),
+    nodeStates: workflow.nodes.map((n) => {
+      if (n.type === 'trigger') return { nodeId: n.id, status: 'success' as const }
+      if (targetSlice && !targetSlice.has(n.id)) {
+        return { nodeId: n.id, status: 'skipped' as const, skipReason: 'target' as const }
+      }
+      return { nodeId: n.id, status: 'pending' as const }
+    }),
     ...(targetSlice && { partial: true }),
     triggerTaskId: context?.task?.id,
     connectorItem: context?.connectorItem,
@@ -1528,6 +1526,33 @@ export function contextFromRun(run: WorkflowExecution): WorkflowExecutionContext
 }
 
 /**
+ * The node states a retry starts from: successes adopted, deliberate skips
+ * (condition branches, a partial run's slice) preserved, everything else —
+ * failures, gate rejections, loop bodies — reset to pending.
+ */
+export function seedRetryStates(
+  workflow: WorkflowDefinition,
+  failedRun: WorkflowExecution
+): NodeExecutionState[] {
+  const priorById = new Map(failedRun.nodeStates.map((ns) => [ns.nodeId, ns]))
+  // Body steps chain by real edges but are driven only by their loop; adopting
+  // one as completed would let the wave loop race its successor with the loop.
+  const bodyIds = new Set<string>()
+  for (const n of workflow.nodes) {
+    if (n.type !== 'loop') continue
+    for (const id of (n.config as LoopConfig).bodyNodeIds ?? []) bodyIds.add(id)
+  }
+  return workflow.nodes.map((n) => {
+    const prior = priorById.get(n.id)
+    if (n.type === 'trigger') return { nodeId: n.id, status: 'success' }
+    if (bodyIds.has(n.id)) return { nodeId: n.id, status: 'pending' }
+    if (prior?.status === 'success') return { ...prior }
+    if (prior?.status === 'skipped' && prior.skipReason) return { ...prior }
+    return { nodeId: n.id, status: 'pending' }
+  })
+}
+
+/**
  * Resume a failed run as a new one: completed steps keep their recorded
  * outputs and are never re-executed; scheduling restarts at the failure.
  */
@@ -1544,20 +1569,12 @@ export async function retryRunFromFailure(
     throw new Error(`A retry of this run is already in flight`)
   }
 
-  const priorById = new Map(failedRun.nodeStates.map((ns) => [ns.nodeId, ns]))
   const execution: WorkflowExecution = {
     runId: claim.runId,
     workflowId: workflow.id,
     startedAt: new Date().toISOString(),
     status: 'running',
-    nodeStates: workflow.nodes.map((n) => {
-      const prior = priorById.get(n.id)
-      if (n.type === 'trigger') return { nodeId: n.id, status: 'success' }
-      if (prior?.status === 'success') return { ...prior }
-      // Condition skips carry no error; failure skips do and must re-run.
-      if (prior?.status === 'skipped' && !prior.error) return { ...prior }
-      return { nodeId: n.id, status: 'pending' }
-    }),
+    nodeStates: seedRetryStates(workflow, failedRun),
     partial: failedRun.partial,
     retryOfRunId: failedRun.runId,
     triggerTaskId: failedRun.triggerTaskId,
@@ -1871,6 +1888,7 @@ async function runExecution(
               for (const skippedId of skippedByCondition) {
                 updateNodeState(execution, skippedId, {
                   status: 'skipped',
+                  skipReason: 'branch',
                   completedAt: new Date().toISOString()
                 })
               }

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -17,7 +17,12 @@ import {
   ConnectorItemContext,
   getProjectRemoteHostId
 } from '../../shared/types'
-import { resolveContextField, resolveTemplateVars, StepOutputs } from './template-vars'
+import {
+  getAncestorNodes,
+  resolveContextField,
+  resolveTemplateVars,
+  StepOutputs
+} from './template-vars'
 import { getWorktreeMode } from './workflow-helpers'
 import { buildTaskPrompt, buildWorkflowPrompt } from '../../shared/prompt-builder'
 import { extractStructuredOutput } from '../../shared/structured-output'
@@ -325,6 +330,8 @@ export function rescheduleWaitingGateTimers(
 
 export interface ExecuteWorkflowOptions {
   source?: 'scheduler' | 'manual'
+  /** Run only this node and its upstream slice; everything else is skipped. */
+  targetNodeId?: string
 }
 
 /**
@@ -450,7 +457,7 @@ function updateNodeState(
   }
 }
 
-function buildStepOutputsMap(
+export function buildStepOutputsMap(
   execution: WorkflowExecution,
   nodeMap: Map<string, WorkflowNode>
 ): StepOutputs {
@@ -1454,7 +1461,9 @@ export async function executeWorkflow(
 
   // Ask the core, not this window, whether we own this trigger. Every instance
   // hears the same scheduler tick; only the one granted the claim runs it.
-  const dedupeParams = dedupeFingerprint(context)
+  const dedupeParams = options?.targetNodeId
+    ? `${dedupeFingerprint(context)}:target:${options.targetNodeId}`
+    : dedupeFingerprint(context)
   const claim = await window.api.claimWorkflowRun({ workflowId: workflow.id, params: dedupeParams })
   if (!claim.granted) {
     console.warn(
@@ -1465,6 +1474,13 @@ export async function executeWorkflow(
     throw new Error(`Workflow "${workflow.name}" is already running for this trigger`)
   }
 
+  const targetSlice = options?.targetNodeId
+    ? new Set([
+        options.targetNodeId,
+        ...getAncestorNodes(workflow.nodes, workflow.edges, options.targetNodeId).map((n) => n.id)
+      ])
+    : null
+
   const execution: WorkflowExecution = {
     runId: claim.runId,
     workflowId: workflow.id,
@@ -1472,8 +1488,14 @@ export async function executeWorkflow(
     status: 'running',
     nodeStates: workflow.nodes.map((n) => ({
       nodeId: n.id,
-      status: n.type === 'trigger' ? 'success' : 'pending'
+      status:
+        n.type === 'trigger'
+          ? 'success'
+          : targetSlice && !targetSlice.has(n.id)
+            ? 'skipped'
+            : 'pending'
     })),
+    ...(targetSlice && { partial: true }),
     triggerTaskId: context?.task?.id,
     connectorItem: context?.connectorItem,
     connectorInboxId: context?.connectorItem?.inboxId,
@@ -1490,6 +1512,70 @@ export async function executeWorkflow(
   persistExecution(execution)
 
   return runExecution(workflow, execution, context, options)
+}
+
+/** Rebuild a run's launch context so a retry or re-run resolves the same templates. */
+export function contextFromRun(run: WorkflowExecution): WorkflowExecutionContext | undefined {
+  const task = run.triggerTaskId
+    ? useAppStore.getState().config?.tasks?.find((t) => t.id === run.triggerTaskId)
+    : undefined
+  // The inbox lease belongs to the original run; a re-run must not double-ack it.
+  const connectorItem = run.connectorItem
+    ? { ...run.connectorItem, inboxId: undefined, inboxLeaseToken: undefined }
+    : undefined
+  if (!task && !connectorItem && !run.inputs) return undefined
+  return { task, connectorItem, inputs: run.inputs }
+}
+
+/**
+ * Resume a failed run as a new one: completed steps keep their recorded
+ * outputs and are never re-executed; scheduling restarts at the failure.
+ */
+export async function retryRunFromFailure(
+  workflow: WorkflowDefinition,
+  failedRun: WorkflowExecution
+): Promise<WorkflowExecution> {
+  const context = contextFromRun(failedRun)
+  const params = `${failedRun.dedupeParams ?? 'manual'}:retry:${failedRun.runId}`
+  const claim = await window.api.claimWorkflowRun({ workflowId: workflow.id, params })
+  if (!claim.granted) {
+    const existing = useAppStore.getState().workflowExecutions.get(claim.runId)
+    if (existing) return existing
+    throw new Error(`A retry of this run is already in flight`)
+  }
+
+  const priorById = new Map(failedRun.nodeStates.map((ns) => [ns.nodeId, ns]))
+  const execution: WorkflowExecution = {
+    runId: claim.runId,
+    workflowId: workflow.id,
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    nodeStates: workflow.nodes.map((n) => {
+      const prior = priorById.get(n.id)
+      if (n.type === 'trigger') return { nodeId: n.id, status: 'success' }
+      if (prior?.status === 'success') return { ...prior }
+      // Condition skips carry no error; failure skips do and must re-run.
+      if (prior?.status === 'skipped' && !prior.error) return { ...prior }
+      return { nodeId: n.id, status: 'pending' }
+    }),
+    partial: failedRun.partial,
+    retryOfRunId: failedRun.runId,
+    triggerTaskId: failedRun.triggerTaskId,
+    connectorItem: context?.connectorItem,
+    dedupeParams: params,
+    inputs: failedRun.inputs
+  }
+
+  persistExecution(execution)
+  return runExecution(workflow, execution, context)
+}
+
+/** Start a fresh run with the same launch context as an earlier one. */
+export async function rerunWorkflowRun(
+  workflow: WorkflowDefinition,
+  run: WorkflowExecution
+): Promise<WorkflowExecution> {
+  return executeWorkflow(workflow, contextFromRun(run), { source: 'manual' })
 }
 
 /** Live runs of one workflow, newest first. */

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -39,12 +39,16 @@ export type WorkflowMenuContext = ManualRunContext
  * `executeWorkflow` itself stays unguarded because the scheduler, connector
  * triggers and missed-schedule recovery legitimately run without a user.
  */
-export function startManualRun(workflow: WorkflowDefinition, ctx?: ManualRunContext): void {
+export function startManualRun(
+  workflow: WorkflowDefinition,
+  ctx?: ManualRunContext,
+  options?: { targetNodeId?: string }
+): void {
   if (needsRunPrompt(workflow, ctx)) {
-    useAppStore.getState().setPendingWorkflowRun(workflow.id, ctx)
+    useAppStore.getState().setPendingWorkflowRun(workflow.id, ctx, options?.targetNodeId)
     return
   }
-  void executeWorkflow(workflow, ctx, { source: 'manual' })
+  void executeWorkflow(workflow, ctx, { source: 'manual', targetNodeId: options?.targetNodeId })
 }
 
 export function buildWorkflowMenuItems(

--- a/src/renderer/lib/workflow-status.ts
+++ b/src/renderer/lib/workflow-status.ts
@@ -30,7 +30,11 @@ export const WORKFLOW_STATUS_TONE: Record<WorkflowStatusKey, StatusTone> = {
   cancelled: 'idle'
 }
 
-export const WORKFLOW_STATUS_DOT = byTone(WORKFLOW_STATUS_TONE, TONE_DOT)
+// Success earns the task board's done green: a finished step must read at a glance.
+export const WORKFLOW_STATUS_DOT = {
+  ...byTone(WORKFLOW_STATUS_TONE, TONE_DOT),
+  success: 'bg-status-sage'
+}
 
 /**
  * The same dots, animated for the state that is actually moving.
@@ -39,7 +43,10 @@ export const WORKFLOW_STATUS_DOT = byTone(WORKFLOW_STATUS_TONE, TONE_DOT)
  * legends, not live indicators — a pulsing key would suggest the *filter* is
  * doing something.
  */
-export const WORKFLOW_STATUS_DOT_PULSE = byTone(WORKFLOW_STATUS_TONE, TONE_DOT_MOVING)
+export const WORKFLOW_STATUS_DOT_PULSE = {
+  ...byTone(WORKFLOW_STATUS_TONE, TONE_DOT_MOVING),
+  success: 'bg-status-sage'
+}
 
 export const WORKFLOW_STATUS_TEXT = byTone(WORKFLOW_STATUS_TONE, TONE_TEXT)
 

--- a/src/renderer/lib/workflow-status.ts
+++ b/src/renderer/lib/workflow-status.ts
@@ -48,6 +48,7 @@ export const WORKFLOW_STATUS_DOT_PULSE = {
   success: 'bg-status-sage'
 }
 
+// Words stay off the category palette; only the success dot borrows the done green.
 export const WORKFLOW_STATUS_TEXT = byTone(WORKFLOW_STATUS_TONE, TONE_TEXT)
 
 /**

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -333,6 +333,7 @@ export interface UISlice {
   pendingWorkflowRun: {
     workflowId: string
     context?: { task?: TaskConfig; source?: TerminalSession }
+    targetNodeId?: string
   } | null
   editingProject: ProjectConfig | null
   isCommandPaletteOpen: boolean
@@ -429,7 +430,8 @@ export interface UISlice {
   setWorkflowEditorOpen: (open: boolean) => void
   setPendingWorkflowRun: (
     workflowId: string | null,
-    context?: { task?: TaskConfig; source?: TerminalSession }
+    context?: { task?: TaskConfig; source?: TerminalSession },
+    targetNodeId?: string
   ) => void
   setEditingWorkflowId: (id: string | null) => void
   setEditingProject: (project: ProjectConfig | null) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -649,8 +649,8 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
 
   setWorkflowEditorOpen: (open) => set({ isWorkflowEditorOpen: open }),
 
-  setPendingWorkflowRun: (workflowId, context) =>
-    set({ pendingWorkflowRun: workflowId ? { workflowId, context } : null }),
+  setPendingWorkflowRun: (workflowId, context, targetNodeId) =>
+    set({ pendingWorkflowRun: workflowId ? { workflowId, context, targetNodeId } : null }),
 
   setEditingWorkflowId: (id) => set({ editingWorkflowId: id }),
 

--- a/tests/loop-canvas.test.tsx
+++ b/tests/loop-canvas.test.tsx
@@ -281,6 +281,12 @@ describe('a live run on the canvas', () => {
     }
   })
 
+  it('breathes the rail while the loop runs', () => {
+    const { container } = renderWith(nodes, null, edges, { loop: 'running' })
+    const rail = container.querySelector('[data-loop-rail]') as HTMLElement
+    expect(rail.querySelector('span.absolute.inset-0.animate-pulse')).not.toBeNull()
+  })
+
   it('shows the loop itself the state it is in', () => {
     // The rail draws its own header rather than going through a node card, so
     // it is the one node that has to read its status separately — and a loop

--- a/tests/node-cards-status.test.tsx
+++ b/tests/node-cards-status.test.tsx
@@ -68,3 +68,42 @@ describe('node cards — executionStatus dot', () => {
     expect(container.querySelector(`.${WORKFLOW_STATUS_DOT.success}`)).not.toBeInTheDocument()
   })
 })
+
+describe('node cards — running breath and failure border', () => {
+  it('breathes a border overlay while running', () => {
+    const { container } = render(
+      <ScriptNode
+        label="Script"
+        config={{ scriptType: 'bash', scriptContent: '' }}
+        selected={false}
+        onClick={() => {}}
+        executionStatus="running"
+      />
+    )
+    expect(container.querySelector('span.absolute.inset-0.animate-pulse')).toBeInTheDocument()
+  })
+
+  it('borders danger on the failed step, and only there', () => {
+    const failed = render(
+      <ScriptNode
+        label="Script"
+        config={{ scriptType: 'bash', scriptContent: '' }}
+        selected={false}
+        onClick={() => {}}
+        executionStatus="error"
+      />
+    )
+    expect((failed.container.firstChild as HTMLElement).className).toContain('border-danger')
+    expect(failed.container.querySelector('span.absolute.inset-0.animate-pulse')).toBeNull()
+
+    const idle = render(
+      <ScriptNode
+        label="Script"
+        config={{ scriptType: 'bash', scriptContent: '' }}
+        selected={false}
+        onClick={() => {}}
+      />
+    )
+    expect((idle.container.firstChild as HTMLElement).className).not.toContain('border-danger')
+  })
+})

--- a/tests/node-config-panel.test.tsx
+++ b/tests/node-config-panel.test.tsx
@@ -127,18 +127,9 @@ describe('NodeConfigPanel', () => {
     expect(onDelete).toHaveBeenCalledWith('n1')
   })
 
-  it('renders a step ref hint for non-trigger nodes with a slug', () => {
-    const node = { ...makeNode('script'), slug: 'my_step' }
-    render(
-      <NodeConfigPanel
-        node={node}
-        onChange={vi.fn()}
-        onLabelChange={vi.fn()}
-        onDelete={vi.fn()}
-        onClose={vi.fn()}
-      />
-    )
-    expect(screen.getByText(/steps\.my_step\.output/)).toBeInTheDocument()
+  it('keeps raw step references out of the panel chrome', () => {
+    const { container } = renderPanel(scriptNode)
+    expect(container.textContent).not.toContain('Ref:')
   })
 
   it('renders the approval form for approval nodes', () => {

--- a/tests/node-config-panel.test.tsx
+++ b/tests/node-config-panel.test.tsx
@@ -128,7 +128,15 @@ describe('NodeConfigPanel', () => {
   })
 
   it('keeps raw step references out of the panel chrome', () => {
-    const { container } = renderPanel(scriptNode)
+    const { container } = render(
+      <NodeConfigPanel
+        node={makeNode('script')}
+        onChange={vi.fn()}
+        onLabelChange={vi.fn()}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
     expect(container.textContent).not.toContain('Ref:')
   })
 

--- a/tests/run-completion-toast.test.ts
+++ b/tests/run-completion-toast.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { runCompletionToast } from '../src/renderer/lib/run-presentation'
+import type { WorkflowExecution, WorkflowNode } from '../packages/shared/src/types'
+
+const nodes = [
+  { id: 't', type: 'trigger', label: 'Manual', position: { x: 0, y: 0 }, config: {} },
+  { id: 'a', type: 'script', label: 'Fetch', position: { x: 0, y: 0 }, config: {} },
+  { id: 'b', type: 'script', label: 'Deliver', position: { x: 0, y: 0 }, config: {} }
+] as unknown as WorkflowNode[]
+
+const run = (over: Partial<WorkflowExecution>): WorkflowExecution =>
+  ({
+    runId: 'r',
+    workflowId: 'wf',
+    startedAt: '2026-08-31T14:00:00Z',
+    completedAt: '2026-08-31T14:00:42Z',
+    status: 'success',
+    nodeStates: [],
+    ...over
+  }) as WorkflowExecution
+
+describe('what a finished run says', () => {
+  it('counts only real steps into the success line', () => {
+    const note = runCompletionToast(
+      run({
+        nodeStates: [
+          { nodeId: 't', status: 'success' },
+          { nodeId: 'a', status: 'success' },
+          { nodeId: 'b', status: 'success' }
+        ]
+      }),
+      nodes
+    )
+    expect(note.kind).toBe('success')
+    expect(note.message).toBe('Run finished — 2 steps in 42.0s')
+  })
+
+  it('blames the step that failed, not the ones skipped because of it', () => {
+    const note = runCompletionToast(
+      run({
+        status: 'error',
+        nodeStates: [
+          { nodeId: 't', status: 'success' },
+          { nodeId: 'a', status: 'error', error: 'Skipped: "Fetch" failed' },
+          { nodeId: 'b', status: 'error', error: 'Exit code 1' }
+        ]
+      }),
+      nodes
+    )
+    expect(note.kind).toBe('error')
+    expect(note.message).toBe('Run failed at "Deliver"')
+    expect(note.failedNodeId).toBe('b')
+  })
+
+  it('stays quiet for a cancelled run', () => {
+    expect(runCompletionToast(run({ status: 'cancelled' }), nodes).kind).toBe('quiet')
+  })
+})

--- a/tests/run-feedback.test.tsx
+++ b/tests/run-feedback.test.tsx
@@ -1,0 +1,253 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowExecution } from '../src/shared/types'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('../src/renderer/components/SidebarToggleButton', () => ({
+  SidebarToggleButton: () => <div />
+}))
+vi.mock('../src/renderer/components/MainViewPills', () => ({ MainViewPills: () => <div /> }))
+vi.mock('../src/renderer/components/WindowControls', () => ({ WindowControls: () => <div /> }))
+
+vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', () => ({
+  WorkflowCanvas: () => <div data-testid="canvas" />
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/NodeConfigPanel', () => ({
+  NodeConfigPanel: () => <div data-testid="node-config" />
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/StepLibrary', () => ({
+  StepLibrary: () => <div data-testid="step-library" />
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel', () => ({
+  WorkflowPropertiesPanel: () => <div data-testid="properties-panel" />
+}))
+
+const captured = vi.hoisted(() => ({
+  historyProps: null as Record<string, unknown> | null
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/RunHistoryPanel', () => ({
+  RunHistoryPanel: (props: Record<string, unknown>) => {
+    captured.historyProps = props
+    return <div data-testid="run-history" />
+  }
+}))
+
+const toastFn = vi.hoisted(() => {
+  const fn = vi.fn() as ReturnType<typeof vi.fn> & {
+    success: ReturnType<typeof vi.fn>
+    error: ReturnType<typeof vi.fn>
+    dismiss: ReturnType<typeof vi.fn>
+  }
+  fn.success = vi.fn()
+  fn.error = vi.fn()
+  fn.dismiss = vi.fn()
+  return fn
+})
+vi.mock('../src/renderer/components/Toast', () => ({ toast: toastFn }))
+
+const executeWorkflow = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const retryRunFromFailure = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const stopWorkflowRun = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow,
+  retryRunFromFailure,
+  rerunWorkflowRun: vi.fn().mockResolvedValue(undefined),
+  stopWorkflowRun,
+  buildStepOutputsMap: vi.fn(() => ({}))
+}))
+
+const workflow = {
+  id: 'wf-x',
+  name: 'Bench',
+  icon: 'Workflow',
+  iconColor: '#3b82f6',
+  enabled: true,
+  workspaceId: 'personal',
+  nodes: [
+    {
+      id: 'trigger',
+      type: 'trigger',
+      label: 'Manual',
+      position: { x: 0, y: 0 },
+      config: { triggerType: 'manual' }
+    },
+    {
+      id: 'agent',
+      type: 'launchAgent',
+      label: 'Do the work',
+      slug: 'do_the_work',
+      position: { x: 0, y: 140 },
+      config: { agentType: 'claude', projectName: '', projectPath: '', headless: true }
+    }
+  ],
+  edges: [{ id: 'e1', source: 'trigger', target: 'agent' }]
+}
+
+const mockState = {
+  isWorkflowEditorOpen: true,
+  isSidebarOpen: true,
+  editingWorkflowId: 'wf-x' as string | null,
+  setWorkflowEditorOpen: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  addWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  removeWorkflow: vi.fn(),
+  config: { workflows: [workflow], tasks: [], projects: [], defaults: {} },
+  setPendingWorkflowRun: vi.fn(),
+  addTerminal: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  setSelectedTaskId: vi.fn(),
+  activeWorkspace: 'personal',
+  workflowExecutions: new Map<string, WorkflowExecution>()
+}
+
+vi.mock('../src/renderer/stores', () => {
+  const useAppStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+  useAppStore.getState = () => mockState
+  return { useAppStore }
+})
+;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  api: {
+    listWorkflowRuns: vi.fn().mockResolvedValue([]),
+    listConnectionActions: vi.fn().mockResolvedValue([]),
+    createTerminal: vi.fn(),
+    isWindowMaximized: vi.fn().mockResolvedValue(false),
+    onWindowMaximizedChange: vi.fn(() => () => {}),
+    windowMinimize: vi.fn(),
+    windowMaximize: vi.fn(),
+    windowClose: vi.fn()
+  }
+}
+
+const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
+
+const runningExec = (): WorkflowExecution =>
+  ({
+    runId: 'r1',
+    workflowId: 'wf-x',
+    startedAt: new Date().toISOString(),
+    status: 'running',
+    nodeStates: [
+      { nodeId: 'trigger', status: 'success' },
+      { nodeId: 'agent', status: 'running' }
+    ]
+  }) as WorkflowExecution
+
+beforeEach(() => {
+  mockState.workflowExecutions.clear()
+  captured.historyProps = null
+  toastFn.mockClear()
+  toastFn.success.mockClear()
+  retryRunFromFailure.mockClear()
+  executeWorkflow.mockClear()
+  stopWorkflowRun.mockClear()
+})
+
+describe('the first second of a run', () => {
+  it('answers the click before the server does', () => {
+    const { getByLabelText, getByTestId, queryByLabelText } = render(<WorkflowEditor inline />)
+    expect(queryByLabelText('Stop run')).toBeNull()
+
+    fireEvent.click(getByLabelText('Run workflow'))
+
+    expect(getByLabelText('Stop run')).toBeInTheDocument()
+    expect(getByTestId('run-history')).toBeInTheDocument()
+  })
+
+  it('pins the panel to the run it launched and stops the real run', () => {
+    const { getByLabelText, rerender } = render(<WorkflowEditor inline />)
+    fireEvent.click(getByLabelText('Run workflow'))
+
+    act(() => {
+      mockState.workflowExecutions.set('r1', runningExec())
+    })
+    rerender(<WorkflowEditor inline />)
+
+    expect(captured.historyProps?.followRunId).toBe('r1')
+    fireEvent.click(getByLabelText('Stop run'))
+    expect(stopWorkflowRun).toHaveBeenCalledWith('r1')
+  })
+
+  it('never lets a background run hijack the panel', () => {
+    const { queryByTestId, rerender } = render(<WorkflowEditor inline />)
+    act(() => {
+      mockState.workflowExecutions.set('r1', runningExec())
+    })
+    rerender(<WorkflowEditor inline />)
+
+    expect(queryByTestId('run-history')).toBeNull()
+    expect(captured.historyProps).toBeNull()
+  })
+})
+
+describe('completion toasts', () => {
+  function launchAndAdopt() {
+    const utils = render(<WorkflowEditor inline />)
+    fireEvent.click(utils.getByLabelText('Run workflow'))
+    act(() => {
+      mockState.workflowExecutions.set('r1', runningExec())
+    })
+    utils.rerender(<WorkflowEditor inline />)
+    return utils
+  }
+
+  it('toasts a quiet success with steps and duration', () => {
+    const utils = launchAndAdopt()
+    act(() => {
+      const done = runningExec()
+      done.status = 'success'
+      done.completedAt = new Date().toISOString()
+      done.nodeStates[1].status = 'success'
+      mockState.workflowExecutions.set('r1', done)
+    })
+    utils.rerender(<WorkflowEditor inline />)
+
+    expect(toastFn.success).toHaveBeenCalledWith(expect.stringMatching(/1 step in/))
+  })
+
+  it('keeps a failure up, names the step, and retries from it', () => {
+    const utils = launchAndAdopt()
+    act(() => {
+      const failed = runningExec()
+      failed.status = 'error'
+      failed.nodeStates[1] = { nodeId: 'agent', status: 'error', error: 'Exit code 1' }
+      mockState.workflowExecutions.set('r1', failed)
+    })
+    utils.rerender(<WorkflowEditor inline />)
+
+    expect(toastFn).toHaveBeenCalledWith(
+      expect.stringContaining('Do the work'),
+      'error',
+      expect.objectContaining({ duration: Number.POSITIVE_INFINITY })
+    )
+    const opts = toastFn.mock.lastCall![2] as {
+      actions: { label: string; onClick: (id: string) => void }[]
+    }
+    expect(opts.actions[0].label).toBe('Retry')
+    opts.actions[0].onClick('toast-1')
+    expect(toastFn.dismiss).toHaveBeenCalledWith('toast-1')
+    expect(retryRunFromFailure).toHaveBeenCalled()
+  })
+})

--- a/tests/run-feedback.test.tsx
+++ b/tests/run-feedback.test.tsx
@@ -251,3 +251,44 @@ describe('completion toasts', () => {
     expect(retryRunFromFailure).toHaveBeenCalled()
   })
 })
+
+describe('switching workflows mid-run', () => {
+  const otherWorkflow = { ...workflow, id: 'wf-y', name: 'Other' }
+
+  it('drops the tracked run so its ending never toasts against the wrong workflow', () => {
+    const utils = render(<WorkflowEditor inline />)
+    fireEvent.click(utils.getByLabelText('Run workflow'))
+    act(() => {
+      mockState.workflowExecutions.set('r1', runningExec())
+    })
+    utils.rerender(<WorkflowEditor inline />)
+    expect(captured.historyProps?.followRunId).toBe('r1')
+
+    act(() => {
+      mockState.editingWorkflowId = 'wf-y'
+      mockState.config.workflows = [workflow, otherWorkflow]
+    })
+    utils.rerender(<WorkflowEditor inline />)
+
+    act(() => {
+      const failed = runningExec()
+      failed.status = 'error'
+      failed.nodeStates[1] = { nodeId: 'agent', status: 'error', error: 'Exit code 1' }
+      mockState.workflowExecutions.set('r1', failed)
+    })
+    utils.rerender(<WorkflowEditor inline />)
+
+    expect(toastFn).not.toHaveBeenCalled()
+    mockState.editingWorkflowId = 'wf-x'
+    mockState.config.workflows = [workflow]
+  })
+
+  it('refuses to retry a run that belongs to another workflow', () => {
+    const utils = render(<WorkflowEditor inline />)
+    fireEvent.click(utils.getByLabelText('Run workflow'))
+    utils.rerender(<WorkflowEditor inline />)
+    const onRetryRun = captured.historyProps?.onRetryRun as (run: WorkflowExecution) => void
+    onRetryRun({ ...runningExec(), workflowId: 'wf-somewhere-else' })
+    expect(retryRunFromFailure).not.toHaveBeenCalled()
+  })
+})

--- a/tests/run-feedback.test.tsx
+++ b/tests/run-feedback.test.tsx
@@ -117,6 +117,7 @@ const mockState = {
   setFocusedTerminal: vi.fn(),
   setSelectedTaskId: vi.fn(),
   activeWorkspace: 'personal',
+  pendingWorkflowRun: null as { workflowId: string } | null,
   workflowExecutions: new Map<string, WorkflowExecution>()
 }
 
@@ -157,6 +158,7 @@ const runningExec = (): WorkflowExecution =>
 
 beforeEach(() => {
   mockState.workflowExecutions.clear()
+  mockState.pendingWorkflowRun = null
   captured.historyProps = null
   toastFn.mockClear()
   toastFn.success.mockClear()
@@ -290,5 +292,54 @@ describe('switching workflows mid-run', () => {
     const onRetryRun = captured.historyProps?.onRetryRun as (run: WorkflowExecution) => void
     onRetryRun({ ...runningExec(), workflowId: 'wf-somewhere-else' })
     expect(retryRunFromFailure).not.toHaveBeenCalled()
+  })
+})
+
+describe('a dismissed run prompt', () => {
+  const promptWorkflow = {
+    ...workflow,
+    id: 'wf-x',
+    nodes: [
+      {
+        ...workflow.nodes[0],
+        config: {
+          triggerType: 'manual',
+          inputs: [{ key: 'pr_number', label: 'PR number', type: 'text' }]
+        }
+      },
+      workflow.nodes[1]
+    ]
+  }
+
+  it('drops the arm, so the next background run is not adopted', () => {
+    vi.useFakeTimers()
+    try {
+      mockState.config.workflows = [promptWorkflow] as unknown as typeof mockState.config.workflows
+      const utils = render(<WorkflowEditor inline />)
+      fireEvent.click(utils.getByLabelText('Run workflow'))
+      expect(mockState.setPendingWorkflowRun).toHaveBeenCalled()
+
+      act(() => {
+        mockState.pendingWorkflowRun = { workflowId: 'wf-x' }
+      })
+      utils.rerender(<WorkflowEditor inline />)
+      act(() => {
+        mockState.pendingWorkflowRun = null
+      })
+      utils.rerender(<WorkflowEditor inline />)
+      act(() => {
+        vi.advanceTimersByTime(2100)
+      })
+
+      act(() => {
+        mockState.workflowExecutions.set('r1', runningExec())
+      })
+      utils.rerender(<WorkflowEditor inline />)
+
+      expect(captured.historyProps?.followRunId ?? null).toBeNull()
+    } finally {
+      vi.useRealTimers()
+      mockState.config.workflows = [workflow]
+    }
   })
 })

--- a/tests/run-follow.test.tsx
+++ b/tests/run-follow.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [],
+  useConnectorIdFor: () => null,
+  useConnectionIconFor: () => undefined
+}))
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  isRunStoppable: () => false,
+  stopWorkflowRun: vi.fn(),
+  approveWorkflowGate: vi.fn(),
+  rejectWorkflowGate: vi.fn()
+}))
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+import { RunEntry } from '../src/renderer/components/workflow-editor/RunEntry'
+import type { WorkflowExecution, WorkflowNode } from '../packages/shared/src/types'
+
+const nodes = [
+  { id: 't', type: 'trigger', label: 'Manual', position: { x: 0, y: 0 }, config: {} },
+  {
+    id: 'a',
+    type: 'launchAgent',
+    label: 'Do the work',
+    slug: 'do_the_work',
+    position: { x: 0, y: 0 },
+    config: { agentType: 'claude', projectName: '', projectPath: '', headless: true }
+  }
+] as unknown as WorkflowNode[]
+
+const running: WorkflowExecution = {
+  runId: 'r1',
+  workflowId: 'wf',
+  startedAt: new Date().toISOString(),
+  status: 'running',
+  nodeStates: [
+    { nodeId: 't', status: 'success' },
+    { nodeId: 'a', status: 'running' }
+  ]
+} as WorkflowExecution
+
+describe('a followed run', () => {
+  it('starts expanded with its live step timeline open', () => {
+    const { getByText } = render(<RunEntry execution={running} nodes={nodes} follow />)
+    // Expanded without a click, down to the running step's own detail.
+    expect(getByText('Do the work')).toBeInTheDocument()
+    expect(getByText(/No output captured yet/)).toBeInTheDocument()
+  })
+
+  it('stays collapsed when not followed', () => {
+    const { queryByText } = render(<RunEntry execution={running} nodes={nodes} />)
+    expect(queryByText('Do the work')).toBeNull()
+  })
+})

--- a/tests/template-preview.test.ts
+++ b/tests/template-preview.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildStepGroups,
+  formatRunValue,
+  previewStepTokens,
+  suggestNearestPath,
+  type LastRunData
+} from '../src/renderer/lib/template-vars'
+import type { WorkflowNode } from '../packages/shared/src/types'
+
+const agent = (id: string, slug: string): WorkflowNode =>
+  ({
+    id,
+    type: 'launchAgent',
+    label: slug,
+    slug,
+    position: { x: 0, y: 0 },
+    config: { agentType: 'claude', projectName: '', projectPath: '', headless: true }
+  }) as unknown as WorkflowNode
+
+const lastRun: LastRunData = {
+  outputs: {
+    triage: { output: 'done', status: 'success', error: '', severity: 'bug' }
+  },
+  states: { n1: { status: 'success', completedAt: '2026-08-31T14:14:00Z' } }
+}
+
+describe('step groups carrying the last run', () => {
+  it('attaches a rendered value and the run identity to each group', () => {
+    const groups = buildStepGroups([agent('n1', 'triage')], undefined, lastRun)
+    expect(groups[0].runStatus).toBe('success')
+    expect(groups[0].runCompletedAt).toBe('2026-08-31T14:14:00Z')
+    expect(groups[0].keys.find((k) => k.key === 'output')?.value).toBe('"done"')
+  })
+
+  it('leaves values off when the workflow has never run', () => {
+    const groups = buildStepGroups([agent('n1', 'triage')])
+    expect(groups[0].runStatus).toBeUndefined()
+    expect(groups[0].keys.every((k) => k.value === undefined)).toBe(true)
+  })
+})
+
+describe('formatRunValue', () => {
+  it('quotes strings, flattens whitespace, and clips long values', () => {
+    expect(formatRunValue('a\n b')).toBe('"a b"')
+    expect(formatRunValue(42)).toBe('42')
+    expect(formatRunValue('x'.repeat(100))).toContain('…')
+  })
+})
+
+describe('previewing steps tokens', () => {
+  const groups = buildStepGroups([agent('n1', 'triage')], undefined, lastRun)
+
+  it('resolves a known path against the last run', () => {
+    const preview = previewStepTokens('Sev: {{steps.triage.severity}}', groups)
+    expect(preview.resolved).toBe('Sev: bug')
+    expect(preview.broken).toBeUndefined()
+  })
+
+  it('flags a path that resolves nowhere and suggests the nearest real one', () => {
+    const preview = previewStepTokens('{{steps.triaje.severity}}', groups)
+    expect(preview.broken?.token).toBe('steps.triaje.severity')
+    expect(preview.broken?.suggestion).toBe('steps.triage.severity')
+  })
+
+  it('stays quiet with no steps tokens or no run data', () => {
+    expect(previewStepTokens('plain text', groups)).toEqual({})
+    const dry = buildStepGroups([agent('n1', 'triage')])
+    expect(previewStepTokens('{{steps.triage.output}}', dry)).toEqual({})
+  })
+})
+
+describe('suggestNearestPath', () => {
+  it('offers nothing when everything is far away', () => {
+    expect(suggestNearestPath('steps.zzzzzzzzzzzz.qqq', ['steps.triage.output'])).toBeUndefined()
+  })
+})

--- a/tests/template-preview.test.ts
+++ b/tests/template-preview.test.ts
@@ -70,7 +70,25 @@ describe('previewing steps tokens', () => {
   })
 })
 
+describe('declared paths are trusted', () => {
+  it('never breaks a schema-declared path the last run did not emit', () => {
+    // `status` is declared on every step; this run's outputs lack it.
+    const partialRun: LastRunData = {
+      outputs: { triage: { severity: 'bug' } },
+      states: { n1: { status: 'success' } }
+    }
+    const declared = buildStepGroups([agent('n1', 'triage')], undefined, partialRun)
+    const preview = previewStepTokens('{{steps.triage.status}}', declared)
+    expect(preview.broken).toBeUndefined()
+    expect(preview.resolved).toBeUndefined()
+  })
+})
+
 describe('suggestNearestPath', () => {
+  it('never suggests the token itself', () => {
+    expect(suggestNearestPath('steps.triage.output', ['steps.triage.output'])).toBeUndefined()
+  })
+
   it('offers nothing when everything is far away', () => {
     expect(suggestNearestPath('steps.zzzzzzzzzzzz.qqq', ['steps.triage.output'])).toBeUndefined()
   })

--- a/tests/template-preview.test.ts
+++ b/tests/template-preview.test.ts
@@ -71,6 +71,23 @@ describe('previewing steps tokens', () => {
 })
 
 describe('declared paths are trusted', () => {
+  it('flags a deeper walk that fails on a key the run did emit', () => {
+    // `output` came back as a string; walking into it cannot succeed.
+    const emitted = buildStepGroups([agent('n1', 'triage')], undefined, lastRun)
+    const preview = previewStepTokens('{{steps.triage.output.foo}}', emitted)
+    expect(preview.broken?.token).toBe('steps.triage.output.foo')
+    expect(preview.broken?.suggestion).not.toBe('steps.triage.output.foo')
+  })
+
+  it('still trusts a deeper path under a declared key this run did not emit', () => {
+    const partialRun: LastRunData = {
+      outputs: { triage: { severity: 'bug' } },
+      states: { n1: { status: 'success' } }
+    }
+    const declared = buildStepGroups([agent('n1', 'triage')], undefined, partialRun)
+    expect(previewStepTokens('{{steps.triage.status.x}}', declared).broken).toBeUndefined()
+  })
+
   it('never breaks a schema-declared path the last run did not emit', () => {
     // `status` is declared on every step; this run's outputs lack it.
     const partialRun: LastRunData = {

--- a/tests/variable-picker-values.test.tsx
+++ b/tests/variable-picker-values.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [],
+  useConnectorIdFor: () => null,
+  useConnectionIconFor: () => undefined
+}))
+
+import { VariableAutocomplete } from '../src/renderer/components/workflow-editor/panels/VariableAutocomplete'
+import type { StepVariableGroup } from '../src/renderer/lib/template-vars'
+
+const triageGroup: StepVariableGroup = {
+  nodeId: 'n1',
+  label: 'Triage the issue',
+  slug: 'triage',
+  nodeType: 'launchAgent',
+  runStatus: 'success',
+  runCompletedAt: '2026-08-31T14:14:00Z',
+  runOutputs: { severity: 'bug', summary: 'Crash on save' },
+  keys: [
+    { key: 'severity', label: 'severity', description: 'From the last run', value: '"bug"' },
+    { key: 'output', label: 'Output', description: 'Primary output', value: '"done"' }
+  ]
+}
+
+function open(value = '', groups = [triageGroup]) {
+  const utils = render(
+    <VariableAutocomplete value={value} onChange={vi.fn()} stepGroups={groups} contextVars={[]} />
+  )
+  const textarea = utils.container.querySelector('textarea')!
+  fireEvent.change(textarea, { target: { value: value + '{{' } })
+  return utils
+}
+
+describe('the picker carrying run data', () => {
+  it('shows each entry beside its real last-run value', () => {
+    const { getByText } = open()
+    expect(getByText('"bug"')).toBeInTheDocument()
+    expect(getByText('"done"')).toBeInTheDocument()
+  })
+
+  it('renders the group header as the step, with when it ran', () => {
+    const { getByText, container } = open()
+    expect(getByText('Triage the issue')).toBeInTheDocument()
+    // The header carries the run's local time, not an uppercase category label.
+    expect(container.textContent).toMatch(/\d{1,2}:\d{2}/)
+  })
+})
+
+describe('the resolved preview under a field', () => {
+  it('previews a template that resolves against the last run', () => {
+    const { getByText } = render(
+      <VariableAutocomplete
+        value="Sev: {{steps.triage.severity}}"
+        onChange={vi.fn()}
+        stepGroups={[triageGroup]}
+        contextVars={[]}
+      />
+    )
+    expect(getByText('→ Sev: bug')).toBeInTheDocument()
+  })
+
+  it('flags a broken path and suggests the nearest real one', () => {
+    const { getByText } = render(
+      <VariableAutocomplete
+        value="{{steps.triaje.severity}}"
+        onChange={vi.fn()}
+        stepGroups={[triageGroup]}
+        contextVars={[]}
+      />
+    )
+    expect(getByText(/steps\.triaje\.severity not found/)).toBeInTheDocument()
+    expect(getByText(/did you mean steps\.triage\.severity\?/)).toBeInTheDocument()
+  })
+})

--- a/tests/workflow-canvas-layout.test.ts
+++ b/tests/workflow-canvas-layout.test.ts
@@ -136,7 +136,7 @@ describe('layout edge shapes', () => {
     ]
     const { nodes: rf } = toCanvasElements(emptyLoop, [{ id: 'e1', source: 't', target: 'loop' }])
     const loop = rf.find((n) => n.id === 'loop')!
-    expect(loop.height).toBeGreaterThan(120)
+    expect(loop.initialHeight).toBeGreaterThan(120)
   })
 
   it('gives an empty fork branch a full column of width', () => {

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -188,7 +188,7 @@ describe('WorkflowEditor', () => {
     const { container } = render(<WorkflowEditor />)
     fireEvent.click(container.querySelector('button[aria-label="Run workflow"]')!)
 
-    expect(mockState.setPendingWorkflowRun).toHaveBeenCalledWith('wf-inputs', undefined)
+    expect(mockState.setPendingWorkflowRun).toHaveBeenCalledWith('wf-inputs', undefined, undefined)
     expect(executeWorkflow).not.toHaveBeenCalled()
 
     mockState.editingWorkflowId = null

--- a/tests/workflow-menu-items.test.tsx
+++ b/tests/workflow-menu-items.test.tsx
@@ -123,7 +123,7 @@ describe('buildWorkflowMenuItems', () => {
 describe('startManualRun', () => {
   it('opens SourcePromptDialog for contextual workflows', () => {
     startManualRun(makeWorkflow('a', true))
-    expect(mockSetPending).toHaveBeenCalledWith('a', undefined)
+    expect(mockSetPending).toHaveBeenCalledWith('a', undefined, undefined)
     expect(mockExecuteWorkflow).not.toHaveBeenCalled()
   })
 
@@ -160,7 +160,7 @@ describe('workflows declaring run inputs', () => {
   it('prompts instead of launching from a global surface', () => {
     startManualRun(withInputs(makeWorkflow('wf-i', false)))
     expect(mockExecuteWorkflow).not.toHaveBeenCalled()
-    expect(mockSetPending).toHaveBeenCalledWith('wf-i', undefined)
+    expect(mockSetPending).toHaveBeenCalledWith('wf-i', undefined, undefined)
   })
 
   it('prompts from a card menu too, forwarding the card as context', () => {
@@ -170,7 +170,11 @@ describe('workflows declaring run inputs', () => {
     items[0].onClick()
 
     expect(mockExecuteWorkflow).not.toHaveBeenCalled()
-    expect(mockSetPending).toHaveBeenCalledWith('wf-i', { task: someTask, source: undefined })
+    expect(mockSetPending).toHaveBeenCalledWith(
+      'wf-i',
+      { task: someTask, source: undefined },
+      undefined
+    )
   })
 
   it('still launches straight away when no inputs are declared', () => {

--- a/tests/workflow-partial-and-retry.test.ts
+++ b/tests/workflow-partial-and-retry.test.ts
@@ -79,7 +79,7 @@ vi.mock('../src/renderer/lib/notifications', () => ({
   sendWorkflowGateNotification: vi.fn()
 }))
 
-const { executeWorkflow, retryRunFromFailure, rerunWorkflowRun, contextFromRun } =
+const { executeWorkflow, retryRunFromFailure, rerunWorkflowRun, contextFromRun, seedRetryStates } =
   await import('../src/renderer/lib/workflow-execution')
 
 const agentNode = (id: string, prompt: string) => ({
@@ -180,6 +180,7 @@ describe('running up to one step', () => {
     expect(execution.nodeStates.find((n) => n.nodeId === 'a')?.status).toBe('success')
     expect(execution.nodeStates.find((n) => n.nodeId === 'b')?.status).toBe('success')
     expect(execution.nodeStates.find((n) => n.nodeId === 'c')?.status).toBe('skipped')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'c')?.skipReason).toBe('target')
     expect(createHeadlessSession).toHaveBeenCalledTimes(2)
   })
 
@@ -261,5 +262,73 @@ describe('retrying a failed run', () => {
     expect(context?.connectorItem?.inboxId).toBeUndefined()
     expect(context?.connectorItem?.inboxLeaseToken).toBeUndefined()
     expect(context?.connectorItem?.externalId).toBe('1')
+  })
+})
+
+describe('what a retry adopts', () => {
+  const seededStatus = (
+    states: { nodeId: string; status: string }[],
+    id: string
+  ): string | undefined => states.find((n) => n.nodeId === id)?.status
+
+  it('never adopts a loop-body success; the loop re-drives its body', () => {
+    const wf = {
+      ...makeChain(),
+      nodes: [
+        { id: 'trigger', type: 'trigger', label: 'Trigger', position: { x: 0, y: 0 }, config: {} },
+        {
+          id: 'loop',
+          type: 'loop',
+          label: 'Loop',
+          slug: 'loop',
+          position: { x: 0, y: 0 },
+          config: { nodeType: 'loop', bodyNodeIds: ['x'], maxIterations: 2 }
+        },
+        agentNode('x', 'body'),
+        agentNode('after', 'after')
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'loop' },
+        { id: 'e2', source: 'loop', target: 'x' },
+        { id: 'e3', source: 'x', target: 'after' }
+      ]
+    } as unknown as WorkflowDefinition
+    const failed = {
+      runId: 'r0',
+      workflowId: wf.id,
+      startedAt: 's',
+      status: 'error',
+      nodeStates: [
+        { nodeId: 'trigger', status: 'success' },
+        { nodeId: 'loop', status: 'success' },
+        { nodeId: 'x', status: 'success' },
+        { nodeId: 'after', status: 'error', error: 'Exit code 1' }
+      ]
+    } as unknown as WorkflowExecution
+
+    const seeded = seedRetryStates(wf, failed)
+    expect(seededStatus(seeded, 'loop')).toBe('success')
+    expect(seededStatus(seeded, 'x')).toBe('pending')
+  })
+
+  it('resets a gate rejection but preserves condition and target skips', () => {
+    const wf = makeChain()
+    const failed = {
+      runId: 'r0',
+      workflowId: wf.id,
+      startedAt: 's',
+      status: 'error',
+      nodeStates: [
+        { nodeId: 'trigger', status: 'success' },
+        { nodeId: 'a', status: 'skipped' },
+        { nodeId: 'b', status: 'skipped', skipReason: 'branch' },
+        { nodeId: 'c', status: 'skipped', skipReason: 'target' }
+      ]
+    } as unknown as WorkflowExecution
+
+    const seeded = seedRetryStates(wf, failed)
+    expect(seededStatus(seeded, 'a')).toBe('pending')
+    expect(seededStatus(seeded, 'b')).toBe('skipped')
+    expect(seededStatus(seeded, 'c')).toBe('skipped')
   })
 })

--- a/tests/workflow-partial-and-retry.test.ts
+++ b/tests/workflow-partial-and-retry.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { WorkflowDefinition, WorkflowExecution } from '../src/shared/types'
+
+type ExitListener = (p: { id: string; exitCode: number }) => void
+
+const exitListeners = new Set<ExitListener>()
+
+function emitExit(id: string, exitCode: number): void {
+  for (const l of [...exitListeners]) l({ id, exitCode })
+}
+
+const claims = new Map<string, string>()
+let runSeq = 0
+let sessionSeq = 0
+
+const claimWorkflowRun = vi.fn(
+  ({ workflowId, params }: { workflowId: string; params?: string }) => {
+    const key = JSON.stringify([workflowId, params || 'manual'])
+    const held = claims.get(key)
+    if (held) return Promise.resolve({ granted: false, runId: held })
+    const runId = `run-${++runSeq}`
+    claims.set(key, runId)
+    return Promise.resolve({ granted: true, runId })
+  }
+)
+
+const releaseWorkflowRun = vi.fn(
+  ({ workflowId, params, runId }: { workflowId: string; params?: string; runId: string }) => {
+    const key = JSON.stringify([workflowId, params || 'manual'])
+    if (claims.get(key) === runId) claims.delete(key)
+    return Promise.resolve()
+  }
+)
+
+/** Remembers which prompt each session was launched with, keyed by session id. */
+const launchedPrompts = new Map<string, string>()
+let onSessionCreated: ((id: string) => void) | null = null
+
+const createHeadlessSession = vi.fn((opts: { initialPrompt?: string }) => {
+  const id = `sess-${++sessionSeq}`
+  launchedPrompts.set(id, opts.initialPrompt ?? '')
+  queueMicrotask(() => onSessionCreated?.(id))
+  return Promise.resolve({
+    id,
+    pid: 4242,
+    launchCommand: 'claude --dangerously-skip-permissions -p',
+    agentSessionId: undefined,
+    worktreePath: undefined
+  })
+})
+
+const mockState = {
+  config: {
+    defaults: { defaultAgent: 'claude', headlessStepTimeoutMinutes: 60 },
+    projects: [{ name: 'p', path: '/p' }],
+    tasks: [],
+    workflows: [] as WorkflowDefinition[]
+  },
+  workflowExecutions: new Map<string, WorkflowExecution>(),
+  terminals: new Map(),
+  headlessSessions: [] as { id: string; agentSessionId?: string }[],
+  setWorkflowExecution: (runId: string, execution: WorkflowExecution) => {
+    mockState.workflowExecutions.set(runId, execution)
+  },
+  addHeadlessSession: vi.fn(),
+  startTask: vi.fn(),
+  reopenTask: vi.fn(),
+  getNextTask: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  setWorkflowEditorOpen: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: { getState: () => mockState }
+}))
+
+vi.mock('../src/renderer/lib/notifications', () => ({
+  sendWorkflowGateNotification: vi.fn()
+}))
+
+const { executeWorkflow, retryRunFromFailure, rerunWorkflowRun, contextFromRun } =
+  await import('../src/renderer/lib/workflow-execution')
+
+const agentNode = (id: string, prompt: string) => ({
+  id,
+  type: 'launchAgent' as const,
+  label: id,
+  slug: id,
+  position: { x: 0, y: 0 },
+  config: {
+    agentType: 'claude',
+    projectName: 'p',
+    projectPath: '/p',
+    headless: true,
+    prompt
+  }
+})
+
+/** trigger → a → b → c */
+function makeChain(): WorkflowDefinition {
+  return {
+    id: 'wf-chain',
+    name: 'Chain',
+    icon: 'Rocket',
+    enabled: true,
+    nodes: [
+      { id: 'trigger', type: 'trigger', label: 'Trigger', position: { x: 0, y: 0 }, config: {} },
+      agentNode('a', 'first'),
+      agentNode('b', 'second'),
+      agentNode('c', 'third')
+    ],
+    edges: [
+      { id: 'e1', source: 'trigger', target: 'a' },
+      { id: 'e2', source: 'a', target: 'b' },
+      { id: 'e3', source: 'b', target: 'c' }
+    ]
+  } as unknown as WorkflowDefinition
+}
+
+function nextSession(): Promise<string> {
+  return new Promise((resolve) => {
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      resolve(id)
+    }
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).Notification = { permission: 'denied' }
+  exitListeners.clear()
+  claims.clear()
+  launchedPrompts.clear()
+  runSeq = 0
+  sessionSeq = 0
+  onSessionCreated = null
+  mockState.workflowExecutions.clear()
+
+  globalThis.window.api = {
+    claimWorkflowRun,
+    releaseWorkflowRun,
+    createHeadlessSession,
+    killHeadlessSession: vi.fn(() => Promise.resolve()),
+    saveWorkflowRun: vi.fn(() => Promise.resolve()),
+    reportWorkflowComplete: vi.fn(() => Promise.resolve()),
+    completeConnectorInbox: vi.fn(() => Promise.resolve()),
+    renewConnectorInbox: vi.fn(() => Promise.resolve(true)),
+    runWorkflowManual: vi.fn(() => Promise.resolve()),
+    listSessionEventsBySession: vi.fn(() => Promise.resolve([])),
+    getWorktreeActiveSessions: vi.fn(() => Promise.resolve({ count: 0 })),
+    isWorktreeDirty: vi.fn(() => Promise.resolve(false)),
+    removeWorktree: vi.fn(() => Promise.resolve()),
+    onHeadlessData: () => () => {},
+    onHeadlessExit: (fn: ExitListener) => {
+      exitListeners.add(fn)
+      return () => exitListeners.delete(fn)
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('running up to one step', () => {
+  it('executes only the target and its upstream slice', async () => {
+    const wf = makeChain()
+    const runPromise = executeWorkflow(wf, undefined, { targetNodeId: 'b' })
+
+    emitExit(await nextSession(), 0)
+    emitExit(await nextSession(), 0)
+
+    const execution = await runPromise
+    expect(execution.partial).toBe(true)
+    expect(execution.status).toBe('success')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'a')?.status).toBe('success')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'b')?.status).toBe('success')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'c')?.status).toBe('skipped')
+    expect(createHeadlessSession).toHaveBeenCalledTimes(2)
+  })
+
+  it('claims separately from a full run, so it never blocks one', async () => {
+    const wf = makeChain()
+    const partialPromise = executeWorkflow(wf, undefined, { targetNodeId: 'a' })
+    emitExit(await nextSession(), 0)
+    await partialPromise
+    expect(claimWorkflowRun).toHaveBeenCalledWith(
+      expect.objectContaining({ params: expect.stringContaining(':target:a') })
+    )
+  })
+})
+
+describe('retrying a failed run', () => {
+  async function failAtB(): Promise<{ wf: WorkflowDefinition; failed: WorkflowExecution }> {
+    const wf = makeChain()
+    const runPromise = executeWorkflow(wf)
+    emitExit(await nextSession(), 0)
+    emitExit(await nextSession(), 1)
+    const failed = await runPromise
+    expect(failed.status).toBe('error')
+    return { wf, failed }
+  }
+
+  it('adopts completed outputs and restarts at the failure', async () => {
+    const { wf, failed } = await failAtB()
+    createHeadlessSession.mockClear()
+
+    const retryPromise = retryRunFromFailure(wf, failed)
+    emitExit(await nextSession(), 0)
+    emitExit(await nextSession(), 0)
+
+    const retried = await retryPromise
+    expect(retried.status).toBe('success')
+    expect(retried.retryOfRunId).toBe(failed.runId)
+    // Step a is adopted, never relaunched: only b and c run.
+    expect(createHeadlessSession).toHaveBeenCalledTimes(2)
+    const prompts = [...launchedPrompts.values()]
+    expect(prompts.filter((p) => p.includes('first'))).toHaveLength(1)
+    expect(retried.nodeStates.find((n) => n.nodeId === 'a')?.status).toBe('success')
+  })
+
+  it('re-runs a run from scratch with its original context', async () => {
+    const { wf, failed } = await failAtB()
+    createHeadlessSession.mockClear()
+
+    const rerunPromise = rerunWorkflowRun(wf, failed)
+    emitExit(await nextSession(), 0)
+    emitExit(await nextSession(), 0)
+    emitExit(await nextSession(), 0)
+
+    const rerun = await rerunPromise
+    expect(rerun.status).toBe('success')
+    expect(rerun.runId).not.toBe(failed.runId)
+    expect(createHeadlessSession).toHaveBeenCalledTimes(3)
+  })
+
+  it('rebuilds a context that never carries the inbox lease', () => {
+    const run = {
+      runId: 'r',
+      workflowId: 'wf',
+      startedAt: 's',
+      status: 'error',
+      nodeStates: [],
+      inputs: { pr: '7' },
+      connectorItem: {
+        inboxId: 9,
+        inboxLeaseToken: 'lease',
+        connectionId: 'c',
+        connectorId: 'github',
+        externalId: '1',
+        title: 't',
+        raw: {}
+      }
+    } as unknown as WorkflowExecution
+    const context = contextFromRun(run)
+    expect(context?.inputs).toEqual({ pr: '7' })
+    expect(context?.connectorItem?.inboxId).toBeUndefined()
+    expect(context?.connectorItem?.inboxLeaseToken).toBeUndefined()
+    expect(context?.connectorItem?.externalId).toBe('1')
+  })
+})

--- a/tests/workflow-status.test.ts
+++ b/tests/workflow-status.test.ts
@@ -57,6 +57,9 @@ describe('workflow status colours', () => {
     // ship at roughly 1.7:1.
     const tone = (c: string): string => c.replace(/^(bg|text)-/, '').replace(/-(faint|ghost)$/, '')
     for (const s of EVERY_STATUS) {
+      // Success is the sanctioned exception: its dot borrows the done green,
+      // while the word stays off the category palette (see task-status.test).
+      if (s === 'success') continue
       expect(tone(WORKFLOW_STATUS_TEXT[s])).toBe(tone(WORKFLOW_STATUS_DOT[s]))
     }
   })


### PR DESCRIPTION
Editing a step is no longer blind, and running one is no longer silent.

## Data at the node
- The `{}` picker shows every variable with its **real last-run value**; group headers are the steps themselves — glyph or connector brand mark, name, status dot, ran-at — with run-discovered fields included.
- Templated fields render a **resolved preview** underneath, live; an unresolvable path tints danger with a nearest-path suggestion (declared-but-unemitted paths are trusted, and a suggestion never repeats the token).
- **Run to this step**: executes only the upstream slice through the normal run prompt; recorded as a labeled *partial* run. Available from the config panel and the card hover toolbar (with tooltips, beside delete).
- **Retry from the failed step** adopts completed steps' outputs without re-executing them (loop bodies stay loop-driven; only deliberate skips are preserved via a new `skipReason`); **Run again** starts fresh with the same trigger context. Both live on run rows in the editor and All Runs, with partial chips everywhere.

## The first second of a run
- Run flips **synchronously** to a spinner with an elapsed clock; Stop appears beside it.
- Editor-initiated runs open the run panel pinned to that run, auto-expanding and following the active step; background runs never hijack it.
- Running cards breathe (slow border pulse); a failed step borders danger; success dots take the done green while words stay ink.
- Completion toasts: a quiet auto-dismissing success line; a sticky failure naming the step with Retry-from-here built in.
- Saving no longer resets open panels; canvas edges anchor to measured card bounds.

## Testing & review
- 4,806 tests passing (only the two known ambient-environment failures); new suites for partial/retry seeding, previews, picker values, run feedback, follow behavior.
- Two-reviewer pass with reproduction: four confirmed findings (loop-body adoption race, gate-skip preserved on retry, preview false positives, cross-workflow run tracking leak) — all fixed with regressions in the final commit.
- Hands-on pass in the dev app throughout, including a purpose-built test workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc