### PR TITLE
Pick triggers from the library, receive webhooks, and call any API

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -195,6 +195,7 @@ const nodeSchema = z
       'approval',
       'createTaskFromItem',
       'callConnectorAction',
+      'httpRequest',
       'loop'
     ]),
     label: V.shortText,

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -167,6 +167,18 @@ const triggerConfigSchema = z.union([
     projectFilter: V.name.optional(),
     fromStatus: z.enum(['todo', 'in_progress', 'in_review', 'done', 'cancelled']).optional(),
     toStatus: z.enum(['todo', 'in_progress', 'in_review', 'done', 'cancelled']).optional()
+  }),
+  z.object({
+    triggerType: z.literal('connectorPoll'),
+    connectionId: V.id,
+    event: V.shortText,
+    cron: V.shortText,
+    timezone: V.shortText.optional()
+  }),
+  z.object({
+    triggerType: z.literal('webhook'),
+    method: z.enum(['POST', 'GET']),
+    token: V.shortText
   })
 ])
 

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -149,7 +149,7 @@ export const workflowInputsSchema = z.array(workflowInputDefSchema).superRefine(
   })
 })
 
-const triggerConfigSchema = z.union([
+export const triggerConfigSchema = z.union([
   z.object({
     triggerType: z.literal('manual'),
     contextual: z.boolean().optional(),
@@ -182,7 +182,7 @@ const triggerConfigSchema = z.union([
   })
 ])
 
-const nodeSchema = z
+export const nodeSchema = z
   .object({
     id: V.id,
     // Full node palette — parity with the editor. `config` is a passthrough so

--- a/packages/server/src/connectors/http.ts
+++ b/packages/server/src/connectors/http.ts
@@ -24,6 +24,21 @@ function asString(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
+const ALLOWED_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'])
+
+/**
+ * A profile whose password fields never made it through decryption still holds
+ * ciphertext; sending that as a bearer token is a silent, confusing failure.
+ */
+export function lockedProfileError(
+  filters: Record<string, unknown>,
+  decrypted: Record<string, string> | undefined
+): string | null {
+  if (typeof filters.secret !== 'string' || !filters.secret) return null
+  if (decrypted?.secret !== undefined) return null
+  return "This profile's secret is locked - decryption is unavailable or has not synced yet."
+}
+
 /**
  * Execute one HTTP request with a profile's injection applied. This runs in
  * the server so the secret never crosses into the renderer and responses skip
@@ -33,12 +48,40 @@ export async function performHttpRequest(
   profile: HttpProfileFields,
   spec: HttpRequestSpec
 ): Promise<ActionResult> {
+  const method = asString(spec.method).toUpperCase()
+  if (!ALLOWED_METHODS.has(method)) {
+    return { success: false, error: `Invalid HTTP method: ${spec.method || '(none)'}` }
+  }
   const secret = asString(profile.secret)
   let url: URL
   try {
     url = new URL(spec.url, asString(profile.baseUrl) || undefined)
   } catch {
     return { success: false, error: `Invalid URL: ${spec.url}` }
+  }
+
+  // The URL is template-resolved, so an absolute URL can point anywhere; a
+  // profile's auth only ever travels to the origin the profile names.
+  const hasInjection = !!(
+    asString(profile.authHeader) ||
+    asString(profile.authQuery) ||
+    asString(profile.authBody).trim() ||
+    secret
+  )
+  if (hasInjection) {
+    let baseOrigin: string | null
+    try {
+      const base = asString(profile.baseUrl)
+      baseOrigin = base ? new URL(base).origin : null
+    } catch {
+      baseOrigin = null
+    }
+    if (!baseOrigin || url.origin !== baseOrigin) {
+      return {
+        success: false,
+        error: `This profile only signs requests to ${baseOrigin ?? 'its base URL (none set)'}; refusing ${url.origin}`
+      }
+    }
   }
 
   const headers: Record<string, string> = { ...(spec.headers ?? {}) }
@@ -79,13 +122,14 @@ export async function performHttpRequest(
     }
   }
 
-  const method = spec.method.toUpperCase()
   const sendBody = body && method !== 'GET' && method !== 'HEAD'
   try {
     const res = await fetch(url, {
       method,
       headers,
       ...(sendBody ? { body } : {}),
+      // A redirect could carry the auth to a different host; report it instead.
+      redirect: 'manual',
       signal: AbortSignal.timeout(30_000)
     })
     const text = await res.text()

--- a/packages/server/src/connectors/http.ts
+++ b/packages/server/src/connectors/http.ts
@@ -249,7 +249,7 @@ export const httpConnector: VornConnector = {
             properties: {
               status: { type: 'number' },
               headers: { type: 'object' },
-              body: { type: 'object' }
+              body: { type: ['object', 'array', 'string', 'number', 'boolean', 'null'] }
             }
           }
         }

--- a/packages/server/src/connectors/http.ts
+++ b/packages/server/src/connectors/http.ts
@@ -39,6 +39,18 @@ export function lockedProfileError(
   return "This profile's secret is locked - decryption is unavailable or has not synced yet."
 }
 
+export const HTTP_CONNECTOR_ID = 'http'
+
+/** Why this connection cannot sign a request: it is not an auth profile, or its secret is locked. */
+export function httpProfileError(
+  conn: { connectorId: string; filters: Record<string, unknown> },
+  decrypted: Record<string, string> | undefined
+): string | null {
+  if (conn.connectorId !== HTTP_CONNECTOR_ID)
+    return `Connection belongs to the ${conn.connectorId} connector, not an HTTP auth profile`
+  return lockedProfileError(conn.filters, decrypted)
+}
+
 /**
  * Execute one HTTP request with a profile's injection applied. This runs in
  * the server so the secret never crosses into the renderer and responses skip

--- a/packages/server/src/connectors/http.ts
+++ b/packages/server/src/connectors/http.ts
@@ -1,0 +1,215 @@
+import type { ActionResult, ConnectorManifest, VornConnector } from '@vornrun/shared/types'
+
+/** Auth-profile fields; `secret` arrives already decrypted from the creds store. */
+export interface HttpProfileFields {
+  baseUrl?: unknown
+  authHeader?: unknown
+  authQuery?: unknown
+  authBody?: unknown
+  secret?: unknown
+}
+
+export interface HttpRequestSpec {
+  method: string
+  url: string
+  headers?: Record<string, string>
+  body?: string
+}
+
+function injectSecret(template: string, secret: string): string {
+  return template.replaceAll('{{secret}}', secret)
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+/**
+ * Execute one HTTP request with a profile's injection applied. This runs in
+ * the server so the secret never crosses into the renderer and responses skip
+ * browser CORS entirely.
+ */
+export async function performHttpRequest(
+  profile: HttpProfileFields,
+  spec: HttpRequestSpec
+): Promise<ActionResult> {
+  const secret = asString(profile.secret)
+  let url: URL
+  try {
+    url = new URL(spec.url, asString(profile.baseUrl) || undefined)
+  } catch {
+    return { success: false, error: `Invalid URL: ${spec.url}` }
+  }
+
+  const headers: Record<string, string> = { ...(spec.headers ?? {}) }
+  const authHeader = asString(profile.authHeader)
+  if (authHeader.includes(':')) {
+    const i = authHeader.indexOf(':')
+    headers[authHeader.slice(0, i).trim()] = injectSecret(authHeader.slice(i + 1).trim(), secret)
+  }
+  const authQuery = asString(profile.authQuery)
+  if (authQuery.includes('=')) {
+    const i = authQuery.indexOf('=')
+    url.searchParams.set(
+      authQuery.slice(0, i).trim(),
+      injectSecret(authQuery.slice(i + 1).trim(), secret)
+    )
+  }
+
+  let body = spec.body
+  const authBody = asString(profile.authBody).trim()
+  if (authBody) {
+    try {
+      const inject: unknown = JSON.parse(injectSecret(authBody, secret))
+      const current: unknown = body?.trim() ? JSON.parse(body) : {}
+      const bothObjects =
+        inject !== null &&
+        typeof inject === 'object' &&
+        !Array.isArray(inject) &&
+        current !== null &&
+        typeof current === 'object' &&
+        !Array.isArray(current)
+      if (bothObjects) {
+        body = JSON.stringify({ ...(current as object), ...(inject as object) })
+        const hasContentType = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type')
+        if (!hasContentType) headers['Content-Type'] = 'application/json'
+      }
+    } catch {
+      // A body that is not a JSON object passes through untouched.
+    }
+  }
+
+  const method = spec.method.toUpperCase()
+  const sendBody = body && method !== 'GET' && method !== 'HEAD'
+  try {
+    const res = await fetch(url, {
+      method,
+      headers,
+      ...(sendBody ? { body } : {}),
+      signal: AbortSignal.timeout(30_000)
+    })
+    const text = await res.text()
+    let parsed: unknown = text
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      // Non-JSON responses stay as text.
+    }
+    const responseHeaders: Record<string, string> = {}
+    res.headers.forEach((value, key) => {
+      responseHeaders[key] = value
+    })
+    return { success: true, output: { status: res.status, headers: responseHeaders, body: parsed } }
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/**
+ * Auth profiles are connections of this connector: a base URL plus injection
+ * rules that carry a secret into every request made through the profile.
+ */
+export const httpConnector: VornConnector = {
+  id: 'http',
+  name: 'HTTP',
+  icon: 'http',
+  capabilities: ['actions'],
+
+  async execute(actionType: string, args: Record<string, unknown>): Promise<ActionResult> {
+    const profile = args as HttpProfileFields
+    if (actionType === 'test') {
+      const baseUrl = asString(profile.baseUrl)
+      if (!baseUrl) return { success: false, error: 'Set a base URL to test this profile' }
+      return performHttpRequest(profile, { method: 'GET', url: baseUrl })
+    }
+    if (actionType === 'request') {
+      const url = asString(args.url)
+      if (!url) return { success: false, error: 'url is required' }
+      const headers =
+        args.headers && typeof args.headers === 'object' && !Array.isArray(args.headers)
+          ? (args.headers as Record<string, string>)
+          : undefined
+      return performHttpRequest(profile, {
+        method: asString(args.method) || 'GET',
+        url,
+        headers,
+        body: asString(args.body) || undefined
+      })
+    }
+    return { success: false, error: `Unknown action: ${actionType}` }
+  },
+
+  describe(): ConnectorManifest {
+    return {
+      auth: [
+        {
+          key: 'profileName',
+          label: 'Profile name',
+          type: 'text',
+          required: true,
+          placeholder: 'Acme API'
+        },
+        { key: 'baseUrl', label: 'Base URL', type: 'text', placeholder: 'https://api.example.com' },
+        {
+          key: 'authHeader',
+          label: 'Header added to every request',
+          type: 'text',
+          placeholder: 'Authorization: Bearer {{secret}}'
+        },
+        {
+          key: 'authQuery',
+          label: 'Query parameter added to every request',
+          type: 'text',
+          placeholder: 'api_key={{secret}}'
+        },
+        {
+          key: 'authBody',
+          label: 'JSON merged into every request body',
+          type: 'text',
+          placeholder: '{"token": "{{secret}}"}'
+        },
+        {
+          key: 'secret',
+          label: 'Secret',
+          type: 'password',
+          description: 'Stored encrypted. {{secret}} in the fields above stands for this value.'
+        }
+      ],
+      actions: [
+        {
+          type: 'request',
+          label: 'HTTP request',
+          description: 'Send a request through this profile',
+          configFields: [
+            {
+              key: 'method',
+              label: 'Method',
+              type: 'select',
+              options: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((m) => ({
+                value: m,
+                label: m
+              }))
+            },
+            {
+              key: 'url',
+              label: 'URL or path',
+              type: 'text',
+              required: true,
+              placeholder: '/v1/items',
+              supportsTemplates: true
+            },
+            { key: 'body', label: 'Body', type: 'textarea', supportsTemplates: true }
+          ],
+          outputSchema: {
+            type: 'object',
+            properties: {
+              status: { type: 'number' },
+              headers: { type: 'object' },
+              body: { type: 'object' }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2081,6 +2081,30 @@ export function dbCountActiveConnectorInboxLeases(now: string): number {
  * A crash can leave both absent or both present, never a cursor that points
  * beyond events which were only held in memory.
  */
+/** One webhook request becomes one durable inbox row, deduped by event id. */
+export function dbEnqueueWebhookEvent(args: {
+  workflowId: string
+  eventId: string
+  receivedAt: string
+  item: ConnectorItemContext
+}): void {
+  const d = getDb()
+  d.prepare(
+    `INSERT OR IGNORE INTO connector_inbox (
+      workflow_id, connection_id, connector_id, event_id, event_type,
+      event_timestamp, payload, status, attempts, available_at, created_at
+    ) VALUES (?, ?, 'webhook', ?, 'webhook', ?, ?, 'pending', 0, ?, ?)`
+  ).run(
+    args.workflowId,
+    args.item.connectionId,
+    args.eventId,
+    args.receivedAt,
+    JSON.stringify(args.item),
+    args.receivedAt,
+    args.receivedAt
+  )
+}
+
 export function dbRecordConnectorPollPage(args: {
   workflowId: string
   connectionId: string

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2081,7 +2081,7 @@ export function dbCountActiveConnectorInboxLeases(now: string): number {
  * A crash can leave both absent or both present, never a cursor that points
  * beyond events which were only held in memory.
  */
-/** One webhook request becomes one durable inbox row, deduped by event id. */
+/** One webhook request becomes one durable inbox row. */
 export function dbEnqueueWebhookEvent(args: {
   workflowId: string
   eventId: string
@@ -2260,6 +2260,9 @@ export function dbCompleteConnectorInbox(
   return result.changes === 1
 }
 
+/** Retries stop here: a row this old is failing for a reason a retry won't fix. */
+export const MAX_INBOX_ATTEMPTS = 8
+
 export function dbRetryConnectorInbox(args: {
   id: number
   leaseToken: string
@@ -2269,11 +2272,30 @@ export function dbRetryConnectorInbox(args: {
   const d = getDb()
   const row = d
     .prepare(
-      `SELECT attempts FROM connector_inbox
+      `SELECT attempts, workflow_id FROM connector_inbox
        WHERE id = ? AND status = 'leased' AND lease_token = ?`
     )
-    .get(args.id, args.leaseToken) as { attempts: number } | undefined
+    .get(args.id, args.leaseToken) as { attempts: number; workflow_id: string } | undefined
   if (!row) return false
+  // Attributed to the workflow, since webhook rows share one connection row.
+  const attributed = `Workflow ${row.workflow_id}: ${args.error}`
+  if (row.attempts >= MAX_INBOX_ATTEMPTS) {
+    const dead = d
+      .prepare(
+        `UPDATE connector_inbox
+         SET status = 'dead', lease_until = NULL, lease_token = NULL,
+             last_error = ?, processed_at = ?
+         WHERE id = ? AND status = 'leased' AND lease_token = ?`
+      )
+      .run(args.error, args.now, args.id, args.leaseToken)
+    if (dead.changes !== 1) return false
+    d.prepare(
+      `UPDATE source_connections
+       SET last_sync_error = ?
+       WHERE id = (SELECT connection_id FROM connector_inbox WHERE id = ?)`
+    ).run(`${attributed} (gave up after ${MAX_INBOX_ATTEMPTS} attempts)`, args.id)
+    return true
+  }
   const delayMs = Math.min(60_000 * 2 ** Math.max(0, row.attempts - 1), 60 * 60_000)
   const availableAt = new Date(Date.parse(args.now) + delayMs).toISOString()
   const result = d
@@ -2289,7 +2311,7 @@ export function dbRetryConnectorInbox(args: {
     `UPDATE source_connections
      SET last_sync_error = ?
      WHERE id = (SELECT connection_id FROM connector_inbox WHERE id = ?)`
-  ).run(args.error, args.id)
+  ).run(attributed, args.id)
   return true
 }
 

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -2089,14 +2089,18 @@ export function dbEnqueueWebhookEvent(args: {
   item: ConnectorItemContext
 }): void {
   const d = getDb()
+  // The inbox requires a connection row; webhook events share one internal one.
+  d.prepare(
+    `INSERT OR IGNORE INTO source_connections (id, connector_id, name, created_at)
+     VALUES ('webhook', 'webhook', 'Webhook', ?)`
+  ).run(args.receivedAt)
   d.prepare(
     `INSERT OR IGNORE INTO connector_inbox (
       workflow_id, connection_id, connector_id, event_id, event_type,
       event_timestamp, payload, status, attempts, available_at, created_at
-    ) VALUES (?, ?, 'webhook', ?, 'webhook', ?, ?, 'pending', 0, ?, ?)`
+    ) VALUES (?, 'webhook', 'webhook', ?, 'webhook', ?, ?, 'pending', 0, ?, ?)`
   ).run(
     args.workflowId,
-    args.item.connectionId,
     args.eventId,
     args.receivedAt,
     JSON.stringify(args.item),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -145,8 +145,10 @@ export async function startServer(
   // Register built-in connectors
   const { connectorRegistry } = await import('./connectors')
   const { githubConnector } = await import('./connectors/github')
+  const { httpConnector } = await import('./connectors/http')
   const { mcpConnector } = await import('./connectors/mcp')
   connectorRegistry.register(githubConnector)
+  connectorRegistry.register(httpConnector)
   connectorRegistry.register(mcpConnector)
 
   // Load initial config and wire up managers

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,6 +21,7 @@ import { browserBridge } from './browser-bridge'
 import { parseTopics, clientRegistry } from './broadcast'
 import { IPC } from '@vornrun/shared/types'
 import { registerAllMethods, setServerPort } from './register-methods'
+import { registerWebhookRoute } from './webhook-trigger'
 import { configManager } from './config-manager'
 import { claimPublishedFiles, writePortFile, removePortFile } from './published-files'
 import { openLocalEndpoint, type LocalEndpoint } from './local-endpoint'
@@ -222,6 +223,8 @@ export async function startServer(
   )
 
   app.get('/health', async () => ({ status: 'ok' }))
+
+  registerWebhookRoute(app, () => scheduler.deliverPendingConnectorInbox())
 
   /**
    * Pairing, the phone's half.

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1054,6 +1054,8 @@ export function registerAllMethods(): void {
     return reachableUrls(serverPort, tailscaleIps)
   })
 
+  registerMethod('webhook:info', () => ({ baseUrl: `http://127.0.0.1:${serverPort}` }))
+
   // Tailscale network access. Informational only now: it supplies an address and
   // a QR code, and no longer decides whether the server binds wide.
   registerMethod('tailscale:status', async () => {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -128,6 +128,7 @@ import {
   backfillMcpConnection,
   preflightMcpConnection
 } from './connectors/mcp'
+import { httpConnector, performHttpRequest } from './connectors/http'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
 import { forEachConnectorItem } from './connectors/paging'
@@ -1363,6 +1364,16 @@ export function registerAllMethods(): void {
     clearDecryptedCreds(connectionId)
   })
 
+  registerMethod('http:request', async ({ profileConnectionId, method, url, headers, body }) => {
+    let profile: Record<string, unknown> = {}
+    if (profileConnectionId) {
+      const conn = dbGetSourceConnection(profileConnectionId)
+      if (!conn) return { success: false, error: `Connection ${profileConnectionId} not found` }
+      profile = applyDecryptedCreds(conn)
+    }
+    return performHttpRequest(profile, { method, url, headers, body })
+  })
+
   registerMethod('connection:executeAction', async ({ connectionId, action, args }) => {
     const conn = dbGetSourceConnection(connectionId)
     if (!conn) return { success: false, error: `Connection ${connectionId} not found` }
@@ -1435,6 +1446,13 @@ export function registerAllMethods(): void {
     // under "nothing to check" — the one reading a user is most likely to take
     // as reassurance.
     if (!conn) throw new Error(`connection ${connectionId} not found`)
+    // An http profile's preflight is a real request through its injection.
+    if (conn.connectorId === 'http') {
+      const result = await httpConnector.execute!('test', applyDecryptedCreds(conn))
+      const status = (result.output as { status?: number } | undefined)?.status
+      if (!result.success) return { ok: false, message: result.error }
+      return { ok: (status ?? 500) < 400, message: `HTTP ${status}` }
+    }
     // A built-in connector genuinely declares no preflight, so this really is
     // "nothing to check".
     if (conn.connectorId !== MCP_CONNECTOR_ID) return { ok: null }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1219,7 +1219,8 @@ export function registerAllMethods(): void {
   })
 
   registerMethod('connection:list', ({ connectorId }) => {
-    return dbListSourceConnections(connectorId)
+    // The internal webhook row only satisfies the inbox's connection reference.
+    return dbListSourceConnections(connectorId).filter((c) => c.connectorId !== 'webhook')
   })
 
   registerMethod('connection:create', (params) => {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -128,7 +128,12 @@ import {
   backfillMcpConnection,
   preflightMcpConnection
 } from './connectors/mcp'
-import { httpConnector, lockedProfileError, performHttpRequest } from './connectors/http'
+import {
+  httpConnector,
+  httpProfileError,
+  lockedProfileError,
+  performHttpRequest
+} from './connectors/http'
 import { getDecryptedCreds } from './connectors/decrypted-creds'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
@@ -1377,8 +1382,8 @@ export function registerAllMethods(): void {
     if (profileConnectionId) {
       const conn = dbGetSourceConnection(profileConnectionId)
       if (!conn) return { success: false, error: `Connection ${profileConnectionId} not found` }
-      const locked = lockedProfileError(conn.filters, getDecryptedCreds(conn.id))
-      if (locked) return { success: false, error: locked }
+      const problem = httpProfileError(conn, getDecryptedCreds(conn.id))
+      if (problem) return { success: false, error: problem }
       profile = applyDecryptedCreds(conn)
     }
     return performHttpRequest(profile, { method, url, headers, body })

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1327,6 +1327,12 @@ export function registerAllMethods(): void {
   })
 
   registerMethod('workflow:runManual', ({ workflowId, inputs }) => {
+    const wf = dbGetWorkflow(workflowId)
+    if (!wf) throw new Error(`Workflow ${workflowId} not found`)
+    // Refuse a startless run here rather than burning a claim on a fake run.
+    if (!wf.nodes.some((n) => n.type === 'trigger')) {
+      throw new Error(`Workflow "${wf.name}" has no trigger; add one before running it`)
+    }
     scheduler.triggerWorkflow(workflowId, inputs)
   })
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -128,7 +128,8 @@ import {
   backfillMcpConnection,
   preflightMcpConnection
 } from './connectors/mcp'
-import { httpConnector, performHttpRequest } from './connectors/http'
+import { httpConnector, lockedProfileError, performHttpRequest } from './connectors/http'
+import { getDecryptedCreds } from './connectors/decrypted-creds'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
 import { forEachConnectorItem } from './connectors/paging'
@@ -1370,6 +1371,8 @@ export function registerAllMethods(): void {
     if (profileConnectionId) {
       const conn = dbGetSourceConnection(profileConnectionId)
       if (!conn) return { success: false, error: `Connection ${profileConnectionId} not found` }
+      const locked = lockedProfileError(conn.filters, getDecryptedCreds(conn.id))
+      if (locked) return { success: false, error: locked }
       profile = applyDecryptedCreds(conn)
     }
     return performHttpRequest(profile, { method, url, headers, body })
@@ -1392,6 +1395,10 @@ export function registerAllMethods(): void {
         success: false,
         error: `Connector ${conn.connectorId} does not support actions`
       }
+    }
+    if (conn.connectorId === 'http') {
+      const locked = lockedProfileError(conn.filters, getDecryptedCreds(conn.id))
+      if (locked) return { success: false, error: locked }
     }
     // Merge auth (from decrypted store) + connection filters + call-specific args.
     // Call args take precedence so users can override e.g. repo per-call.
@@ -1449,6 +1456,8 @@ export function registerAllMethods(): void {
     if (!conn) throw new Error(`connection ${connectionId} not found`)
     // An http profile's preflight is a real request through its injection.
     if (conn.connectorId === 'http') {
+      const locked = lockedProfileError(conn.filters, getDecryptedCreds(conn.id))
+      if (locked) return { ok: false, message: locked }
       const result = await httpConnector.execute!('test', applyDecryptedCreds(conn))
       const status = (result.output as { status?: number } | undefined)?.status
       if (!result.success) return { ok: false, message: result.error }

--- a/packages/server/src/webhook-trigger.ts
+++ b/packages/server/src/webhook-trigger.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from 'node:crypto'
+import type { FastifyInstance } from 'fastify'
+import type { TriggerConfig, WebhookTriggerConfig } from '@vornrun/shared/types'
+import { dbGetWorkflow, dbEnqueueWebhookEvent } from './database'
+import log from './logger'
+
+export const WEBHOOK_CONNECTOR_ID = 'webhook'
+
+/** Headers worth exposing to templates; auth-bearing ones stay out of run records. */
+const HEADER_ALLOWLIST = new Set(['content-type', 'user-agent', 'x-event', 'x-request-id'])
+
+function isLoopback(ip: string | undefined): boolean {
+  return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1'
+}
+
+function webhookTrigger(triggerConfig: TriggerConfig | null): WebhookTriggerConfig | null {
+  return triggerConfig?.triggerType === 'webhook' ? triggerConfig : null
+}
+
+/**
+ * One localhost route starts workflows over HTTP. Events land in the durable
+ * connector inbox, so a request received with no window open still runs when
+ * a client next connects.
+ */
+export function registerWebhookRoute(app: FastifyInstance, onEnqueued: () => void): void {
+  app.route({
+    method: ['GET', 'POST'],
+    url: '/wf-hooks/:workflowId/:token',
+    handler: async (req, reply) => {
+      if (!isLoopback(req.ip)) return reply.code(403).send({ error: 'Local machine only' })
+
+      const { workflowId, token } = req.params as { workflowId: string; token: string }
+      const workflow = dbGetWorkflow(workflowId)
+      const triggerNode = workflow?.nodes.find((n) => n.type === 'trigger')
+      const trigger = webhookTrigger((triggerNode?.config as TriggerConfig) ?? null)
+      // One answer for every miss, so the route confirms nothing about ids or tokens.
+      if (!workflow || !workflow.enabled || !trigger || trigger.token !== token) {
+        return reply.code(404).send({ error: 'Not found' })
+      }
+      if (req.method !== trigger.method) {
+        return reply.code(405).send({ error: `This webhook accepts ${trigger.method}` })
+      }
+
+      const headers: Record<string, string> = {}
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (HEADER_ALLOWLIST.has(key) && typeof value === 'string') headers[key] = value
+      }
+      const eventId = randomUUID()
+      dbEnqueueWebhookEvent({
+        workflowId,
+        eventId,
+        receivedAt: new Date().toISOString(),
+        item: {
+          connectionId: `${WEBHOOK_CONNECTOR_ID}:${workflowId}`,
+          connectorId: WEBHOOK_CONNECTOR_ID,
+          externalId: eventId,
+          title: `Webhook ${trigger.method}`,
+          raw: {
+            body: req.body ?? null,
+            headers,
+            method: req.method,
+            receivedAt: new Date().toISOString()
+          }
+        }
+      })
+      log.info(`[webhook] queued event for workflow ${workflowId}`)
+      onEnqueued()
+      return reply.code(202).send({ accepted: true })
+    }
+  })
+}

--- a/packages/server/src/webhook-trigger.ts
+++ b/packages/server/src/webhook-trigger.ts
@@ -47,9 +47,8 @@ export function registerWebhookRoute(app: FastifyInstance, onEnqueued: () => voi
 
       const headers: Record<string, string> = {}
       for (const [key, value] of Object.entries(req.headers)) {
-        if (!HEADER_DENYLIST.has(key.toLowerCase()) && typeof value === 'string') {
-          headers[key] = value
-        }
+        if (HEADER_DENYLIST.has(key.toLowerCase()) || value === undefined) continue
+        headers[key] = Array.isArray(value) ? value.join(', ') : value
       }
       const query: Record<string, string> = {}
       for (const [key, value] of Object.entries((req.query as Record<string, unknown>) ?? {})) {

--- a/packages/server/src/webhook-trigger.ts
+++ b/packages/server/src/webhook-trigger.ts
@@ -6,8 +6,8 @@ import log from './logger'
 
 export const WEBHOOK_CONNECTOR_ID = 'webhook'
 
-/** Headers worth exposing to templates; auth-bearing ones stay out of run records. */
-const HEADER_ALLOWLIST = new Set(['content-type', 'user-agent', 'x-event', 'x-request-id'])
+/** Auth-bearing headers stay out of run records; everything else comes through. */
+const HEADER_DENYLIST = new Set(['authorization', 'cookie', 'proxy-authorization', 'x-api-key'])
 
 function isLoopback(ip: string | undefined): boolean {
   return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1'
@@ -33,17 +33,27 @@ export function registerWebhookRoute(app: FastifyInstance, onEnqueued: () => voi
       const workflow = dbGetWorkflow(workflowId)
       const triggerNode = workflow?.nodes.find((n) => n.type === 'trigger')
       const trigger = webhookTrigger((triggerNode?.config as TriggerConfig) ?? null)
-      // One answer for every miss, so the route confirms nothing about ids or tokens.
-      if (!workflow || !workflow.enabled || !trigger || trigger.token !== token) {
+      // One answer for every miss - wrong method included - so the route
+      // confirms nothing about ids, tokens, or configuration.
+      if (
+        !workflow ||
+        !workflow.enabled ||
+        !trigger ||
+        trigger.token !== token ||
+        req.method !== trigger.method
+      ) {
         return reply.code(404).send({ error: 'Not found' })
-      }
-      if (req.method !== trigger.method) {
-        return reply.code(405).send({ error: `This webhook accepts ${trigger.method}` })
       }
 
       const headers: Record<string, string> = {}
       for (const [key, value] of Object.entries(req.headers)) {
-        if (HEADER_ALLOWLIST.has(key) && typeof value === 'string') headers[key] = value
+        if (!HEADER_DENYLIST.has(key.toLowerCase()) && typeof value === 'string') {
+          headers[key] = value
+        }
+      }
+      const query: Record<string, string> = {}
+      for (const [key, value] of Object.entries((req.query as Record<string, unknown>) ?? {})) {
+        if (typeof value === 'string') query[key] = value
       }
       const eventId = randomUUID()
       dbEnqueueWebhookEvent({
@@ -58,6 +68,7 @@ export function registerWebhookRoute(app: FastifyInstance, onEnqueued: () => voi
           raw: {
             body: req.body ?? null,
             headers,
+            query,
             method: req.method,
             receivedAt: new Date().toISOString()
           }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -257,6 +257,7 @@ export interface RequestMethods {
   /** Present a credential. The only method accepted before authenticating. */
   'auth:authenticate': { params: { token: string }; result: { ok: boolean } }
   'server:reachableUrls': { params: void; result: ReachableUrls }
+  'webhook:info': { params: void; result: { baseUrl: string } }
   // Device tokens. Namespaced `token:` rather than `device:`, which belongs
   // entirely to the simulator registry — thirteen methods of it.
   'token:list': { params: void; result: DeviceToken[] }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -808,6 +808,18 @@ export interface RequestMethods {
   }
   /** Invoke a connector's action (createIssue, commentOnIssue, ...) via the
    *  connection's auth. Used by callConnectorAction workflow nodes. */
+  /** Execute one HTTP request server-side, applying an optional profile's
+   *  auth injection there so secrets never reach the renderer. */
+  'http:request': {
+    params: {
+      profileConnectionId?: string
+      method: string
+      url: string
+      headers?: Record<string, string>
+      body?: string
+    }
+    result: { success: boolean; output?: Record<string, unknown>; error?: string }
+  }
   'connection:executeAction': {
     params: {
       connectionId: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -559,6 +559,7 @@ export interface WorkflowExecutionContext {
     /** Webhook runs: the received request, for {{trigger.body.*}} / {{trigger.headers.*}}. */
     body?: unknown
     headers?: Record<string, string>
+    query?: Record<string, string>
     method?: string
   }
   connectorItem?: ConnectorItemContext

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -582,6 +582,7 @@ export type WorkflowNodeType =
   | 'approval'
   | 'createTaskFromItem'
   | 'callConnectorAction'
+  | 'httpRequest'
   | 'loop'
 
 export interface WorkflowNodePosition {
@@ -805,6 +806,19 @@ export interface CallConnectorActionConfig {
   args: Record<string, string>
 }
 
+export interface HttpRequestConfig {
+  nodeType: 'httpRequest'
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  /** Absolute, or a path resolved against the profile's base URL. */
+  url: string
+  /** Header names are literal; values support template placeholders. */
+  headers: Record<string, string>
+  /** Raw request body; empty sends none. Template placeholders allowed. */
+  body: string
+  /** An `http` connection whose auth injection is applied server-side. */
+  profileConnectionId?: string
+}
+
 export type WorkflowNodeConfig =
   | TriggerConfig
   | LaunchAgentConfig
@@ -813,6 +827,7 @@ export type WorkflowNodeConfig =
   | ApprovalConfig
   | CreateTaskFromItemConfig
   | CallConnectorActionConfig
+  | HttpRequestConfig
   | LoopConfig
 
 /**
@@ -1647,6 +1662,8 @@ export const IPC = {
   CONNECTION_EXECUTE_ACTION: 'connection:executeAction',
   CONNECTION_LIST_ACTIONS: 'connection:listActions',
   WEBHOOK_INFO: 'webhook:info',
+  HTTP_REQUEST: 'http:request',
+  CONNECTION_PREFLIGHT: 'connection:preflight',
   CONNECTION_LIST_MCP_TOOLS: 'connection:listMcpTools',
   CONNECTION_REFRESH_MCP_TOOLS: 'connection:refreshMcpTools',
   CONNECTOR_PROBE_SDK: 'connector:probeSdk',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -556,6 +556,10 @@ export interface WorkflowExecutionContext {
     type: TriggerConfig['triggerType']
     fromStatus?: TaskStatus
     toStatus?: TaskStatus
+    /** Webhook runs: the received request, for {{trigger.body.*}} / {{trigger.headers.*}}. */
+    body?: unknown
+    headers?: Record<string, string>
+    method?: string
   }
   connectorItem?: ConnectorItemContext
   /**
@@ -671,6 +675,13 @@ export interface ConnectorPollTriggerConfig {
   cron: string
   timezone?: string
 }
+/** Fires when the server's localhost webhook route receives a matching request. */
+export interface WebhookTriggerConfig {
+  triggerType: 'webhook'
+  method: 'POST' | 'GET'
+  /** Per-trigger secret path segment; requests without it are rejected. */
+  token: string
+}
 export type TriggerConfig =
   | ManualTriggerConfig
   | OnceTriggerConfig
@@ -678,6 +689,7 @@ export type TriggerConfig =
   | TaskCreatedTriggerConfig
   | TaskStatusChangedTriggerConfig
   | ConnectorPollTriggerConfig
+  | WebhookTriggerConfig
 
 /**
  * Agent type as used in a launchAgent workflow node. A concrete AgentType runs
@@ -1634,6 +1646,7 @@ export const IPC = {
   CREDENTIALS_CLEAR_DECRYPTED: 'credentials:clearDecrypted',
   CONNECTION_EXECUTE_ACTION: 'connection:executeAction',
   CONNECTION_LIST_ACTIONS: 'connection:listActions',
+  WEBHOOK_INFO: 'webhook:info',
   CONNECTION_LIST_MCP_TOOLS: 'connection:listMcpTools',
   CONNECTION_REFRESH_MCP_TOOLS: 'connection:refreshMcpTools',
   CONNECTOR_PROBE_SDK: 'connector:probeSdk',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -707,6 +707,15 @@ export function createApiShim(wsUrl: string) {
       rpc.invoke('connection:backfill', { connectionId }),
     listConnectionActions: (connectionId: string) =>
       rpc.invoke('connection:listActions', connectionId),
+    getWebhookInfo: () => rpc.invoke('webhook:info', undefined),
+    httpRequest: (params: {
+      profileConnectionId?: string
+      method: string
+      url: string
+      headers?: Record<string, string>
+      body?: string
+    }) => rpc.invoke('http:request', params),
+    preflightConnection: (connectionId: string) => rpc.invoke('connection:preflight', connectionId),
     executeConnectorAction: (params: {
       connectionId: string
       action: string

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -346,6 +346,10 @@ export function registerIpcHandlers(): void {
     requireBridge().request(IPC.CONNECTION_EXECUTE_ACTION, params)
   )
   safeHandle(IPC.WEBHOOK_INFO, () => requireBridge().request(IPC.WEBHOOK_INFO, undefined))
+  safeHandle(IPC.HTTP_REQUEST, (_e, params) => requireBridge().request(IPC.HTTP_REQUEST, params))
+  safeHandle(IPC.CONNECTION_PREFLIGHT, (_e, connectionId) =>
+    requireBridge().request(IPC.CONNECTION_PREFLIGHT, connectionId)
+  )
   safeHandle(IPC.CONNECTION_LIST_ACTIONS, (_, connectionId) =>
     requireBridge().request(IPC.CONNECTION_LIST_ACTIONS, connectionId)
   )

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -345,6 +345,7 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.CONNECTION_EXECUTE_ACTION, (_, params) =>
     requireBridge().request(IPC.CONNECTION_EXECUTE_ACTION, params)
   )
+  safeHandle(IPC.WEBHOOK_INFO, () => requireBridge().request(IPC.WEBHOOK_INFO, undefined))
   safeHandle(IPC.CONNECTION_LIST_ACTIONS, (_, connectionId) =>
     requireBridge().request(IPC.CONNECTION_LIST_ACTIONS, connectionId)
   )

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -850,6 +850,16 @@ const api = {
     ipcRenderer.invoke(IPC.CONNECTION_LIST_ACTIONS, connectionId),
 
   getWebhookInfo: (): Promise<{ baseUrl: string }> => ipcRenderer.invoke(IPC.WEBHOOK_INFO),
+  httpRequest: (params: {
+    profileConnectionId?: string
+    method: string
+    url: string
+    headers?: Record<string, string>
+    body?: string
+  }): Promise<{ success: boolean; output?: Record<string, unknown>; error?: string }> =>
+    ipcRenderer.invoke(IPC.HTTP_REQUEST, params),
+  preflightConnection: (connectionId: string): Promise<{ ok: boolean | null; message?: string }> =>
+    ipcRenderer.invoke(IPC.CONNECTION_PREFLIGHT, connectionId),
 
   listMcpTools: (
     connectionId: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -849,6 +849,8 @@ const api = {
   listConnectionActions: (connectionId: string): Promise<ConnectorActionDef[]> =>
     ipcRenderer.invoke(IPC.CONNECTION_LIST_ACTIONS, connectionId),
 
+  getWebhookInfo: (): Promise<{ baseUrl: string }> => ipcRenderer.invoke(IPC.WEBHOOK_INFO),
+
   listMcpTools: (
     connectionId: string
   ): Promise<

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,3 +1,4 @@
+import { schedulerExecutionContext } from './lib/workflow-helpers'
 import { useEffect, useState, Suspense, lazy } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { AnimatePresence } from 'framer-motion'
@@ -359,30 +360,7 @@ export function App() {
           return
         }
 
-        // A webhook event rides the connector pipe; its payload feeds {{trigger.*}}.
-        const webhookRaw =
-          connectorItem?.connectorId === 'webhook'
-            ? (connectorItem.raw as {
-                body?: unknown
-                headers?: Record<string, string>
-                method?: string
-              })
-            : null
-        const context =
-          connectorItem || inputs
-            ? {
-                connectorItem,
-                inputs,
-                ...(webhookRaw && {
-                  trigger: {
-                    type: 'webhook' as const,
-                    body: webhookRaw.body,
-                    headers: webhookRaw.headers,
-                    method: webhookRaw.method
-                  }
-                })
-              }
-            : undefined
+        const context = schedulerExecutionContext(connectorItem, inputs)
         try {
           const execution = await runWorkflow(workflow, context, { source: 'scheduler' })
           // A different run may be parked on an approval gate. It did not

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -359,7 +359,30 @@ export function App() {
           return
         }
 
-        const context = connectorItem || inputs ? { connectorItem, inputs } : undefined
+        // A webhook event rides the connector pipe; its payload feeds {{trigger.*}}.
+        const webhookRaw =
+          connectorItem?.connectorId === 'webhook'
+            ? (connectorItem.raw as {
+                body?: unknown
+                headers?: Record<string, string>
+                method?: string
+              })
+            : null
+        const context =
+          connectorItem || inputs
+            ? {
+                connectorItem,
+                inputs,
+                ...(webhookRaw && {
+                  trigger: {
+                    type: 'webhook' as const,
+                    body: webhookRaw.body,
+                    headers: webhookRaw.headers,
+                    method: webhookRaw.method
+                  }
+                })
+              }
+            : undefined
         try {
           const execution = await runWorkflow(workflow, context, { source: 'scheduler' })
           // A different run may be parked on an approval gate. It did not

--- a/src/renderer/components/ConnectorIcon.tsx
+++ b/src/renderer/components/ConnectorIcon.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Globe } from 'lucide-react'
 import { Tooltip } from './Tooltip'
 import type { SdkConnectorIcon } from '../../shared/types'
 
@@ -16,6 +16,7 @@ const CONNECTOR_ICONS: Record<string, React.FC<{ size: number; className?: strin
       <path d="M5.66301 5.59517C9.18091 2.12137 14.8488 2.135 18.3498 5.63604C21.8508 9.13708 21.8645 14.8049 18.3907 18.3228L5.66301 5.59517Z" />
     </svg>
   ),
+  http: ({ size, className }) => <Globe size={size} className={className} />,
   mcp: ({ size, className }) => (
     <svg
       viewBox="0 0 24 24"

--- a/src/renderer/components/project-sidebar/ProjectItem.tsx
+++ b/src/renderer/components/project-sidebar/ProjectItem.tsx
@@ -192,6 +192,8 @@ export function ProjectItem({
           role="button"
           tabIndex={0}
           onKeyDown={(e) => {
+            // Keys bubbling from a nested control are that control's, not the row's.
+            if (e.target !== e.currentTarget) return
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()
               e.currentTarget.click()
@@ -201,7 +203,7 @@ export function ProjectItem({
             setActiveProject(project.name)
             setFocusedTerminal(null)
           }}
-          className={`flex-1 cursor-pointer text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
+          className={`flex-1 cursor-pointer select-none text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
             isActive
               ? 'bg-white/[0.08] text-white'
               : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
@@ -375,6 +377,8 @@ export function ProjectItem({
                       role="button"
                       tabIndex={0}
                       onKeyDown={(e) => {
+                        // Keys bubbling from a nested control are that control's, not the row's.
+                        if (e.target !== e.currentTarget) return
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
                           e.currentTarget.click()
@@ -385,7 +389,7 @@ export function ProjectItem({
                         setActiveWorktreePath(isMainActive ? null : MAIN_WORKTREE_SENTINEL)
                         setFocusedTerminal(null)
                       }}
-                      className={`flex-1 cursor-pointer text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+                      className={`flex-1 cursor-pointer select-none text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
                         isMainActive
                           ? 'bg-white/[0.08] text-white'
                           : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'

--- a/src/renderer/components/project-sidebar/ProjectItem.tsx
+++ b/src/renderer/components/project-sidebar/ProjectItem.tsx
@@ -187,12 +187,21 @@ export function ProjectItem({
   return (
     <div>
       <div className="group relative flex items-center">
-        <button
+        {/* A div with the button role: the row nests real buttons inside it. */}
+        <div
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              e.currentTarget.click()
+            }
+          }}
           onClick={() => {
             setActiveProject(project.name)
             setFocusedTerminal(null)
           }}
-          className={`flex-1 text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
+          className={`flex-1 cursor-pointer text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 ${
             isActive
               ? 'bg-white/[0.08] text-white'
               : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
@@ -328,7 +337,7 @@ export function ProjectItem({
               </div>
             </>
           )}
-        </button>
+        </div>
         {!isCollapsed && openMenu && (
           <div className="relative">
             <ProjectContextMenu
@@ -362,13 +371,21 @@ export function ProjectItem({
               {mainWt && (
                 <>
                   <div className="group/main flex items-center">
-                    <button
+                    <div
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          e.currentTarget.click()
+                        }
+                      }}
                       onClick={() => {
                         setActiveProject(project.name)
                         setActiveWorktreePath(isMainActive ? null : MAIN_WORKTREE_SENTINEL)
                         setFocusedTerminal(null)
                       }}
-                      className={`flex-1 text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+                      className={`flex-1 cursor-pointer text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
                         isMainActive
                           ? 'bg-white/[0.08] text-white'
                           : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
@@ -461,7 +478,7 @@ export function ProjectItem({
                           </button>
                         </Tooltip>
                       </div>
-                    </button>
+                    </div>
                   </div>
                   {showSessions &&
                     !collapsedBranches.has('__main__') &&

--- a/src/renderer/components/project-sidebar/PromotedCardItem.tsx
+++ b/src/renderer/components/project-sidebar/PromotedCardItem.tsx
@@ -69,6 +69,8 @@ export function PromotedCardItem({ card }: { card: PromotedCard }) {
       tabIndex={0}
       onClick={reveal}
       onKeyDown={(e) => {
+        // Keys bubbling from a nested control are that control's, not the row's.
+        if (e.target !== e.currentTarget) return
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
           reveal()

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -95,14 +95,15 @@ export function SessionItem({
   }, [previewTerminalId, session.id, setPreviewTerminal])
 
   return (
-    // A fragment, because the cards this session popped out are listed beneath
-    // it — and they cannot go inside the row, which is itself a button.
+    // A fragment, because the cards this session popped out are listed beneath the row.
     <>
       {/* A div with the button role: the row nests real buttons inside it. */}
       <div
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
+          // Keys bubbling from a nested control are that control's, not the row's.
+          if (e.target !== e.currentTarget) return
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault()
             e.currentTarget.click()
@@ -122,7 +123,7 @@ export function SessionItem({
         }}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className={`group/session relative w-full cursor-pointer text-left px-2 py-1 rounded-md text-[12px] flex items-center gap-2 min-w-0 transition-colors ${
+        className={`group/session relative w-full cursor-pointer select-none text-left px-2 py-1 rounded-md text-[12px] flex items-center gap-2 min-w-0 transition-colors ${
           isSelected ? 'text-white' : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
         }`}
       >

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -98,7 +98,16 @@ export function SessionItem({
     // A fragment, because the cards this session popped out are listed beneath
     // it — and they cannot go inside the row, which is itself a button.
     <>
-      <button
+      {/* A div with the button role: the row nests real buttons inside it. */}
+      <div
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.currentTarget.click()
+          }
+        }}
         onClick={() => {
           if (hoverTimerRef.current) {
             clearTimeout(hoverTimerRef.current)
@@ -113,7 +122,7 @@ export function SessionItem({
         }}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        className={`group/session relative w-full text-left px-2 py-1 rounded-md text-[12px] flex items-center gap-2 min-w-0 transition-colors ${
+        className={`group/session relative w-full cursor-pointer text-left px-2 py-1 rounded-md text-[12px] flex items-center gap-2 min-w-0 transition-colors ${
           isSelected ? 'text-white' : 'text-gray-400 hover:text-white hover:bg-white/[0.04]'
         }`}
       >
@@ -247,7 +256,7 @@ export function SessionItem({
         >
           <X size={12} strokeWidth={2} />
         </button>
-      </button>
+      </div>
       {promotedCards.map((card) => (
         <PromotedCardItem key={card.id} card={card} />
       ))}

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -97,14 +97,23 @@ export function WorkflowItem({
   }
 
   return (
-    <button
+    // A div with the button role: real buttons (Run, More) nest inside the row.
+    <div
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          e.currentTarget.click()
+        }
+      }}
       onClick={handleEdit}
       onContextMenu={(e) => {
         e.preventDefault()
         onContextMenu(e, workflow.id)
       }}
       title={isCollapsed ? workflow.name : undefined}
-      className={`group/wf relative w-full text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+      className={`group/wf relative w-full cursor-pointer text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
         isSelected ? 'text-white' : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
       } ${isDisabled ? 'opacity-40' : ''} ${isCollapsed ? 'justify-center px-0' : ''}`}
     >
@@ -153,6 +162,6 @@ export function WorkflowItem({
           </Tooltip>
         </>
       )}
-    </button>
+    </div>
   )
 }

--- a/src/renderer/components/project-sidebar/WorkflowItem.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowItem.tsx
@@ -102,6 +102,8 @@ export function WorkflowItem({
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
+        // Keys bubbling from a nested control are that control's, not the row's.
+        if (e.target !== e.currentTarget) return
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
           e.currentTarget.click()
@@ -113,7 +115,7 @@ export function WorkflowItem({
         onContextMenu(e, workflow.id)
       }}
       title={isCollapsed ? workflow.name : undefined}
-      className={`group/wf relative w-full cursor-pointer text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+      className={`group/wf relative w-full cursor-pointer select-none text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
         isSelected ? 'text-white' : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
       } ${isDisabled ? 'opacity-40' : ''} ${isCollapsed ? 'justify-center px-0' : ''}`}
     >

--- a/src/renderer/components/settings/ConnectionRow.tsx
+++ b/src/renderer/components/settings/ConnectionRow.tsx
@@ -1,4 +1,5 @@
-import { Play, Trash2, AlertCircle, Workflow, Import } from 'lucide-react'
+import { useState } from 'react'
+import { Play, Trash2, AlertCircle, Workflow, Import, Activity } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { connectionIcon } from '../../lib/connection-icon'
@@ -45,6 +46,23 @@ export function ConnectionRow({
   onOpenWorkflow: (workflowId: string) => void
   onRefresh: () => void
 }) {
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<{ ok: boolean | null; message?: string } | null>(
+    null
+  )
+
+  const runTest = async () => {
+    setTesting(true)
+    setTestResult(null)
+    try {
+      setTestResult(await window.api.preflightConnection(conn.id))
+    } catch (err) {
+      setTestResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
   return (
     <div className="px-4 py-2 bg-white/[0.03] border border-white/[0.06] rounded-sm">
       <div className="flex items-center justify-between">
@@ -69,6 +87,17 @@ export function ConnectionRow({
               <Import size={13} className={backfillingId === conn.id ? 'animate-pulse' : ''} />
             </button>
           </Tooltip>
+          {conn.connectorId === 'http' && (
+            <Tooltip label="Send a request through this profile now and report the status">
+              <button
+                onClick={runTest}
+                disabled={testing}
+                className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-50"
+              >
+                <Activity size={13} className={testing ? 'animate-pulse' : ''} />
+              </button>
+            </Tooltip>
+          )}
           <Tooltip label="Remove this connection (seeded workflows are also deleted)">
             <button
               onClick={() => onDelete(conn.id)}
@@ -79,6 +108,12 @@ export function ConnectionRow({
           </Tooltip>
         </div>
       </div>
+
+      {testResult && (
+        <div className={`mt-1 text-[11px] ${testResult.ok ? 'text-green-400' : 'text-red-400'}`}>
+          {testResult.message || (testResult.ok ? 'Reachable' : 'Failed')}
+        </div>
+      )}
 
       {/* Polled-by-workflow rows — make the mechanism visible */}
       <div className="mt-1.5 space-y-1">

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -345,6 +345,7 @@ function AddConnectionForm({
         name = `${owner}/${repo}`
       } else {
         name =
+          auth.profileName?.trim() ||
           (filters.teamKey && `${connector.name}: ${filters.teamKey}`) ||
           `${connector.name}${selectedProject ? ` · ${selectedProject}` : ''}`
       }

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -87,6 +87,8 @@ interface Props {
   selectedNodeId: string | null
   /** What each node is doing in live runs; absent when nothing is running. */
   nodeStatus?: Record<string, NodeExecutionStatus>
+  /** Changes when a different workflow loads; re-fits the view top-aligned. */
+  loadKey?: string | null
 }
 
 /** Kept in context so selection/status churn re-renders cards without rebuilding the node array. */
@@ -190,10 +192,15 @@ function StepNode({ data, id }: NodeProps) {
   const node = nodesById.get(data.nodeId as string)
   const updateNodeInternals = useUpdateNodeInternals()
   // A replace-in-place keeps the id, so React Flow would keep the old card's
-  // measured handle positions; re-measure whenever the rendered shape changes.
+  // measured handle positions; re-measure when the rendered shape changes.
+  // Never on mount: that races the initial measure while fitView settles.
   const shape = node ? `${node.type}:${estimateNodeHeight(node, allNodes)}` : ''
+  const lastShape = useRef<string | null>(null)
   useEffect(() => {
-    if (shape) updateNodeInternals(id)
+    if (shape && lastShape.current !== null && lastShape.current !== shape) {
+      updateNodeInternals(id)
+    }
+    lastShape.current = shape || lastShape.current
   }, [id, shape, updateNodeInternals])
   if (!node) return null
 
@@ -228,8 +235,12 @@ function LoopNode({ data, id }: NodeProps) {
   const node = nodesById.get(data.nodeId as string)
   const updateNodeInternals = useUpdateNodeInternals()
   const shape = node ? `${node.type}:${estimateNodeHeight(node, allNodes)}` : ''
+  const lastShape = useRef<string | null>(null)
   useEffect(() => {
-    if (shape) updateNodeInternals(id)
+    if (shape && lastShape.current !== null && lastShape.current !== shape) {
+      updateNodeInternals(id)
+    }
+    lastShape.current = shape || lastShape.current
   }, [id, shape, updateNodeInternals])
   if (!node || node.type !== 'loop') return null
 
@@ -484,9 +495,11 @@ function WorkflowCanvasInner({
   onRunToStep,
   onTidyUp,
   selectedNodeId,
-  nodeStatus
+  nodeStatus,
+  loadKey
 }: Props) {
-  const { screenToFlowPosition, zoomIn, zoomOut, zoomTo, fitView } = useReactFlow()
+  const { screenToFlowPosition, zoomIn, zoomOut, zoomTo, fitView, getViewport, setViewport } =
+    useReactFlow()
   const wrapperRef = useRef<HTMLDivElement>(null)
 
   const elements = useMemo(() => toCanvasElements(nodes, edges), [nodes, edges])
@@ -498,6 +511,27 @@ function WorkflowCanvasInner({
     setSyncedElements(elements)
     setRfNodes(elements.nodes)
   }
+
+  // The flow is vertical: on load, keep fitView's zoom and centering but pin
+  // the topmost node near the top instead of vertically centering the chain.
+  const elementsRef = useRef(elements)
+  useEffect(() => {
+    elementsRef.current = elements
+  }, [elements])
+  const alignTopView = useCallback(async () => {
+    const drawn = elementsRef.current.nodes
+    if (drawn.length === 0) return
+    await fitView({ padding: 0.2, maxZoom: 1 })
+    const { x, zoom } = getViewport()
+    const minY = Math.min(...drawn.map((n) => n.position.y))
+    setViewport({ x, y: 48 - minY * zoom, zoom })
+  }, [fitView, getViewport, setViewport])
+
+  const [rfReady, setRfReady] = useState(false)
+  useEffect(() => {
+    if (!rfReady) return
+    void alignTopView()
+  }, [rfReady, loadKey, alignTopView])
 
   const handleNodesChange = useCallback((changes: NodeChange[]) => {
     // The canvas owns position only; selection and structure stay the editor's.
@@ -651,8 +685,7 @@ function WorkflowCanvasInner({
           onConnectEnd={handleConnectEnd}
           isValidConnection={isValidConnection}
           onPaneClick={() => onNodeClick('')}
-          fitView
-          fitViewOptions={{ padding: 0.2, maxZoom: 1 }}
+          onInit={() => setRfReady(true)}
           minZoom={0.2}
           maxZoom={1.75}
           snapToGrid

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -137,19 +137,24 @@ function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
           </button>
         </Tooltip>
       )}
-      {replaceable && (
+      {(replaceable || isTrigger) && (
         <Tooltip label="Replace step" position="right">
           <button
             aria-label="Replace step"
             onClick={(e) => {
               e.stopPropagation()
-              onOpenLibrary({
-                afterNodeId: nodeId,
-                beforeNodeId: null,
-                insideBranch: false,
-                bodyOnly: false,
-                replaceNodeId: nodeId
-              })
+              // The trigger swaps through its own library scope; both keep id and edges.
+              onOpenLibrary(
+                isTrigger
+                  ? TRIGGER_ANCHOR
+                  : {
+                      afterNodeId: nodeId,
+                      beforeNodeId: null,
+                      insideBranch: false,
+                      bodyOnly: false,
+                      replaceNodeId: nodeId
+                    }
+              )
             }}
             className={TOOLBAR_BUTTON}
           >

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -22,13 +22,15 @@ import {
   type NodeProps
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { AlignVerticalSpaceAround, Repeat, StepForward, Trash2 } from 'lucide-react'
+import { AlignVerticalSpaceAround, Repeat, StepForward, Trash2, Zap } from 'lucide-react'
 import { LoopConfig, NodeExecutionStatus, WorkflowEdge, WorkflowNode } from '../../../shared/types'
 import {
   AddStepNodeData,
   CanvasEdgeData,
   canConnect,
-  toCanvasElements
+  toCanvasElements,
+  TRIGGER_ANCHOR,
+  TRIGGER_ANCHOR_ID
 } from '../../lib/workflow-canvas-layout'
 import { NODE_GLYPH, NODE_SELECTED, NODE_UNSELECTED } from './node-visuals'
 import { WORKFLOW_STATUS_DOT_PULSE } from '../../lib/workflow-status'
@@ -304,6 +306,29 @@ function AddStepNode({ data }: NodeProps) {
   )
 }
 
+/** The dashed spot where a workflow's trigger goes; opens the library in trigger scope. */
+function AddTriggerNode() {
+  const { onOpenLibrary, libraryAnchor } = useInteractions()
+  const active = libraryAnchor?.afterNodeId === TRIGGER_ANCHOR_ID
+  return (
+    <div className="relative pointer-events-auto">
+      <button
+        onClick={() => onOpenLibrary(TRIGGER_ANCHOR)}
+        className={`w-[280px] h-[58px] flex items-center justify-center gap-2 rounded-lg border border-dashed
+                    text-[13px] transition-colors
+                    ${
+                      active
+                        ? 'border-white/40 text-white'
+                        : 'border-white/[0.15] text-gray-500 hover:text-gray-300 hover:border-white/[0.3]'
+                    }`}
+      >
+        <Zap size={14} strokeWidth={2} />
+        Add a trigger
+      </button>
+    </div>
+  )
+}
+
 /** The line, the branch pill, and a hover + whose delayed leave lets the mouse reach it. */
 function StepEdge({
   id,
@@ -396,7 +421,12 @@ function StepEdge({
   )
 }
 
-const NODE_TYPES = { step: StepNode, loop: LoopNode, addStep: AddStepNode }
+const NODE_TYPES = {
+  step: StepNode,
+  loop: LoopNode,
+  addStep: AddStepNode,
+  addTrigger: AddTriggerNode
+}
 const EDGE_TYPES = { step: StepEdge }
 
 function WorkflowCanvasInner({
@@ -436,7 +466,7 @@ function WorkflowCanvasInner({
     // Committing every displayed position materializes the computed layout on first drag.
     const positions: Record<string, { x: number; y: number }> = {}
     for (const rfNode of rfNodes) {
-      if (rfNode.type === 'addStep') continue
+      if (rfNode.type === 'addStep' || rfNode.type === 'addTrigger') continue
       positions[rfNode.id] = { x: rfNode.position.x, y: rfNode.position.y }
     }
     onPositionsCommit(positions)

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -194,7 +194,9 @@ function StepNode({ data, id }: NodeProps) {
   // A replace-in-place keeps the id, so React Flow would keep the old card's
   // measured handle positions; re-measure when the rendered shape changes.
   // Never on mount: that races the initial measure while fitView settles.
-  const shape = node ? `${node.type}:${estimateNodeHeight(node, allNodes)}` : ''
+  // Trigger kinds share a type and height, so the kind is part of the shape.
+  const kind = (node?.config as { triggerType?: string } | undefined)?.triggerType ?? ''
+  const shape = node ? `${node.type}:${kind}:${estimateNodeHeight(node, allNodes)}` : ''
   const lastShape = useRef<string | null>(null)
   useEffect(() => {
     if (shape && lastShape.current !== null && lastShape.current !== shape) {

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -22,7 +22,7 @@ import {
   type NodeProps
 } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
-import { AlignVerticalSpaceAround, Repeat, StepForward, Trash2, Zap } from 'lucide-react'
+import { AlignVerticalSpaceAround, Repeat, Replace, StepForward, Trash2, Zap } from 'lucide-react'
 import { LoopConfig, NodeExecutionStatus, WorkflowEdge, WorkflowNode } from '../../../shared/types'
 import {
   AddStepNodeData,
@@ -32,6 +32,7 @@ import {
   TRIGGER_ANCHOR,
   TRIGGER_ANCHOR_ID
 } from '../../lib/workflow-canvas-layout'
+import { REPLACEABLE_NODE_TYPES } from '../../lib/workflow-helpers'
 import { NODE_GLYPH, NODE_SELECTED, NODE_UNSELECTED } from './node-visuals'
 import { WORKFLOW_STATUS_DOT_PULSE } from '../../lib/workflow-status'
 import { Tooltip } from '../Tooltip'
@@ -56,6 +57,8 @@ export interface InsertAnchor {
   bodyOnly: boolean
   /** Flow coordinates for picks that land where something was dropped. */
   position?: { x: number; y: number }
+  /** Set when the pick swaps this node in place instead of inserting. */
+  replaceNodeId?: string
 }
 
 function isAnchor(anchor: InsertAnchor | null, afterNodeId: string, beforeNodeId: string | null) {
@@ -74,7 +77,7 @@ interface Props {
   onConnectEdge: (sourceId: string, targetId: string) => void
   /** Dragged nodes settled; write the new positions into the definition. */
   onPositionsCommit: (positions: Record<string, { x: number; y: number }>) => void
-  /** Delete-key removal of the selected step (never the trigger). */
+  /** Delete-key removal of the selected step, trigger included. */
   onDeleteNode?: (nodeId: string) => void
   /** Hover-toolbar shortcut into the editor's run-to-step path. */
   onRunToStep?: (nodeId: string) => void
@@ -110,14 +113,17 @@ const TOOLBAR_BUTTON = `p-1.5 rounded-md bg-surface-overlay border border-white/
                         hover:text-white hover:border-white/[0.2] transition-colors`
 
 function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
-  const { onDeleteNode, onRunToStep } = useInteractions()
+  const { nodesById, onDeleteNode, onRunToStep, onOpenLibrary } = useInteractions()
+  const node = nodesById.get(nodeId)
   if (!onDeleteNode && !onRunToStep) return null
+  const isTrigger = node?.type === 'trigger'
+  const replaceable = !!node && REPLACEABLE_NODE_TYPES.has(node.type)
   return (
     <div
       className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 flex flex-col gap-1 opacity-0
                  group-hover:opacity-100 transition-opacity duration-100 z-10"
     >
-      {onRunToStep && (
+      {onRunToStep && !isTrigger && (
         <Tooltip label="Run to this step" position="right">
           <button
             aria-label="Run to this step"
@@ -128,6 +134,26 @@ function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
             className={TOOLBAR_BUTTON}
           >
             <StepForward size={12} />
+          </button>
+        </Tooltip>
+      )}
+      {replaceable && (
+        <Tooltip label="Replace step" position="right">
+          <button
+            aria-label="Replace step"
+            onClick={(e) => {
+              e.stopPropagation()
+              onOpenLibrary({
+                afterNodeId: nodeId,
+                beforeNodeId: null,
+                insideBranch: false,
+                bodyOnly: false,
+                replaceNodeId: nodeId
+              })
+            }}
+            className={TOOLBAR_BUTTON}
+          >
+            <Replace size={12} />
           </button>
         </Tooltip>
       )}
@@ -160,11 +186,9 @@ function StepNode({ data }: NodeProps) {
   return (
     <div className="relative group">
       {node.type !== 'trigger' && (
-        <>
-          <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
-          <NodeHoverToolbar nodeId={node.id} />
-        </>
+        <Handle type="target" position={Position.Top} className={HANDLE_CLASS} />
       )}
+      <NodeHoverToolbar nodeId={node.id} />
       <NodeCard
         node={node}
         selected={node.id === selectedNodeId}
@@ -545,7 +569,7 @@ function WorkflowCanvasInner({
         void fitView({ padding: 0.2, maxZoom: 1 })
       } else if ((e.key === 'Delete' || e.key === 'Backspace') && selectedNodeId) {
         const node = nodes.find((n) => n.id === selectedNodeId)
-        if (node && node.type !== 'trigger' && onDeleteNode) {
+        if (node && onDeleteNode) {
           e.preventDefault()
           onDeleteNode(selectedNodeId)
         }

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -42,6 +42,7 @@ export type AddableNodeType =
   | 'condition'
   | 'approval'
   | 'connectorAction'
+  | 'httpRequest'
   | 'loop'
 
 /** Where a pick from the step library lands, and what that spot allows. */

--- a/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowCanvas.tsx
@@ -14,6 +14,7 @@ import {
   applyNodeChanges,
   getBezierPath,
   useReactFlow,
+  useUpdateNodeInternals,
   type Connection,
   type Edge,
   type EdgeProps,
@@ -28,6 +29,7 @@ import {
   AddStepNodeData,
   CanvasEdgeData,
   canConnect,
+  estimateNodeHeight,
   toCanvasElements,
   TRIGGER_ANCHOR,
   TRIGGER_ANCHOR_ID
@@ -183,9 +185,16 @@ function NodeHoverToolbar({ nodeId }: { nodeId: string }) {
 const HANDLE_CLASS = '!w-[7px] !h-[7px] !bg-surface-base !border !border-white/[0.35] !rounded-full'
 
 /** A single step: the existing card, with ports above and below. */
-function StepNode({ data }: NodeProps) {
-  const { nodesById, selectedNodeId, nodeStatus, onNodeClick } = useInteractions()
+function StepNode({ data, id }: NodeProps) {
+  const { nodesById, allNodes, selectedNodeId, nodeStatus, onNodeClick } = useInteractions()
   const node = nodesById.get(data.nodeId as string)
+  const updateNodeInternals = useUpdateNodeInternals()
+  // A replace-in-place keeps the id, so React Flow would keep the old card's
+  // measured handle positions; re-measure whenever the rendered shape changes.
+  const shape = node ? `${node.type}:${estimateNodeHeight(node, allNodes)}` : ''
+  useEffect(() => {
+    if (shape) updateNodeInternals(id)
+  }, [id, shape, updateNodeInternals])
   if (!node) return null
 
   return (
@@ -206,7 +215,7 @@ function StepNode({ data }: NodeProps) {
 }
 
 /** A loop and its body as one enclosure; membership stays `bodyNodeIds`, not canvas geometry. */
-function LoopNode({ data }: NodeProps) {
+function LoopNode({ data, id }: NodeProps) {
   const {
     nodesById,
     allNodes,
@@ -217,6 +226,11 @@ function LoopNode({ data }: NodeProps) {
     libraryAnchor
   } = useInteractions()
   const node = nodesById.get(data.nodeId as string)
+  const updateNodeInternals = useUpdateNodeInternals()
+  const shape = node ? `${node.type}:${estimateNodeHeight(node, allNodes)}` : ''
+  useEffect(() => {
+    if (shape) updateNodeInternals(id)
+  }, [id, shape, updateNodeInternals])
   if (!node || node.type !== 'loop') return null
 
   const config = node.config as LoopConfig

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -1202,6 +1202,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         <WorkflowCanvas
           nodes={nodes}
           edges={edges}
+          loadKey={editingId}
           onNodeClick={handleNodeClick}
           onOpenLibrary={handleOpenLibrary}
           libraryAnchor={pendingInsert}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -40,6 +40,7 @@ import { WorkflowCanvas, AddableNodeType, InsertAnchor } from './WorkflowCanvas'
 import { StepLibrary, type LibraryPick } from './panels/StepLibrary'
 import {
   layoutPositions,
+  loopBodyMembers,
   TRIGGER_ANCHOR,
   TRIGGER_ANCHOR_ID
 } from '../../lib/workflow-canvas-layout'
@@ -76,7 +77,6 @@ import {
   rerunWorkflowRun,
   stopWorkflowRun
 } from '../../lib/workflow-execution'
-import { loopBodyMembers } from '../../lib/workflow-canvas-layout'
 import { toast } from '../Toast'
 import {
   slugify,
@@ -793,16 +793,37 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         // while the label resets to the new type's default like any swap.
         const existing = nodes.find((n) => n.type === 'trigger')
         if (existing) {
+          const cur = existing.config as TriggerConfig
+          // Re-picking what is already there must not rotate tokens or reset config.
+          const same =
+            pick.kind === 'triggerType'
+              ? cur.triggerType === pick.triggerType
+              : cur.triggerType === 'connectorPoll' &&
+                cur.connectionId === pick.connectionId &&
+                cur.event === pick.event
+          if (same) return
           const fresh = createTriggerNode(config)
           setNodes(
             nodes.map((n) =>
-              n.id === existing.id ? { ...fresh, id: existing.id, position: existing.position } : n
+              n.id === existing.id
+                ? { ...fresh, id: existing.id, position: existing.position, slug: existing.slug }
+                : n
             )
           )
           setSelectedNodeId(existing.id)
         } else {
           const trigger = createTriggerNode(config)
+          // Re-adding a trigger reconnects the orphaned chain: every top-level
+          // node with no incoming edge becomes its successor.
+          const bodySet = loopBodyMembers(nodes)
+          const hasIncoming = new Set(edges.map((e) => e.target))
           setNodes([...nodes, trigger])
+          setEdges([
+            ...edges,
+            ...nodes
+              .filter((n) => !hasIncoming.has(n.id) && !bodySet.has(n.id))
+              .map((n) => ({ id: crypto.randomUUID(), source: trigger.id, target: n.id }))
+          ])
           setSelectedNodeId(trigger.id)
         }
         return
@@ -826,10 +847,18 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
                 }
               })()
             : createNodeWithUniqueSlug(pick.type, target.id)
-        // Same in-place swap the trigger uses: id, position, and edges survive.
+        // Same swap the trigger uses: id, position, edges, and the slug survive,
+        // so downstream {{steps.<slug>.*}} references keep resolving.
         setNodes(
           nodes.map((n) =>
-            n.id === target.id ? { ...fresh, id: target.id, position: target.position } : n
+            n.id === target.id
+              ? {
+                  ...fresh,
+                  id: target.id,
+                  position: target.position,
+                  slug: target.slug ?? fresh.slug
+                }
+              : n
           )
         )
         setSelectedNodeId(target.id)
@@ -857,6 +886,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     [
       pendingInsert,
       nodes,
+      edges,
       createNodeWithUniqueSlug,
       handleAddParallelBranch,
       handlePaletteInsert,

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -38,7 +38,11 @@ import {
 } from '../../../shared/types'
 import { WorkflowCanvas, AddableNodeType, InsertAnchor } from './WorkflowCanvas'
 import { StepLibrary, type LibraryPick } from './panels/StepLibrary'
-import { layoutPositions } from '../../lib/workflow-canvas-layout'
+import {
+  layoutPositions,
+  TRIGGER_ANCHOR,
+  TRIGGER_ANCHOR_ID
+} from '../../lib/workflow-canvas-layout'
 import { useDefinitionHistory } from '../../lib/use-definition-history'
 import { NodeConfigPanel } from './panels/NodeConfigPanel'
 import { RunHistoryPanel } from './panels/RunHistoryPanel'
@@ -50,6 +54,7 @@ import {
   createScriptNode,
   createConditionNode,
   createHttpRequestNode,
+  switchTriggerType,
   createApprovalNode,
   createCallConnectorActionNode,
   appendNodeAfter,
@@ -376,12 +381,11 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setStaggerDelayMs(existingWorkflow.staggerDelayMs)
       setAutoCleanupWorktrees(existingWorkflow.autoCleanupWorktrees ?? false)
     } else if (!editingId) {
-      // New workflow — start with a manual trigger
-      const trigger = createTriggerNode({ triggerType: 'manual' })
+      // New workflow — an empty canvas whose first pick is the trigger.
       setName('New Workflow')
       setIcon('Workflow')
       setIconColor('#3b82f6')
-      setNodes([trigger])
+      setNodes([])
       setEdges([])
       setEnabled(true)
       setStaggerDelayMs(undefined)
@@ -554,6 +558,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     if (!inline) handleClose()
   }, [persistWorkflow, editingId, inline, handleClose])
 
+  const hasTrigger = nodes.some((n) => n.type === 'trigger')
+
   const handleRun = useCallback(() => {
     const workflow = persistWorkflow()
     if (!inline) {
@@ -703,7 +709,10 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
 
   const handlePaletteInsert = useCallback(
     (
-      pick: Exclude<LibraryPick, { kind: 'parallel' }>,
+      pick: Exclude<
+        LibraryPick,
+        { kind: 'parallel' } | { kind: 'triggerType' } | { kind: 'connectorTrigger' }
+      >,
       afterNodeId: string,
       position: { x: number; y: number }
     ) => {
@@ -768,6 +777,28 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       const anchor = pendingInsert
       if (!anchor) return
       setPendingInsert(null)
+      if (pick.kind === 'triggerType' || pick.kind === 'connectorTrigger') {
+        const config: TriggerConfig =
+          pick.kind === 'triggerType'
+            ? switchTriggerType(pick.triggerType)
+            : {
+                triggerType: 'connectorPoll',
+                connectionId: pick.connectionId,
+                event: pick.event,
+                cron: '*/5 * * * *'
+              }
+        // A pick replaces the existing trigger in place; edges stay put.
+        const existing = nodes.find((n) => n.type === 'trigger')
+        if (existing) {
+          setNodes(nodes.map((n) => (n.id === existing.id ? { ...n, config } : n)))
+          setSelectedNodeId(existing.id)
+        } else {
+          const trigger = createTriggerNode(config)
+          setNodes([...nodes, trigger])
+          setSelectedNodeId(trigger.id)
+        }
+        return
+      }
       // A delete or undo can outlive the anchor; inserting against a ghost writes dangling edges.
       if (!nodes.some((n) => n.id === anchor.afterNodeId)) return
       const before = anchor.beforeNodeId
@@ -1018,11 +1049,15 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
               </Tooltip>
             </div>
           ) : (
-            <Tooltip label="Run workflow" position="bottom">
+            <Tooltip
+              label={hasTrigger ? 'Run workflow' : 'Add a trigger before running'}
+              position="bottom"
+            >
               <button
                 onClick={handleRun}
+                disabled={!hasTrigger}
                 aria-label="Run workflow"
-                className="text-gray-400 hover:text-white p-1.5 rounded-md hover:bg-white/[0.06] transition-colors"
+                className="text-gray-400 hover:text-white p-1.5 rounded-md hover:bg-white/[0.06] transition-colors disabled:opacity-40 disabled:hover:text-gray-400 disabled:hover:bg-transparent"
               >
                 <Play size={15} />
               </button>
@@ -1138,7 +1173,11 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
 
         {pendingInsert && (
           <StepLibrary
-            scope={{ bodyOnly: pendingInsert.bodyOnly, insideBranch: pendingInsert.insideBranch }}
+            scope={{
+              bodyOnly: pendingInsert.bodyOnly,
+              insideBranch: pendingInsert.insideBranch,
+              triggers: pendingInsert.afterNodeId === TRIGGER_ANCHOR_ID
+            }}
             onPick={handleLibraryPick}
             onClose={() => setPendingInsert(null)}
           />
@@ -1164,6 +1203,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         {selectedNode && !showRunHistory && !pendingInsert && (
           <NodeConfigPanel
             node={selectedNode}
+            onOpenTriggerLibrary={() => handleOpenLibrary(TRIGGER_ANCHOR)}
             allNodes={nodes}
             onChange={handleNodeConfigChange}
             onLabelChange={handleNodeLabelChange}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -578,7 +578,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   }, [editingId, removeWorkflowFromStore, handleClose])
 
   const createNodeWithUniqueSlug = useCallback(
-    (type: AddableNodeType) => {
+    (type: AddableNodeType, excludeNodeId?: string) => {
       const projects = useAppStore.getState().config?.projects || []
       const firstProject = projects[0]
       const factories: Record<AddableNodeType, () => WorkflowNode> = {
@@ -595,7 +595,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       }
       const newNode = factories[type]()
       if (newNode.slug) {
-        const existingSlugs = new Set(nodes.filter((n) => n.slug).map((n) => n.slug!))
+        const existingSlugs = new Set(
+          nodes.filter((n) => n.slug && n.id !== excludeNodeId).map((n) => n.slug!)
+        )
         newNode.slug = ensureUniqueSlug(newNode.slug, existingSlugs)
       }
       return newNode
@@ -799,6 +801,34 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         }
         return
       }
+      if (anchor.replaceNodeId) {
+        const target = nodes.find((n) => n.id === anchor.replaceNodeId)
+        if (!target) return
+        if (pick.kind !== 'type' && pick.kind !== 'connectorAction') return
+        if (pick.kind === 'type' && (pick.type === 'condition' || pick.type === 'loop')) return
+        const fresh =
+          pick.kind === 'connectorAction'
+            ? (() => {
+                const n = createNodeWithUniqueSlug('connectorAction', target.id)
+                return {
+                  ...n,
+                  config: {
+                    ...(n.config as CallConnectorActionConfig),
+                    connectionId: pick.connectionId,
+                    action: pick.action
+                  }
+                }
+              })()
+            : createNodeWithUniqueSlug(pick.type, target.id)
+        // Same in-place swap the trigger uses: id, position, and edges survive.
+        setNodes(
+          nodes.map((n) =>
+            n.id === target.id ? { ...fresh, id: target.id, position: target.position } : n
+          )
+        )
+        setSelectedNodeId(target.id)
+        return
+      }
       // A delete or undo can outlive the anchor; inserting against a ghost writes dangling edges.
       if (!nodes.some((n) => n.id === anchor.afterNodeId)) return
       const before = anchor.beforeNodeId
@@ -818,7 +848,14 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, pick.type)
       }
     },
-    [pendingInsert, nodes, handleAddParallelBranch, handlePaletteInsert, handleInsertNode]
+    [
+      pendingInsert,
+      nodes,
+      createNodeWithUniqueSlug,
+      handleAddParallelBranch,
+      handlePaletteInsert,
+      handleInsertNode
+    ]
   )
 
   const handleNodeConfigChange = useCallback((nodeId: string, config: WorkflowNode['config']) => {
@@ -1176,7 +1213,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             scope={{
               bodyOnly: pendingInsert.bodyOnly,
               insideBranch: pendingInsert.insideBranch,
-              triggers: pendingInsert.afterNodeId === TRIGGER_ANCHOR_ID
+              triggers: pendingInsert.afterNodeId === TRIGGER_ANCHOR_ID,
+              replacing: !!pendingInsert.replaceNodeId
             }}
             onPick={handleLibraryPick}
             onClose={() => setPendingInsert(null)}
@@ -1204,6 +1242,15 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           <NodeConfigPanel
             node={selectedNode}
             onOpenTriggerLibrary={() => handleOpenLibrary(TRIGGER_ANCHOR)}
+            onOpenReplaceLibrary={(nodeId) =>
+              handleOpenLibrary({
+                afterNodeId: nodeId,
+                beforeNodeId: null,
+                insideBranch: false,
+                bodyOnly: false,
+                replaceNodeId: nodeId
+              })
+            }
             allNodes={nodes}
             onChange={handleNodeConfigChange}
             onLabelChange={handleNodeLabelChange}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -49,6 +49,7 @@ import {
   positionsAreSeed,
   createScriptNode,
   createConditionNode,
+  createHttpRequestNode,
   createApprovalNode,
   createCallConnectorActionNode,
   appendNodeAfter,
@@ -580,6 +581,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         loop: () => createLoopNode(),
         script: () => createScriptNode(),
         connectorAction: () => createCallConnectorActionNode(),
+        httpRequest: () => createHttpRequestNode(),
         agent: () =>
           createLaunchAgentNode(
             firstProject ? { projectName: firstProject.name, projectPath: firstProject.path } : {}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -789,10 +789,16 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
                 event: pick.event,
                 cron: '*/5 * * * *'
               }
-        // A pick replaces the existing trigger in place; edges stay put.
+        // A pick replaces the existing trigger in place; edges stay put,
+        // while the label resets to the new type's default like any swap.
         const existing = nodes.find((n) => n.type === 'trigger')
         if (existing) {
-          setNodes(nodes.map((n) => (n.id === existing.id ? { ...n, config } : n)))
+          const fresh = createTriggerNode(config)
+          setNodes(
+            nodes.map((n) =>
+              n.id === existing.id ? { ...fresh, id: existing.id, position: existing.position } : n
+            )
+          )
           setSelectedNodeId(existing.id)
         } else {
           const trigger = createTriggerNode(config)

--- a/src/renderer/components/workflow-editor/node-visuals.ts
+++ b/src/renderer/components/workflow-editor/node-visuals.ts
@@ -1,4 +1,4 @@
-import { Zap, Play, Terminal, GitFork, Hand, ListPlus, Repeat } from 'lucide-react'
+import { Zap, Play, Terminal, GitFork, Hand, ListPlus, Repeat, Globe } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { NodeExecutionState, WorkflowNode } from '../../../shared/types'
 
@@ -19,6 +19,7 @@ export const NODE_TYPE_ICON: Record<WorkflowNode['type'], LucideIcon> = {
   approval: Hand,
   createTaskFromItem: ListPlus,
   callConnectorAction: Zap,
+  httpRequest: Globe,
   loop: Repeat
 }
 
@@ -91,6 +92,8 @@ export function stepMeta(node: WorkflowNode | undefined, connectorId?: string): 
       return joinMeta(str('project'), str('initialStatus'))
     case 'callConnectorAction':
       return joinMeta(connectorId, str('action'))
+    case 'httpRequest':
+      return joinMeta(str('method'), str('url'))
     default:
       return undefined
   }
@@ -117,6 +120,8 @@ export function stepPreview(node: WorkflowNode | undefined): string | undefined 
       return configString(node, 'prompt')
     case 'approval':
       return configString(node, 'message')
+    case 'httpRequest':
+      return configString(node, 'body')
     case 'callConnectorAction': {
       const args = (node.config as { args?: Record<string, unknown> } | undefined)?.args
       const entries = args ? Object.entries(args) : []

--- a/src/renderer/components/workflow-editor/nodes/HttpRequestNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/HttpRequestNode.tsx
@@ -1,7 +1,7 @@
 import { Globe } from 'lucide-react'
 import type { HttpRequestConfig, NodeExecutionStatus } from '../../../../shared/types'
-import { NODE_GLYPH } from '../node-visuals'
-import { NodeShell } from './NodeShell'
+import { NODE_GLYPH, truncate } from '../node-visuals'
+import { NodeShell, NodeFooter } from './NodeShell'
 
 interface Props {
   label: string
@@ -20,6 +20,8 @@ export function HttpRequestNode({ label, config, selected, executionStatus, onCl
       selected={selected}
       executionStatus={executionStatus}
       onClick={onClick}
-    />
+    >
+      {config.body?.trim() && <NodeFooter mono>{truncate(config.body.trim(), 50)}</NodeFooter>}
+    </NodeShell>
   )
 }

--- a/src/renderer/components/workflow-editor/nodes/HttpRequestNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/HttpRequestNode.tsx
@@ -1,0 +1,25 @@
+import { Globe } from 'lucide-react'
+import type { HttpRequestConfig, NodeExecutionStatus } from '../../../../shared/types'
+import { NODE_GLYPH } from '../node-visuals'
+import { NodeShell } from './NodeShell'
+
+interface Props {
+  label: string
+  config: HttpRequestConfig
+  selected?: boolean
+  executionStatus?: NodeExecutionStatus
+  onClick: () => void
+}
+
+export function HttpRequestNode({ label, config, selected, executionStatus, onClick }: Props) {
+  return (
+    <NodeShell
+      icon={<Globe size={18} className={`${NODE_GLYPH} shrink-0`} strokeWidth={2} />}
+      label={label}
+      subtitle={config.url ? `${config.method} ${config.url}` : 'Set URL'}
+      selected={selected}
+      executionStatus={executionStatus}
+      onClick={onClick}
+    />
+  )
+}

--- a/src/renderer/components/workflow-editor/nodes/NodeCard.tsx
+++ b/src/renderer/components/workflow-editor/nodes/NodeCard.tsx
@@ -7,6 +7,7 @@ import {
   ApprovalConfig,
   CreateTaskFromItemConfig,
   CallConnectorActionConfig,
+  HttpRequestConfig,
   NodeExecutionStatus
 } from '../../../../shared/types'
 import { TriggerNode } from './TriggerNode'
@@ -16,6 +17,7 @@ import { ConditionNode } from './ConditionNode'
 import { ApprovalNode } from './ApprovalNode'
 import { CreateTaskFromItemNode } from './CreateTaskFromItemNode'
 import { CallConnectorActionNode } from './CallConnectorActionNode'
+import { HttpRequestNode } from './HttpRequestNode'
 
 /** The card for a single step, dispatched by type; loops render as composites, not cards. */
 export function NodeCard({
@@ -81,6 +83,18 @@ export function NodeCard({
       <CreateTaskFromItemNode
         label={node.label}
         config={node.config as CreateTaskFromItemConfig}
+        selected={selected}
+        onClick={onClick}
+        executionStatus={executionStatus}
+      />
+    )
+  }
+
+  if (node.type === 'httpRequest') {
+    return (
+      <HttpRequestNode
+        label={node.label}
+        config={node.config as HttpRequestConfig}
         selected={selected}
         onClick={onClick}
         executionStatus={executionStatus}

--- a/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
@@ -1,4 +1,13 @@
-import { Zap, Clock, Calendar, ListPlus, ArrowRightLeft, Plug, type LucideIcon } from 'lucide-react'
+import {
+  Zap,
+  Clock,
+  Calendar,
+  ListPlus,
+  ArrowRightLeft,
+  Plug,
+  Globe,
+  type LucideIcon
+} from 'lucide-react'
 import type {
   TriggerConfig,
   ConnectorPollTriggerConfig,
@@ -22,7 +31,8 @@ const TRIGGER_ICONS: Record<string, LucideIcon> = {
   recurring: Clock,
   taskCreated: ListPlus,
   taskStatusChanged: ArrowRightLeft,
-  connectorPoll: Plug
+  connectorPoll: Plug,
+  webhook: Globe
 }
 const DEFAULT_ICON = Zap
 
@@ -62,6 +72,8 @@ function getSubtitle(config: TriggerConfig): string {
     }
     case 'connectorPoll':
       return `${config.event} · ${config.cron}`
+    case 'webhook':
+      return `${config.method} · this machine`
   }
 }
 

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -61,7 +61,11 @@ export function CallConnectorActionNodeForm({
     }
     if (v.category === 'trigger') {
       if (triggerType === 'webhook') {
-        return v.key.includes('trigger.body') || v.key.includes('trigger.headers')
+        return (
+          v.key.includes('trigger.body') ||
+          v.key.includes('trigger.headers') ||
+          v.key.includes('trigger.query')
+        )
       }
       return triggerType === 'taskStatusChanged' && v.key.includes('Status')
     }

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -60,7 +60,10 @@ export function CallConnectorActionNodeForm({
       return triggerType === 'connectorPoll'
     }
     if (v.category === 'trigger') {
-      return triggerType === 'taskStatusChanged'
+      if (triggerType === 'webhook') {
+        return v.key.includes('trigger.body') || v.key.includes('trigger.headers')
+      }
+      return triggerType === 'taskStatusChanged' && v.key.includes('Status')
     }
     return false
   }).concat(inputVars)

--- a/src/renderer/components/workflow-editor/panels/ConditionConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/ConditionConfigForm.tsx
@@ -35,7 +35,11 @@ export function ConditionConfigForm({
     }
     if (v.category === 'trigger') {
       if (triggerType === 'webhook') {
-        return v.key.includes('trigger.body') || v.key.includes('trigger.headers')
+        return (
+          v.key.includes('trigger.body') ||
+          v.key.includes('trigger.headers') ||
+          v.key.includes('trigger.query')
+        )
       }
       return triggerType === 'taskStatusChanged' && v.key.includes('Status')
     }

--- a/src/renderer/components/workflow-editor/panels/ConditionConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/ConditionConfigForm.tsx
@@ -34,7 +34,10 @@ export function ConditionConfigForm({
       return triggerType === 'taskCreated' || triggerType === 'taskStatusChanged'
     }
     if (v.category === 'trigger') {
-      return triggerType === 'taskStatusChanged'
+      if (triggerType === 'webhook') {
+        return v.key.includes('trigger.body') || v.key.includes('trigger.headers')
+      }
+      return triggerType === 'taskStatusChanged' && v.key.includes('Status')
     }
     return false
   }).concat(inputVars)

--- a/src/renderer/components/workflow-editor/panels/HttpRequestConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/HttpRequestConfigForm.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react'
+import { Plus, X } from 'lucide-react'
+import type { HttpRequestConfig, SourceConnection, TriggerConfig } from '../../../../shared/types'
+import { SelectPicker } from '../../SelectPicker'
+import {
+  getAvailableContextVars,
+  StepVariableGroup,
+  TemplateVariable
+} from '../../../lib/template-vars'
+import { VariableAutocomplete } from './VariableAutocomplete'
+
+const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((m) => ({ value: m, label: m }))
+
+interface Props {
+  config: HttpRequestConfig
+  onChange: (config: HttpRequestConfig) => void
+  triggerType?: TriggerConfig['triggerType']
+  isContextualTrigger?: boolean
+  inputVars?: TemplateVariable[]
+  stepGroups?: StepVariableGroup[]
+}
+
+export function HttpRequestConfigForm({
+  config,
+  onChange,
+  triggerType,
+  isContextualTrigger = false,
+  inputVars = [],
+  stepGroups = []
+}: Props) {
+  const [profiles, setProfiles] = useState<SourceConnection[]>([])
+
+  useEffect(() => {
+    window.api.listConnections().then((conns) => {
+      setProfiles(conns.filter((c) => c.connectorId === 'http'))
+    })
+  }, [])
+
+  const contextVars = [
+    ...getAvailableContextVars({ triggerType, isContextualTrigger }),
+    ...inputVars
+  ]
+  const headerEntries = Object.entries(config.headers ?? {})
+
+  const setHeaders = (entries: [string, string][]) => {
+    onChange({ ...config, headers: Object.fromEntries(entries) })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex gap-2">
+        <div className="w-[110px]">
+          <label className="text-[13px] text-gray-400 font-medium block mb-2">Method</label>
+          <SelectPicker
+            value={config.method}
+            options={METHODS}
+            onChange={(v) => onChange({ ...config, method: v as HttpRequestConfig['method'] })}
+            variant="form"
+          />
+        </div>
+        <div className="flex-1 min-w-0">
+          <label className="text-[13px] text-gray-400 font-medium block mb-2">URL</label>
+          <VariableAutocomplete
+            value={config.url}
+            onChange={(url) => onChange({ ...config, url })}
+            placeholder={config.profileConnectionId ? '/v1/items' : 'https://api.example.com/items'}
+            rows={1}
+            stepGroups={stepGroups}
+            contextVars={contextVars}
+            mono
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Auth profile</label>
+        <SelectPicker
+          value={config.profileConnectionId ?? ''}
+          options={[
+            { value: '', label: 'None' },
+            ...profiles.map((p) => ({ value: p.id, label: p.name }))
+          ]}
+          onChange={(v) => onChange({ ...config, profileConnectionId: v || undefined })}
+          variant="form"
+        />
+        <p className="text-[11px] text-gray-600 mt-1.5">
+          A profile adds its base URL and auth to the request on the server, so its secret never
+          enters this workflow.
+        </p>
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Headers</label>
+        <div className="space-y-1.5">
+          {headerEntries.map(([name, value], i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <input
+                value={name}
+                onChange={(e) => {
+                  const next = [...headerEntries] as [string, string][]
+                  next[i] = [e.target.value, value]
+                  setHeaders(next)
+                }}
+                placeholder="Name"
+                className="w-[140px] bg-white/[0.03] border border-white/[0.08] rounded px-2 py-1.5 text-[12px] font-mono text-white placeholder:text-gray-600 focus:outline-none focus:border-white/[0.2]"
+              />
+              <div className="flex-1 min-w-0">
+                <VariableAutocomplete
+                  value={value}
+                  onChange={(v) => {
+                    const next = [...headerEntries] as [string, string][]
+                    next[i] = [name, v]
+                    setHeaders(next)
+                  }}
+                  placeholder="Value"
+                  rows={1}
+                  stepGroups={stepGroups}
+                  contextVars={contextVars}
+                  mono
+                />
+              </div>
+              <button
+                aria-label="Remove header"
+                onClick={() =>
+                  setHeaders(headerEntries.filter((_, j) => j !== i) as [string, string][])
+                }
+                className="p-1 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ))}
+          <button
+            onClick={() => setHeaders([...headerEntries, ['', '']] as [string, string][])}
+            className="flex items-center gap-1 text-[11px] text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            <Plus size={11} />
+            Add header
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Body</label>
+        <VariableAutocomplete
+          value={config.body}
+          onChange={(body) => onChange({ ...config, body })}
+          placeholder='{"name": "{{trigger.body.name}}"}'
+          rows={6}
+          stepGroups={stepGroups}
+          contextVars={contextVars}
+          mono
+        />
+        <p className="text-[11px] text-gray-600 mt-1.5">Sent as-is. GET requests send no body.</p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { X, MoreHorizontal, Trash2, StepForward } from 'lucide-react'
+import { X, MoreHorizontal, Trash2, Replace, StepForward } from 'lucide-react'
 import {
   WorkflowNode,
   LoopConfig,
@@ -14,6 +14,7 @@ import {
   WorkflowNodeErrorPolicy
 } from '../../../../shared/types'
 import { ConnectorIcon } from '../../ConnectorIcon'
+import { REPLACEABLE_NODE_TYPES } from '../../../lib/workflow-helpers'
 import { useConnectorIdFor, useConnectionIconFor } from '../../../lib/use-connections'
 import { TriggerConfigForm } from './TriggerConfigForm'
 import { LaunchAgentConfigForm } from './LaunchAgentConfigForm'
@@ -30,6 +31,8 @@ import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-
 interface Props {
   /** Open the step library in trigger scope; shown on trigger nodes. */
   onOpenTriggerLibrary?: () => void
+  /** Open the step library to swap this step in place; shown on replaceable steps. */
+  onOpenReplaceLibrary?: (nodeId: string) => void
   node: WorkflowNode
   allNodes?: WorkflowNode[]
   onChange: (nodeId: string, config: WorkflowNode['config']) => void
@@ -48,6 +51,7 @@ interface Props {
 
 export function NodeConfigPanel({
   onOpenTriggerLibrary,
+  onOpenReplaceLibrary,
   node,
   onRunToStep,
   allNodes,
@@ -77,7 +81,6 @@ export function NodeConfigPanel({
 
   const tc = NODE_TYPE_ICON[node.type]
   const Icon = tc
-  const canDelete = node.type !== 'trigger'
 
   // For connector-action nodes the generic Zap is uninformative — show the
   // connector's own mark (GitHub / Linear / MCP / …) by looking the selected
@@ -109,38 +112,49 @@ export function NodeConfigPanel({
           placeholder="Label"
         />
         <div className="flex items-center gap-0.5 shrink-0">
-          {canDelete && (
-            <div className="relative">
-              <button
-                onClick={() => setShowMenu(!showMenu)}
-                aria-label="More node actions"
-                aria-haspopup="menu"
-                aria-expanded={showMenu}
-                className="text-gray-500 hover:text-white p-1 rounded-md transition-colors"
+          <div className="relative">
+            <button
+              onClick={() => setShowMenu(!showMenu)}
+              aria-label="More node actions"
+              aria-haspopup="menu"
+              aria-expanded={showMenu}
+              className="text-gray-500 hover:text-white p-1 rounded-md transition-colors"
+            >
+              <MoreHorizontal size={14} />
+            </button>
+            {showMenu && (
+              <div
+                ref={menuRef}
+                className="absolute right-0 top-full mt-1 z-50 min-w-[160px] py-1 border border-white/[0.08] rounded-lg shadow-xl"
+                style={{ background: 'var(--color-surface-overlay)' }}
               >
-                <MoreHorizontal size={14} />
-              </button>
-              {showMenu && (
-                <div
-                  ref={menuRef}
-                  className="absolute right-0 top-full mt-1 z-50 min-w-[160px] py-1 border border-white/[0.08] rounded-lg shadow-xl"
-                  style={{ background: 'var(--color-surface-overlay)' }}
-                >
+                {onOpenReplaceLibrary && REPLACEABLE_NODE_TYPES.has(node.type) && (
                   <button
                     onClick={() => {
                       setShowMenu(false)
-                      onDelete(node.id)
+                      onOpenReplaceLibrary(node.id)
                     }}
-                    className="w-full px-3 py-2 text-left text-[12px] text-danger/80 hover:text-danger
-                               hover:bg-white/[0.06] flex items-center gap-2 transition-colors"
+                    className="w-full px-3 py-2 text-left text-[12px] text-gray-300 hover:text-white
+                                 hover:bg-white/[0.06] flex items-center gap-2 transition-colors"
                   >
-                    <Trash2 size={12} strokeWidth={1.5} />
-                    Remove action
+                    <Replace size={12} strokeWidth={1.5} />
+                    Replace step
                   </button>
-                </div>
-              )}
-            </div>
-          )}
+                )}
+                <button
+                  onClick={() => {
+                    setShowMenu(false)
+                    onDelete(node.id)
+                  }}
+                  className="w-full px-3 py-2 text-left text-[12px] text-danger/80 hover:text-danger
+                               hover:bg-white/[0.06] flex items-center gap-2 transition-colors"
+                >
+                  <Trash2 size={12} strokeWidth={1.5} />
+                  {node.type === 'trigger' ? 'Remove trigger' : 'Remove action'}
+                </button>
+              </div>
+            )}
+          </div>
           <button
             onClick={onClose}
             aria-label="Close node config"

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -10,6 +10,7 @@ import {
   ApprovalConfig,
   CreateTaskFromItemConfig,
   CallConnectorActionConfig,
+  HttpRequestConfig,
   WorkflowNodeErrorPolicy
 } from '../../../../shared/types'
 import { ConnectorIcon } from '../../ConnectorIcon'
@@ -22,6 +23,7 @@ import { ApprovalConfigForm } from './ApprovalConfigForm'
 import { LoopConfigForm } from './LoopConfigForm'
 import { CreateTaskFromItemNodeForm } from './CreateTaskFromItemNodeForm'
 import { CallConnectorActionNodeForm } from './CallConnectorActionNodeForm'
+import { HttpRequestConfigForm } from './HttpRequestConfigForm'
 import { NODE_TYPE_ICON, NODE_GLYPH } from '../node-visuals'
 import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 
@@ -206,6 +208,17 @@ export function NodeConfigPanel({
           <CreateTaskFromItemNodeForm
             config={node.config as CreateTaskFromItemConfig}
             onChange={(config) => onChange(node.id, config)}
+          />
+        )}
+
+        {node.type === 'httpRequest' && (
+          <HttpRequestConfigForm
+            inputVars={inputVars}
+            config={node.config as HttpRequestConfig}
+            onChange={(config) => onChange(node.id, config)}
+            triggerType={triggerType}
+            isContextualTrigger={isContextualTrigger}
+            stepGroups={stepGroups}
           />
         )}
 

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -28,6 +28,8 @@ import { NODE_TYPE_ICON, NODE_GLYPH } from '../node-visuals'
 import type { StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 
 interface Props {
+  /** Open the step library in trigger scope; shown on trigger nodes. */
+  onOpenTriggerLibrary?: () => void
   node: WorkflowNode
   allNodes?: WorkflowNode[]
   onChange: (nodeId: string, config: WorkflowNode['config']) => void
@@ -45,6 +47,7 @@ interface Props {
 }
 
 export function NodeConfigPanel({
+  onOpenTriggerLibrary,
   node,
   onRunToStep,
   allNodes,
@@ -153,6 +156,7 @@ export function NodeConfigPanel({
           <TriggerConfigForm
             config={node.config as TriggerConfig}
             onChange={(config) => onChange(node.id, config)}
+            onOpenLibrary={onOpenTriggerLibrary}
           />
         )}
 

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Play, Terminal, GitFork, Hand, Repeat, Split, Search, X, Zap } from 'lucide-react'
+import { Play, Terminal, GitFork, Hand, Repeat, Split, Search, X, Zap, Globe } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { ConnectorActionDef, SourceConnection } from '../../../../shared/types'
 import {
@@ -28,6 +28,7 @@ export interface LibraryScope {
 const STEP_ITEMS: { type: AddableNodeType; label: string; icon: LucideIcon }[] = [
   { type: 'agent', label: 'Agent', icon: Play },
   { type: 'script', label: 'Script', icon: Terminal },
+  { type: 'httpRequest', label: 'HTTP request', icon: Globe },
   { type: 'condition', label: 'Condition', icon: GitFork },
   { type: 'approval', label: 'Approval gate', icon: Hand },
   { type: 'loop', label: 'Loop', icon: Repeat }

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -1,7 +1,27 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Play, Terminal, GitFork, Hand, Repeat, Split, Search, X, Zap, Globe } from 'lucide-react'
+import {
+  Play,
+  Terminal,
+  GitFork,
+  Hand,
+  Repeat,
+  Split,
+  Search,
+  X,
+  Zap,
+  Globe,
+  Clock,
+  Calendar,
+  ListPlus,
+  ArrowRightLeft
+} from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
-import type { ConnectorActionDef, SourceConnection } from '../../../../shared/types'
+import type {
+  ConnectorActionDef,
+  ConnectorManifest,
+  SourceConnection,
+  TriggerConfig
+} from '../../../../shared/types'
 import {
   useConnections,
   useConnectorIdFor,
@@ -11,11 +31,13 @@ import { ConnectorIcon } from '../../ConnectorIcon'
 import { NODE_GLYPH } from '../node-visuals'
 import type { AddableNodeType } from '../WorkflowCanvas'
 
-/** A step type, a parallel branch, or a connector action with its connection chosen. */
+/** A step type, a parallel branch, a connector action, or a trigger. */
 export type LibraryPick =
   | { kind: 'type'; type: AddableNodeType }
   | { kind: 'parallel' }
   | { kind: 'connectorAction'; connectionId: string; action: string }
+  | { kind: 'triggerType'; triggerType: TriggerConfig['triggerType'] }
+  | { kind: 'connectorTrigger'; connectionId: string; event: string }
 
 /** What the anchor that opened the library allows. */
 export interface LibraryScope {
@@ -23,7 +45,22 @@ export interface LibraryScope {
   bodyOnly: boolean
   /** Loop and parallel insertion stay off anchors inside a fork branch. */
   insideBranch: boolean
+  /** The trigger spot takes only triggers: built-in types and connector events. */
+  triggers?: boolean
 }
+
+const TRIGGER_ITEMS: {
+  triggerType: TriggerConfig['triggerType']
+  label: string
+  icon: LucideIcon
+}[] = [
+  { triggerType: 'manual', label: 'Manual', icon: Zap },
+  { triggerType: 'recurring', label: 'Recurring schedule', icon: Clock },
+  { triggerType: 'once', label: 'Schedule once', icon: Calendar },
+  { triggerType: 'taskCreated', label: 'Task created', icon: ListPlus },
+  { triggerType: 'taskStatusChanged', label: 'Task moved', icon: ArrowRightLeft },
+  { triggerType: 'webhook', label: 'Webhook', icon: Globe }
+]
 
 const STEP_ITEMS: { type: AddableNodeType; label: string; icon: LucideIcon }[] = [
   { type: 'agent', label: 'Agent', icon: Play },
@@ -76,6 +113,16 @@ export function StepLibrary({
   const [actionsByConnection, setActionsByConnection] = useState<Map<string, ConnectorActionDef[]>>(
     () => new Map()
   )
+  const [manifestsByConnector, setManifestsByConnector] = useState<Map<string, ConnectorManifest>>(
+    () => new Map()
+  )
+
+  useEffect(() => {
+    if (!scope.triggers) return
+    window.api.listConnectors().then((connectors) => {
+      setManifestsByConnector(new Map(connectors.map((c) => [c.id, c.manifest])))
+    })
+  }, [scope.triggers])
 
   useEffect(() => {
     inputRef.current?.focus()
@@ -102,6 +149,41 @@ export function StepLibrary({
   const { rows, pickable } = useMemo(() => {
     const q = query.trim().toLowerCase()
     const rows: (Row | GroupHeader)[] = []
+
+    if (scope.triggers) {
+      rows.push(
+        ...TRIGGER_ITEMS.filter((t) => !q || t.label.toLowerCase().includes(q)).map((t) => ({
+          key: `trigger:${t.triggerType}`,
+          label: t.label,
+          icon: t.icon,
+          pick: { kind: 'triggerType', triggerType: t.triggerType } as LibraryPick
+        }))
+      )
+      for (const conn of connections) {
+        const triggers = (manifestsByConnector.get(conn.connectorId)?.triggers ?? []).filter(
+          (t) =>
+            !q ||
+            (t.label || t.type).toLowerCase().includes(q) ||
+            conn.name.toLowerCase().includes(q)
+        )
+        if (triggers.length === 0) continue
+        rows.push({
+          key: `group:${conn.id}`,
+          header: true,
+          connection: conn,
+          count: triggers.length
+        })
+        for (const trigger of triggers) {
+          rows.push({
+            key: `event:${conn.id}:${trigger.type}`,
+            label: trigger.label || trigger.type,
+            connection: conn,
+            pick: { kind: 'connectorTrigger', connectionId: conn.id, event: trigger.type }
+          })
+        }
+      }
+      return { rows, pickable: rows.filter((r): r is Row => !('header' in r && r.header)) }
+    }
 
     const steps: Row[] = STEP_ITEMS.filter(
       (s) => !scope.bodyOnly || s.type === 'agent' || s.type === 'script'
@@ -151,7 +233,7 @@ export function StepLibrary({
     }
 
     return { rows, pickable: rows.filter((r): r is Row => !('header' in r && r.header)) }
-  }, [query, scope, connections, actionsByConnection])
+  }, [query, scope, connections, actionsByConnection, manifestsByConnector])
 
   const clamped = Math.min(highlight, Math.max(0, pickable.length - 1))
 
@@ -177,7 +259,9 @@ export function StepLibrary({
     >
       <div className="px-4 py-3 border-b border-white/[0.08]">
         <div className="flex items-center justify-between mb-2.5">
-          <span className="text-[13px] font-medium text-white">Add a step</span>
+          <span className="text-[13px] font-medium text-white">
+            {scope.triggers ? 'Add a trigger' : 'Add a step'}
+          </span>
           <button
             aria-label="Close"
             onClick={onClose}
@@ -195,7 +279,7 @@ export function StepLibrary({
               setQuery(e.target.value)
               setHighlight(0)
             }}
-            placeholder="Search steps and actions"
+            placeholder={scope.triggers ? 'Search triggers' : 'Search steps and actions'}
             className="w-full bg-transparent text-[12px] text-white placeholder:text-gray-600 outline-none"
           />
         </div>
@@ -207,7 +291,7 @@ export function StepLibrary({
         )}
         {pickable.length > 0 && rows[0] && !('header' in rows[0] && rows[0].header) && (
           <div className="px-2 pt-1 pb-1 text-[10px] font-mono uppercase tracking-wider text-gray-600">
-            Steps
+            {scope.triggers ? 'Triggers' : 'Steps'}
           </div>
         )}
         {(() => {

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -47,6 +47,8 @@ export interface LibraryScope {
   insideBranch: boolean
   /** The trigger spot takes only triggers: built-in types and connector events. */
   triggers?: boolean
+  /** Swapping a step in place: structural entries (condition, loop, parallel) stay out. */
+  replacing?: boolean
 }
 
 const TRIGGER_ITEMS: {
@@ -189,6 +191,7 @@ export function StepLibrary({
       (s) => !scope.bodyOnly || s.type === 'agent' || s.type === 'script'
     )
       .filter((s) => !(scope.insideBranch && s.type === 'loop'))
+      .filter((s) => !(scope.replacing && (s.type === 'condition' || s.type === 'loop')))
       .filter((s) => !q || s.label.toLowerCase().includes(q))
       .map((s) => ({
         key: `type:${s.type}`,
@@ -196,7 +199,12 @@ export function StepLibrary({
         icon: s.icon,
         pick: { kind: 'type', type: s.type }
       }))
-    if (!scope.bodyOnly && !scope.insideBranch && (!q || 'parallel branch'.includes(q))) {
+    if (
+      !scope.bodyOnly &&
+      !scope.insideBranch &&
+      !scope.replacing &&
+      (!q || 'parallel branch'.includes(q))
+    ) {
       steps.push({
         key: 'parallel',
         label: 'Parallel branch',
@@ -260,7 +268,7 @@ export function StepLibrary({
       <div className="px-4 py-3 border-b border-white/[0.08]">
         <div className="flex items-center justify-between mb-2.5">
           <span className="text-[13px] font-medium text-white">
-            {scope.triggers ? 'Add a trigger' : 'Add a step'}
+            {scope.triggers ? 'Add a trigger' : scope.replacing ? 'Replace step' : 'Add a step'}
           </span>
           <button
             aria-label="Close"

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -15,7 +15,6 @@ import { TriggerConfig, TaskStatus } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
 import { ProjectPicker } from '../../ProjectPicker'
 import { ConnectorPollTriggerForm } from './ConnectorPollTriggerForm'
-import { switchTriggerType } from '../../../lib/workflow-helpers'
 import { WorkflowInputsEditor } from './WorkflowInputsEditor'
 
 interface Props {
@@ -91,16 +90,18 @@ export function TriggerConfigForm({ config, onChange, onOpenLibrary }: Props) {
     <div className="space-y-5">
       <div>
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Trigger Type</label>
-        <SelectPicker
-          value={config.triggerType}
-          options={TRIGGER_TYPES.map(({ type, label, icon: Icon }) => ({
-            value: type,
-            label,
-            icon: <Icon size={12} className="text-gray-400" />
-          }))}
-          onChange={(v) => onChange(switchTriggerType(v as TriggerConfig['triggerType']))}
-          variant="form"
-        />
+        {(() => {
+          const current = TRIGGER_TYPES.find((t) => t.type === config.triggerType)
+          const Icon = current?.icon
+          return (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-white/[0.06] bg-white/[0.02]">
+              {Icon && <Icon size={13} className="text-gray-400 shrink-0" />}
+              <span className="text-[13px] text-gray-200">
+                {current?.label ?? config.triggerType}
+              </span>
+            </div>
+          )
+        })()}
         <p className="text-[11px] text-gray-500 mt-1.5">
           {TRIGGER_TYPES.find((t) => t.type === config.triggerType)?.hint}
         </p>
@@ -109,7 +110,7 @@ export function TriggerConfigForm({ config, onChange, onOpenLibrary }: Props) {
             onClick={onOpenLibrary}
             className="mt-2 text-[11px] text-gray-500 hover:text-gray-300 underline underline-offset-2 transition-colors"
           >
-            Choose from the library, including connector events
+            Change trigger from the library
           </button>
         )}
       </div>

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -15,11 +15,14 @@ import { TriggerConfig, TaskStatus } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
 import { ProjectPicker } from '../../ProjectPicker'
 import { ConnectorPollTriggerForm } from './ConnectorPollTriggerForm'
+import { switchTriggerType } from '../../../lib/workflow-helpers'
 import { WorkflowInputsEditor } from './WorkflowInputsEditor'
 
 interface Props {
   config: TriggerConfig
   onChange: (config: TriggerConfig) => void
+  /** Open the step library in trigger scope to swap this trigger. */
+  onOpenLibrary?: () => void
 }
 
 const CRON_PRESETS = [
@@ -79,28 +82,9 @@ const STATUS_PICKER_OPTIONS = [
   { value: 'cancelled', label: 'Cancelled' }
 ]
 
-function switchTriggerType(type: TriggerConfig['triggerType']): TriggerConfig {
-  switch (type) {
-    case 'manual':
-      return { triggerType: 'manual' }
-    case 'once':
-      return { triggerType: 'once', runAt: new Date().toISOString() }
-    case 'recurring':
-      return { triggerType: 'recurring', cron: '0 9 * * *' }
-    case 'taskCreated':
-      return { triggerType: 'taskCreated' }
-    case 'taskStatusChanged':
-      return { triggerType: 'taskStatusChanged' }
-    case 'connectorPoll':
-      return { triggerType: 'connectorPoll', connectionId: '', event: '', cron: '*/5 * * * *' }
-    case 'webhook':
-      return { triggerType: 'webhook', method: 'POST', token: crypto.randomUUID().slice(0, 13) }
-  }
-}
-
 const EMPTY_PROJECTS: import('../../../../shared/types').ProjectConfig[] = []
 
-export function TriggerConfigForm({ config, onChange }: Props) {
+export function TriggerConfigForm({ config, onChange, onOpenLibrary }: Props) {
   const projects = useAppStore((s) => s.config?.projects ?? EMPTY_PROJECTS)
 
   return (
@@ -120,6 +104,14 @@ export function TriggerConfigForm({ config, onChange }: Props) {
         <p className="text-[11px] text-gray-500 mt-1.5">
           {TRIGGER_TYPES.find((t) => t.type === config.triggerType)?.hint}
         </p>
+        {onOpenLibrary && (
+          <button
+            onClick={onOpenLibrary}
+            className="mt-2 text-[11px] text-gray-500 hover:text-gray-300 underline underline-offset-2 transition-colors"
+          >
+            Choose from the library, including connector events
+          </button>
+        )}
       </div>
 
       {config.triggerType === 'manual' &&

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -360,7 +360,8 @@ function WebhookTriggerFields({
           variant="form"
         />
         <p className="text-[11px] text-gray-500 mt-1.5">
-          The request lands as {'{{trigger.body.*}}'} and {'{{trigger.headers.*}}'}.
+          The request lands as {'{{trigger.body.*}}'}, {'{{trigger.headers.*}}'}, and{' '}
+          {'{{trigger.query.*}}'}.
         </p>
       </div>
     </>

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -1,4 +1,15 @@
-import { Zap, Clock, RefreshCw, ListPlus, ArrowRightLeft, Plug } from 'lucide-react'
+import {
+  Zap,
+  Clock,
+  RefreshCw,
+  ListPlus,
+  ArrowRightLeft,
+  Plug,
+  Globe,
+  Copy,
+  Check
+} from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { useAppStore } from '../../../stores'
 import { TriggerConfig, TaskStatus } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
@@ -50,6 +61,12 @@ const TRIGGER_TYPES = [
     label: 'Connector Poll',
     icon: Plug,
     hint: 'Polls an external connector on cron and fires per new item'
+  },
+  {
+    type: 'webhook' as const,
+    label: 'Webhook',
+    icon: Globe,
+    hint: 'Fires when this machine receives an HTTP request at the workflow URL'
   }
 ]
 
@@ -76,6 +93,8 @@ function switchTriggerType(type: TriggerConfig['triggerType']): TriggerConfig {
       return { triggerType: 'taskStatusChanged' }
     case 'connectorPoll':
       return { triggerType: 'connectorPoll', connectionId: '', event: '', cron: '*/5 * * * *' }
+    case 'webhook':
+      return { triggerType: 'webhook', method: 'POST', token: crypto.randomUUID().slice(0, 13) }
   }
 }
 
@@ -231,6 +250,10 @@ export function TriggerConfigForm({ config, onChange }: Props) {
         <ConnectorPollTriggerForm config={config} onChange={onChange} />
       )}
 
+      {config.triggerType === 'webhook' && (
+        <WebhookTriggerFields config={config} onChange={onChange} />
+      )}
+
       {config.triggerType === 'taskStatusChanged' && (
         <>
           <div>
@@ -272,5 +295,81 @@ export function TriggerConfigForm({ config, onChange }: Props) {
         </>
       )}
     </div>
+  )
+}
+
+function WebhookTriggerFields({
+  config,
+  onChange
+}: {
+  config: Extract<TriggerConfig, { triggerType: 'webhook' }>
+  onChange: (config: TriggerConfig) => void
+}) {
+  const [baseUrl, setBaseUrl] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    window.api
+      .getWebhookInfo()
+      .then((info) => {
+        if (!cancelled) setBaseUrl(info.baseUrl)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const workflowId = useAppStore((s) => s.editingWorkflowId)
+  const url = baseUrl && workflowId ? `${baseUrl}/wf-hooks/${workflowId}/${config.token}` : null
+
+  return (
+    <>
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">URL</label>
+        {url ? (
+          <div className="flex items-center gap-2">
+            <code className="flex-1 min-w-0 px-3 py-2 text-[11px] bg-white/[0.06] border border-white/[0.1] rounded-md text-gray-300 font-mono truncate">
+              {url}
+            </code>
+            <button
+              aria-label="Copy URL"
+              onClick={() => {
+                void navigator.clipboard.writeText(url)
+                setCopied(true)
+                setTimeout(() => setCopied(false), 1500)
+              }}
+              className="p-2 rounded-md border border-white/[0.1] text-gray-400 hover:text-white hover:border-white/[0.2] transition-colors shrink-0"
+            >
+              {copied ? <Check size={12} /> : <Copy size={12} />}
+            </button>
+          </div>
+        ) : (
+          <p className="text-[11px] text-gray-500">
+            Save the workflow first — the URL includes its id.
+          </p>
+        )}
+        <p className="text-[11px] text-gray-500 mt-1.5">
+          Local machine only, and only while the app is open. Exposing it is a deliberate, separate
+          step.
+        </p>
+      </div>
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Method</label>
+        <SelectPicker
+          value={config.method}
+          options={[
+            { value: 'POST', label: 'POST' },
+            { value: 'GET', label: 'GET' }
+          ]}
+          onChange={(v) => onChange({ ...config, method: v as 'POST' | 'GET' })}
+          variant="form"
+        />
+        <p className="text-[11px] text-gray-500 mt-1.5">
+          The request lands as {'{{trigger.body.*}}'} and {'{{trigger.headers.*}}'}.
+        </p>
+      </div>
+    </>
   )
 }

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -441,7 +441,8 @@ export function resolveTemplateVars(
   // `{{ ns.k1.k2.k3... }}` — identifier-first, then any number of dotted
   // segments. The resolver walks those segments into whichever namespace
   // matches (steps / task / trigger / connectorItem).
-  return template.replace(/\{\{\s*([a-zA-Z_][\w.]*)\s*\}\}/g, (match, path: string) => {
+  // Hyphens allowed so header names like content-type resolve as path segments.
+  return template.replace(/\{\{\s*([a-zA-Z_][\w.-]*)\s*\}\}/g, (match, path: string) => {
     const segments = path.split('.')
     const ns = segments[0]
     const rest = segments.slice(1)

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -87,6 +87,8 @@ export const TEMPLATE_VARIABLES: TemplateVariable[] = [
   { key: '{{task.projectName}}', label: 'Project', category: 'task' },
   { key: '{{trigger.fromStatus}}', label: 'Previous Status', category: 'trigger' },
   { key: '{{trigger.toStatus}}', label: 'New Status', category: 'trigger' },
+  { key: '{{trigger.body}}', label: 'Request Body', category: 'trigger' },
+  { key: '{{trigger.headers}}', label: 'Request Headers', category: 'trigger' },
   { key: '{{connectorItem.externalId}}', label: 'External ID', category: 'connectorItem' },
   { key: '{{connectorItem.title}}', label: 'Item Title', category: 'connectorItem' },
   { key: '{{connectorItem.externalUrl}}', label: 'Item URL', category: 'connectorItem' },
@@ -129,7 +131,10 @@ export function getAvailableContextVars(opts: {
   return TEMPLATE_VARIABLES.filter((v) => {
     if (isTaskTrigger && v.category === 'task') return true
     if (isTaskTrigger && v.category === 'trigger' && opts.triggerType === 'taskStatusChanged') {
-      return true
+      return v.key.includes('Status')
+    }
+    if (opts.triggerType === 'webhook' && v.category === 'trigger') {
+      return v.key.includes('trigger.body') || v.key.includes('trigger.headers')
     }
     if (opts.isContextualTrigger && v.category === 'context') return true
     return false

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -89,6 +89,7 @@ export const TEMPLATE_VARIABLES: TemplateVariable[] = [
   { key: '{{trigger.toStatus}}', label: 'New Status', category: 'trigger' },
   { key: '{{trigger.body}}', label: 'Request Body', category: 'trigger' },
   { key: '{{trigger.headers}}', label: 'Request Headers', category: 'trigger' },
+  { key: '{{trigger.query}}', label: 'Query Parameters', category: 'trigger' },
   { key: '{{connectorItem.externalId}}', label: 'External ID', category: 'connectorItem' },
   { key: '{{connectorItem.title}}', label: 'Item Title', category: 'connectorItem' },
   { key: '{{connectorItem.externalUrl}}', label: 'Item URL', category: 'connectorItem' },
@@ -134,7 +135,11 @@ export function getAvailableContextVars(opts: {
       return v.key.includes('Status')
     }
     if (opts.triggerType === 'webhook' && v.category === 'trigger') {
-      return v.key.includes('trigger.body') || v.key.includes('trigger.headers')
+      return (
+        v.key.includes('trigger.body') ||
+        v.key.includes('trigger.headers') ||
+        v.key.includes('trigger.query')
+      )
     }
     if (opts.isContextualTrigger && v.category === 'context') return true
     return false

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -261,6 +261,13 @@ export function buildStepGroups(
             keys = [...schemaKeys, ...defaultKeys]
           }
         }
+      } else if (n.type === 'httpRequest') {
+        keys = [
+          { key: 'status', label: 'status', description: 'HTTP status code' },
+          { key: 'body', label: 'body', description: 'Response body, JSON-parsed when possible' },
+          { key: 'headers', label: 'headers', description: 'Response headers' },
+          ...defaultKeys
+        ]
       } else if (n.type === 'launchAgent') {
         // A headless launchAgent with a declared outputSchema surfaces its typed
         // fields the same way — `{{steps.<slug>.<field>}}` — populated at run

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -5,6 +5,16 @@ import { computeFlowLayout, FlowRow } from './workflow-helpers'
 
 // Projects a workflow definition into canvas elements; the definition stays the source of truth.
 
+/** The anchor id that opens the library in trigger scope. */
+export const TRIGGER_ANCHOR_ID = '__TRIGGER__'
+
+export const TRIGGER_ANCHOR = {
+  afterNodeId: TRIGGER_ANCHOR_ID,
+  beforeNodeId: null,
+  insideBranch: false,
+  bodyOnly: false
+}
+
 export const CARD_WIDTH = 280
 export const LOOP_WIDTH = 312
 /** Horizontal gap between fork branches. */
@@ -238,6 +248,20 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
       source: node.id,
       target: `add:${node.id}`,
       type: 'step',
+      selectable: false
+    })
+  }
+
+  // A workflow with no trigger yet shows the spot where one goes.
+  if (!nodes.some((n) => n.type === 'trigger')) {
+    rfNodes.push({
+      id: 'add-trigger',
+      type: 'addTrigger',
+      position: { x: 0, y: 0 },
+      data: {},
+      width: CARD_WIDTH,
+      height: 58,
+      draggable: false,
       selectable: false
     })
   }

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -77,6 +77,9 @@ export function estimateNodeHeight(node: WorkflowNode, allNodes: WorkflowNode[])
     const cfg = node.config as { variable?: string }
     return cfg.variable ? 90 : 58
   }
+  // A trigger card draws one subtitle line for every kind; its stepPreview
+  // (cron/event) belongs to the run trace, not the card.
+  if (node.type === 'trigger') return 58
   return stepPreview(node) ? 90 : 58
 }
 

--- a/src/renderer/lib/workflow-canvas-layout.ts
+++ b/src/renderer/lib/workflow-canvas-layout.ts
@@ -255,12 +255,23 @@ export function toCanvasElements(nodes: WorkflowNode[], edges: WorkflowEdge[]): 
     })
   }
 
-  // A workflow with no trigger yet shows the spot where one goes.
+  // A workflow with no trigger yet shows the spot where one goes, sitting
+  // above the topmost drawn card and centered on it.
   if (!nodes.some((n) => n.type === 'trigger')) {
+    const cards = rfNodes.filter((n) => n.type === 'step' || n.type === 'loop')
+    let position = { x: 0, y: 0 }
+    if (cards.length > 0) {
+      const top = cards.reduce((a, b) => (b.position.y < a.position.y ? b : a))
+      const topWidth = top.type === 'loop' ? LOOP_WIDTH : CARD_WIDTH
+      position = {
+        x: top.position.x + topWidth / 2 - CARD_WIDTH / 2,
+        y: top.position.y - 58 - ROW_GAP
+      }
+    }
     rfNodes.push({
       id: 'add-trigger',
       type: 'addTrigger',
-      position: { x: 0, y: 0 },
+      position,
       data: {},
       width: CARD_WIDTH,
       height: 58,

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -24,7 +24,7 @@ import {
   resolveTemplateVars,
   StepOutputs
 } from './template-vars'
-import { getWorktreeMode } from './workflow-helpers'
+import { getWorktreeMode, webhookTriggerFromItem } from './workflow-helpers'
 import { buildTaskPrompt, buildWorkflowPrompt } from '../../shared/prompt-builder'
 import { extractStructuredOutput } from '../../shared/structured-output'
 import { useAppStore } from '../stores'
@@ -1560,7 +1560,8 @@ export function contextFromRun(run: WorkflowExecution): WorkflowExecutionContext
     ? { ...run.connectorItem, inboxId: undefined, inboxLeaseToken: undefined }
     : undefined
   if (!task && !connectorItem && !run.inputs) return undefined
-  return { task, connectorItem, inputs: run.inputs }
+  const trigger = webhookTriggerFromItem(connectorItem)
+  return { task, connectorItem, inputs: run.inputs, ...(trigger && { trigger }) }
 }
 
 /**
@@ -2096,7 +2097,13 @@ function rebuildContextForResume(
     ? (useAppStore.getState().config?.tasks || []).find((t) => t.id === execution.triggerTaskId)
     : undefined
   if (!task && !execution.connectorItem && !execution.inputs) return undefined
-  return { task, connectorItem: execution.connectorItem, inputs: execution.inputs }
+  const trigger = webhookTriggerFromItem(execution.connectorItem)
+  return {
+    task,
+    connectorItem: execution.connectorItem,
+    inputs: execution.inputs,
+    ...(trigger && { trigger })
+  }
 }
 
 export async function adoptConnectorInboxLease(

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -13,6 +13,7 @@ import {
   ApprovalConfig,
   CreateTaskFromItemConfig,
   CallConnectorActionConfig,
+  HttpRequestConfig,
   TaskConfig,
   ConnectorItemContext,
   getProjectRemoteHostId
@@ -845,6 +846,43 @@ async function executeNode(
         status: result.success ? 'success' : 'error',
         completedAt: new Date().toISOString(),
         output: result.success ? `${cfg.action} succeeded` : `${cfg.action} failed`,
+        logs: JSON.stringify(result, null, 2),
+        ...(isPlainObject && { structuredOutput: result.output }),
+        ...(result.error && { error: result.error })
+      })
+    } catch (err) {
+      updateNodeState(execution, node.id, {
+        status: 'error',
+        completedAt: new Date().toISOString(),
+        error: err instanceof Error ? err.message : String(err)
+      })
+    }
+    persistExecution(execution)
+    return
+  }
+
+  if (node.type === 'httpRequest') {
+    const cfg = node.config as HttpRequestConfig
+    const headers: Record<string, string> = {}
+    for (const [name, value] of Object.entries(cfg.headers ?? {})) {
+      if (name.trim()) headers[name] = resolveTemplateVars(value, context, stepOutputs)
+    }
+    try {
+      const result = await window.api.httpRequest({
+        profileConnectionId: cfg.profileConnectionId || undefined,
+        method: cfg.method,
+        url: resolveTemplateVars(cfg.url ?? '', context, stepOutputs),
+        headers,
+        body: cfg.body ? resolveTemplateVars(cfg.body, context, stepOutputs) : undefined
+      })
+      const status = (result.output as { status?: number } | undefined)?.status
+      // Same plain-object guard as connector actions, for the same reason.
+      const isPlainObject =
+        !!result.output && typeof result.output === 'object' && !Array.isArray(result.output)
+      updateNodeState(execution, node.id, {
+        status: result.success ? 'success' : 'error',
+        completedAt: new Date().toISOString(),
+        output: result.success ? `HTTP ${status}` : 'Request failed',
         logs: JSON.stringify(result, null, 2),
         ...(isPlainObject && { structuredOutput: result.output }),
         ...(result.error && { error: result.error })

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -865,7 +865,7 @@ async function executeNode(
     const cfg = node.config as HttpRequestConfig
     const headers: Record<string, string> = {}
     for (const [name, value] of Object.entries(cfg.headers ?? {})) {
-      if (name.trim()) headers[name] = resolveTemplateVars(value, context, stepOutputs)
+      if (name.trim()) headers[name.trim()] = resolveTemplateVars(value, context, stepOutputs)
     }
     try {
       const result = await window.api.httpRequest({

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -388,6 +388,26 @@ export function createCallConnectorActionNode(
   }
 }
 
+export function createHttpRequestNode(
+  config: Partial<import('../../shared/types').HttpRequestConfig> = {}
+): WorkflowNode {
+  return {
+    id: crypto.randomUUID(),
+    type: 'httpRequest',
+    label: 'HTTP Request',
+    slug: slugify('HTTP Request'),
+    config: {
+      nodeType: 'httpRequest',
+      method: 'GET',
+      url: '',
+      headers: {},
+      body: '',
+      ...config
+    } as import('../../shared/types').HttpRequestConfig,
+    position: { x: 0, y: 0 }
+  }
+}
+
 export function createConditionNode(config: Partial<ConditionConfig> = {}): WorkflowNode {
   return {
     id: crypto.randomUUID(),

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -632,7 +632,9 @@ export function autoLayoutNodes(nodes: WorkflowNode[], edges: WorkflowEdge[]): W
   if (nodes.length === 0) return nodes
 
   const triggerNode = nodes.find((n) => n.type === 'trigger')
-  const ordered = triggerNode ? [triggerNode] : []
+  const hasIncoming = new Set(edges.map((e) => e.target))
+  // Without a trigger, seed from the roots so the walk still orders the chain.
+  const ordered = triggerNode ? [triggerNode] : nodes.filter((n) => !hasIncoming.has(n.id))
 
   const childrenMap = new Map<string, string[]>()
   for (const edge of edges) {
@@ -810,9 +812,18 @@ export function computeFlowLayout(nodes: WorkflowNode[], edges: WorkflowEdge[]):
   const successorsMap = buildSuccessorsMap(edges)
   const triggerNode = nodes.find((n) => n.type === 'trigger')
 
-  if (!triggerNode) return nodes.map((n) => ({ kind: 'node' as const, node: n }))
-
-  const rows = buildFlowFromNode(triggerNode.id, null, nodeMap, successorsMap)
+  // Without a trigger the walk seeds from every root, so the chain still
+  // draws as a chain rather than a flat column of disconnected rows.
+  const rows: FlowRow[] = []
+  if (triggerNode) {
+    rows.push(...buildFlowFromNode(triggerNode.id, null, nodeMap, successorsMap))
+  } else {
+    const hasIncoming = new Set(edges.map((e) => e.target))
+    const seen = new Set<string>()
+    for (const root of nodes.filter((n) => !hasIncoming.has(n.id))) {
+      rows.push(...buildFlowFromNode(root.id, null, nodeMap, successorsMap, seen))
+    }
+  }
 
   // Append orphan nodes not reachable from the trigger
   const visited = collectNodeIds(rows)

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -388,6 +388,26 @@ export function createCallConnectorActionNode(
   }
 }
 
+/** The default config for each trigger type, used by the form and the library. */
+export function switchTriggerType(type: TriggerConfig['triggerType']): TriggerConfig {
+  switch (type) {
+    case 'manual':
+      return { triggerType: 'manual' }
+    case 'once':
+      return { triggerType: 'once', runAt: new Date().toISOString() }
+    case 'recurring':
+      return { triggerType: 'recurring', cron: '0 9 * * *' }
+    case 'taskCreated':
+      return { triggerType: 'taskCreated' }
+    case 'taskStatusChanged':
+      return { triggerType: 'taskStatusChanged' }
+    case 'connectorPoll':
+      return { triggerType: 'connectorPoll', connectionId: '', event: '', cron: '*/5 * * * *' }
+    case 'webhook':
+      return { triggerType: 'webhook', method: 'POST', token: crypto.randomUUID().slice(0, 13) }
+  }
+}
+
 export function createHttpRequestNode(
   config: Partial<import('../../shared/types').HttpRequestConfig> = {}
 ): WorkflowNode {

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -390,6 +390,26 @@ export function createCallConnectorActionNode(
   }
 }
 
+/** The {{trigger.*}} namespace of a webhook run, rebuilt from the event's stored payload. */
+export function webhookTriggerFromItem(
+  connectorItem: import('../../shared/types').ConnectorItemContext | undefined
+): import('../../shared/types').WorkflowExecutionContext['trigger'] | undefined {
+  if (connectorItem?.connectorId !== 'webhook') return undefined
+  const raw = connectorItem.raw as {
+    body?: unknown
+    headers?: Record<string, string>
+    query?: Record<string, string>
+    method?: string
+  }
+  return {
+    type: 'webhook' as const,
+    body: raw.body,
+    headers: raw.headers,
+    query: raw.query,
+    method: raw.method
+  }
+}
+
 /**
  * The run context for a scheduler-delivered event. A webhook event rides the
  * connector pipe for durability, so its payload is lifted into the trigger
@@ -400,22 +420,8 @@ export function schedulerExecutionContext(
   inputs: Record<string, unknown> | undefined
 ): import('../../shared/types').WorkflowExecutionContext | undefined {
   if (!connectorItem && !inputs) return undefined
-  const webhookRaw =
-    connectorItem?.connectorId === 'webhook'
-      ? (connectorItem.raw as { body?: unknown; headers?: Record<string, string>; method?: string })
-      : null
-  return {
-    connectorItem,
-    inputs,
-    ...(webhookRaw && {
-      trigger: {
-        type: 'webhook' as const,
-        body: webhookRaw.body,
-        headers: webhookRaw.headers,
-        method: webhookRaw.method
-      }
-    })
-  }
+  const trigger = webhookTriggerFromItem(connectorItem)
+  return { connectorItem, inputs, ...(trigger && { trigger }) }
 }
 
 /** Steps that can swap type in place; condition, loop, and trigger own structure or their own path. */
@@ -444,7 +450,7 @@ export function switchTriggerType(type: TriggerConfig['triggerType']): TriggerCo
     case 'connectorPoll':
       return { triggerType: 'connectorPoll', connectionId: '', event: '', cron: '*/5 * * * *' }
     case 'webhook':
-      return { triggerType: 'webhook', method: 'POST', token: crypto.randomUUID().slice(0, 13) }
+      return { triggerType: 'webhook', method: 'POST', token: crypto.randomUUID() }
   }
 }
 

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -388,6 +388,34 @@ export function createCallConnectorActionNode(
   }
 }
 
+/**
+ * The run context for a scheduler-delivered event. A webhook event rides the
+ * connector pipe for durability, so its payload is lifted into the trigger
+ * namespace here while the connectorItem keeps the lease machinery working.
+ */
+export function schedulerExecutionContext(
+  connectorItem: import('../../shared/types').ConnectorItemContext | undefined,
+  inputs: Record<string, unknown> | undefined
+): import('../../shared/types').WorkflowExecutionContext | undefined {
+  if (!connectorItem && !inputs) return undefined
+  const webhookRaw =
+    connectorItem?.connectorId === 'webhook'
+      ? (connectorItem.raw as { body?: unknown; headers?: Record<string, string>; method?: string })
+      : null
+  return {
+    connectorItem,
+    inputs,
+    ...(webhookRaw && {
+      trigger: {
+        type: 'webhook' as const,
+        body: webhookRaw.body,
+        headers: webhookRaw.headers,
+        method: webhookRaw.method
+      }
+    })
+  }
+}
+
 /** The default config for each trigger type, used by the form and the library. */
 export function switchTriggerType(type: TriggerConfig['triggerType']): TriggerConfig {
   switch (type) {

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -416,6 +416,16 @@ export function schedulerExecutionContext(
   }
 }
 
+/** Steps that can swap type in place; condition, loop, and trigger own structure or their own path. */
+export const REPLACEABLE_NODE_TYPES: ReadonlySet<string> = new Set([
+  'launchAgent',
+  'script',
+  'approval',
+  'createTaskFromItem',
+  'callConnectorAction',
+  'httpRequest'
+])
+
 /** The default config for each trigger type, used by the form and the library. */
 export function switchTriggerType(type: TriggerConfig['triggerType']): TriggerConfig {
   switch (type) {

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -203,7 +203,9 @@ export function createTriggerNode(config: TriggerConfig = { triggerType: 'manual
     once: 'Schedule (Once)',
     recurring: 'Schedule (Recurring)',
     taskCreated: 'When Task Created',
-    taskStatusChanged: 'When Task Status Changes'
+    taskStatusChanged: 'When Task Status Changes',
+    connectorPoll: 'Connector Poll',
+    webhook: 'Webhook'
   }
   return {
     id: crypto.randomUUID(),

--- a/src/renderer/lib/workflow-menu-items.tsx
+++ b/src/renderer/lib/workflow-menu-items.tsx
@@ -5,6 +5,7 @@ import { executeWorkflow } from './workflow-execution'
 import { isContextualWorkflow, needsRunPrompt } from './workflow-helpers'
 import type { ManualRunContext } from './workflow-helpers'
 import { useAppStore } from '../stores'
+import { toast } from '../components/Toast'
 import type { WorkflowDefinition } from '../../shared/types'
 
 export interface WorkflowMenuItem {
@@ -44,6 +45,11 @@ export function startManualRun(
   ctx?: ManualRunContext,
   options?: { targetNodeId?: string }
 ): void {
+  // Every manual surface funnels here; a startless workflow cannot run.
+  if (!workflow.nodes.some((n) => n.type === 'trigger')) {
+    toast.error(`"${workflow.name}" has no trigger — add one in the editor first`)
+    return
+  }
   if (needsRunPrompt(workflow, ctx)) {
     useAppStore.getState().setPendingWorkflowRun(workflow.id, ctx, options?.targetNodeId)
     return

--- a/tests/add-trigger-placeholder.test.ts
+++ b/tests/add-trigger-placeholder.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkflowNode } from '../src/shared/types'
+import { toCanvasElements } from '../src/renderer/lib/workflow-canvas-layout'
+import { createTriggerNode, createScriptNode } from '../src/renderer/lib/workflow-helpers'
+
+describe('the add-trigger placeholder', () => {
+  it('appears on a canvas with no trigger node', () => {
+    const { nodes } = toCanvasElements([], [])
+    const placeholder = nodes.find((n) => n.type === 'addTrigger')
+    expect(placeholder).toBeDefined()
+    expect(placeholder?.draggable).toBe(false)
+  })
+
+  it('disappears once a trigger exists', () => {
+    const trigger = createTriggerNode({ triggerType: 'manual' })
+    const { nodes } = toCanvasElements([trigger], [])
+    expect(nodes.find((n) => n.type === 'addTrigger')).toBeUndefined()
+  })
+
+  it('still appears when steps exist but no trigger does', () => {
+    const script: WorkflowNode = createScriptNode()
+    const { nodes } = toCanvasElements([script], [])
+    expect(nodes.find((n) => n.type === 'addTrigger')).toBeDefined()
+  })
+})

--- a/tests/add-trigger-placeholder.test.ts
+++ b/tests/add-trigger-placeholder.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { WorkflowNode } from '../src/shared/types'
-import { toCanvasElements } from '../src/renderer/lib/workflow-canvas-layout'
-import { createTriggerNode, createScriptNode } from '../src/renderer/lib/workflow-helpers'
+import { layoutPositions, toCanvasElements } from '../src/renderer/lib/workflow-canvas-layout'
+import {
+  autoLayoutNodes,
+  createTriggerNode,
+  createScriptNode
+} from '../src/renderer/lib/workflow-helpers'
 
 describe('the add-trigger placeholder', () => {
   it('appears on a canvas with no trigger node', () => {
@@ -21,5 +25,35 @@ describe('the add-trigger placeholder', () => {
     const script: WorkflowNode = createScriptNode()
     const { nodes } = toCanvasElements([script], [])
     expect(nodes.find((n) => n.type === 'addTrigger')).toBeDefined()
+  })
+
+  it('sits centered above the topmost drawn card', () => {
+    const script = { ...createScriptNode(), position: { x: 12, y: 120 } }
+    const { nodes } = toCanvasElements([script], [])
+    const placeholder = nodes.find((n) => n.type === 'addTrigger')!
+    expect(placeholder.position).toEqual({ x: 12, y: 120 - 58 - 56 })
+  })
+})
+
+describe('layout without a trigger', () => {
+  it('keeps a trigger-less fork side by side instead of one flat column', () => {
+    const a = { ...createScriptNode(), id: 'a' }
+    const b = { ...createScriptNode(), id: 'b' }
+    const c = { ...createScriptNode(), id: 'c' }
+    const edges = [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'a', target: 'c' }
+    ]
+    const { positions } = layoutPositions([a, b, c], edges)
+    expect(positions.get('b')!.y).toBeGreaterThan(positions.get('a')!.y)
+    expect(positions.get('b')!.x).not.toBe(positions.get('c')!.x)
+  })
+
+  it('orders a trigger-less chain top to bottom', () => {
+    const a = { ...createScriptNode(), id: 'a' }
+    const b = { ...createScriptNode(), id: 'b' }
+    const laid = autoLayoutNodes([a, b], [{ id: 'e1', source: 'a', target: 'b' }])
+    const byId = new Map(laid.map((n) => [n.id, n]))
+    expect(byId.get('b')!.position.y).toBeGreaterThan(byId.get('a')!.position.y)
   })
 })

--- a/tests/canvas-interactions.test.tsx
+++ b/tests/canvas-interactions.test.tsx
@@ -132,12 +132,16 @@ describe('the hover toolbar', () => {
     expect(onDeleteNode).toHaveBeenCalledTimes(1)
   })
 
-  it('offers replace only on swappable steps, never the trigger', () => {
+  it('offers replace on every node, routing the trigger to its own scope', () => {
     const { onOpenLibrary } = renderCanvas()
     const replaces = screen.getAllByRole('button', { name: 'Replace step' })
-    // The two scripts are swappable; the trigger has its own library path.
-    expect(replaces).toHaveLength(2)
+    expect(replaces).toHaveLength(3)
+    // The first card in the layout is the trigger; its replace opens trigger scope.
     fireEvent.click(replaces[0])
+    expect(onOpenLibrary).toHaveBeenCalledWith(
+      expect.objectContaining({ afterNodeId: '__TRIGGER__' })
+    )
+    fireEvent.click(replaces[1])
     expect(onOpenLibrary).toHaveBeenCalledWith(
       expect.objectContaining({ replaceNodeId: 'a', afterNodeId: 'a' })
     )

--- a/tests/canvas-interactions.test.tsx
+++ b/tests/canvas-interactions.test.tsx
@@ -124,13 +124,23 @@ describe('every + opens the library at its anchor', () => {
 })
 
 describe('the hover toolbar', () => {
-  it('deletes the hovered step, and never offers itself on the trigger', () => {
+  it('offers delete on every node, the trigger included', () => {
     const { onDeleteNode } = renderCanvas()
     const deletes = screen.getAllByRole('button', { name: 'Delete step' })
-    // One per non-trigger node: the trigger card carries none.
-    expect(deletes).toHaveLength(2)
+    expect(deletes).toHaveLength(3)
     fireEvent.click(deletes[0])
     expect(onDeleteNode).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers replace only on swappable steps, never the trigger', () => {
+    const { onOpenLibrary } = renderCanvas()
+    const replaces = screen.getAllByRole('button', { name: 'Replace step' })
+    // The two scripts are swappable; the trigger has its own library path.
+    expect(replaces).toHaveLength(2)
+    fireEvent.click(replaces[0])
+    expect(onOpenLibrary).toHaveBeenCalledWith(
+      expect.objectContaining({ replaceNodeId: 'a', afterNodeId: 'a' })
+    )
   })
 })
 
@@ -142,11 +152,11 @@ describe('the keyboard on the canvas', () => {
     expect(onDeleteNode).toHaveBeenCalledWith('b')
   })
 
-  it('never deletes the trigger', () => {
+  it('deletes the selected trigger too', () => {
     const { container, onDeleteNode } = renderCanvas({ selectedNodeId: 't' })
     const wrapper = container.querySelector('[tabindex="0"]') as HTMLElement
     fireEvent.keyDown(wrapper, { key: 'Delete' })
-    expect(onDeleteNode).not.toHaveBeenCalled()
+    expect(onDeleteNode).toHaveBeenCalledWith('t')
   })
 })
 

--- a/tests/canvas-interactions.test.tsx
+++ b/tests/canvas-interactions.test.tsx
@@ -164,6 +164,70 @@ describe('the keyboard on the canvas', () => {
   })
 })
 
+describe('the add-trigger placeholder card', () => {
+  it('opens the library in trigger scope when clicked', () => {
+    const { onOpenLibrary } = renderCanvas({
+      nodes: [nodes[1], nodes[2]],
+      edges: [{ id: 'e2', source: 'a', target: 'b' }]
+    })
+    const placeholder = screen.getByRole('button', { name: /Add a trigger/ })
+    fireEvent.click(placeholder)
+    expect(onOpenLibrary).toHaveBeenCalledWith(
+      expect.objectContaining({ afterNodeId: '__TRIGGER__' })
+    )
+  })
+
+  it('highlights while the library points at the trigger anchor', () => {
+    renderCanvas({
+      nodes: [nodes[1]],
+      edges: [],
+      libraryAnchor: {
+        afterNodeId: '__TRIGGER__',
+        beforeNodeId: null,
+        insideBranch: false,
+        bodyOnly: false
+      }
+    })
+    expect(screen.getByRole('button', { name: /Add a trigger/ }).className).toContain(
+      'border-white/40'
+    )
+  })
+})
+
+describe('the load fit', () => {
+  it('survives a workflow switch re-fitting the view', () => {
+    const { rerender } = render(
+      <WorkflowCanvas
+        nodes={nodes}
+        edges={edges}
+        selectedNodeId={null}
+        libraryAnchor={null}
+        loadKey="wf-a"
+        onNodeClick={vi.fn()}
+        onOpenLibrary={vi.fn()}
+        onConnectEdge={vi.fn()}
+        onPositionsCommit={vi.fn()}
+        onTidyUp={vi.fn()}
+      />
+    )
+    rerender(
+      <WorkflowCanvas
+        nodes={nodes}
+        edges={edges}
+        selectedNodeId={null}
+        libraryAnchor={null}
+        loadKey="wf-b"
+        onNodeClick={vi.fn()}
+        onOpenLibrary={vi.fn()}
+        onConnectEdge={vi.fn()}
+        onPositionsCommit={vi.fn()}
+        onTidyUp={vi.fn()}
+      />
+    )
+    expect(screen.getByText('First step')).toBeInTheDocument()
+  })
+})
+
 describe('the tidy up control', () => {
   it('sits with the zoom controls', () => {
     const { onTidyUp } = renderCanvas()

--- a/tests/connection-row-test-button.test.tsx
+++ b/tests/connection-row-test-button.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { SourceConnection } from '../src/shared/types'
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const preflightConnection = vi.fn()
+;(window as unknown as { api: Record<string, unknown> }).api = {
+  ...(window as unknown as { api?: Record<string, unknown> }).api,
+  preflightConnection
+}
+
+import { ConnectionRow } from '../src/renderer/components/settings/ConnectionRow'
+
+afterEach(() => {
+  cleanup()
+  preflightConnection.mockReset()
+})
+
+const conn = (connectorId: string): SourceConnection => ({
+  id: 'c1',
+  connectorId,
+  name: 'Acme API',
+  filters: {},
+  syncIntervalMinutes: 5,
+  statusMapping: {},
+  createdAt: '2026-08-30T00:00:00.000Z'
+})
+
+function renderRow(connectorId = 'http') {
+  return render(
+    <ConnectionRow
+      conn={conn(connectorId)}
+      seededWorkflows={[]}
+      missingEvents={[]}
+      runningId={null}
+      backfillingId={null}
+      backfillResult={{}}
+      onRun={vi.fn()}
+      onBackfill={vi.fn()}
+      onDelete={vi.fn()}
+      onResetWorkflow={vi.fn()}
+      onOpenWorkflow={vi.fn()}
+      onRefresh={vi.fn()}
+    />
+  )
+}
+
+describe('the http profile Test button', () => {
+  it('runs the preflight and reports the status it got back', async () => {
+    preflightConnection.mockResolvedValue({ ok: true, message: 'HTTP 200' })
+    const { container } = renderRow()
+    fireEvent.click(container.querySelector('svg.lucide-activity')!.closest('button')!)
+    await waitFor(() => expect(screen.getByText('HTTP 200')).toBeInTheDocument())
+    expect(preflightConnection).toHaveBeenCalledWith('c1')
+  })
+
+  it('reports a failed test in the error tone', async () => {
+    preflightConnection.mockResolvedValue({ ok: false, message: 'HTTP 401' })
+    const { container } = renderRow()
+    fireEvent.click(container.querySelector('svg.lucide-activity')!.closest('button')!)
+    await waitFor(() => expect(screen.getByText('HTTP 401')).toBeInTheDocument())
+    expect(screen.getByText('HTTP 401').className).toContain('text-red-400')
+  })
+
+  it('surfaces a thrown preflight as a failure message', async () => {
+    preflightConnection.mockRejectedValue(new Error('bridge down'))
+    const { container } = renderRow()
+    fireEvent.click(container.querySelector('svg.lucide-activity')!.closest('button')!)
+    await waitFor(() => expect(screen.getByText('bridge down')).toBeInTheDocument())
+  })
+
+  it('does not exist on non-http connections', () => {
+    const { container } = renderRow('github')
+    expect(container.querySelector('svg.lucide-activity')).toBeNull()
+  })
+})

--- a/tests/grid-context-menu.test.tsx
+++ b/tests/grid-context-menu.test.tsx
@@ -172,7 +172,15 @@ describe('GridContextMenu', () => {
           name: 'Deploy',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -200,7 +208,15 @@ describe('GridContextMenu', () => {
           name: 'Deploy Staging',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -234,7 +250,15 @@ describe('GridContextMenu', () => {
           name: 'Personal Deploy',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -244,7 +268,15 @@ describe('GridContextMenu', () => {
           name: 'Work Deploy',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'work'
@@ -270,7 +302,15 @@ describe('GridContextMenu', () => {
           name: 'Manual Deploy',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'

--- a/tests/http-connector.test.ts
+++ b/tests/http-connector.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { httpConnector, performHttpRequest } from '../packages/server/src/connectors/http'
+import {
+  httpConnector,
+  lockedProfileError,
+  performHttpRequest
+} from '../packages/server/src/connectors/http'
 
 type FetchCall = { url: URL; init: RequestInit }
 
@@ -24,7 +28,11 @@ describe('performHttpRequest', () => {
   it('injects the secret into the profile header and never echoes it back', async () => {
     const calls = stubFetch()
     const result = await performHttpRequest(
-      { authHeader: 'Authorization: Bearer {{secret}}', secret: 'top-secret' },
+      {
+        baseUrl: 'https://api.example.com',
+        authHeader: 'Authorization: Bearer {{secret}}',
+        secret: 'top-secret'
+      },
       { method: 'GET', url: 'https://api.example.com/me' }
     )
     const sent = calls[0].init.headers as Record<string, string>
@@ -36,7 +44,7 @@ describe('performHttpRequest', () => {
   it('injects the secret as a query parameter', async () => {
     const calls = stubFetch()
     await performHttpRequest(
-      { authQuery: 'api_key={{secret}}', secret: 's3' },
+      { baseUrl: 'https://api.example.com', authQuery: 'api_key={{secret}}', secret: 's3' },
       { method: 'GET', url: 'https://api.example.com/items?limit=2' }
     )
     expect(calls[0].url.searchParams.get('api_key')).toBe('s3')
@@ -46,7 +54,7 @@ describe('performHttpRequest', () => {
   it('merges the profile JSON into a JSON object body', async () => {
     const calls = stubFetch()
     await performHttpRequest(
-      { authBody: '{"token": "{{secret}}"}', secret: 's4' },
+      { baseUrl: 'https://api.example.com', authBody: '{"token": "{{secret}}"}', secret: 's4' },
       { method: 'POST', url: 'https://api.example.com/x', body: '{"name": "a"}' }
     )
     expect(JSON.parse(calls[0].init.body as string)).toEqual({ name: 'a', token: 's4' })
@@ -55,7 +63,7 @@ describe('performHttpRequest', () => {
   it('leaves a non-JSON body untouched by body injection', async () => {
     const calls = stubFetch()
     await performHttpRequest(
-      { authBody: '{"token": "{{secret}}"}', secret: 's5' },
+      { baseUrl: 'https://api.example.com', authBody: '{"token": "{{secret}}"}', secret: 's5' },
       { method: 'POST', url: 'https://api.example.com/x', body: 'plain text' }
     )
     expect(calls[0].init.body).toBe('plain text')
@@ -88,6 +96,46 @@ describe('performHttpRequest', () => {
     expect(calls[0].init.body).toBeUndefined()
   })
 
+  it('refuses to sign a request whose origin is not the profile base URL', async () => {
+    const calls = stubFetch()
+    const result = await performHttpRequest(
+      {
+        baseUrl: 'https://api.example.com',
+        authHeader: 'Authorization: Bearer {{secret}}',
+        secret: 's'
+      },
+      { method: 'POST', url: 'https://evil.example.net/collect' }
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('only signs requests to https://api.example.com')
+    expect(calls).toHaveLength(0)
+  })
+
+  it('refuses injection entirely when the profile has no base URL', async () => {
+    const calls = stubFetch()
+    const result = await performHttpRequest(
+      { authHeader: 'X-Key: {{secret}}', secret: 's' },
+      { method: 'GET', url: 'https://anywhere.example.com/a' }
+    )
+    expect(result.success).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('rejects a missing or invalid method as a result, not a throw', async () => {
+    const calls = stubFetch()
+    const missing = await performHttpRequest({}, { method: '', url: 'https://x.test/a' })
+    const bogus = await performHttpRequest({}, { method: 'YEET', url: 'https://x.test/a' })
+    expect(missing).toMatchObject({ success: false })
+    expect(bogus).toMatchObject({ success: false })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('never follows redirects', async () => {
+    const calls = stubFetch()
+    await performHttpRequest({}, { method: 'GET', url: 'https://x.test/a' })
+    expect(calls[0].init.redirect).toBe('manual')
+  })
+
   it('reports an invalid URL without calling out', async () => {
     const calls = stubFetch()
     const result = await performHttpRequest({}, { method: 'GET', url: 'not a url' })
@@ -99,6 +147,20 @@ describe('performHttpRequest', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')))
     const result = await performHttpRequest({}, { method: 'GET', url: 'https://x.test/a' })
     expect(result).toMatchObject({ success: false, error: 'connect ECONNREFUSED' })
+  })
+})
+
+describe('lockedProfileError', () => {
+  it('flags a stored secret with no decrypted counterpart', () => {
+    expect(lockedProfileError({ secret: 'AAECbase64blob' }, undefined)).toContain('locked')
+  })
+
+  it('passes once the decrypted store holds the secret', () => {
+    expect(lockedProfileError({ secret: 'blob' }, { secret: 'plain' })).toBeNull()
+  })
+
+  it('passes for a profile with no secret at all', () => {
+    expect(lockedProfileError({ baseUrl: 'https://x.test' }, undefined)).toBeNull()
   })
 })
 

--- a/tests/http-connector.test.ts
+++ b/tests/http-connector.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   httpConnector,
+  httpProfileError,
   lockedProfileError,
   performHttpRequest
 } from '../packages/server/src/connectors/http'
@@ -161,6 +162,29 @@ describe('lockedProfileError', () => {
 
   it('passes for a profile with no secret at all', () => {
     expect(lockedProfileError({ baseUrl: 'https://x.test' }, undefined)).toBeNull()
+  })
+})
+
+/**
+ * A profile id travels from the renderer as a plain string, so the request path
+ * has to say what a profile is rather than trust the caller to send one.
+ */
+describe('httpProfileError', () => {
+  it('refuses a connection belonging to another connector', () => {
+    const problem = httpProfileError({ connectorId: 'github', filters: {} }, undefined)
+    expect(problem).toContain('github')
+    expect(problem).toContain('not an HTTP auth profile')
+  })
+
+  it('still reports a locked secret on a real profile', () => {
+    const profile = { connectorId: 'http', filters: { secret: 'blob' } }
+    expect(httpProfileError(profile, undefined)).toContain('locked')
+  })
+
+  it('passes an unlocked profile', () => {
+    expect(
+      httpProfileError({ connectorId: 'http', filters: { secret: 'blob' } }, { secret: 'plain' })
+    ).toBeNull()
   })
 })
 

--- a/tests/http-connector.test.ts
+++ b/tests/http-connector.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { httpConnector, performHttpRequest } from '../packages/server/src/connectors/http'
+
+type FetchCall = { url: URL; init: RequestInit }
+
+function stubFetch(response: { status?: number; body?: string; contentType?: string } = {}) {
+  const calls: FetchCall[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: URL, init: RequestInit) => {
+      calls.push({ url, init })
+      return new Response(response.body ?? '{"ok":true}', {
+        status: response.status ?? 200,
+        headers: { 'content-type': response.contentType ?? 'application/json' }
+      })
+    })
+  )
+  return calls
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('performHttpRequest', () => {
+  it('injects the secret into the profile header and never echoes it back', async () => {
+    const calls = stubFetch()
+    const result = await performHttpRequest(
+      { authHeader: 'Authorization: Bearer {{secret}}', secret: 'top-secret' },
+      { method: 'GET', url: 'https://api.example.com/me' }
+    )
+    const sent = calls[0].init.headers as Record<string, string>
+    expect(sent.Authorization).toBe('Bearer top-secret')
+    expect(result.success).toBe(true)
+    expect(JSON.stringify(result)).not.toContain('top-secret')
+  })
+
+  it('injects the secret as a query parameter', async () => {
+    const calls = stubFetch()
+    await performHttpRequest(
+      { authQuery: 'api_key={{secret}}', secret: 's3' },
+      { method: 'GET', url: 'https://api.example.com/items?limit=2' }
+    )
+    expect(calls[0].url.searchParams.get('api_key')).toBe('s3')
+    expect(calls[0].url.searchParams.get('limit')).toBe('2')
+  })
+
+  it('merges the profile JSON into a JSON object body', async () => {
+    const calls = stubFetch()
+    await performHttpRequest(
+      { authBody: '{"token": "{{secret}}"}', secret: 's4' },
+      { method: 'POST', url: 'https://api.example.com/x', body: '{"name": "a"}' }
+    )
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({ name: 'a', token: 's4' })
+  })
+
+  it('leaves a non-JSON body untouched by body injection', async () => {
+    const calls = stubFetch()
+    await performHttpRequest(
+      { authBody: '{"token": "{{secret}}"}', secret: 's5' },
+      { method: 'POST', url: 'https://api.example.com/x', body: 'plain text' }
+    )
+    expect(calls[0].init.body).toBe('plain text')
+  })
+
+  it('resolves a relative path against the profile base URL', async () => {
+    const calls = stubFetch()
+    await performHttpRequest(
+      { baseUrl: 'https://api.example.com' },
+      { method: 'GET', url: '/v1/items' }
+    )
+    expect(calls[0].url.toString()).toBe('https://api.example.com/v1/items')
+  })
+
+  it('returns status, headers, and a JSON-parsed body', async () => {
+    stubFetch({ status: 201, body: '{"id": 7}' })
+    const result = await performHttpRequest({}, { method: 'POST', url: 'https://x.test/a' })
+    expect(result.output).toMatchObject({ status: 201, body: { id: 7 } })
+  })
+
+  it('keeps a non-JSON response body as text', async () => {
+    stubFetch({ body: 'hello', contentType: 'text/plain' })
+    const result = await performHttpRequest({}, { method: 'GET', url: 'https://x.test/a' })
+    expect(result.output?.body).toBe('hello')
+  })
+
+  it('sends no body on GET', async () => {
+    const calls = stubFetch()
+    await performHttpRequest({}, { method: 'GET', url: 'https://x.test/a', body: 'nope' })
+    expect(calls[0].init.body).toBeUndefined()
+  })
+
+  it('reports an invalid URL without calling out', async () => {
+    const calls = stubFetch()
+    const result = await performHttpRequest({}, { method: 'GET', url: 'not a url' })
+    expect(result.success).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('reports a network failure as an error result', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')))
+    const result = await performHttpRequest({}, { method: 'GET', url: 'https://x.test/a' })
+    expect(result).toMatchObject({ success: false, error: 'connect ECONNREFUSED' })
+  })
+})
+
+describe('the http connector', () => {
+  it('tests a profile with a real request against its base URL', async () => {
+    const calls = stubFetch({ status: 200 })
+    const result = await httpConnector.execute!('test', {
+      baseUrl: 'https://api.example.com',
+      authHeader: 'X-Key: {{secret}}',
+      secret: 'k'
+    })
+    expect(result.success).toBe(true)
+    expect(result.output?.status).toBe(200)
+    expect((calls[0].init.headers as Record<string, string>)['X-Key']).toBe('k')
+  })
+
+  it('refuses to test a profile with no base URL', async () => {
+    const calls = stubFetch()
+    const result = await httpConnector.execute!('test', {})
+    expect(result.success).toBe(false)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('executes the request action with merged profile fields', async () => {
+    const calls = stubFetch()
+    const result = await httpConnector.execute!('request', {
+      baseUrl: 'https://api.example.com',
+      authQuery: 'key={{secret}}',
+      secret: 's',
+      method: 'GET',
+      url: '/v1/things'
+    })
+    expect(result.success).toBe(true)
+    expect(calls[0].url.toString()).toBe('https://api.example.com/v1/things?key=s')
+  })
+
+  it('declares auth fields including an encrypted secret', () => {
+    const manifest = httpConnector.describe()
+    const secret = manifest.auth.find((f) => f.key === 'secret')
+    expect(secret?.type).toBe('password')
+    expect(manifest.auth.find((f) => f.key === 'profileName')?.required).toBe(true)
+  })
+})

--- a/tests/http-request-form.test.tsx
+++ b/tests/http-request-form.test.tsx
@@ -74,3 +74,22 @@ describe('the HTTP request form', () => {
     expect(screen.getByText(/its secret never/)).toBeInTheDocument()
   })
 })
+
+describe('the profile dropdown and header rows', () => {
+  it('lists only http connections and reports a selection', async () => {
+    const { onChange } = renderForm()
+    fireEvent.click(screen.getByText('None'))
+    expect(await screen.findByText('Acme API')).toBeInTheDocument()
+    expect(screen.queryByText('owner/repo')).not.toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByText('Acme API'))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ profileConnectionId: 'p1' }))
+  })
+
+  it('edits an existing header name and value', () => {
+    const { onChange } = renderForm({ headers: { 'X-One': '1' } })
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'X-Two' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ headers: { 'X-Two': '1' } }))
+    fireEvent.change(screen.getByPlaceholderText('Value'), { target: { value: '2' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ headers: { 'X-One': '2' } }))
+  })
+})

--- a/tests/http-request-form.test.tsx
+++ b/tests/http-request-form.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { HttpRequestConfig } from '../src/shared/types'
+
+const listConnections = vi.fn(async () => [
+  { id: 'p1', name: 'Acme API', connectorId: 'http' },
+  { id: 'g1', name: 'owner/repo', connectorId: 'github' }
+])
+;(window as unknown as { api: Record<string, unknown> }).api = {
+  ...(window as unknown as { api?: Record<string, unknown> }).api,
+  listConnections
+}
+
+import { HttpRequestConfigForm } from '../src/renderer/components/workflow-editor/panels/HttpRequestConfigForm'
+
+afterEach(cleanup)
+
+const baseConfig: HttpRequestConfig = {
+  nodeType: 'httpRequest',
+  method: 'GET',
+  url: '',
+  headers: {},
+  body: ''
+}
+
+function renderForm(config: Partial<HttpRequestConfig> = {}) {
+  const onChange = vi.fn()
+  const utils = render(
+    <HttpRequestConfigForm config={{ ...baseConfig, ...config }} onChange={onChange} />
+  )
+  return { ...utils, onChange }
+}
+
+describe('the HTTP request form', () => {
+  it('shows method, URL, profile, headers, and body fields', () => {
+    renderForm()
+    expect(screen.getByText('Method')).toBeInTheDocument()
+    expect(screen.getByText('URL')).toBeInTheDocument()
+    expect(screen.getByText('Auth profile')).toBeInTheDocument()
+    expect(screen.getByText('Headers')).toBeInTheDocument()
+    expect(screen.getByText('Body')).toBeInTheDocument()
+  })
+
+  it('reports URL edits with the rest of the config intact', () => {
+    const { onChange } = renderForm({ method: 'POST' })
+    const url = screen.getByPlaceholderText('https://api.example.com/items')
+    fireEvent.change(url, { target: { value: 'https://x.test/{{trigger.body.id}}' } })
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST', url: 'https://x.test/{{trigger.body.id}}' })
+    )
+  })
+
+  it('hints a relative path once a profile is chosen', () => {
+    renderForm({ profileConnectionId: 'p1' })
+    expect(screen.getByPlaceholderText('/v1/items')).toBeInTheDocument()
+  })
+
+  it('adds a header row', () => {
+    const { onChange } = renderForm()
+    fireEvent.click(screen.getByText('Add header'))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ headers: { '': '' } }))
+  })
+
+  it('removes a header row', () => {
+    const { onChange } = renderForm({ headers: { 'X-One': '1' } })
+    fireEvent.click(screen.getByLabelText('Remove header'))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ headers: {} }))
+  })
+
+  it('says the profile keeps its secret on the server', () => {
+    renderForm()
+    expect(screen.getByText(/its secret never/)).toBeInTheDocument()
+  })
+})

--- a/tests/http-request-node.test.tsx
+++ b/tests/http-request-node.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { HttpRequestConfig } from '../src/shared/types'
+import { HttpRequestNode } from '../src/renderer/components/workflow-editor/nodes/HttpRequestNode'
+import { stepPreview } from '../src/renderer/components/workflow-editor/node-visuals'
+
+const config = (over: Partial<HttpRequestConfig> = {}): HttpRequestConfig => ({
+  nodeType: 'httpRequest',
+  method: 'POST',
+  url: 'https://x.test/a',
+  headers: {},
+  body: '',
+  ...over
+})
+
+describe('HttpRequestNode', () => {
+  it('shows method and URL in the subtitle', () => {
+    const { container } = render(
+      <HttpRequestNode label="Call API" config={config()} onClick={vi.fn()} />
+    )
+    expect(container.textContent).toContain('POST https://x.test/a')
+  })
+
+  it('renders the body footer exactly when the height estimate charges for one', () => {
+    const withBody = config({ body: '{"n": 1}' })
+    const { container } = render(
+      <HttpRequestNode label="Call API" config={withBody} onClick={vi.fn()} />
+    )
+    expect(container.textContent).toContain('{"n": 1}')
+    // The layout's preview check and the card's footer must agree, or the
+    // declared height drifts from the drawn card and edges detach.
+    const node = {
+      id: 'h',
+      type: 'httpRequest',
+      label: 'x',
+      config: withBody,
+      position: { x: 0, y: 0 }
+    }
+    expect(stepPreview(node as never)).toBeTruthy()
+
+    const { container: bare } = render(
+      <HttpRequestNode label="Call API" config={config()} onClick={vi.fn()} />
+    )
+    expect(bare.textContent).not.toContain('{')
+    const bareNode = { ...node, config: config() }
+    expect(stepPreview(bareNode as never)).toBeUndefined()
+  })
+})

--- a/tests/mcp-workflow-authoring-schemas.test.ts
+++ b/tests/mcp-workflow-authoring-schemas.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { triggerConfigSchema, nodeSchema } from '../packages/mcp/src/tools/workflows'
+
+describe('MCP workflow authoring schemas', () => {
+  it('accepts a webhook trigger', () => {
+    const parsed = triggerConfigSchema.parse({
+      triggerType: 'webhook',
+      method: 'POST',
+      token: 'abc123'
+    })
+    expect(parsed).toMatchObject({ triggerType: 'webhook', method: 'POST' })
+  })
+
+  it('rejects a webhook trigger with an unsupported method', () => {
+    expect(() =>
+      triggerConfigSchema.parse({ triggerType: 'webhook', method: 'DELETE', token: 'abc123' })
+    ).toThrow()
+  })
+
+  it('accepts a connector poll trigger', () => {
+    const parsed = triggerConfigSchema.parse({
+      triggerType: 'connectorPoll',
+      connectionId: 'conn-1',
+      event: 'issueCreated',
+      cron: '*/5 * * * *'
+    })
+    expect(parsed).toMatchObject({ triggerType: 'connectorPoll', event: 'issueCreated' })
+  })
+
+  it('accepts an httpRequest node', () => {
+    const parsed = nodeSchema.parse({
+      id: 'n1',
+      type: 'httpRequest',
+      label: 'Call API',
+      slug: 'call-api',
+      config: {
+        nodeType: 'httpRequest',
+        method: 'GET',
+        url: 'https://x.test',
+        headers: {},
+        body: ''
+      },
+      position: { x: 0, y: 0 }
+    })
+    expect(parsed.type).toBe('httpRequest')
+  })
+})

--- a/tests/project-item.test.tsx
+++ b/tests/project-item.test.tsx
@@ -260,3 +260,35 @@ describe('ProjectItem progress-toast handlers', () => {
     await waitFor(() => expect(mockUpdate).toHaveBeenCalled())
   })
 })
+
+describe('the project row keyboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsGitRepo.mockResolvedValue(true)
+    useAppStore.setState({ config: baseConfig as AppConfig })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState)
+  })
+
+  it('activates the project on Enter pressed on the row itself', async () => {
+    const setActiveProject = vi.fn()
+    useAppStore.setState({ setActiveProject })
+    const { container } = renderProjectItem()
+    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
+    const row = container.querySelector('[role="button"]') as HTMLElement
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(setActiveProject).toHaveBeenCalled()
+  })
+
+  it('ignores Enter bubbling from the nested new-session button', async () => {
+    const setActiveProject = vi.fn()
+    useAppStore.setState({ setActiveProject })
+    const { container } = renderProjectItem()
+    await waitFor(() => expect(mockIsGitRepo).toHaveBeenCalled())
+    const sessionBtn = container.querySelector('button[aria-label="New session"]') as HTMLElement
+    fireEvent.keyDown(sessionBtn, { key: 'Enter' })
+    expect(setActiveProject).not.toHaveBeenCalled()
+  })
+})

--- a/tests/replace-remeasure.test.tsx
+++ b/tests/replace-remeasure.test.tsx
@@ -111,9 +111,14 @@ describe('re-measuring after a replace-in-place', () => {
     expect(after.y).toBe(after.height)
   })
 
+  it("leaves the initial mount to React Flow's own measure", () => {
+    renderCanvas([trigger, script])
+    expect(internalsCalls.ids).toHaveLength(0)
+  })
+
   it('asks React Flow to re-measure the swapped node', () => {
     const { rerender } = renderCanvas([trigger, script])
-    internalsCalls.ids.length = 0
+    expect(internalsCalls.ids).toHaveLength(0)
 
     rerender(
       <WorkflowCanvas

--- a/tests/replace-remeasure.test.tsx
+++ b/tests/replace-remeasure.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.hoisted(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    value: () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }),
+    writable: true
+  })
+  class NoopResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(window, 'ResizeObserver', { value: NoopResizeObserver, writable: true })
+  ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = NoopResizeObserver
+})
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [],
+  useConnectorIdFor: () => undefined,
+  useConnectionIconFor: () => undefined
+}))
+
+const internalsCalls = vi.hoisted(() => ({ ids: [] as string[] }))
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual<typeof import('@xyflow/react')>('@xyflow/react')
+  return {
+    ...actual,
+    useUpdateNodeInternals: () => {
+      const real = actual.useUpdateNodeInternals()
+      return (id: string | string[]) => {
+        for (const one of Array.isArray(id) ? id : [id]) internalsCalls.ids.push(one)
+        return real(id)
+      }
+    }
+  }
+})
+
+import { WorkflowCanvas } from '../src/renderer/components/workflow-editor/WorkflowCanvas'
+import { toCanvasElements } from '../src/renderer/lib/workflow-canvas-layout'
+import type { WorkflowEdge, WorkflowNode } from '../packages/shared/src/types'
+
+afterEach(() => {
+  cleanup()
+  internalsCalls.ids.length = 0
+})
+
+const trigger: WorkflowNode = {
+  id: 't',
+  type: 'trigger',
+  label: 'Manual',
+  config: { triggerType: 'manual' },
+  position: { x: 0, y: 0 }
+}
+
+const script: WorkflowNode = {
+  id: 'a',
+  type: 'script',
+  label: 'Old script',
+  slug: 'old-script',
+  // A script with content renders a preview, so its estimated height is the tall one.
+  config: { scriptType: 'bash', scriptContent: 'echo hi' } as WorkflowNode['config'],
+  position: { x: 0, y: 120 }
+}
+
+const swapped: WorkflowNode = {
+  id: 'a',
+  type: 'approval',
+  label: 'Approval gate',
+  slug: 'approval-gate',
+  config: {} as WorkflowNode['config'],
+  position: { x: 0, y: 120 }
+}
+
+const edges: WorkflowEdge[] = [{ id: 'e1', source: 't', target: 'a' }]
+
+const handlers = {
+  onNodeClick: vi.fn(),
+  onOpenLibrary: vi.fn(),
+  onConnectEdge: vi.fn(),
+  onPositionsCommit: vi.fn(),
+  onTidyUp: vi.fn()
+}
+
+function renderCanvas(nodes: WorkflowNode[]) {
+  return render(
+    <WorkflowCanvas
+      nodes={nodes}
+      edges={edges}
+      selectedNodeId={null}
+      libraryAnchor={null}
+      {...handlers}
+    />
+  )
+}
+
+describe('re-measuring after a replace-in-place', () => {
+  it('re-declares the node height and source-handle y for the swapped type', () => {
+    const handleY = (nodes: WorkflowNode[]) => {
+      const rf = toCanvasElements(nodes, edges).nodes.find((n) => n.id === 'a')!
+      const source = (rf.handles ?? []).find((h) => h.type === 'source')!
+      return { height: rf.initialHeight, y: source.y }
+    }
+    const before = handleY([trigger, script])
+    const after = handleY([trigger, swapped])
+    // The script previews its content (tall card); the bare approval does not.
+    expect(before.height).not.toBe(after.height)
+    expect(before.y).not.toBe(after.y)
+    expect(after.y).toBe(after.height)
+  })
+
+  it('asks React Flow to re-measure the swapped node', () => {
+    const { rerender } = renderCanvas([trigger, script])
+    internalsCalls.ids.length = 0
+
+    rerender(
+      <WorkflowCanvas
+        nodes={[trigger, swapped]}
+        edges={edges}
+        selectedNodeId={null}
+        libraryAnchor={null}
+        {...handlers}
+      />
+    )
+    expect(internalsCalls.ids).toContain('a')
+  })
+})

--- a/tests/replace-remeasure.test.tsx
+++ b/tests/replace-remeasure.test.tsx
@@ -96,7 +96,39 @@ function renderCanvas(nodes: WorkflowNode[]) {
   )
 }
 
+const manualTrigger: WorkflowNode = {
+  id: 't',
+  type: 'trigger',
+  label: 'Manual Trigger',
+  config: { triggerType: 'manual' },
+  position: { x: 0, y: 0 }
+}
+
+const recurringTrigger: WorkflowNode = {
+  id: 't',
+  type: 'trigger',
+  label: 'Schedule (Recurring)',
+  config: { triggerType: 'recurring', cron: '0 9 * * *' } as WorkflowNode['config'],
+  position: { x: 0, y: 0 }
+}
+
 describe('re-measuring after a replace-in-place', () => {
+  it('re-measures a trigger whose kind swaps under the same id', () => {
+    const { rerender } = renderCanvas([manualTrigger, script])
+    expect(internalsCalls.ids).toHaveLength(0)
+
+    rerender(
+      <WorkflowCanvas
+        nodes={[recurringTrigger, script]}
+        edges={edges}
+        selectedNodeId={null}
+        libraryAnchor={null}
+        {...handlers}
+      />
+    )
+    expect(internalsCalls.ids).toContain('t')
+  })
+
   it('re-declares the node height and source-handle y for the swapped type', () => {
     const handleY = (nodes: WorkflowNode[]) => {
       const rf = toCanvasElements(nodes, edges).nodes.find((n) => n.id === 'a')!

--- a/tests/replace-step.test.tsx
+++ b/tests/replace-step.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowDefinition, WorkflowNode } from '../src/shared/types'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const captured = vi.hoisted(() => ({
+  canvasProps: null as Record<string, unknown> | null,
+  libraryProps: null as Record<string, unknown> | null
+}))
+vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', async () => {
+  const actual = await vi.importActual<
+    typeof import('../src/renderer/components/workflow-editor/WorkflowCanvas')
+  >('../src/renderer/components/workflow-editor/WorkflowCanvas')
+  return {
+    ...actual,
+    WorkflowCanvas: (props: Record<string, unknown>) => {
+      captured.canvasProps = props
+      return <div data-testid="canvas" />
+    }
+  }
+})
+
+vi.mock('../src/renderer/components/workflow-editor/panels/StepLibrary', () => ({
+  StepLibrary: (props: Record<string, unknown>) => {
+    captured.libraryProps = props
+    return <div data-testid="step-library" />
+  }
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/NodeConfigPanel', () => ({
+  NodeConfigPanel: () => <div data-testid="node-config" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/RunHistoryPanel', () => ({
+  RunHistoryPanel: () => <div data-testid="run-history" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel', () => ({
+  WorkflowPropertiesPanel: () => <div data-testid="properties-panel" />
+}))
+
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: vi.fn().mockResolvedValue(undefined)
+}))
+
+const workflow: WorkflowDefinition = {
+  id: 'wf-replace',
+  name: 'Replace me',
+  icon: 'Workflow',
+  iconColor: '#fff',
+  enabled: true,
+  nodes: [
+    {
+      id: 't',
+      type: 'trigger',
+      label: 'Trigger',
+      config: { triggerType: 'manual' },
+      position: { x: 0, y: 0 }
+    },
+    {
+      id: 's1',
+      type: 'script',
+      label: 'Old script',
+      slug: 'old-script',
+      config: { scriptType: 'bash', scriptContent: 'echo hi' },
+      position: { x: 12, y: 120 }
+    },
+    {
+      id: 's2',
+      type: 'script',
+      label: 'HTTP Request',
+      slug: 'http-request',
+      config: { scriptType: 'bash', scriptContent: '' },
+      position: { x: 12, y: 240 }
+    }
+  ] as WorkflowNode[],
+  edges: [
+    { id: 'e1', source: 't', target: 's1' },
+    { id: 'e2', source: 's1', target: 's2' }
+  ]
+}
+
+const mockState = {
+  isWorkflowEditorOpen: true,
+  editingWorkflowId: 'wf-replace' as string | null,
+  setWorkflowEditorOpen: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  addWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  removeWorkflow: vi.fn(),
+  config: { workflows: [workflow], tasks: [], projects: [], defaults: {} },
+  setPendingWorkflowRun: vi.fn(),
+  addTerminal: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  setSelectedTaskId: vi.fn(),
+  activeWorkspace: 'personal',
+  workflowExecutions: new Map<string, unknown>()
+}
+
+vi.mock('../src/renderer/stores', () => {
+  const useAppStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+  useAppStore.getState = () => mockState
+  return { useAppStore }
+})
+;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  api: {
+    listWorkflowRuns: vi.fn().mockResolvedValue([]),
+    isWindowMaximized: vi.fn().mockResolvedValue(false),
+    onWindowMaximizedChange: vi.fn(() => () => {})
+  }
+}
+
+import { act } from '@testing-library/react'
+const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
+
+afterEach(() => {
+  cleanup()
+  captured.canvasProps = null
+  captured.libraryProps = null
+})
+
+const canvasNodes = () => (captured.canvasProps?.nodes ?? []) as WorkflowNode[]
+const canvasEdges = () =>
+  (captured.canvasProps?.edges ?? []) as { id: string; source: string; target: string }[]
+
+function openReplace(nodeId: string) {
+  act(() => {
+    ;(captured.canvasProps!.onOpenLibrary as (a: unknown) => void)({
+      afterNodeId: nodeId,
+      beforeNodeId: null,
+      insideBranch: false,
+      bodyOnly: false,
+      replaceNodeId: nodeId
+    })
+  })
+}
+
+function pick(p: unknown) {
+  act(() => {
+    ;(captured.libraryProps!.onPick as (p: unknown) => void)(p)
+  })
+}
+
+describe('replacing a step in place', () => {
+  it('opens the library in replace scope', () => {
+    render(<WorkflowEditor />)
+    openReplace('s1')
+    expect(screen.getByTestId('step-library')).toBeInTheDocument()
+    expect(captured.libraryProps?.scope).toMatchObject({ replacing: true })
+  })
+
+  it('keeps the id, position, and every edge while swapping type and config', () => {
+    render(<WorkflowEditor />)
+    openReplace('s1')
+    pick({ kind: 'type', type: 'httpRequest' })
+
+    const swapped = canvasNodes().find((n) => n.id === 's1')!
+    expect(swapped.type).toBe('httpRequest')
+    expect(swapped.config).toMatchObject({ nodeType: 'httpRequest', method: 'GET' })
+    expect(swapped.position).toEqual({ x: 12, y: 120 })
+    expect(
+      canvasEdges()
+        .map((e) => e.id)
+        .sort()
+    ).toEqual(['e1', 'e2'])
+    expect(canvasNodes()).toHaveLength(3)
+  })
+
+  it('resets the slug to the new type, kept unique against its siblings', () => {
+    render(<WorkflowEditor />)
+    openReplace('s1')
+    pick({ kind: 'type', type: 'httpRequest' })
+
+    const swapped = canvasNodes().find((n) => n.id === 's1')!
+    // 'http-request' is taken by s2, so the fresh slug steps around it.
+    expect(swapped.slug).toBeTruthy()
+    expect(swapped.slug).not.toBe('old-script')
+    expect(swapped.slug).not.toBe('http-request')
+  })
+
+  it('swaps to a preconfigured connector action', () => {
+    render(<WorkflowEditor />)
+    openReplace('s2')
+    pick({ kind: 'connectorAction', connectionId: 'c1', action: 'createIssue' })
+
+    const swapped = canvasNodes().find((n) => n.id === 's2')!
+    expect(swapped.type).toBe('callConnectorAction')
+    expect(swapped.config).toMatchObject({ connectionId: 'c1', action: 'createIssue' })
+    expect(swapped.position).toEqual({ x: 12, y: 240 })
+  })
+
+  it('refuses structural picks in replace mode', () => {
+    render(<WorkflowEditor />)
+    openReplace('s1')
+    pick({ kind: 'type', type: 'condition' })
+    const untouched = canvasNodes().find((n) => n.id === 's1')!
+    expect(untouched.type).toBe('script')
+    expect(canvasNodes()).toHaveLength(3)
+  })
+})

--- a/tests/replace-step.test.tsx
+++ b/tests/replace-step.test.tsx
@@ -188,16 +188,13 @@ describe('replacing a step in place', () => {
     expect(canvasNodes()).toHaveLength(3)
   })
 
-  it('resets the slug to the new type, kept unique against its siblings', () => {
+  it('keeps the slug so downstream {{steps.old-script.*}} references resolve', () => {
     render(<WorkflowEditor />)
     openReplace('s1')
     pick({ kind: 'type', type: 'httpRequest' })
 
     const swapped = canvasNodes().find((n) => n.id === 's1')!
-    // 'http-request' is taken by s2, so the fresh slug steps around it.
-    expect(swapped.slug).toBeTruthy()
-    expect(swapped.slug).not.toBe('old-script')
-    expect(swapped.slug).not.toBe('http-request')
+    expect(swapped.slug).toBe('old-script')
   })
 
   it('swaps to a preconfigured connector action', () => {

--- a/tests/scheduler-execution-context.test.ts
+++ b/tests/scheduler-execution-context.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import type { ConnectorItemContext } from '../src/shared/types'
-import { schedulerExecutionContext } from '../src/renderer/lib/workflow-helpers'
+import {
+  schedulerExecutionContext,
+  webhookTriggerFromItem
+} from '../src/renderer/lib/workflow-helpers'
 
 const webhookItem: ConnectorItemContext = {
   connectionId: 'webhook',
   connectorId: 'webhook',
   externalId: 'evt-1',
   title: 'Webhook POST',
-  raw: { body: { n: 1 }, headers: { 'x-event': 'deploy' }, method: 'POST' }
+  raw: { body: { n: 1 }, headers: { 'x-event': 'deploy' }, query: { ref: 'main' }, method: 'POST' }
 }
 
 const pollItem: ConnectorItemContext = {
@@ -25,6 +28,7 @@ describe('schedulerExecutionContext', () => {
       type: 'webhook',
       body: { n: 1 },
       headers: { 'x-event': 'deploy' },
+      query: { ref: 'main' },
       method: 'POST'
     })
     expect(context?.connectorItem).toBe(webhookItem)
@@ -43,5 +47,19 @@ describe('schedulerExecutionContext', () => {
   it('carries manual-run inputs through', () => {
     const context = schedulerExecutionContext(undefined, { name: 'a' })
     expect(context?.inputs).toEqual({ name: 'a' })
+  })
+})
+
+describe('webhookTriggerFromItem', () => {
+  it('rebuilds the trigger namespace from a stored webhook item', () => {
+    expect(webhookTriggerFromItem(webhookItem)).toMatchObject({
+      type: 'webhook',
+      body: { n: 1 },
+      query: { ref: 'main' }
+    })
+  })
+
+  it('returns nothing for a connector poll item', () => {
+    expect(webhookTriggerFromItem(pollItem)).toBeUndefined()
   })
 })

--- a/tests/scheduler-execution-context.test.ts
+++ b/tests/scheduler-execution-context.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { ConnectorItemContext } from '../src/shared/types'
+import { schedulerExecutionContext } from '../src/renderer/lib/workflow-helpers'
+
+const webhookItem: ConnectorItemContext = {
+  connectionId: 'webhook',
+  connectorId: 'webhook',
+  externalId: 'evt-1',
+  title: 'Webhook POST',
+  raw: { body: { n: 1 }, headers: { 'x-event': 'deploy' }, method: 'POST' }
+}
+
+const pollItem: ConnectorItemContext = {
+  connectionId: 'conn-1',
+  connectorId: 'github',
+  externalId: '42',
+  title: 'An issue',
+  raw: { number: 42 }
+}
+
+describe('schedulerExecutionContext', () => {
+  it('lifts a webhook event into the trigger namespace and keeps the connector item', () => {
+    const context = schedulerExecutionContext(webhookItem, undefined)
+    expect(context?.trigger).toEqual({
+      type: 'webhook',
+      body: { n: 1 },
+      headers: { 'x-event': 'deploy' },
+      method: 'POST'
+    })
+    expect(context?.connectorItem).toBe(webhookItem)
+  })
+
+  it('leaves connector poll items alone', () => {
+    const context = schedulerExecutionContext(pollItem, undefined)
+    expect(context?.trigger).toBeUndefined()
+    expect(context?.connectorItem).toBe(pollItem)
+  })
+
+  it('returns undefined with nothing to carry', () => {
+    expect(schedulerExecutionContext(undefined, undefined)).toBeUndefined()
+  })
+
+  it('carries manual-run inputs through', () => {
+    const context = schedulerExecutionContext(undefined, { name: 'a' })
+    expect(context?.inputs).toEqual({ name: 'a' })
+  })
+})

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -78,6 +78,25 @@ describe('SessionItem', () => {
     expect(setFocused).toHaveBeenCalledWith('sess-1')
   })
 
+  it('activates the row itself on Enter and Space', () => {
+    const setFocused = vi.fn()
+    useAppStore.setState({ setFocusedTerminal: setFocused })
+    const { container } = render(<SessionItem session={session} />)
+    const row = container.querySelector('[role="button"]') as HTMLElement
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(setFocused).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(row, { key: ' ' })
+    expect(setFocused).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores Enter bubbling from a nested control', () => {
+    const setFocused = vi.fn()
+    useAppStore.setState({ setFocusedTerminal: setFocused })
+    render(<SessionItem session={session} />)
+    fireEvent.keyDown(screen.getByLabelText(`Close session ${session.name}`), { key: 'Enter' })
+    expect(setFocused).not.toHaveBeenCalled()
+  })
+
   it('applies focused style when session is focused', () => {
     useAppStore.setState({ focusedTerminalId: 'sess-1' })
     const { container } = render(<SessionItem session={session} />)

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -81,15 +81,15 @@ describe('SessionItem', () => {
   it('applies focused style when session is focused', () => {
     useAppStore.setState({ focusedTerminalId: 'sess-1' })
     const { container } = render(<SessionItem session={session} />)
-    const button = container.querySelector('button')
-    expect(button?.className).toContain('text-white')
+    const row = container.querySelector('[role="button"]')
+    expect(row?.className).toContain('text-white')
   })
 
   it('applies unfocused style when session is not focused', () => {
     useAppStore.setState({ focusedTerminalId: 'other' })
     const { container } = render(<SessionItem session={session} />)
-    const button = container.querySelector('button')
-    expect(button?.className).toContain('text-gray-400')
+    const row = container.querySelector('[role="button"]')
+    expect(row?.className).toContain('text-gray-400')
   })
 
   it('renders without branch when session has no branch', () => {
@@ -105,8 +105,8 @@ describe('SessionItem', () => {
       const { container } = render(<SessionItem session={s} />)
       expect(container.querySelector('[data-component="running-glyph"]')).toBeNull()
       // Identity svg should be rendered inside the icon wrapper, not matched globally
-      const sessionButton = screen.getByText('My Session').closest('button')
-      const iconWrapper = sessionButton?.querySelector('span')
+      const sessionRow = screen.getByText('My Session').closest('[role="button"]')
+      const iconWrapper = sessionRow?.querySelector('span')
       expect(iconWrapper?.querySelector('svg')).toBeInTheDocument()
     }
   )

--- a/tests/step-library-triggers.test.tsx
+++ b/tests/step-library-triggers.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [
+    { id: 'c1', name: 'owner/repo', connectorId: 'github' },
+    { id: 'c2', name: 'Notes MCP', connectorId: 'mcp' }
+  ],
+  useConnectorIdFor: () => null,
+  useConnectionIconFor: () => undefined
+}))
+
+const listConnectors = vi.fn(async () => [
+  {
+    id: 'github',
+    name: 'GitHub',
+    icon: 'github',
+    capabilities: ['triggers'],
+    manifest: {
+      auth: [],
+      triggers: [
+        { type: 'issueCreated', label: 'Issue Created', configFields: [] },
+        { type: 'prOpened', label: 'PR Opened', configFields: [] }
+      ]
+    }
+  },
+  { id: 'mcp', name: 'MCP', icon: 'mcp', capabilities: ['actions'], manifest: { auth: [] } }
+])
+;(window as unknown as { api: Record<string, unknown> }).api = {
+  ...(window as unknown as { api?: Record<string, unknown> }).api,
+  listConnectors,
+  listConnectionActions: vi.fn(async () => [])
+}
+
+import {
+  StepLibrary,
+  LibraryPick
+} from '../src/renderer/components/workflow-editor/panels/StepLibrary'
+
+afterEach(cleanup)
+
+function renderTriggerLibrary() {
+  const onPick = vi.fn()
+  const utils = render(
+    <StepLibrary
+      scope={{ bodyOnly: false, insideBranch: false, triggers: true }}
+      onPick={onPick}
+      onClose={vi.fn()}
+    />
+  )
+  return { ...utils, onPick }
+}
+
+describe('the step library in trigger scope', () => {
+  it('lists the built-in trigger types and no steps', async () => {
+    renderTriggerLibrary()
+    for (const label of [
+      'Manual',
+      'Recurring schedule',
+      'Schedule once',
+      'Task created',
+      'Task moved',
+      'Webhook'
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument()
+    }
+    expect(screen.queryByText('Agent')).not.toBeInTheDocument()
+    expect(screen.queryByText('Parallel branch')).not.toBeInTheDocument()
+    expect(screen.getByText('Add a trigger')).toBeInTheDocument()
+  })
+
+  it("lists each connection's trigger events under its name", async () => {
+    renderTriggerLibrary()
+    expect(await screen.findByText('Issue Created')).toBeInTheDocument()
+    expect(screen.getByText('PR Opened')).toBeInTheDocument()
+    expect(screen.getByText('owner/repo')).toBeInTheDocument()
+    // The MCP connection declares no triggers, so it has no group.
+    expect(screen.queryByText('Notes MCP')).not.toBeInTheDocument()
+  })
+
+  it('returns a preconfigured connector trigger pick', async () => {
+    const { onPick } = renderTriggerLibrary()
+    fireEvent.click(await screen.findByText('Issue Created'))
+    expect(onPick).toHaveBeenCalledWith({
+      kind: 'connectorTrigger',
+      connectionId: 'c1',
+      event: 'issueCreated'
+    } satisfies LibraryPick)
+  })
+
+  it('returns a built-in trigger type pick', () => {
+    const { onPick } = renderTriggerLibrary()
+    fireEvent.click(screen.getByText('Webhook'))
+    expect(onPick).toHaveBeenCalledWith({
+      kind: 'triggerType',
+      triggerType: 'webhook'
+    } satisfies LibraryPick)
+  })
+
+  it('filters triggers by search', async () => {
+    renderTriggerLibrary()
+    await screen.findByText('Issue Created')
+    fireEvent.change(screen.getByPlaceholderText('Search triggers'), {
+      target: { value: 'issue' }
+    })
+    expect(screen.getByText('Issue Created')).toBeInTheDocument()
+    expect(screen.queryByText('Webhook')).not.toBeInTheDocument()
+  })
+})

--- a/tests/step-library-triggers.test.tsx
+++ b/tests/step-library-triggers.test.tsx
@@ -53,6 +53,24 @@ function renderTriggerLibrary() {
   return { ...utils, onPick }
 }
 
+describe('the step library in replace scope', () => {
+  it('hides condition, loop, and parallel; header says Replace', () => {
+    render(
+      <StepLibrary
+        scope={{ bodyOnly: false, insideBranch: false, replacing: true }}
+        onPick={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Replace step')).toBeInTheDocument()
+    expect(screen.getByText('Agent')).toBeInTheDocument()
+    expect(screen.getByText('HTTP request')).toBeInTheDocument()
+    expect(screen.queryByText('Condition')).not.toBeInTheDocument()
+    expect(screen.queryByText('Loop')).not.toBeInTheDocument()
+    expect(screen.queryByText('Parallel branch')).not.toBeInTheDocument()
+  })
+})
+
 describe('the step library in trigger scope', () => {
   it('lists the built-in trigger types and no steps', async () => {
     renderTriggerLibrary()

--- a/tests/terminal-context-menu.test.tsx
+++ b/tests/terminal-context-menu.test.tsx
@@ -113,7 +113,15 @@ describe('TerminalContextMenu', () => {
           name: 'Deploy',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -138,7 +146,15 @@ describe('TerminalContextMenu', () => {
           name: 'Deploy Staging',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -177,7 +193,15 @@ describe('TerminalContextMenu', () => {
           name: 'Deploy',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -210,7 +234,15 @@ describe('TerminalContextMenu', () => {
           name: 'Deploy',
           icon: 'Rocket',
           iconColor: '#ff6600',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -246,7 +278,15 @@ describe('TerminalContextMenu', () => {
           name: 'Personal WF',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'
@@ -256,7 +296,15 @@ describe('TerminalContextMenu', () => {
           name: 'Work WF',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'work'
@@ -307,7 +355,15 @@ describe('TerminalContextMenu', () => {
           name: 'Manual Deploy',
           icon: 'Zap',
           iconColor: '#fff',
-          nodes: [],
+          nodes: [
+            {
+              id: 'trigger',
+              type: 'trigger',
+              label: 'Manual',
+              config: { triggerType: 'manual' },
+              position: { x: 0, y: 0 }
+            }
+          ],
           edges: [],
           enabled: true,
           workspaceId: 'personal'

--- a/tests/trigger-config-form.test.tsx
+++ b/tests/trigger-config-form.test.tsx
@@ -76,12 +76,19 @@ describe('TriggerConfigForm', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ triggerType: 'once' }))
   })
 
-  it('switches trigger type via the picker', () => {
-    const onChange = vi.fn()
-    render(<TriggerConfigForm config={{ triggerType: 'manual' }} onChange={onChange} />)
-    fireEvent.click(screen.getByText('Manual'))
-    fireEvent.mouseDown(screen.getByText('Recurring'))
-    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ triggerType: 'recurring' }))
+  it('shows the chosen type read-only, with the library as the only way out', () => {
+    const onOpenLibrary = vi.fn()
+    render(
+      <TriggerConfigForm
+        config={{ triggerType: 'manual' }}
+        onChange={vi.fn()}
+        onOpenLibrary={onOpenLibrary}
+      />
+    )
+    expect(screen.getByText('Manual')).toBeInTheDocument()
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Change trigger from the library'))
+    expect(onOpenLibrary).toHaveBeenCalled()
   })
 })
 

--- a/tests/trigger-config-form.test.tsx
+++ b/tests/trigger-config-form.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type { TriggerConfig } from '../src/shared/types'
@@ -19,6 +19,8 @@ const getWebhookInfo = vi.fn(async () => ({ baseUrl: 'http://127.0.0.1:4444' }))
 
 const { TriggerConfigForm } =
   await import('../src/renderer/components/workflow-editor/panels/TriggerConfigForm')
+
+afterEach(() => vi.unstubAllGlobals())
 
 describe('TriggerConfigForm', () => {
   it('renders the trigger type label and current type hint', () => {
@@ -221,7 +223,7 @@ describe('TriggerConfigForm - webhook fields', () => {
 
   it('shows the full URL with a copy control and the local-only note', async () => {
     const writeText = vi.fn()
-    Object.assign(navigator, { clipboard: { writeText } })
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
     render(<TriggerConfigForm config={config} onChange={vi.fn()} />)
     expect(await screen.findByText('http://127.0.0.1:4444/wf-hooks/wf-1/tok-1')).toBeInTheDocument()
     fireEvent.click(screen.getByLabelText('Copy URL'))

--- a/tests/trigger-config-form.test.tsx
+++ b/tests/trigger-config-form.test.tsx
@@ -5,11 +5,17 @@ import '@testing-library/jest-dom/vitest'
 import type { TriggerConfig } from '../src/shared/types'
 
 vi.mock('../src/renderer/stores', () => {
-  const state = { config: { projects: [] } }
+  const state = { config: { projects: [] }, editingWorkflowId: 'wf-1' }
   return {
     useAppStore: (selector?: (s: unknown) => unknown) => (selector ? selector(state) : state)
   }
 })
+
+const getWebhookInfo = vi.fn(async () => ({ baseUrl: 'http://127.0.0.1:4444' }))
+;(window as unknown as { api: Record<string, unknown> }).api = {
+  ...(window as unknown as { api?: Record<string, unknown> }).api,
+  getWebhookInfo
+}
 
 const { TriggerConfigForm } =
   await import('../src/renderer/components/workflow-editor/panels/TriggerConfigForm')
@@ -207,5 +213,34 @@ describe('TriggerConfigForm — run inputs', () => {
     fireEvent.click(screen.getByLabelText('Remove input issue'))
 
     expect(onChange).toHaveBeenCalledWith({ triggerType: 'manual', inputs: undefined })
+  })
+})
+
+describe('TriggerConfigForm - webhook fields', () => {
+  const config: TriggerConfig = { triggerType: 'webhook', method: 'POST', token: 'tok-1' }
+
+  it('shows the full URL with a copy control and the local-only note', async () => {
+    const writeText = vi.fn()
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<TriggerConfigForm config={config} onChange={vi.fn()} />)
+    expect(await screen.findByText('http://127.0.0.1:4444/wf-hooks/wf-1/tok-1')).toBeInTheDocument()
+    fireEvent.click(screen.getByLabelText('Copy URL'))
+    expect(writeText).toHaveBeenCalledWith('http://127.0.0.1:4444/wf-hooks/wf-1/tok-1')
+    expect(screen.getByText(/Local machine only/)).toBeInTheDocument()
+  })
+
+  it('switches the method through the picker', async () => {
+    const onChange = vi.fn()
+    render(<TriggerConfigForm config={config} onChange={onChange} />)
+    await screen.findByText(/wf-hooks/)
+    fireEvent.click(screen.getByText('POST'))
+    fireEvent.mouseDown(screen.getByText('GET'))
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ method: 'GET' }))
+  })
+
+  it('mentions the template variables the request lands as', async () => {
+    render(<TriggerConfigForm config={config} onChange={vi.fn()} />)
+    expect(await screen.findByText(/trigger.body/)).toBeInTheDocument()
+    expect(screen.getByText(/trigger.query/)).toBeInTheDocument()
   })
 })

--- a/tests/trigger-library-editor.test.tsx
+++ b/tests/trigger-library-editor.test.tsx
@@ -237,5 +237,7 @@ describe('the editor without a trigger', () => {
     expect(triggers).toHaveLength(1)
     expect(triggers[0].id).toBe(firstId)
     expect(triggers[0].config).toMatchObject({ triggerType: 'recurring', cron: '0 9 * * *' })
+    // The old type's label does not survive the swap.
+    expect(triggers[0].label).toBe('Schedule (Recurring)')
   })
 })

--- a/tests/trigger-library-editor.test.tsx
+++ b/tests/trigger-library-editor.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowDefinition, WorkflowNode } from '../src/shared/types'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const captured = vi.hoisted(() => ({
+  canvasProps: null as Record<string, unknown> | null,
+  libraryProps: null as Record<string, unknown> | null
+}))
+vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', async () => {
+  const actual = await vi.importActual<
+    typeof import('../src/renderer/components/workflow-editor/WorkflowCanvas')
+  >('../src/renderer/components/workflow-editor/WorkflowCanvas')
+  return {
+    ...actual,
+    WorkflowCanvas: (props: Record<string, unknown>) => {
+      captured.canvasProps = props
+      return <div data-testid="canvas" />
+    }
+  }
+})
+
+vi.mock('../src/renderer/components/workflow-editor/panels/StepLibrary', () => ({
+  StepLibrary: (props: Record<string, unknown>) => {
+    captured.libraryProps = props
+    return <div data-testid="step-library" />
+  }
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/NodeConfigPanel', () => ({
+  NodeConfigPanel: () => <div data-testid="node-config" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/RunHistoryPanel', () => ({
+  RunHistoryPanel: () => <div data-testid="run-history" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel', () => ({
+  WorkflowPropertiesPanel: () => <div data-testid="properties-panel" />
+}))
+
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: vi.fn().mockResolvedValue(undefined)
+}))
+
+const mockState = {
+  isWorkflowEditorOpen: true,
+  editingWorkflowId: null as string | null,
+  setWorkflowEditorOpen: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  addWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  removeWorkflow: vi.fn(),
+  config: { workflows: [] as WorkflowDefinition[], tasks: [], projects: [], defaults: {} },
+  setPendingWorkflowRun: vi.fn(),
+  addTerminal: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  setSelectedTaskId: vi.fn(),
+  activeWorkspace: 'personal',
+  workflowExecutions: new Map<string, unknown>()
+}
+
+vi.mock('../src/renderer/stores', () => {
+  const useAppStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+  useAppStore.getState = () => mockState
+  return { useAppStore }
+})
+;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  api: {
+    listWorkflowRuns: vi.fn().mockResolvedValue([]),
+    isWindowMaximized: vi.fn().mockResolvedValue(false),
+    onWindowMaximizedChange: vi.fn(() => () => {})
+  }
+}
+
+import { TRIGGER_ANCHOR } from '../src/renderer/lib/workflow-canvas-layout'
+const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
+
+afterEach(() => {
+  cleanup()
+  mockState.editingWorkflowId = null
+  mockState.addWorkflow.mockClear()
+  captured.canvasProps = null
+  captured.libraryProps = null
+})
+
+const canvasNodes = () => (captured.canvasProps?.nodes ?? []) as WorkflowNode[]
+
+function openTriggerLibrary() {
+  act(() => {
+    ;(captured.canvasProps!.onOpenLibrary as (anchor: unknown) => void)(TRIGGER_ANCHOR)
+  })
+}
+
+function pickFromLibrary(pick: unknown) {
+  act(() => {
+    ;(captured.libraryProps!.onPick as (pick: unknown) => void)(pick)
+  })
+}
+
+describe('the editor without a trigger', () => {
+  it('seeds a new workflow with no nodes at all', () => {
+    render(<WorkflowEditor />)
+    expect(canvasNodes()).toHaveLength(0)
+  })
+
+  it('disables Run until a trigger exists', () => {
+    const { container } = render(<WorkflowEditor />)
+    const runButton = container.querySelector('button[aria-label="Run workflow"]')
+    expect(runButton).toBeDisabled()
+  })
+
+  it('opens the library in trigger scope from the placeholder anchor', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    expect(captured.libraryProps?.scope).toMatchObject({ triggers: true })
+  })
+
+  it('creates the trigger node from a built-in pick and enables Run', () => {
+    const { container } = render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'webhook' })
+
+    const trigger = canvasNodes().find((n) => n.type === 'trigger')
+    expect(trigger?.config).toMatchObject({ triggerType: 'webhook', method: 'POST' })
+    expect((trigger?.config as { token?: string }).token).toBeTruthy()
+    expect(container.querySelector('button[aria-label="Run workflow"]')).toBeEnabled()
+  })
+
+  it('creates a preconfigured connector poll from a connector event pick', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'connectorTrigger', connectionId: 'c1', event: 'issueCreated' })
+
+    const trigger = canvasNodes().find((n) => n.type === 'trigger')
+    expect(trigger?.config).toMatchObject({
+      triggerType: 'connectorPoll',
+      connectionId: 'c1',
+      event: 'issueCreated',
+      cron: '*/5 * * * *'
+    })
+  })
+
+  it('replaces the existing trigger in place on a second pick', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'manual' })
+    const firstId = canvasNodes().find((n) => n.type === 'trigger')?.id
+
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'recurring' })
+    const triggers = canvasNodes().filter((n) => n.type === 'trigger')
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0].id).toBe(firstId)
+    expect(triggers[0].config).toMatchObject({ triggerType: 'recurring', cron: '0 9 * * *' })
+  })
+})

--- a/tests/trigger-library-editor.test.tsx
+++ b/tests/trigger-library-editor.test.tsx
@@ -206,6 +206,25 @@ describe('the editor without a trigger', () => {
     expect(edges.some((e) => e.source === triggerId || e.target === triggerId)).toBe(false)
   })
 
+  it('hover-replace on the trigger opens trigger scope and swaps in place', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'manual' })
+    const triggerId = canvasNodes().find((n) => n.type === 'trigger')!.id
+
+    // The toolbar's replace button sends the same anchor the placeholder does.
+    act(() => {
+      ;(captured.canvasProps!.onOpenLibrary as (a: unknown) => void)(TRIGGER_ANCHOR)
+    })
+    expect(captured.libraryProps?.scope).toMatchObject({ triggers: true })
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'webhook' })
+
+    const triggers = canvasNodes().filter((n) => n.type === 'trigger')
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0].id).toBe(triggerId)
+    expect(triggers[0].config).toMatchObject({ triggerType: 'webhook' })
+  })
+
   it('replaces the existing trigger in place on a second pick', () => {
     render(<WorkflowEditor />)
     openTriggerLibrary()

--- a/tests/trigger-library-editor.test.tsx
+++ b/tests/trigger-library-editor.test.tsx
@@ -163,6 +163,49 @@ describe('the editor without a trigger', () => {
     })
   })
 
+  it('deleting the trigger brings the placeholder back and Run goes dark', () => {
+    const { container } = render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'manual' })
+    const triggerId = canvasNodes().find((n) => n.type === 'trigger')!.id
+
+    act(() => {
+      ;(captured.canvasProps!.onDeleteNode as (id: string) => void)(triggerId)
+    })
+    expect(canvasNodes().some((n) => n.type === 'trigger')).toBe(false)
+    expect(container.querySelector('button[aria-label="Run workflow"]')).toBeDisabled()
+
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'recurring' })
+    expect(canvasNodes().some((n) => n.type === 'trigger')).toBe(true)
+    expect(container.querySelector('button[aria-label="Run workflow"]')).toBeEnabled()
+  })
+
+  it('deleting the trigger keeps downstream steps and drops its edges', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'manual' })
+    const triggerId = canvasNodes().find((n) => n.type === 'trigger')!.id
+
+    act(() => {
+      ;(captured.canvasProps!.onOpenLibrary as (a: unknown) => void)({
+        afterNodeId: triggerId,
+        beforeNodeId: null,
+        insideBranch: false,
+        bodyOnly: false
+      })
+    })
+    pickFromLibrary({ kind: 'type', type: 'script' })
+    const script = canvasNodes().find((n) => n.type === 'script')!
+
+    act(() => {
+      ;(captured.canvasProps!.onDeleteNode as (id: string) => void)(triggerId)
+    })
+    const edges = captured.canvasProps!.edges as { source: string; target: string }[]
+    expect(canvasNodes().some((n) => n.id === script.id)).toBe(true)
+    expect(edges.some((e) => e.source === triggerId || e.target === triggerId)).toBe(false)
+  })
+
   it('replaces the existing trigger in place on a second pick', () => {
     render(<WorkflowEditor />)
     openTriggerLibrary()

--- a/tests/trigger-library-editor.test.tsx
+++ b/tests/trigger-library-editor.test.tsx
@@ -181,6 +181,46 @@ describe('the editor without a trigger', () => {
     expect(container.querySelector('button[aria-label="Run workflow"]')).toBeEnabled()
   })
 
+  it('re-adding a trigger reconnects the orphaned chain', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'manual' })
+    const triggerId = canvasNodes().find((n) => n.type === 'trigger')!.id
+    act(() => {
+      ;(captured.canvasProps!.onOpenLibrary as (a: unknown) => void)({
+        afterNodeId: triggerId,
+        beforeNodeId: null,
+        insideBranch: false,
+        bodyOnly: false
+      })
+    })
+    pickFromLibrary({ kind: 'type', type: 'script' })
+    const script = canvasNodes().find((n) => n.type === 'script')!
+
+    act(() => {
+      ;(captured.canvasProps!.onDeleteNode as (id: string) => void)(triggerId)
+    })
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'recurring' })
+
+    const newTrigger = canvasNodes().find((n) => n.type === 'trigger')!
+    const edges = captured.canvasProps!.edges as { source: string; target: string }[]
+    expect(edges.some((e) => e.source === newTrigger.id && e.target === script.id)).toBe(true)
+  })
+
+  it('re-picking the current trigger type changes nothing', () => {
+    render(<WorkflowEditor />)
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'webhook' })
+    const before = canvasNodes().find((n) => n.type === 'trigger')!
+    const token = (before.config as { token: string }).token
+
+    openTriggerLibrary()
+    pickFromLibrary({ kind: 'triggerType', triggerType: 'webhook' })
+    const after = canvasNodes().find((n) => n.type === 'trigger')!
+    expect((after.config as { token: string }).token).toBe(token)
+  })
+
   it('deleting the trigger keeps downstream steps and drops its edges', () => {
     render(<WorkflowEditor />)
     openTriggerLibrary()

--- a/tests/webhook-template-vars.test.ts
+++ b/tests/webhook-template-vars.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkflowExecutionContext } from '../src/shared/types'
+import { getAvailableContextVars, resolveTemplateVars } from '../src/renderer/lib/template-vars'
+
+describe('webhook trigger variables', () => {
+  it('offers only the request body and headers for a webhook trigger', () => {
+    const vars = getAvailableContextVars({ triggerType: 'webhook', isContextualTrigger: false })
+    expect(vars.map((v) => v.key)).toEqual(['{{trigger.body}}', '{{trigger.headers}}'])
+  })
+
+  it('keeps webhook variables out of task status triggers', () => {
+    const vars = getAvailableContextVars({
+      triggerType: 'taskStatusChanged',
+      isContextualTrigger: false
+    })
+    const keys = vars.map((v) => v.key)
+    expect(keys).toContain('{{trigger.fromStatus}}')
+    expect(keys).not.toContain('{{trigger.body}}')
+  })
+
+  it('resolves nested request body and header paths', () => {
+    const context: WorkflowExecutionContext = {
+      trigger: {
+        type: 'webhook',
+        body: { order: { id: 42 } },
+        headers: { 'x-event': 'deploy' },
+        method: 'POST'
+      }
+    }
+    expect(resolveTemplateVars('id={{trigger.body.order.id}}', context, {})).toBe('id=42')
+    expect(resolveTemplateVars('ev={{trigger.headers.x-event}}', context, {})).toBe('ev=deploy')
+  })
+})

--- a/tests/webhook-template-vars.test.ts
+++ b/tests/webhook-template-vars.test.ts
@@ -3,9 +3,13 @@ import type { WorkflowExecutionContext } from '../src/shared/types'
 import { getAvailableContextVars, resolveTemplateVars } from '../src/renderer/lib/template-vars'
 
 describe('webhook trigger variables', () => {
-  it('offers only the request body and headers for a webhook trigger', () => {
+  it('offers only the request body, headers, and query for a webhook trigger', () => {
     const vars = getAvailableContextVars({ triggerType: 'webhook', isContextualTrigger: false })
-    expect(vars.map((v) => v.key)).toEqual(['{{trigger.body}}', '{{trigger.headers}}'])
+    expect(vars.map((v) => v.key)).toEqual([
+      '{{trigger.body}}',
+      '{{trigger.headers}}',
+      '{{trigger.query}}'
+    ])
   })
 
   it('keeps webhook variables out of task status triggers', () => {
@@ -29,5 +33,19 @@ describe('webhook trigger variables', () => {
     }
     expect(resolveTemplateVars('id={{trigger.body.order.id}}', context, {})).toBe('id=42')
     expect(resolveTemplateVars('ev={{trigger.headers.x-event}}', context, {})).toBe('ev=deploy')
+  })
+})
+
+describe('resume context keeps webhook variables resolving', () => {
+  it('resolves {{trigger.query.*}} from a rebuilt context', async () => {
+    const { webhookTriggerFromItem } = await import('../src/renderer/lib/workflow-helpers')
+    const trigger = webhookTriggerFromItem({
+      connectionId: 'webhook',
+      connectorId: 'webhook',
+      externalId: 'e',
+      title: 'Webhook GET',
+      raw: { body: null, headers: {}, query: { ref: 'main' }, method: 'GET' }
+    })
+    expect(resolveTemplateVars('ref={{trigger.query.ref}}', { trigger }, {})).toBe('ref=main')
   })
 })

--- a/tests/webhook-trigger.test.ts
+++ b/tests/webhook-trigger.test.ts
@@ -90,6 +90,27 @@ describe('the webhook route', () => {
     expect(JSON.stringify(item)).not.toContain('topsecret')
   })
 
+  it('drops every auth-bearing header, not just authorization', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    await app.inject({
+      method: 'POST',
+      url: '/wf-hooks/wf-hook/sekret-token',
+      headers: {
+        cookie: 'sid=1',
+        'x-api-key': 'k',
+        'proxy-authorization': 'p',
+        'x-event': 'deploy'
+      },
+      payload: {}
+    })
+    const [item] = claimAll()
+    const raw = item.connectorItem.raw as { headers: Record<string, string> }
+    expect(raw.headers.cookie).toBeUndefined()
+    expect(raw.headers['x-api-key']).toBeUndefined()
+    expect(raw.headers['proxy-authorization']).toBeUndefined()
+    expect(raw.headers['x-event']).toBe('deploy')
+  })
+
   it('answers 404 for a wrong token, an unknown workflow, and a disabled one alike', async () => {
     dbInsertWorkflow(webhookWorkflow())
     dbInsertWorkflow(webhookWorkflow({ id: 'wf-off', enabled: false }))
@@ -125,11 +146,45 @@ describe('the webhook route', () => {
     expect(res.statusCode).toBe(404)
   })
 
-  it('answers 405 when the method does not match the trigger', async () => {
+  it('answers the same 404 when only the method mismatches', async () => {
     dbInsertWorkflow(webhookWorkflow())
     const res = await app.inject({ method: 'GET', url: '/wf-hooks/wf-hook/sekret-token' })
-    expect(res.statusCode).toBe(405)
+    expect(res.statusCode).toBe(404)
+    expect(res.json()).toEqual({ error: 'Not found' })
     expect(claimAll()).toHaveLength(0)
+  })
+
+  it('serves a GET trigger end to end with its query string captured', async () => {
+    dbInsertWorkflow(
+      webhookWorkflow({
+        id: 'wf-get',
+        nodes: [
+          {
+            id: 'trigger-1',
+            type: 'trigger',
+            label: 'Trigger',
+            config: { triggerType: 'webhook', method: 'GET', token: 'sekret-token' },
+            position: { x: 0, y: 0 }
+          }
+        ]
+      })
+    )
+    const res = await app.inject({
+      method: 'GET',
+      url: '/wf-hooks/wf-get/sekret-token?ref=deploy&sha=abc123',
+      headers: { 'x-github-event': 'push' }
+    })
+    expect(res.statusCode).toBe(202)
+    const [item] = claimAll()
+    const raw = item.connectorItem.raw as {
+      query: Record<string, string>
+      headers: Record<string, string>
+      method: string
+    }
+    expect(raw.method).toBe('GET')
+    expect(raw.query).toEqual({ ref: 'deploy', sha: 'abc123' })
+    // Real provider headers come through; only auth-bearing names are dropped.
+    expect(raw.headers['x-github-event']).toBe('push')
   })
 
   it('rejects requests that do not come from this machine', async () => {

--- a/tests/webhook-trigger.test.ts
+++ b/tests/webhook-trigger.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import type { WorkflowDefinition } from '../packages/shared/src/types'
+import {
+  dbClaimConnectorInbox,
+  dbInsertWorkflow,
+  initTestDatabase
+} from '../packages/server/src/database'
+import { registerWebhookRoute } from '../packages/server/src/webhook-trigger'
+
+let teardown: () => void
+let app: FastifyInstance
+let onEnqueued: Mock<() => void>
+
+const webhookWorkflow = (overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition => ({
+  id: 'wf-hook',
+  name: 'Webhook workflow',
+  icon: 'Workflow',
+  iconColor: '#fff',
+  enabled: true,
+  nodes: [
+    {
+      id: 'trigger-1',
+      type: 'trigger',
+      label: 'Trigger',
+      config: { triggerType: 'webhook', method: 'POST', token: 'sekret-token' },
+      position: { x: 0, y: 0 }
+    }
+  ],
+  edges: [],
+  ...overrides
+})
+
+const claimAll = () =>
+  dbClaimConnectorInbox({
+    now: new Date().toISOString(),
+    leaseUntil: new Date(Date.now() + 60_000).toISOString(),
+    limit: 10
+  })
+
+beforeEach(async () => {
+  teardown = initTestDatabase()
+  onEnqueued = vi.fn<() => void>()
+  app = Fastify()
+  registerWebhookRoute(app, onEnqueued)
+  await app.ready()
+})
+
+afterEach(async () => {
+  await app.close()
+  teardown()
+})
+
+describe('the webhook route', () => {
+  it('accepts a matching request and lands it in the durable inbox', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    const res = await app.inject({
+      method: 'POST',
+      url: '/wf-hooks/wf-hook/sekret-token',
+      headers: { 'content-type': 'application/json', 'x-event': 'deploy' },
+      payload: { n: 1 }
+    })
+    expect(res.statusCode).toBe(202)
+    expect(onEnqueued).toHaveBeenCalledOnce()
+
+    const [item] = claimAll()
+    expect(item.workflowId).toBe('wf-hook')
+    expect(item.connectorId).toBe('webhook')
+    const raw = item.connectorItem.raw as {
+      body: unknown
+      headers: Record<string, string>
+      method: string
+    }
+    expect(raw.body).toEqual({ n: 1 })
+    expect(raw.method).toBe('POST')
+    expect(raw.headers['x-event']).toBe('deploy')
+  })
+
+  it('keeps auth-bearing headers out of the recorded event', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    await app.inject({
+      method: 'POST',
+      url: '/wf-hooks/wf-hook/sekret-token',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer topsecret' },
+      payload: {}
+    })
+    const [item] = claimAll()
+    const raw = item.connectorItem.raw as { headers: Record<string, string> }
+    expect(raw.headers.authorization).toBeUndefined()
+    expect(JSON.stringify(item)).not.toContain('topsecret')
+  })
+
+  it('answers 404 for a wrong token, an unknown workflow, and a disabled one alike', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    dbInsertWorkflow(webhookWorkflow({ id: 'wf-off', enabled: false }))
+
+    const wrongToken = await app.inject({ method: 'POST', url: '/wf-hooks/wf-hook/nope' })
+    const unknown = await app.inject({ method: 'POST', url: '/wf-hooks/wf-none/sekret-token' })
+    const disabled = await app.inject({ method: 'POST', url: '/wf-hooks/wf-off/sekret-token' })
+
+    for (const res of [wrongToken, unknown, disabled]) {
+      expect(res.statusCode).toBe(404)
+      expect(res.json()).toEqual({ error: 'Not found' })
+    }
+    expect(onEnqueued).not.toHaveBeenCalled()
+    expect(claimAll()).toHaveLength(0)
+  })
+
+  it('answers 404 when the workflow trigger is not a webhook', async () => {
+    dbInsertWorkflow(
+      webhookWorkflow({
+        id: 'wf-manual',
+        nodes: [
+          {
+            id: 'trigger-1',
+            type: 'trigger',
+            label: 'Trigger',
+            config: { triggerType: 'manual' },
+            position: { x: 0, y: 0 }
+          }
+        ]
+      })
+    )
+    const res = await app.inject({ method: 'POST', url: '/wf-hooks/wf-manual/sekret-token' })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('answers 405 when the method does not match the trigger', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    const res = await app.inject({ method: 'GET', url: '/wf-hooks/wf-hook/sekret-token' })
+    expect(res.statusCode).toBe(405)
+    expect(claimAll()).toHaveLength(0)
+  })
+
+  it('rejects requests that do not come from this machine', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    const res = await app.inject({
+      method: 'POST',
+      url: '/wf-hooks/wf-hook/sekret-token',
+      remoteAddress: '192.168.1.20'
+    })
+    expect(res.statusCode).toBe(403)
+    expect(claimAll()).toHaveLength(0)
+  })
+})

--- a/tests/webhook-trigger.test.ts
+++ b/tests/webhook-trigger.test.ts
@@ -4,7 +4,9 @@ import type { WorkflowDefinition } from '../packages/shared/src/types'
 import {
   dbClaimConnectorInbox,
   dbInsertWorkflow,
-  initTestDatabase
+  dbRetryConnectorInbox,
+  initTestDatabase,
+  MAX_INBOX_ATTEMPTS
 } from '../packages/server/src/database'
 import { registerWebhookRoute } from '../packages/server/src/webhook-trigger'
 
@@ -196,5 +198,39 @@ describe('the webhook route', () => {
     })
     expect(res.statusCode).toBe(403)
     expect(claimAll()).toHaveLength(0)
+  })
+})
+
+describe('the inbox retry cap', () => {
+  it('marks a persistently failing event dead instead of retrying forever', async () => {
+    dbInsertWorkflow(webhookWorkflow())
+    await app.inject({ method: 'POST', url: '/wf-hooks/wf-hook/sekret-token', payload: {} })
+
+    // A virtual clock that jumps past each round's backoff (capped at 1h).
+    const base = Date.now()
+    const HOURS_3 = 3 * 60 * 60_000
+    for (let attempt = 1; attempt <= MAX_INBOX_ATTEMPTS; attempt++) {
+      const now = base + attempt * HOURS_3
+      const claimed = dbClaimConnectorInbox({
+        now: new Date(now).toISOString(),
+        leaseUntil: new Date(now + 60_000).toISOString(),
+        limit: 10
+      })
+      expect(claimed).toHaveLength(1)
+      const ok = dbRetryConnectorInbox({
+        id: claimed[0].id,
+        leaseToken: claimed[0].leaseToken,
+        error: 'renderer exploded',
+        now: new Date(now).toISOString()
+      })
+      expect(ok).toBe(true)
+    }
+
+    const after = dbClaimConnectorInbox({
+      now: new Date(base + 100 * HOURS_3).toISOString(),
+      leaseUntil: new Date(base + 101 * HOURS_3).toISOString(),
+      limit: 10
+    })
+    expect(after).toHaveLength(0)
   })
 })

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -199,12 +199,33 @@ describe('WorkflowEditor', () => {
     const { executeWorkflow } = await import('../src/renderer/lib/workflow-execution')
     vi.mocked(executeWorkflow).mockClear()
     mockState.setPendingWorkflowRun.mockClear()
+    mockState.editingWorkflowId = 'wf-plain' as unknown as null
+    mockState.config.workflows = [
+      {
+        id: 'wf-plain',
+        name: 'Plain',
+        enabled: true,
+        nodes: [
+          {
+            id: 'trigger',
+            type: 'trigger',
+            label: 'Trigger',
+            position: { x: 0, y: 0 },
+            config: { triggerType: 'manual' }
+          }
+        ],
+        edges: []
+      }
+    ] as unknown as never[]
 
     const { container } = render(<WorkflowEditor />)
     fireEvent.click(container.querySelector('button[aria-label="Run workflow"]')!)
 
     expect(executeWorkflow).toHaveBeenCalled()
     expect(mockState.setPendingWorkflowRun).not.toHaveBeenCalled()
+
+    mockState.editingWorkflowId = null
+    mockState.config.workflows = []
   })
 
   it('renders the back button which closes the editor', () => {
@@ -224,11 +245,13 @@ describe('WorkflowEditor', () => {
     mockState.editingWorkflowId = null
   })
 
-  it('triggers Run when the play button is clicked', () => {
+  it('keeps Run disabled on a new workflow until a trigger exists', () => {
+    mockState.addWorkflow.mockClear()
     const { container } = render(<WorkflowEditor />)
     const playButton = container.querySelector('svg.lucide-play')?.closest('button')
+    expect(playButton).toBeDisabled()
     if (playButton) fireEvent.click(playButton)
-    expect(mockState.addWorkflow).toHaveBeenCalled()
+    expect(mockState.addWorkflow).not.toHaveBeenCalled()
   })
 
   it('toggles the run history panel via the history toolbar button when editing', () => {
@@ -339,11 +362,28 @@ describe('the handlers the canvas drives', () => {
     }
   }
 
+  // A new workflow seeds no trigger, so these tests pick one from the library.
+  const seedManualTrigger = () => {
+    act(() =>
+      canvas().onOpenLibrary({
+        afterNodeId: '__TRIGGER__',
+        beforeNodeId: null,
+        insideBranch: false,
+        bodyOnly: false
+      })
+    )
+    act(() =>
+      (captured.libraryProps!.onPick as (p: unknown) => void)({
+        kind: 'triggerType',
+        triggerType: 'manual'
+      })
+    )
+  }
+
   it('writes a hand-drawn connection into the definition', () => {
     mockState.addWorkflow.mockClear()
     const { container } = render(<WorkflowEditor />)
-    const trigger = canvas().nodes?.[0] ?? { id: '' }
-    void trigger
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() => canvas().onConnectEdge(triggerId, 'ghost-target'))
     expect(save(container).edges.some((e) => e.target === 'ghost-target')).toBe(true)
@@ -352,6 +392,7 @@ describe('the handlers the canvas drives', () => {
   it('persists committed drag positions', () => {
     mockState.addWorkflow.mockClear()
     const { container } = render(<WorkflowEditor />)
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() => canvas().onPositionsCommit({ [triggerId]: { x: 48, y: 96 } }))
     expect(save(container).nodes[0].position).toEqual({ x: 48, y: 96 })
@@ -360,6 +401,7 @@ describe('the handlers the canvas drives', () => {
   it('tidy up writes the computed layout into the definition', () => {
     mockState.addWorkflow.mockClear()
     const { container } = render(<WorkflowEditor />)
+    seedManualTrigger()
     act(() => canvas().onTidyUp())
     expect(save(container).nodes[0].position.x).toBe(-140)
   })
@@ -370,6 +412,7 @@ describe('the handlers the canvas drives', () => {
   it('refuses a pick whose anchor no longer exists', () => {
     mockState.addWorkflow.mockClear()
     const { container, getByTestId } = render(<WorkflowEditor />)
+    seedManualTrigger()
     act(() =>
       canvas().onOpenLibrary({
         afterNodeId: 'ghost',
@@ -388,6 +431,7 @@ describe('the handlers the canvas drives', () => {
 
   it('closes the library when its anchor node is deleted', () => {
     const { getByTestId, queryByTestId } = render(<WorkflowEditor />)
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() =>
       canvas().onOpenLibrary({
@@ -409,6 +453,7 @@ describe('the handlers the canvas drives', () => {
   it('a library pick at a dropped position appends after its anchor there', () => {
     mockState.addWorkflow.mockClear()
     const { container, getByTestId } = render(<WorkflowEditor />)
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() =>
       canvas().onOpenLibrary({
@@ -430,6 +475,7 @@ describe('the handlers the canvas drives', () => {
   it('a connector pick lands preconfigured at its anchor', () => {
     mockState.addWorkflow.mockClear()
     const { container } = render(<WorkflowEditor />)
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() =>
       canvas().onOpenLibrary({
@@ -448,6 +494,7 @@ describe('the handlers the canvas drives', () => {
   it('a parallel pick forks from the anchor', () => {
     mockState.addWorkflow.mockClear()
     const { container } = render(<WorkflowEditor />)
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() =>
       canvas().onOpenLibrary({
@@ -466,6 +513,7 @@ describe('the handlers the canvas drives', () => {
     mockState.addWorkflow.mockClear()
     const winAdd = (window.addEventListener as ReturnType<typeof vi.fn>).mock
     const { container } = render(<WorkflowEditor />)
+    seedManualTrigger()
     const triggerId = (captured.canvasProps!.nodes as { id: string }[])[0].id
     act(() => canvas().onConnectEdge(triggerId, 'ghost-target'))
     const keydown = winAdd.calls.filter((c) => c[0] === 'keydown').at(-1)![1] as (

--- a/tests/workflow-item.test.tsx
+++ b/tests/workflow-item.test.tsx
@@ -195,7 +195,7 @@ describe('WorkflowItem', () => {
         onContextMenu={vi.fn()}
       />
     )
-    const row = container.querySelector('button.group\\/wf') as HTMLElement
+    const row = container.querySelector('.group\\/wf') as HTMLElement
     expect(row.className).toContain('text-white')
     expect(container.querySelector('span.absolute.left-0')).toBeInTheDocument()
     mockStore.editingWorkflowId = null

--- a/tests/workflow-item.test.tsx
+++ b/tests/workflow-item.test.tsx
@@ -272,3 +272,31 @@ describe('a gate waiting for approval', () => {
     expect(container.querySelector(`.${WORKFLOW_STATUS_DOT.waiting}`)).toBeNull()
   })
 })
+
+describe('the row keyboard', () => {
+  it('ignores Enter bubbling up from a nested button', () => {
+    render(
+      <WorkflowItem
+        workflow={makeManual()}
+        isCollapsed={false}
+        iconSize={14}
+        onContextMenu={vi.fn()}
+      />
+    )
+    fireEvent.keyDown(screen.getByRole('button', { name: /Run workflow/ }), { key: 'Enter' })
+    expect(mockStore.setEditingWorkflowId).not.toHaveBeenCalled()
+  })
+
+  it('activates the row itself on Enter', () => {
+    const { container } = render(
+      <WorkflowItem
+        workflow={makeManual()}
+        isCollapsed={false}
+        iconSize={14}
+        onContextMenu={vi.fn()}
+      />
+    )
+    fireEvent.keyDown(container.querySelector('.group\\/wf') as HTMLElement, { key: 'Enter' })
+    expect(mockStore.setEditingWorkflowId).toHaveBeenCalledWith('w1')
+  })
+})

--- a/tests/workflow-menu-items.test.tsx
+++ b/tests/workflow-menu-items.test.tsx
@@ -20,6 +20,11 @@ vi.mock('../src/renderer/stores', () => {
   }
 })
 
+const mockToastError = vi.fn()
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { error: (...args: unknown[]) => mockToastError(...args), success: vi.fn() }
+}))
+
 import { buildWorkflowMenuItems, startManualRun } from '../src/renderer/lib/workflow-menu-items'
 import type { TaskConfig, TerminalSession, WorkflowDefinition } from '../src/shared/types'
 
@@ -185,5 +190,24 @@ describe('workflows declaring run inputs', () => {
 
     expect(mockSetPending).not.toHaveBeenCalled()
     expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('the trigger guard on manual runs', () => {
+  beforeEach(() => {
+    mockExecuteWorkflow.mockClear()
+    mockToastError.mockClear()
+  })
+
+  it('refuses a workflow with no trigger and says why', () => {
+    const wf = { ...makeWorkflow('startless', false), nodes: [] }
+    startManualRun(wf)
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled()
+    expect(mockToastError).toHaveBeenCalledWith(expect.stringContaining('no trigger'))
+  })
+
+  it('runs a workflow that has one', () => {
+    startManualRun(makeWorkflow('ready', false))
+    expect(mockExecuteWorkflow).toHaveBeenCalled()
   })
 })

--- a/tests/workflow-partial-and-retry.test.ts
+++ b/tests/workflow-partial-and-retry.test.ts
@@ -263,6 +263,22 @@ describe('retrying a failed run', () => {
     expect(context?.connectorItem?.inboxLeaseToken).toBeUndefined()
     expect(context?.connectorItem?.externalId).toBe('1')
   })
+
+  it('rebuilds the webhook trigger namespace so a retry resolves {{trigger.*}}', () => {
+    const run = {
+      runId: 'r-hook',
+      workflowId: 'wf',
+      connectorItem: {
+        connectionId: 'webhook',
+        connectorId: 'webhook',
+        externalId: 'evt',
+        title: 'Webhook POST',
+        raw: { body: { pr: 9 }, headers: { 'x-event': 'pr' }, query: {}, method: 'POST' }
+      }
+    } as unknown as WorkflowExecution
+    const context = contextFromRun(run)
+    expect(context?.trigger).toMatchObject({ type: 'webhook', body: { pr: 9 } })
+  })
 })
 
 describe('what a retry adopts', () => {


### PR DESCRIPTION
## What this adds

**Triggers come from the step library.** A new workflow starts as an empty canvas with a dashed placeholder; the library's trigger scope lists the built-in types plus every connection's trigger events. The trigger is a step like any other now: deletable, replaceable in place (id, position, wiring, and slug survive a swap), with the library as the one place a step or trigger changes type. Re-picking the current type is a no-op, and Run is guarded everywhere — editor, sidebar, palette, menus, and MCP — when no trigger exists.

**Webhook trigger.** `POST|GET /wf-hooks/:workflowId/:token` on the local server drops the request into the durable inbox and fans out a run with `{{trigger.body.*}}`, `{{trigger.query.*}}`, and `{{trigger.headers.*}}` (auth-bearing headers stripped). Loopback-only, per-trigger token, one 404 for every miss, and an eight-attempt cap before an event is marked dead. Trigger context survives approval gates, retries, and reruns.

**HTTP request step.** A new node type that executes on the server via an `http:request` RPC — no CORS, no secrets in the renderer. Method, URL, headers, and body are all templatable, and the structured `status`/`headers`/`body` output feeds the variable picker.

**Auth profiles.** Connections of a built-in `http` connector: base URL, templated header/query/body injection over an encrypted secret, and a Test button that performs a real request. Injection is confined to the profile's own origin — an absolute URL to another host is refused, redirects are not followed, and a still-locked secret fails loudly instead of sending ciphertext.

**Canvas fixes that fell out of testing.** Swapped cards re-measure so edges stay attached, workflows open top-aligned instead of vertically centered, trigger-less graphs keep their branch layout, and sidebar rows no longer nest buttons inside buttons.

## Review

Two independent passes (diff-only and integration) ran before this PR; all twelve confirmed findings are fixed in the branch with pinning tests, including the origin-confinement rule, the orphaned-chain reconnect on trigger re-add, and the webhook context rebuild on resume.

## Tests

Typecheck clean. Full vitest run 4899/4901 — the two failures are the known ambient-environment cases (pty-session-id inside a Vorn session, process-utils with a dev server up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)