### PR TITLE
Start workflows from templates and carry them as files

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -26,6 +26,7 @@ import { rpcCall } from '../ws-client'
 import {
   toPortable,
   fromPortable,
+  importedWorkflowIdFor,
   unresolvedRequirements,
   residualAbsolutePaths,
   slugify,
@@ -980,7 +981,7 @@ export function registerWorkflowTools(server: McpServer): void {
       const bundle = args.bundle ?? slugify(project.name)
       const portable = { ...parsed, slug: parsed.slug ?? slugify(parsed.name) }
       const connections = await listPortableConnections()
-      const definition = fromPortable(
+      const resolved = fromPortable(
         portable,
         bundle,
         {
@@ -991,7 +992,13 @@ export function registerWorkflowTools(server: McpServer): void {
       )
       const unresolved = unresolvedRequirements(portable, connections)
 
-      const existing = (await dbListWorkflows()).find((w) => w.id === definition.id)
+      const known = await dbListWorkflows()
+      const id = importedWorkflowIdFor(bundle, portable.slug, portable.name, known)
+      const existing = known.find((w) => w.id === id)
+      // A file describes a workflow; whether it runs is this machine's answer,
+      // and one that was already running keeps running.
+      const definition = { ...resolved, id, enabled: existing ? existing.enabled : false }
+
       if (existing) {
         await dbUpdateWorkflow(definition.id, definition)
       } else {
@@ -1013,6 +1020,7 @@ export function registerWorkflowTools(server: McpServer): void {
             type: 'text',
             text:
               `${existing ? 'Updated' : 'Imported'} "${definition.name}" as ${definition.id}, resolved against ${project.path}` +
+              (existing || definition.enabled ? '' : '. It is disabled; enable it when ready') +
               (pending ? `\n\nStill to connect: ${pending}` : '')
           }
         ]

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -26,12 +26,13 @@ import { rpcCall } from '../ws-client'
 import {
   toPortable,
   fromPortable,
-  portabilityBlockers,
+  unresolvedRequirements,
   residualAbsolutePaths,
   slugify,
   PORTABLE_FORMAT_VERSION,
+  type PortableConnection,
   type PortableWorkflow
-} from '../workflow-portability'
+} from '@vornrun/shared/workflow-portability'
 
 const launchAgentConfigSchema = z
   .object({
@@ -451,6 +452,15 @@ export function resolveWorkflowId(args: {
   return { id }
 }
 
+/** Connections for naming and rebinding requirements; absent ones cost detail, not the export. */
+async function listPortableConnections(): Promise<PortableConnection[]> {
+  try {
+    return await rpcCall<PortableConnection[]>('connection:list', { connectorId: undefined })
+  } catch {
+    return []
+  }
+}
+
 export function registerWorkflowTools(server: McpServer): void {
   server.tool(
     'list_workflows',
@@ -834,7 +844,7 @@ export function registerWorkflowTools(server: McpServer): void {
 
   server.tool(
     'export_workflow',
-    'Export a workflow as a portable file you can commit beside the code it drives. Absolute paths become {{project.path}} and the local remote-host binding is dropped, so it runs on another machine after import. Refuses a workflow bound to a connector connection, whose id means nothing elsewhere.',
+    'Export a workflow as a portable file you can commit beside the code it drives. Absolute paths become {{project.path}} and the local remote-host binding is dropped, so it runs on another machine after import. Connections are dropped too and recorded as requirements the importing machine rebinds by connector and name.',
     {
       workflow_id: V.id.optional().describe('Workflow ID (from list_workflows)'),
       id: V.id.optional().describe('Deprecated alias for workflow_id')
@@ -849,22 +859,6 @@ export function registerWorkflowTools(server: McpServer): void {
       if (!workflow) {
         return {
           content: [{ type: 'text', text: `Error: workflow "${resolved.id}" not found` }],
-          isError: true
-        }
-      }
-
-      const blockers = portabilityBlockers(workflow)
-      if (blockers.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text:
-                `Error: "${workflow.name}" cannot be exported portably because ` +
-                blockers.join('; ') +
-                '. Rebuild those steps without the connection, or keep this workflow local.'
-            }
-          ],
           isError: true
         }
       }
@@ -889,8 +883,11 @@ export function registerWorkflowTools(server: McpServer): void {
         }
       }
 
-      const portable = toPortable(workflow, project.path)
+      const portable = toPortable(workflow, project.path, await listPortableConnections())
       const residual = residualAbsolutePaths(portable)
+      const unnamed = (portable.requires ?? []).filter(
+        (requirement) => requirement.kind === 'connection' && requirement.connectorId === ''
+      )
 
       return {
         content: [
@@ -900,6 +897,9 @@ export function registerWorkflowTools(server: McpServer): void {
               JSON.stringify(portable, null, 2) +
               (residual.length > 0
                 ? `\n\nWarning: these still hold a machine-specific path and will not travel: ${residual.join(', ')}`
+                : '') +
+              (unnamed.length > 0
+                ? `\n\nWarning: ${unnamed.length} step(s) point at a connection this install could not name, so an import cannot rebind them automatically.`
                 : '')
           }
         ]
@@ -909,7 +909,7 @@ export function registerWorkflowTools(server: McpServer): void {
 
   server.tool(
     'import_workflow',
-    "Import a workflow exported by export_workflow, resolving {{project.path}} and {{project.name}} against a registered project. The id is derived from the bundle and the workflow's slug, so importing the same file again updates it in place instead of creating a duplicate.",
+    "Import a workflow exported by export_workflow, resolving {{project.path}} and {{project.name}} against a registered project. Recorded connection requirements are rebound when this machine has one unambiguous match, and reported as still to connect otherwise. The id is derived from the bundle and the workflow's slug, so importing the same file again updates it in place instead of creating a duplicate.",
     {
       workflow: z.string().max(500_000).describe('The exported workflow JSON'),
       project_name: V.name.describe('Registered project to resolve paths against'),
@@ -978,31 +978,18 @@ export function registerWorkflowTools(server: McpServer): void {
       }
 
       const bundle = args.bundle ?? slugify(project.name)
+      const portable = { ...parsed, slug: parsed.slug ?? slugify(parsed.name) }
+      const connections = await listPortableConnections()
       const definition = fromPortable(
-        { ...parsed, slug: parsed.slug ?? slugify(parsed.name) },
+        portable,
         bundle,
         {
           name: project.name,
           path: project.path
-        }
+        },
+        connections
       )
-
-      // Export refuses a connector-bound workflow because its connectionId is
-      // local. Import has to refuse the same shape, or a hand-written file
-      // walks straight past that contract and lands a workflow that fails at
-      // run time against a connection this machine never had.
-      const blockers = portabilityBlockers(definition)
-      if (blockers.length > 0) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Error: this workflow cannot be imported because ${blockers.join('; ')}.`
-            }
-          ],
-          isError: true
-        }
-      }
+      const unresolved = unresolvedRequirements(portable, connections)
 
       const existing = (await dbListWorkflows()).find((w) => w.id === definition.id)
       if (existing) {
@@ -1012,11 +999,21 @@ export function registerWorkflowTools(server: McpServer): void {
       }
       dbSignalChange()
 
+      const pending = unresolved
+        .map((requirement) =>
+          requirement.kind === 'httpProfile'
+            ? `${requirement.nodeId} needs an HTTP profile${requirement.name ? ` like "${requirement.name}"` : ''}`
+            : `${requirement.nodeId} needs a ${requirement.connectorId || 'connector'} connection${requirement.name ? ` like "${requirement.name}"` : ''}`
+        )
+        .join('; ')
+
       return {
         content: [
           {
             type: 'text',
-            text: `${existing ? 'Updated' : 'Imported'} "${definition.name}" as ${definition.id}, resolved against ${project.path}`
+            text:
+              `${existing ? 'Updated' : 'Imported'} "${definition.name}" as ${definition.id}, resolved against ${project.path}` +
+              (pending ? `\n\nStill to connect: ${pending}` : '')
           }
         ]
       }

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -29,6 +29,7 @@ import type {
 } from '@vornrun/shared/types'
 import {
   PORTABLE_FORMAT_VERSION,
+  type PortableRequirement,
   type PortableWorkflow
 } from '@vornrun/shared/workflow-portability'
 import { TEMPLATE_SEED } from './template-seed'
@@ -187,8 +188,34 @@ function normalizeTemplate(raw: unknown): WorkflowTemplate | undefined {
     steps: Array.isArray(template.steps)
       ? template.steps.filter((step): step is string => typeof step === 'string')
       : [],
-    portable
+    portable: { ...portable, ...requiresOf(portable) }
   } as WorkflowTemplate
+}
+
+/**
+ * The requirements a template can be trusted with.
+ *
+ * Everything downstream walks this list — the panel to say what a template
+ * wants, the binder to answer it — so a published string where a list belongs,
+ * or an entry missing the node it speaks for, takes the editor down rather than
+ * showing one bad template. Absent stays absent; unusable entries are dropped.
+ */
+function requiresOf(portable: PortableWorkflow): { requires?: PortableRequirement[] } {
+  if (portable.requires === undefined) return {}
+  if (!Array.isArray(portable.requires)) return { requires: [] }
+
+  const requires = portable.requires.filter((entry): entry is PortableRequirement => {
+    const requirement = entry as Record<string, unknown> | null
+    if (typeof requirement?.nodeId !== 'string') return false
+    if (requirement.kind === 'httpProfile') return typeof requirement.name === 'string'
+    return (
+      requirement.kind === 'connection' &&
+      typeof requirement.connectorId === 'string' &&
+      typeof requirement.name === 'string' &&
+      (requirement.event === undefined || typeof requirement.event === 'string')
+    )
+  })
+  return { requires }
 }
 
 /**

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -24,6 +24,7 @@ import os from 'os'
 import type {
   ConnectorCatalogEntry,
   ConnectorCatalogItem,
+  McpServerCatalogEntry,
   WorkflowTemplate
 } from '@vornrun/shared/types'
 import {
@@ -101,6 +102,7 @@ interface CachedCatalog {
   connectors: ConnectorCatalogEntry[]
   /** Absent in a cache written before templates were published. */
   templates?: WorkflowTemplate[]
+  mcpServers?: McpServerCatalogEntry[]
 }
 
 /**
@@ -117,6 +119,47 @@ export function parseTemplates(document: unknown): WorkflowTemplate[] {
   return root.templates
     .map(normalizeTemplate)
     .filter((template): template is WorkflowTemplate => template !== undefined)
+}
+
+/**
+ * Read the MCP servers a catalog document lists, if it lists any.
+ *
+ * Absent for the same reason templates are, and repaired the same way: an
+ * entry without a command is nothing anyone can start, but a missing blurb or
+ * a mistyped keyword list is not worth dropping a server over.
+ */
+export function parseMcpServers(document: unknown): McpServerCatalogEntry[] {
+  const root = document as { mcpServers?: unknown }
+  if (!Array.isArray(root?.mcpServers)) return []
+  return root.mcpServers
+    .map(normalizeMcpServer)
+    .filter((entry): entry is McpServerCatalogEntry => entry !== undefined)
+}
+
+function normalizeMcpServer(raw: unknown): McpServerCatalogEntry | undefined {
+  const entry = raw as Record<string, unknown> | null
+  if (
+    typeof entry?.id !== 'string' ||
+    typeof entry.name !== 'string' ||
+    typeof entry.command !== 'string' ||
+    entry.command.length === 0
+  ) {
+    return undefined
+  }
+
+  return {
+    ...entry,
+    id: entry.id,
+    name: entry.name,
+    command: entry.command,
+    args: strings(entry.args),
+    ...(entry.keywords !== undefined && { keywords: strings(entry.keywords) }),
+    ...(entry.env !== undefined && { env: strings(entry.env) })
+  } as McpServerCatalogEntry
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
 }
 
 /** A template is only usable if it carries a workflow this build can read. */
@@ -272,7 +315,8 @@ function readCache(cachePath: string): CachedCatalog | undefined {
     return {
       fetchedAt: Number(cached.fetchedAt) || 0,
       connectors,
-      templates: parseTemplates(cached)
+      templates: parseTemplates(cached),
+      mcpServers: parseMcpServers(cached)
     }
   } catch {
     // No cache yet, or one written by a version that shaped it differently.
@@ -291,13 +335,22 @@ function writeCache(cachePath: string, document: Omit<CachedCatalog, 'fetchedAt'
 
 async function download(
   get: typeof fetch
-): Promise<{ connectors: ConnectorCatalogEntry[]; templates: WorkflowTemplate[] } | undefined> {
+): Promise<
+  | {
+      connectors: ConnectorCatalogEntry[]
+      templates: WorkflowTemplate[]
+      mcpServers: McpServerCatalogEntry[]
+    }
+  | undefined
+> {
   try {
     const response = await get(CATALOG_URL, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     if (!response.ok) return undefined
     const document = await response.json()
     const connectors = parseCatalog(document)
-    return connectors ? { connectors, templates: parseTemplates(document) } : undefined
+    return connectors
+      ? { connectors, templates: parseTemplates(document), mcpServers: parseMcpServers(document) }
+      : undefined
   } catch {
     // Offline, blocked by a proxy, or serving something that is not the
     // catalog. All of them mean the same thing here: keep what we have.
@@ -307,6 +360,7 @@ async function download(
 
 let resolved: ConnectorCatalogItem[] | undefined
 let resolvedTemplates: WorkflowTemplate[] | undefined
+let resolvedMcpServers: McpServerCatalogEntry[] | undefined
 let resolvedAt: number | undefined
 
 /**
@@ -325,6 +379,7 @@ export function catalogItems(options: CatalogOptions = {}): ConnectorCatalogItem
     // A cached document that predates templates falls back to the seed rather
     // than to nothing, so the start-from list is never empty on an old cache.
     resolvedTemplates = cache?.templates?.length ? cache.templates : TEMPLATE_SEED
+    resolvedMcpServers = cache?.mcpServers ?? []
     resolvedAt = cache?.fetchedAt
     if (!cache || now - cache.fetchedAt > MAX_AGE_MS) void refreshCatalog(options)
   }
@@ -335,6 +390,12 @@ export function catalogItems(options: CatalogOptions = {}): ConnectorCatalogItem
 export function catalogTemplates(options: CatalogOptions = {}): WorkflowTemplate[] {
   catalogItems(options)
   return resolvedTemplates ?? TEMPLATE_SEED
+}
+
+/** The MCP servers the catalog lists. No bundled seed: there is nothing to fall back to. */
+export function catalogMcpServers(options: CatalogOptions = {}): McpServerCatalogEntry[] {
+  catalogItems(options)
+  return resolvedMcpServers ?? []
 }
 
 /**
@@ -348,13 +409,15 @@ export function catalogTemplates(options: CatalogOptions = {}): WorkflowTemplate
 export function catalogSnapshot(options: CatalogOptions = {}): {
   items: ConnectorCatalogItem[]
   templates: WorkflowTemplate[]
+  mcpServers: McpServerCatalogEntry[]
   fetchedAt?: number
 } {
   const items = catalogItems(options)
   const templates = catalogTemplates(options)
+  const mcpServers = catalogMcpServers(options)
   return resolvedAt === undefined
-    ? { items, templates }
-    : { items, templates, fetchedAt: resolvedAt }
+    ? { items, templates, mcpServers }
+    : { items, templates, mcpServers, fetchedAt: resolvedAt }
 }
 
 /** Fetch the published catalog and adopt it if it parses. Never throws. */
@@ -365,6 +428,7 @@ export async function refreshCatalog(options: CatalogOptions = {}): Promise<bool
   writeCache(options.cachePath ?? CACHE_PATH, document, now)
   resolved = withLaunch(document.connectors)
   resolvedTemplates = document.templates.length > 0 ? document.templates : TEMPLATE_SEED
+  resolvedMcpServers = document.mcpServers
   resolvedAt = now
   return true
 }
@@ -377,5 +441,6 @@ function withLaunch(entries: ConnectorCatalogEntry[]): ConnectorCatalogItem[] {
 export function resetCatalogCache(): void {
   resolved = undefined
   resolvedTemplates = undefined
+  resolvedMcpServers = undefined
   resolvedAt = undefined
 }

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -159,7 +159,9 @@ function normalizeMcpServer(raw: unknown): McpServerCatalogEntry | undefined {
 }
 
 function strings(value: unknown): string[] {
-  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : []
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
 }
 
 /** A template is only usable if it carries a workflow this build can read. */
@@ -333,9 +335,7 @@ function writeCache(cachePath: string, document: Omit<CachedCatalog, 'fetchedAt'
   }
 }
 
-async function download(
-  get: typeof fetch
-): Promise<
+async function download(get: typeof fetch): Promise<
   | {
       connectors: ConnectorCatalogEntry[]
       templates: WorkflowTemplate[]

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -21,7 +21,16 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
 import os from 'os'
-import type { ConnectorCatalogEntry, ConnectorCatalogItem } from '@vornrun/shared/types'
+import type {
+  ConnectorCatalogEntry,
+  ConnectorCatalogItem,
+  WorkflowTemplate
+} from '@vornrun/shared/types'
+import {
+  PORTABLE_FORMAT_VERSION,
+  type PortableWorkflow
+} from '@vornrun/shared/workflow-portability'
+import { TEMPLATE_SEED } from './template-seed'
 
 /**
  * Where the published catalog lives.
@@ -90,6 +99,51 @@ export const CONNECTOR_CATALOG: ConnectorCatalogEntry[] = [
 interface CachedCatalog {
   fetchedAt: number
   connectors: ConnectorCatalogEntry[]
+  /** Absent in a cache written before templates were published. */
+  templates?: WorkflowTemplate[]
+}
+
+/**
+ * Read the templates a catalog document carries, if it carries any.
+ *
+ * Absence is not a failure: every document published so far has none, and a
+ * client that treated that as a broken catalog would throw away the connector
+ * list it came for. Individually unusable templates are dropped for the same
+ * reason a malformed connector entry is.
+ */
+export function parseTemplates(document: unknown): WorkflowTemplate[] {
+  const root = document as { templates?: unknown }
+  if (!Array.isArray(root?.templates)) return []
+  return root.templates
+    .map(normalizeTemplate)
+    .filter((template): template is WorkflowTemplate => template !== undefined)
+}
+
+/** A template is only usable if it carries a workflow this build can read. */
+function normalizeTemplate(raw: unknown): WorkflowTemplate | undefined {
+  const template = raw as Record<string, unknown> | null
+  const portable = template?.portable as PortableWorkflow | undefined
+  if (
+    typeof template?.id !== 'string' ||
+    typeof template.name !== 'string' ||
+    portable?.version !== PORTABLE_FORMAT_VERSION ||
+    !Array.isArray(portable.nodes) ||
+    portable.nodes.length === 0 ||
+    !Array.isArray(portable.edges)
+  ) {
+    return undefined
+  }
+
+  return {
+    ...template,
+    id: template.id,
+    name: template.name,
+    description: typeof template.description === 'string' ? template.description : '',
+    steps: Array.isArray(template.steps)
+      ? template.steps.filter((step): step is string => typeof step === 'string')
+      : [],
+    portable
+  } as WorkflowTemplate
 }
 
 /**
@@ -214,27 +268,36 @@ function readCache(cachePath: string): CachedCatalog | undefined {
   try {
     const cached = JSON.parse(readFileSync(cachePath, 'utf8')) as CachedCatalog
     const connectors = parseCatalog({ version: 1, connectors: cached?.connectors })
-    return connectors ? { fetchedAt: Number(cached.fetchedAt) || 0, connectors } : undefined
+    if (!connectors) return undefined
+    return {
+      fetchedAt: Number(cached.fetchedAt) || 0,
+      connectors,
+      templates: parseTemplates(cached)
+    }
   } catch {
     // No cache yet, or one written by a version that shaped it differently.
     return undefined
   }
 }
 
-function writeCache(cachePath: string, connectors: ConnectorCatalogEntry[], now: number): void {
+function writeCache(cachePath: string, document: Omit<CachedCatalog, 'fetchedAt'>, now: number) {
   try {
     mkdirSync(dirname(cachePath), { recursive: true })
-    writeFileSync(cachePath, JSON.stringify({ fetchedAt: now, connectors }, null, 2))
+    writeFileSync(cachePath, JSON.stringify({ fetchedAt: now, ...document }, null, 2))
   } catch {
     // A read-only home directory costs a fetch per session, nothing more.
   }
 }
 
-async function download(get: typeof fetch): Promise<ConnectorCatalogEntry[] | undefined> {
+async function download(
+  get: typeof fetch
+): Promise<{ connectors: ConnectorCatalogEntry[]; templates: WorkflowTemplate[] } | undefined> {
   try {
     const response = await get(CATALOG_URL, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     if (!response.ok) return undefined
-    return parseCatalog(await response.json())
+    const document = await response.json()
+    const connectors = parseCatalog(document)
+    return connectors ? { connectors, templates: parseTemplates(document) } : undefined
   } catch {
     // Offline, blocked by a proxy, or serving something that is not the
     // catalog. All of them mean the same thing here: keep what we have.
@@ -243,6 +306,7 @@ async function download(get: typeof fetch): Promise<ConnectorCatalogEntry[] | un
 }
 
 let resolved: ConnectorCatalogItem[] | undefined
+let resolvedTemplates: WorkflowTemplate[] | undefined
 let resolvedAt: number | undefined
 
 /**
@@ -258,10 +322,19 @@ export function catalogItems(options: CatalogOptions = {}): ConnectorCatalogItem
     const now = options.now ?? Date.now()
     const cache = readCache(options.cachePath ?? CACHE_PATH)
     resolved = withLaunch(cache?.connectors ?? CONNECTOR_CATALOG)
+    // A cached document that predates templates falls back to the seed rather
+    // than to nothing, so the start-from list is never empty on an old cache.
+    resolvedTemplates = cache?.templates?.length ? cache.templates : TEMPLATE_SEED
     resolvedAt = cache?.fetchedAt
     if (!cache || now - cache.fetchedAt > MAX_AGE_MS) void refreshCatalog(options)
   }
   return resolved
+}
+
+/** The templates a new workflow can start from. */
+export function catalogTemplates(options: CatalogOptions = {}): WorkflowTemplate[] {
+  catalogItems(options)
+  return resolvedTemplates ?? TEMPLATE_SEED
 }
 
 /**
@@ -274,19 +347,24 @@ export function catalogItems(options: CatalogOptions = {}): ConnectorCatalogItem
  */
 export function catalogSnapshot(options: CatalogOptions = {}): {
   items: ConnectorCatalogItem[]
+  templates: WorkflowTemplate[]
   fetchedAt?: number
 } {
   const items = catalogItems(options)
-  return resolvedAt === undefined ? { items } : { items, fetchedAt: resolvedAt }
+  const templates = catalogTemplates(options)
+  return resolvedAt === undefined
+    ? { items, templates }
+    : { items, templates, fetchedAt: resolvedAt }
 }
 
 /** Fetch the published catalog and adopt it if it parses. Never throws. */
 export async function refreshCatalog(options: CatalogOptions = {}): Promise<boolean> {
-  const connectors = await download(options.fetchImpl ?? fetch)
-  if (!connectors) return false
+  const document = await download(options.fetchImpl ?? fetch)
+  if (!document) return false
   const now = options.now ?? Date.now()
-  writeCache(options.cachePath ?? CACHE_PATH, connectors, now)
-  resolved = withLaunch(connectors)
+  writeCache(options.cachePath ?? CACHE_PATH, document, now)
+  resolved = withLaunch(document.connectors)
+  resolvedTemplates = document.templates.length > 0 ? document.templates : TEMPLATE_SEED
   resolvedAt = now
   return true
 }
@@ -298,5 +376,6 @@ function withLaunch(entries: ConnectorCatalogEntry[]): ConnectorCatalogItem[] {
 /** Test seam: forget what has been resolved this process. */
 export function resetCatalogCache(): void {
   resolved = undefined
+  resolvedTemplates = undefined
   resolvedAt = undefined
 }

--- a/packages/server/src/connectors/template-seed.ts
+++ b/packages/server/src/connectors/template-seed.ts
@@ -1,0 +1,163 @@
+import type { WorkflowTemplate } from '@vornrun/shared/types'
+import { PORTABLE_FORMAT_VERSION } from '@vornrun/shared/workflow-portability'
+
+/**
+ * Enough templates that a first run has somewhere to start.
+ *
+ * A seed, not a library: these use only built-in steps, so they work on an
+ * install with nothing connected, and they are replaced by the published list
+ * as soon as one is fetched. Adding to this is not how the catalog grows —
+ * publishing is — and a test holds it to that.
+ *
+ * The webhook trigger ships without a token on purpose. A token published here
+ * would be the same secret on every machine that ever used this template, so
+ * one is minted when a template becomes a workflow.
+ */
+export const TEMPLATE_SEED: WorkflowTemplate[] = [
+  {
+    id: 'webhook-to-report',
+    name: 'Webhook to report',
+    description:
+      'Take a request from another system, look at what it says, and post the ones that matter on somewhere else.',
+    steps: ['Webhook', 'Condition', 'HTTP request'],
+    category: 'Integrations',
+    portable: {
+      version: PORTABLE_FORMAT_VERSION,
+      slug: 'webhook-to-report',
+      name: 'Webhook to report',
+      icon: 'Webhook',
+      iconColor: '#6f8faf',
+      requires: [{ kind: 'httpProfile', nodeId: 'report', name: 'reporting API' }],
+      nodes: [
+        {
+          id: 'trigger',
+          type: 'trigger',
+          label: 'Webhook',
+          config: { triggerType: 'webhook', method: 'POST', token: '' },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'check',
+          type: 'condition',
+          label: 'Condition',
+          slug: 'condition',
+          config: { variable: '{{trigger.body.severity}}', operator: 'contains', value: 'bug' },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'report',
+          type: 'httpRequest',
+          label: 'HTTP Request',
+          slug: 'http-request',
+          config: {
+            nodeType: 'httpRequest',
+            method: 'POST',
+            url: '/reports',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{"summary": "{{trigger.body.summary}}"}'
+          },
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'check' },
+        { id: 'e2', source: 'check', target: 'report', conditionBranch: 'true' }
+      ]
+    }
+  },
+  {
+    id: 'morning-digest',
+    name: 'Morning digest',
+    description:
+      'Every weekday morning, gather what changed overnight and have an agent write it up.',
+    steps: ['Schedule', 'Script', 'Agent'],
+    category: 'Reporting',
+    portable: {
+      version: PORTABLE_FORMAT_VERSION,
+      slug: 'morning-digest',
+      name: 'Morning digest',
+      icon: 'Newspaper',
+      iconColor: '#c9972a',
+      nodes: [
+        {
+          id: 'trigger',
+          type: 'trigger',
+          label: 'Schedule (Recurring)',
+          config: { triggerType: 'recurring', cron: '0 9 * * 1-5' },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'gather',
+          type: 'script',
+          label: 'Execute Script',
+          slug: 'execute-script',
+          config: {
+            scriptType: 'bash',
+            projectName: '{{project.name}}',
+            projectPath: '{{project.path}}',
+            scriptContent: 'git log --since=yesterday --oneline\n'
+          },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'write',
+          type: 'launchAgent',
+          label: 'Launch Agent',
+          slug: 'launch-agent',
+          config: {
+            agentType: 'claude',
+            projectName: '{{project.name}}',
+            projectPath: '{{project.path}}',
+            headless: true,
+            prompt:
+              'Write a short digest of these commits for the team:\n\n{{steps.execute-script.output}}'
+          },
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'gather' },
+        { id: 'e2', source: 'gather', target: 'write' }
+      ]
+    }
+  },
+  {
+    id: 'triage-new-tasks',
+    name: 'Triage new tasks',
+    description: 'When a task is created, have an agent read it and say what it will take.',
+    steps: ['Task created', 'Agent'],
+    category: 'Tasks',
+    portable: {
+      version: PORTABLE_FORMAT_VERSION,
+      slug: 'triage-new-tasks',
+      name: 'Triage new tasks',
+      icon: 'ListChecks',
+      iconColor: '#7d9471',
+      nodes: [
+        {
+          id: 'trigger',
+          type: 'trigger',
+          label: 'When Task Created',
+          config: { triggerType: 'taskCreated' },
+          position: { x: 0, y: 0 }
+        },
+        {
+          id: 'triage',
+          type: 'launchAgent',
+          label: 'Launch Agent',
+          slug: 'launch-agent',
+          config: {
+            agentType: 'claude',
+            projectName: '{{project.name}}',
+            projectPath: '{{project.path}}',
+            headless: true,
+            prompt:
+              'Read this task and reply with the files it touches and a rough size:\n\n{{task.title}}\n\n{{task.description}}'
+          },
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: [{ id: 'e1', source: 'trigger', target: 'triage' }]
+    }
+  }
+]

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "./structured-output": "./src/structured-output.ts",
     "./config-scope": "./src/config-scope.ts",
     "./session-restore": "./src/session-restore.ts",
+    "./workflow-portability": "./src/workflow-portability.ts",
     "./viewer-settings-store": "./src/viewer-settings-store.ts"
   }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1816,9 +1816,29 @@ export interface WorkflowTemplate {
   portable: PortableWorkflow
 }
 
+/**
+ * An MCP server worth knowing about, listed beside the connectors.
+ *
+ * It carries a command rather than a package because that is what a generic
+ * server is: something Vorn starts and speaks MCP to. There is no manifest to
+ * probe, so what a person needs is the launch line filled in for them.
+ */
+export interface McpServerCatalogEntry {
+  id: string
+  name: string
+  description?: string
+  command: string
+  args: string[]
+  category?: string
+  keywords?: string[]
+  /** Environment variables the server expects, named so the form can ask. */
+  env?: string[]
+}
+
 export interface ConnectorCatalogSnapshot {
   items: ConnectorCatalogItem[]
   templates: WorkflowTemplate[]
+  mcpServers: McpServerCatalogEntry[]
   fetchedAt?: number
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,3 +1,6 @@
+// Type-only, so the portability module can keep importing values from here.
+import type { PortableWorkflow } from './workflow-portability'
+
 /** AI agents only. Use this for icon maps, install status, command configs, and
  *  anything else that applies exclusively to an AI CLI — not to plain shells. */
 export type AiAgentType = 'claude' | 'copilot' | 'codex' | 'opencode' | 'gemini'
@@ -1796,8 +1799,26 @@ export interface ConnectorCatalogItem extends ConnectorCatalogEntry {
  * every attempt so far has failed — so the UI can say that rather than showing
  * a timestamp for a list that may be missing everything published since.
  */
+/**
+ * A workflow someone can start from rather than an empty canvas.
+ *
+ * Published beside the connectors and carried in the same document, because a
+ * template goes stale for the same reasons a connector entry does and there is
+ * no reason to fetch, cache and repair two lists.
+ */
+export interface WorkflowTemplate {
+  id: string
+  name: string
+  description: string
+  /** The chain as a person reads it, e.g. ['Webhook', 'Condition', 'HTTP request']. */
+  steps: string[]
+  category?: string
+  portable: PortableWorkflow
+}
+
 export interface ConnectorCatalogSnapshot {
   items: ConnectorCatalogItem[]
+  templates: WorkflowTemplate[]
   fetchedAt?: number
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1600,6 +1600,7 @@ export const IPC = {
   TASK_IMAGE_GET_PATH: 'task:imageGetPath',
   TASK_IMAGE_CLEANUP: 'task:imageCleanup',
   DIALOG_OPEN_IMAGE: 'dialog:openImage',
+  DIALOG_SAVE_TEXT_FILE: 'dialog:saveTextFile',
   HEADLESS_CREATE: 'headless:create',
   HEADLESS_KILL: 'headless:kill',
   HEADLESS_LIST: 'headless:list',

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -216,6 +216,9 @@ function normalizeForCompare(p: string): string {
 function replacePath(value: string, projectPath: string): string {
   const v = normalizeForCompare(value)
   const root = normalizeForCompare(projectPath)
+  // No project to be relative to: leaving the path alone beats rewriting every
+  // absolute path as if it sat inside an empty root.
+  if (root === '') return value
   if (v === root) return PROJECT_PATH_TOKEN
   // A path inside the project keeps its tail, so a worktree or a subdirectory
   // survives the round trip instead of collapsing onto the project root.

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -78,6 +78,27 @@ export function importedWorkflowId(bundle: string, slug: string): string {
   return `import:${bundle}:${slug}`
 }
 
+/**
+ * The id an import should take, given what this machine already has.
+ *
+ * Deriving from the slug is what makes re-importing a file update the workflow
+ * it made last time. Two different names can slugify the same, though — "Deploy!"
+ * and "Deploy?" — and the second would silently replace the first. A derived id
+ * already held by a workflow of another name steps aside instead.
+ */
+export function importedWorkflowIdFor(
+  bundle: string,
+  slug: string,
+  name: string,
+  existing: Array<{ id: string; name: string }>
+): string {
+  for (let attempt = 1; ; attempt++) {
+    const id = importedWorkflowId(bundle, attempt === 1 ? slug : `${slug}-${attempt}`)
+    const held = existing.find((workflow) => workflow.id === id)
+    if (!held || held.name === name) return id
+  }
+}
+
 export function parseImportedWorkflowId(id: string): { bundle: string; slug: string } | null {
   if (!id.startsWith('import:')) return null
   const rest = id.slice('import:'.length)
@@ -289,7 +310,9 @@ export function fromPortable(
     name: portable.name,
     icon: portable.icon ?? 'Zap',
     iconColor: portable.iconColor ?? '#6366f1',
-    enabled: true,
+    // A file cannot ask to be running: a dropped cron workflow would start
+    // firing before anyone had read it. Callers restore what they had.
+    enabled: false,
     ...(portable.staggerDelayMs !== undefined && { staggerDelayMs: portable.staggerDelayMs }),
     nodes,
     edges: portable.edges

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -148,6 +148,10 @@ export function toPortable(
   const nodes = workflow.nodes.map((node) => {
     const config = { ...(node.config as Record<string, unknown>) }
 
+    // The token is the only thing guarding this install's hook route, so it
+    // does not belong in a file meant to be committed and shared.
+    if (node.type === 'trigger' && config.triggerType === 'webhook') config.token = ''
+
     if (node.type === 'launchAgent' || node.type === 'script') {
       for (const key of ['projectPath', 'cwd', 'existingWorktreePath']) {
         const value = config[key]
@@ -243,7 +247,8 @@ export function fromPortable(
   portable: PortableWorkflow,
   bundle: string,
   project: { name: string; path: string },
-  connections: PortableConnection[] = []
+  connections: PortableConnection[] = [],
+  mintToken: () => string = () => crypto.randomUUID()
 ): WorkflowDefinition {
   const bindings = new Map<string, PortableRequirement[]>()
   for (const requirement of portable.requires ?? []) {
@@ -269,6 +274,11 @@ export function fromPortable(
       if (resolved === undefined) continue
       if (requirement.kind === 'httpProfile') config.profileConnectionId = resolved
       else config.connectionId = resolved
+    }
+
+    // Export blanks it; this install gets a hook secret of its own.
+    if (node.type === 'trigger' && config.triggerType === 'webhook' && !config.token) {
+      config.token = mintToken()
     }
 
     return { ...node, config } as WorkflowNode

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -1,4 +1,5 @@
-import type { WorkflowDefinition, WorkflowNode } from '@vornrun/shared/types'
+import { connectionConnectorId } from './types'
+import type { SourceConnection, WorkflowDefinition, WorkflowNode } from './types'
 
 /**
  * Making a workflow portable, and putting it back.
@@ -13,6 +14,12 @@ import type { WorkflowDefinition, WorkflowNode } from '@vornrun/shared/types'
  * is no flat list of paths to walk — every rewrite has to know the node type it
  * is looking at. That is the whole reason this file exists rather than a
  * two-line `JSON.stringify`.
+ *
+ * Connections are the other machine-specific thing, and they are handled
+ * differently from paths: a connection id cannot be rewritten to a placeholder
+ * because there is nothing on the far side to resolve it against. Export drops
+ * the id and records what it stood for; import rebinds it when this machine has
+ * an unambiguous answer, and leaves the step unconfigured when it does not.
  */
 
 /** Stands in for the importing project's directory. */
@@ -22,6 +29,21 @@ export const PROJECT_NAME_TOKEN = '{{project.name}}'
 
 export const PORTABLE_FORMAT_VERSION = 1
 
+/** The built-in connector whose connections are HTTP auth profiles. */
+export const HTTP_PROFILE_CONNECTOR = 'http'
+
+/** What a step needs bound before it can run, named so any machine can match it. */
+export type PortableRequirement =
+  | {
+      kind: 'connection'
+      nodeId: string
+      /** Empty when the exporting machine could not name the connector. */
+      connectorId: string
+      name: string
+      event?: string
+    }
+  | { kind: 'httpProfile'; nodeId: string; name: string }
+
 export type PortableWorkflow = {
   version: number
   slug: string
@@ -29,8 +51,18 @@ export type PortableWorkflow = {
   icon?: string
   iconColor?: string
   staggerDelayMs?: number
+  /** Absent when nothing in the workflow was bound to a connection. */
+  requires?: PortableRequirement[]
   nodes: WorkflowNode[]
   edges: WorkflowDefinition['edges']
+}
+
+/** Enough of a connection to match one; a whole `SourceConnection` satisfies it. */
+export interface PortableConnection {
+  id: string
+  name: string
+  connectorId: string
+  filters?: SourceConnection['filters']
 }
 
 /**
@@ -64,35 +96,54 @@ export function slugify(name: string): string {
   )
 }
 
-/**
- * Why a workflow cannot travel, if it cannot.
- *
- * A connector-bound workflow carries a `connectionId` that is a UUID minted on
- * this machine. Rewriting it to a placeholder would produce a file that
- * imports cleanly and then fails at run time against a connection that does
- * not exist — so this refuses instead, the way install_connector refuses
- * secrets rather than guessing at them.
- */
-export function portabilityBlockers(workflow: WorkflowDefinition): string[] {
-  const blockers: string[] = []
-
-  for (const node of workflow.nodes) {
-    const config = node.config as Record<string, unknown>
-
-    if (node.type === 'trigger' && config.triggerType === 'connectorPoll') {
-      blockers.push(`the trigger polls a connector connection, which exists only on this machine`)
-    }
-    if (node.type === 'callConnectorAction') {
-      blockers.push(`step "${node.label}" calls a connector action bound to a local connection`)
-    }
-  }
-
-  return blockers
+/** The connector a connection belongs to, packaged connectors included. */
+function connectorOf(connection: PortableConnection): string {
+  return connectionConnectorId({
+    connectorId: connection.connectorId,
+    filters: connection.filters ?? {}
+  })
 }
 
-/** Replace this machine's paths with placeholders. */
-export function toPortable(workflow: WorkflowDefinition, projectPath: string): PortableWorkflow {
+/** Whether this node runs against a connector connection. */
+function boundConnectionKey(node: WorkflowNode, config: Record<string, unknown>): string | null {
+  if (node.type === 'trigger' && config.triggerType === 'connectorPoll') return 'connectionId'
+  if (node.type === 'callConnectorAction') return 'connectionId'
+  if (node.type === 'httpRequest') return 'profileConnectionId'
+  return null
+}
+
+/**
+ * The connection a requirement should bind to here, if this machine has one answer.
+ *
+ * A name match wins over a bare type match, so re-importing where the file was
+ * written rebinds what it was actually pointed at. Anything ambiguous is left
+ * for a person, because guessing binds a workflow to the wrong account.
+ */
+export function resolveRequirement(
+  requirement: PortableRequirement,
+  connections: PortableConnection[]
+): string | undefined {
+  const candidates = connections.filter((connection) =>
+    requirement.kind === 'httpProfile'
+      ? connectorOf(connection) === HTTP_PROFILE_CONNECTOR
+      : requirement.connectorId !== '' && connectorOf(connection) === requirement.connectorId
+  )
+  if (candidates.length === 0) return undefined
+  if (requirement.name !== '') {
+    const named = candidates.filter((connection) => connection.name === requirement.name)
+    if (named.length === 1) return named[0].id
+  }
+  return candidates.length === 1 ? candidates[0].id : undefined
+}
+
+/** Replace this machine's paths with placeholders and unbind its connections. */
+export function toPortable(
+  workflow: WorkflowDefinition,
+  projectPath: string,
+  connections: PortableConnection[] = []
+): PortableWorkflow {
   const slug = slugify(workflow.name)
+  const requires: PortableRequirement[] = []
 
   const nodes = workflow.nodes.map((node) => {
     const config = { ...(node.config as Record<string, unknown>) }
@@ -113,6 +164,27 @@ export function toPortable(workflow: WorkflowDefinition, projectPath: string): P
       delete config.remoteHostId
     }
 
+    const key = boundConnectionKey(node, config)
+    const bound = key === null ? '' : config[key]
+    if (key !== null && typeof bound === 'string' && bound !== '') {
+      const source = connections.find((connection) => connection.id === bound)
+      const event = config.event
+      requires.push(
+        key === 'profileConnectionId'
+          ? { kind: 'httpProfile', nodeId: node.id, name: source?.name ?? '' }
+          : {
+              kind: 'connection',
+              nodeId: node.id,
+              connectorId: source ? connectorOf(source) : '',
+              name: source?.name ?? '',
+              ...(typeof event === 'string' && event !== '' && { event })
+            }
+      )
+      // Optional on the node, so the step reads as simply having no profile.
+      if (key === 'profileConnectionId') delete config[key]
+      else config[key] = ''
+    }
+
     return { ...node, config } as WorkflowNode
   })
 
@@ -123,6 +195,7 @@ export function toPortable(workflow: WorkflowDefinition, projectPath: string): P
     ...(workflow.icon && { icon: workflow.icon }),
     ...(workflow.iconColor && { iconColor: workflow.iconColor }),
     ...(workflow.staggerDelayMs !== undefined && { staggerDelayMs: workflow.staggerDelayMs }),
+    ...(requires.length > 0 && { requires }),
     nodes,
     edges: workflow.edges
   }
@@ -150,12 +223,30 @@ function replacePath(value: string, projectPath: string): string {
   return value
 }
 
+/** Which of this file's requirements this machine cannot answer on its own. */
+export function unresolvedRequirements(
+  portable: PortableWorkflow,
+  connections: PortableConnection[]
+): PortableRequirement[] {
+  const present = new Set(portable.nodes.map((node) => node.id))
+  return (portable.requires ?? []).filter(
+    (requirement) =>
+      present.has(requirement.nodeId) && resolveRequirement(requirement, connections) === undefined
+  )
+}
+
 /** Resolve placeholders against the project this workflow is being imported into. */
 export function fromPortable(
   portable: PortableWorkflow,
   bundle: string,
-  project: { name: string; path: string }
+  project: { name: string; path: string },
+  connections: PortableConnection[] = []
 ): WorkflowDefinition {
+  const bindings = new Map<string, PortableRequirement[]>()
+  for (const requirement of portable.requires ?? []) {
+    bindings.set(requirement.nodeId, [...(bindings.get(requirement.nodeId) ?? []), requirement])
+  }
+
   const nodes = portable.nodes.map((node) => {
     const config = { ...(node.config as Record<string, unknown>) }
 
@@ -168,6 +259,13 @@ export function fromPortable(
         .join(project.path.replace(/[/\\]+$/, ''))
         .split(PROJECT_NAME_TOKEN)
         .join(project.name)
+    }
+
+    for (const requirement of bindings.get(node.id) ?? []) {
+      const resolved = resolveRequirement(requirement, connections)
+      if (resolved === undefined) continue
+      if (requirement.kind === 'httpProfile') config.profileConnectionId = resolved
+      else config.connectionId = resolved
     }
 
     return { ...node, config } as WorkflowNode

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -454,6 +454,21 @@ export function createApiShim(wsUrl: string) {
       const path = window.prompt('Enter the file path on the server:')
       return path?.trim() || null
     },
+    // The browser has no save dialog, so the file lands wherever downloads go.
+    saveTextFile: async (params: {
+      defaultName: string
+      contents: string
+    }): Promise<string | null> => {
+      const url = URL.createObjectURL(new Blob([params.contents], { type: 'application/json' }))
+      const link = document.createElement('a')
+      link.href = url
+      link.download = params.defaultName
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      URL.revokeObjectURL(url)
+      return params.defaultName
+    },
     openImageDialog: async (): Promise<string[] | null> => {
       const files = await pickFiles('image/*', true)
       if (!files)

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -466,7 +466,8 @@ export function createApiShim(wsUrl: string) {
       document.body.appendChild(link)
       link.click()
       link.remove()
-      URL.revokeObjectURL(url)
+      // Revoking before the blob navigation settles can truncate the download.
+      setTimeout(() => URL.revokeObjectURL(url), 0)
       return params.defaultName
     },
     openImageDialog: async (): Promise<string[] | null> => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,5 +1,6 @@
 import { app, dialog, BrowserWindow, session, shell } from 'electron'
 import { ipcMain } from 'electron'
+import { writeFile } from 'node:fs/promises'
 import { safeHandle } from './ipc-safe-handle'
 import { IPC, ResizePayload, browserPartition } from '../shared/types'
 import type { ServerBridge } from './server/server-bridge'
@@ -414,6 +415,23 @@ export function registerIpcHandlers(): void {
     if (result.canceled || result.filePaths.length === 0) return null
     return result.filePaths[0]
   })
+
+  safeHandle(
+    IPC.DIALOG_SAVE_TEXT_FILE,
+    async (event, params: { defaultName: string; contents: string; title?: string }) => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win) return null
+      if (typeof params?.contents !== 'string') throw new Error('Nothing to save')
+      const result = await dialog.showSaveDialog(win, {
+        defaultPath: params.defaultName,
+        title: params.title ?? 'Save file',
+        filters: [{ name: 'JSON', extensions: ['json'] }]
+      })
+      if (result.canceled || !result.filePath) return null
+      await writeFile(result.filePath, params.contents, 'utf8')
+      return result.filePath
+    }
+  )
 
   safeHandle(IPC.DIALOG_OPEN_IMAGE, async () => {
     const win = BrowserWindow.getFocusedWindow()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -188,6 +188,12 @@ const api = {
 
   openFileDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.DIALOG_OPEN_FILE),
 
+  saveTextFile: (params: {
+    defaultName: string
+    contents: string
+    title?: string
+  }): Promise<string | null> => ipcRenderer.invoke(IPC.DIALOG_SAVE_TEXT_FILE, params),
+
   detectIDEs: (): Promise<{ id: string; name: string; command: string }[]> =>
     ipcRenderer.invoke(IPC.IDE_DETECT),
 

--- a/src/renderer/components/project-sidebar/WorkflowContextMenu.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowContextMenu.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react'
-import { Pencil, Trash2, Power } from 'lucide-react'
+import { Pencil, Trash2, Power, Upload } from 'lucide-react'
 
 const MENU_WIDTH = 180
-const MENU_MAX_HEIGHT = 132
+const MENU_MAX_HEIGHT = 176
 const MENU_MARGIN = 8
 
 function clampToViewport(x: number, y: number) {
@@ -19,6 +19,7 @@ function clampToViewport(x: number, y: number) {
 
 export function WorkflowContextMenu({
   onEdit,
+  onExport,
   onDelete,
   onToggleEnabled,
   isScheduled,
@@ -28,6 +29,7 @@ export function WorkflowContextMenu({
   y
 }: {
   onEdit: () => void
+  onExport?: () => void
   onDelete: () => void
   onToggleEnabled?: () => void
   isScheduled?: boolean
@@ -88,6 +90,19 @@ export function WorkflowContextMenu({
         >
           <Power size={12} strokeWidth={1.5} />
           {isEnabled ? 'Disable Schedule' : 'Enable Schedule'}
+        </button>
+      )}
+      {onExport && (
+        <button
+          onClick={() => {
+            onExport()
+            onClose()
+          }}
+          className="w-full px-3 py-2 text-left text-[12px] text-gray-300 hover:text-white
+                     hover:bg-white/[0.06] active:bg-white/[0.1] flex items-center gap-2 transition-colors"
+        >
+          <Upload size={12} strokeWidth={1.5} />
+          Export as file…
         </button>
       )}
       <button

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -155,7 +155,7 @@ export function WorkflowsSection({
 
   const handleDragOver = useCallback((e: React.DragEvent, index: number) => {
     // A dragged file is on its way to the list's own drop target, not between rows.
-    if (e.dataTransfer.types.includes('Files')) return
+    if (e.dataTransfer?.types?.includes('Files')) return
     e.preventDefault()
     e.dataTransfer.dropEffect = 'move'
     setDragOverIndex(index)
@@ -225,7 +225,7 @@ export function WorkflowsSection({
       <div
         className="space-y-0.5"
         onDragOver={(e) => {
-          if (!e.dataTransfer.types.includes('Files')) return
+          if (!e.dataTransfer?.types?.includes('Files')) return
           e.preventDefault()
           setFileOver(true)
         }}

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -151,6 +151,8 @@ export function WorkflowsSection({
   }, [])
 
   const handleDragOver = useCallback((e: React.DragEvent, index: number) => {
+    // A dragged file is on its way to the list's own drop target, not between rows.
+    if (e.dataTransfer.types.includes('Files')) return
     e.preventDefault()
     e.dataTransfer.dropEffect = 'move'
     setDragOverIndex(index)

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -59,7 +59,7 @@ export function WorkflowsSection({
     async (workflow: WorkflowDefinition) => {
       const project = projectForWorkflow(workflow, projects ?? [])
       const file = fileFromWorkflow(workflow, project?.path ?? '', connections)
-      const saved = await window.api.saveTextFile({
+      const saved = await window.api.saveTextFile?.({
         defaultName: file.name,
         contents: file.contents,
         title: 'Export workflow'

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -101,11 +101,7 @@ export function WorkflowsSection({
       else addWorkflow(placed)
 
       const pending = result.unresolved.map(describeRequirement).join(', ')
-      const note = pending
-        ? ` — still needs ${pending}`
-        : existing
-          ? ''
-          : ' — enable it when ready'
+      const note = pending ? ` — still needs ${pending}` : existing ? '' : ' — enable it when ready'
       toast.success(`${existing ? 'Updated' : 'Imported'} "${placed.name}"${note}`)
     },
     [

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -57,7 +57,7 @@ export function WorkflowsSection({
 
   const handleExport = useCallback(
     async (workflow: WorkflowDefinition) => {
-      const project = projectForWorkflow(workflow, projects ?? [])
+      const project = projectForWorkflow(workflow, projects ?? [], activeProject)
       const file = fileFromWorkflow(workflow, project?.path ?? '', connections)
       const saved = await window.api.saveTextFile?.({
         defaultName: file.name,
@@ -71,7 +71,7 @@ export function WorkflowsSection({
         toast.success(`Exported "${workflow.name}"`)
       }
     },
-    [projects, connections]
+    [projects, activeProject, connections]
   )
 
   const handleImport = useCallback(
@@ -87,7 +87,8 @@ export function WorkflowsSection({
         picked.contents,
         project,
         slugify(project.name),
-        connections
+        connections,
+        allWorkflows ?? []
       )
       if (!result.ok) {
         toast.error(result.error)
@@ -100,9 +101,12 @@ export function WorkflowsSection({
       else addWorkflow(placed)
 
       const pending = result.unresolved.map(describeRequirement).join(', ')
-      toast.success(
-        `${existing ? 'Updated' : 'Imported'} "${placed.name}"${pending ? ` — still needs ${pending}` : ''}`
-      )
+      const note = pending
+        ? ` — still needs ${pending}`
+        : existing
+          ? ''
+          : ' — enable it when ready'
+      toast.success(`${existing ? 'Updated' : 'Imported'} "${placed.name}"${note}`)
     },
     [
       projects,
@@ -120,13 +124,16 @@ export function WorkflowsSection({
       setFileOver(false)
       if (!e.dataTransfer.files?.length) return
       e.preventDefault()
-      void readDroppedWorkflowFile(e.dataTransfer.files).then((picked) => {
-        if (!picked) {
-          toast.error('That is not a workflow file')
-          return
-        }
-        handleImport(picked)
-      })
+      void readDroppedWorkflowFile(e.dataTransfer.files).then(
+        (picked) => {
+          if (!picked) {
+            toast.error('That is not a workflow file')
+            return
+          }
+          handleImport(picked)
+        },
+        (err: unknown) => toast.error(err instanceof Error ? err.message : String(err))
+      )
     },
     [handleImport]
   )
@@ -191,7 +198,11 @@ export function WorkflowsSection({
             <WorkflowFilterToolbar />
             <Tooltip label="Import workflow file" position="bottom">
               <button
-                onClick={() => void pickWorkflowFile().then(handleImport)}
+                onClick={() =>
+                  void pickWorkflowFile().then(handleImport, (err: unknown) =>
+                    toast.error(err instanceof Error ? err.message : String(err))
+                  )
+                }
                 aria-label="Import workflow file"
                 className="p-0.5 rounded text-gray-600 hover:text-white hover:bg-white/[0.08] transition-colors"
               >

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -1,12 +1,24 @@
 import { useState, useMemo, useCallback } from 'react'
 import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
+import { toast } from '../Toast'
 import { WorkflowItem } from './WorkflowItem'
 import { WorkflowFilterToolbar } from './WorkflowFilterToolbar'
 import { WorkflowContextMenu } from './WorkflowContextMenu'
 import { SidebarSectionHeader } from './SidebarSectionHeader'
 import { isScheduledWorkflow } from '../../lib/workflow-helpers'
-import { Workflow, Activity } from 'lucide-react'
+import { useConnections } from '../../lib/use-connections'
+import {
+  definitionFromFile,
+  describeRequirement,
+  fileFromWorkflow,
+  pickWorkflowFile,
+  placeImportedWorkflow,
+  projectForWorkflow,
+  readDroppedWorkflowFile
+} from '../../lib/workflow-files'
+import { slugify } from '../../../shared/workflow-portability'
+import { Workflow, Activity, Download } from 'lucide-react'
 import type { WorkflowDefinition } from '../../../shared/types'
 import { useWaitingApprovals } from '../../hooks/useWaitingApprovals'
 
@@ -34,6 +46,82 @@ export function WorkflowsSection({
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null)
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const [dragSourceIndex, setDragSourceIndex] = useState<number | null>(null)
+  const [fileOver, setFileOver] = useState(false)
+
+  const projects = useAppStore((s) => s.config?.projects)
+  const allWorkflows = useAppStore((s) => s.config?.workflows)
+  const activeProject = useAppStore((s) => s.activeProject)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  const addWorkflow = useAppStore((s) => s.addWorkflow)
+  const connections = useConnections()
+
+  const handleExport = useCallback(
+    async (workflow: WorkflowDefinition) => {
+      const project = projectForWorkflow(workflow, projects ?? [])
+      const file = fileFromWorkflow(workflow, project?.path ?? '', connections)
+      const saved = await window.api.saveTextFile({
+        defaultName: file.name,
+        contents: file.contents,
+        title: 'Export workflow'
+      })
+      if (!saved) return
+      if (file.residual.length > 0) {
+        toast.error(`Exported, but these still name this machine: ${file.residual.join(', ')}`)
+      } else {
+        toast.success(`Exported "${workflow.name}"`)
+      }
+    },
+    [projects, connections]
+  )
+
+  const handleImport = useCallback(
+    (picked: { name: string; contents: string } | null) => {
+      if (!picked) return
+      const project = projects?.find((p) => p.name === activeProject) ?? projects?.[0]
+      if (!project) {
+        toast.error('Add a project first, so the imported paths have somewhere to resolve')
+        return
+      }
+
+      const result = definitionFromFile(
+        picked.contents,
+        project,
+        slugify(project.name),
+        connections
+      )
+      if (!result.ok) {
+        toast.error(result.error)
+        return
+      }
+
+      const existing = (allWorkflows ?? []).find((w) => w.id === result.definition.id)
+      const placed = placeImportedWorkflow(result.definition, existing, activeWorkspace)
+      if (existing) updateWorkflow(placed.id, placed)
+      else addWorkflow(placed)
+
+      const pending = result.unresolved.map(describeRequirement).join(', ')
+      toast.success(
+        `${existing ? 'Updated' : 'Imported'} "${placed.name}"${pending ? ` — still needs ${pending}` : ''}`
+      )
+    },
+    [projects, activeProject, activeWorkspace, allWorkflows, connections, addWorkflow, updateWorkflow]
+  )
+
+  const handleFileDrop = useCallback(
+    (e: React.DragEvent) => {
+      setFileOver(false)
+      if (!e.dataTransfer.files?.length) return
+      e.preventDefault()
+      void readDroppedWorkflowFile(e.dataTransfer.files).then((picked) => {
+        if (!picked) {
+          toast.error('That is not a workflow file')
+          return
+        }
+        handleImport(picked)
+      })
+    },
+    [handleImport]
+  )
 
   const iconSize = isCollapsed ? 22 : 14
 
@@ -91,6 +179,15 @@ export function WorkflowsSection({
         actions={
           <>
             <WorkflowFilterToolbar />
+            <Tooltip label="Import workflow file" position="bottom">
+              <button
+                onClick={() => void pickWorkflowFile().then(handleImport)}
+                aria-label="Import workflow file"
+                className="p-0.5 rounded text-gray-600 hover:text-white hover:bg-white/[0.08] transition-colors"
+              >
+                <Download size={13} strokeWidth={1.5} />
+              </button>
+            </Tooltip>
             <Tooltip label="New workflow" position="bottom">
               <button
                 onClick={() => {
@@ -107,7 +204,26 @@ export function WorkflowsSection({
         }
       />
 
-      {!sectionCollapsed && (
+      {/* Wraps the list so a dropped file lands anywhere in it, empty included. */}
+      <div
+        className="space-y-0.5"
+        onDragOver={(e) => {
+          if (!e.dataTransfer.types.includes('Files')) return
+          e.preventDefault()
+          setFileOver(true)
+        }}
+        onDragLeave={(e) => {
+          // Crossing a child fires leave too; only leaving the list clears it.
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) setFileOver(false)
+        }}
+        onDrop={handleFileDrop}
+      >
+        {fileOver && !isCollapsed && (
+          <p className="mx-2 my-1 px-2 py-3 text-center text-[11px] text-gray-400 border border-dashed border-white/[0.14] rounded">
+            Drop to import a workflow file
+          </p>
+        )}
+        {!sectionCollapsed && (
         <button
           type="button"
           onClick={() => {
@@ -181,6 +297,7 @@ export function WorkflowsSection({
             onContextMenu={handleContextMenu}
           />
         ))}
+      </div>
 
       {contextMenu && menuWorkflow && (
         <WorkflowContextMenu
@@ -192,6 +309,7 @@ export function WorkflowsSection({
             setEditingWorkflowId(menuWorkflow.id)
             setWorkflowEditorOpen(true)
           }}
+          onExport={() => void handleExport(menuWorkflow)}
           onDelete={() => removeWorkflow(menuWorkflow.id)}
           onToggleEnabled={
             menuIsScheduled

--- a/src/renderer/components/project-sidebar/WorkflowsSection.tsx
+++ b/src/renderer/components/project-sidebar/WorkflowsSection.tsx
@@ -104,7 +104,15 @@ export function WorkflowsSection({
         `${existing ? 'Updated' : 'Imported'} "${placed.name}"${pending ? ` — still needs ${pending}` : ''}`
       )
     },
-    [projects, activeProject, activeWorkspace, allWorkflows, connections, addWorkflow, updateWorkflow]
+    [
+      projects,
+      activeProject,
+      activeWorkspace,
+      allWorkflows,
+      connections,
+      addWorkflow,
+      updateWorkflow
+    ]
   )
 
   const handleFileDrop = useCallback(
@@ -224,79 +232,81 @@ export function WorkflowsSection({
           </p>
         )}
         {!sectionCollapsed && (
-        <button
-          type="button"
-          onClick={() => {
-            setEditingWorkflowId(null)
-            setWorkflowEditorOpen(false)
-          }}
-          title={isCollapsed ? 'All runs' : undefined}
-          aria-label="All runs"
-          aria-pressed={allRunsSelected}
-          className={`group/all relative w-full text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
-            allRunsSelected ? 'text-white' : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
-          } ${isCollapsed ? 'justify-center px-0' : ''}`}
-        >
-          {allRunsSelected && !isCollapsed && (
-            <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />
-          )}
-          <Activity size={iconSize} strokeWidth={1.5} className="text-gray-400 shrink-0" />
-          {!isCollapsed && (
-            <>
-              <span className="min-w-0 flex-1 truncate">All runs</span>
-              {waitingCount > 0 && (
-                <span className="font-mono text-[10px] text-bronzo tabular-nums">
-                  {waitingCount}
-                </span>
-              )}
-            </>
-          )}
-        </button>
-      )}
+          <button
+            type="button"
+            onClick={() => {
+              setEditingWorkflowId(null)
+              setWorkflowEditorOpen(false)
+            }}
+            title={isCollapsed ? 'All runs' : undefined}
+            aria-label="All runs"
+            aria-pressed={allRunsSelected}
+            className={`group/all relative w-full text-left px-2 py-1.5 rounded-md text-[13px] flex items-center gap-2 min-w-0 transition-colors ${
+              allRunsSelected
+                ? 'text-white'
+                : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
+            } ${isCollapsed ? 'justify-center px-0' : ''}`}
+          >
+            {allRunsSelected && !isCollapsed && (
+              <span className="absolute left-0 top-1 bottom-1 w-px bg-white rounded-full" />
+            )}
+            <Activity size={iconSize} strokeWidth={1.5} className="text-gray-400 shrink-0" />
+            {!isCollapsed && (
+              <>
+                <span className="min-w-0 flex-1 truncate">All runs</span>
+                {waitingCount > 0 && (
+                  <span className="font-mono text-[10px] text-bronzo tabular-nums">
+                    {waitingCount}
+                  </span>
+                )}
+              </>
+            )}
+          </button>
+        )}
 
-      {!isCollapsed && !sectionCollapsed && filteredWorkflows.length === 0 && (
-        <p className="text-[13px] text-gray-600 px-2.5 py-1">No workflows</p>
-      )}
+        {!isCollapsed && !sectionCollapsed && filteredWorkflows.length === 0 && (
+          <p className="text-[13px] text-gray-600 px-2.5 py-1">No workflows</p>
+        )}
 
-      {!isCollapsed &&
-        !sectionCollapsed &&
-        filteredWorkflows.map((wf) => {
-          const fullIndex = workspaceWorkflows.findIndex((w) => w.id === wf.id)
-          const canReorder = workflowFilter === 'all'
-          return (
-            <div
+        {!isCollapsed &&
+          !sectionCollapsed &&
+          filteredWorkflows.map((wf) => {
+            const fullIndex = workspaceWorkflows.findIndex((w) => w.id === wf.id)
+            const canReorder = workflowFilter === 'all'
+            return (
+              <div
+                key={wf.id}
+                draggable={canReorder && !isCollapsed}
+                onDragStart={canReorder ? (e) => handleDragStart(e, fullIndex) : undefined}
+                onDragOver={canReorder ? (e) => handleDragOver(e, fullIndex) : undefined}
+                onDrop={canReorder ? (e) => handleDrop(e, fullIndex) : undefined}
+                onDragEnd={canReorder ? handleDragEnd : undefined}
+                className={`${canReorder ? 'cursor-grab active:cursor-grabbing' : ''} ${
+                  dragOverIndex === fullIndex && dragSourceIndex !== fullIndex
+                    ? 'border-t border-white/40'
+                    : ''
+                }`}
+              >
+                <WorkflowItem
+                  workflow={wf}
+                  isCollapsed={isCollapsed}
+                  iconSize={iconSize}
+                  onContextMenu={handleContextMenu}
+                />
+              </div>
+            )
+          })}
+
+        {isCollapsed &&
+          filteredWorkflows.map((wf) => (
+            <WorkflowItem
               key={wf.id}
-              draggable={canReorder && !isCollapsed}
-              onDragStart={canReorder ? (e) => handleDragStart(e, fullIndex) : undefined}
-              onDragOver={canReorder ? (e) => handleDragOver(e, fullIndex) : undefined}
-              onDrop={canReorder ? (e) => handleDrop(e, fullIndex) : undefined}
-              onDragEnd={canReorder ? handleDragEnd : undefined}
-              className={`${canReorder ? 'cursor-grab active:cursor-grabbing' : ''} ${
-                dragOverIndex === fullIndex && dragSourceIndex !== fullIndex
-                  ? 'border-t border-white/40'
-                  : ''
-              }`}
-            >
-              <WorkflowItem
-                workflow={wf}
-                isCollapsed={isCollapsed}
-                iconSize={iconSize}
-                onContextMenu={handleContextMenu}
-              />
-            </div>
-          )
-        })}
-
-      {isCollapsed &&
-        filteredWorkflows.map((wf) => (
-          <WorkflowItem
-            key={wf.id}
-            workflow={wf}
-            isCollapsed={isCollapsed}
-            iconSize={iconSize}
-            onContextMenu={handleContextMenu}
-          />
-        ))}
+              workflow={wf}
+              isCollapsed={isCollapsed}
+              iconSize={iconSize}
+              onContextMenu={handleContextMenu}
+            />
+          ))}
       </div>
 
       {contextMenu && menuWorkflow && (

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -299,7 +299,12 @@ export function ConnectorRow({
             onClick={onAdd}
             className="text-[11.5px] text-gray-300 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
           >
-            <Plus size={11} /> {listing.connectedCount > 0 ? 'Add another' : 'Add'}
+            <Plus size={11} />{' '}
+            {listing.connectedCount > 0
+              ? 'Add another'
+              : listing.source === 'mcp'
+                ? 'Add server'
+                : 'Add'}
           </button>
         )}
       </div>

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -222,7 +222,9 @@ export function ConnectorRow({
     progress
   })
   const status = describePackStatus(state)
-  const installable = listing.source !== 'builtin' && onInstall !== undefined
+  // An MCP server is a command this machine runs, so there is no pack to install.
+  const installable =
+    listing.source !== 'builtin' && listing.source !== 'mcp' && onInstall !== undefined
 
   return (
     <div className="flex items-start gap-3 py-3 border-t border-white/[0.06]">

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '../../stores'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { buildConnectorListings, type ConnectorListing } from '../../lib/connector-browse'
+import { SDK_FILTER_KEYS } from '../../../shared/types'
 import { ConnectorDirectory } from './ConnectorDirectory'
 import { ConnectorDetail } from './ConnectorDetail'
 import { ConnectionGroups, type ConnectorStatus } from './ConnectionGroups'
@@ -419,22 +420,30 @@ export function ConnectorSettings() {
 
       {/* A generic server has no manifest to probe, so it goes to the manual
           form with its launch line already written. */}
-      {adding?.mcpServer && mcpConnector && (
-        <AddConnectionForm
-          connector={mcpConnector}
-          startManual
-          initialAuth={{
-            command: adding.mcpServer.command,
-            args: JSON.stringify(adding.mcpServer.args)
-          }}
-          onDone={() => {
-            setAdding(null)
-            setView('connections')
-            load()
-          }}
-          onCancel={() => setAdding(null)}
-        />
-      )}
+      {adding?.mcpServer &&
+        (mcpConnector ? (
+          <AddConnectionForm
+            connector={mcpConnector}
+            startManual
+            initialAuth={{
+              command: adding.mcpServer.command,
+              args: JSON.stringify(adding.mcpServer.args)
+            }}
+            // Names the server the connection belongs to, so its row counts it
+            // rather than lumping it in with every other stdio connection.
+            extraFilters={{ [SDK_FILTER_KEYS.connectorId]: adding.mcpServer.id }}
+            onDone={() => {
+              setAdding(null)
+              setView('connections')
+              load()
+            }}
+            onCancel={() => setAdding(null)}
+          />
+        ) : (
+          <p className="p-4 text-[12px] text-danger border border-white/[0.08] rounded-sm">
+            The MCP connector is not available in this build, so {adding.name} cannot be added here.
+          </p>
+        ))}
     </div>
   )
 }
@@ -442,6 +451,7 @@ export function ConnectorSettings() {
 function AddConnectionForm({
   connector,
   initialAuth,
+  extraFilters,
   startManual,
   onDone,
   onCancel
@@ -449,6 +459,8 @@ function AddConnectionForm({
   connector: ConnectorInfo
   /** Pre-filled fields, so a listed server arrives with its launch line written. */
   initialAuth?: Record<string, string>
+  /** Stamped onto the saved connection, whatever the form asked for. */
+  extraFilters?: Record<string, string>
   startManual?: boolean
   onDone: () => void
   onCancel: () => void
@@ -525,7 +537,11 @@ function AddConnectionForm({
         }
       }
 
-      const connectionFilters: Record<string, unknown> = { ...encryptedAuth, ...filters }
+      const connectionFilters: Record<string, unknown> = {
+        ...encryptedAuth,
+        ...filters,
+        ...extraFilters
+      }
       let name: string
       if (usesRepoDetect) {
         const owner = detectedRepo?.owner ?? manualRepo.owner.trim()

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -13,6 +13,7 @@ import type {
   ConnectorPackSource,
   ConnectorPackSummary,
   InstalledConnectorPack,
+  McpServerCatalogEntry,
   SourceConnection,
   ConnectorManifest,
   TaskStatus
@@ -53,6 +54,7 @@ export function ConnectorSettings() {
   // One selection, so "both open at once" is not a representable state.
   const [adding, setAdding] = useState<ConnectorListing | null>(null)
   const [catalog, setCatalog] = useState<ConnectorCatalogItem[]>([])
+  const [mcpServers, setMcpServers] = useState<McpServerCatalogEntry[]>([])
   const [catalogFetchedAt, setCatalogFetchedAt] = useState<number>()
   // What the detail view is describing. Separate from `adding` so opening a
   // connector to read about it is not the same as committing to install it.
@@ -108,6 +110,7 @@ export function ConnectorSettings() {
   // would be a round trip that always returns the same answer.
   const applyCatalog = useCallback((snapshot: ConnectorCatalogSnapshot) => {
     setCatalog(snapshot.items)
+    setMcpServers(snapshot.mcpServers ?? [])
     setCatalogFetchedAt(snapshot.fetchedAt)
   }, [])
 
@@ -235,8 +238,8 @@ export function ConnectorSettings() {
   )
 
   const listings = useMemo(
-    () => buildConnectorListings(connectors, catalog, connections, packs),
-    [connectors, catalog, connections, packs]
+    () => buildConnectorListings(connectors, catalog, connections, packs, mcpServers),
+    [connectors, catalog, connections, packs, mcpServers]
   )
   // Re-read from the current listings so a connection made while the panel is
   // open updates its "connected" count rather than showing the stale copy.
@@ -253,6 +256,8 @@ export function ConnectorSettings() {
   // connector to hand it.
   const addingBuiltIn =
     adding?.source === 'builtin' ? connectors.find((c) => c.id === adding.id) : undefined
+  // Every listed server is a connection to the built-in `mcp` connector.
+  const mcpConnector = connectors.find((c) => c.id === MCP_CONNECTOR_ID)
 
   const handleRun = async (workflowId: string) => {
     setRunningId(workflowId)
@@ -411,16 +416,40 @@ export function ConnectorSettings() {
           onCancel={() => setAdding(null)}
         />
       )}
+
+      {/* A generic server has no manifest to probe, so it goes to the manual
+          form with its launch line already written. */}
+      {adding?.mcpServer && mcpConnector && (
+        <AddConnectionForm
+          connector={mcpConnector}
+          startManual
+          initialAuth={{
+            command: adding.mcpServer.command,
+            args: JSON.stringify(adding.mcpServer.args)
+          }}
+          onDone={() => {
+            setAdding(null)
+            setView('connections')
+            load()
+          }}
+          onCancel={() => setAdding(null)}
+        />
+      )}
     </div>
   )
 }
 
 function AddConnectionForm({
   connector,
+  initialAuth,
+  startManual,
   onDone,
   onCancel
 }: {
   connector: ConnectorInfo
+  /** Pre-filled fields, so a listed server arrives with its launch line written. */
+  initialAuth?: Record<string, string>
+  startManual?: boolean
   onDone: () => void
   onCancel: () => void
 }) {
@@ -431,7 +460,7 @@ function AddConnectionForm({
   // a raw server the user wires up by hand. The first covers most cases, so
   // it leads.
   const isMcp = connector.id === MCP_CONNECTOR_ID
-  const [fromPackage, setFromPackage] = useState(isMcp)
+  const [fromPackage, setFromPackage] = useState(isMcp && startManual !== true)
 
   const [selectedProject, setSelectedProject] = useState(projects[0]?.name || '')
   const [detectedRepo, setDetectedRepo] = useState<{
@@ -439,7 +468,7 @@ function AddConnectionForm({
     repo: string
   } | null>(null)
   const [detecting, setDetecting] = useState(false)
-  const [auth, setAuth] = useState<Record<string, string>>({})
+  const [auth, setAuth] = useState<Record<string, string>>(initialAuth ?? {})
   const [filters, setFilters] = useState<Record<string, string>>({})
   const [manualRepo, setManualRepo] = useState<{ owner: string; repo: string }>({
     owner: '',

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -157,6 +157,20 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const triggerNode = useMemo(() => nodes.find((n) => n.type === 'trigger') ?? null, [nodes])
   const triggerConfig = triggerNode?.config as TriggerConfig | undefined
 
+  /**
+   * The right-hand slot holds one panel, and a workflow with nothing in it yet
+   * has one thing worth asking. Settings for a workflow that does not exist are
+   * not it, so start-from wins the empty canvas and yields to everything a
+   * person opened deliberately.
+   */
+  const startFromOpen =
+    !editingId &&
+    nodes.length === 0 &&
+    showStartFrom &&
+    !pendingInsert &&
+    !showRunHistory &&
+    !selectedNode
+
   const triggerType = triggerConfig?.triggerType
   const isContextualTrigger =
     triggerConfig?.triggerType === 'manual' && triggerConfig.contextual === true
@@ -264,7 +278,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       loadedRunsForId.current = editingId
       window.api.listWorkflowRuns(editingId, 20).then(setExecutionHistory)
     }
-    if (!isActive) {
+    // A new workflow has no runs, and the last one's must not answer for it.
+    // Clearing the id too means returning to that workflow re-reads its runs.
+    if (!isActive || !editingId) {
       loadedRunsForId.current = null
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setExecutionHistory([])
@@ -406,6 +422,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setEdges([])
       setEnabled(true)
       setStaggerDelayMs(undefined)
+      // Settings are the previous workflow's until they are put back too.
+      setAutoCleanupWorktrees(false)
       setShowStartFrom(true)
     }
     // Saving hands back a new workflow object; only an actual switch resets the panels.
@@ -1294,6 +1312,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
                   onClick={() => {
                     setSelectedNodeId(null)
                     setShowRunHistory(false)
+                    // Asking for settings answers what start-from was asking.
+                    setShowStartFrom(false)
                     setShowProperties(true)
                     setShowOverflowMenu(false)
                   }}
@@ -1367,7 +1387,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           />
         )}
 
-        {!editingId && nodes.length === 0 && showStartFrom && !pendingInsert && (
+        {startFromOpen && (
           <StartFromPanel
             templates={templates}
             connections={connections}
@@ -1423,7 +1443,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           />
         )}
 
-        {!selectedNode && !showRunHistory && !pendingInsert && showProperties && (
+        {!selectedNode && !showRunHistory && !pendingInsert && !startFromOpen && showProperties && (
           <WorkflowPropertiesPanel
             enabled={enabled}
             onEnabledChange={setEnabled}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -10,7 +10,8 @@ import {
   MoreHorizontal,
   Settings,
   Loader2,
-  Square
+  Square,
+  Upload
 } from 'lucide-react'
 import { ICON_MAP } from '../project-sidebar/icon-map'
 import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../../lib/project-icons'
@@ -78,6 +79,8 @@ import {
   stopWorkflowRun
 } from '../../lib/workflow-execution'
 import { toast } from '../Toast'
+import { useConnections } from '../../lib/use-connections'
+import { fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
 import {
   slugify,
   ensureUniqueSlug,
@@ -96,6 +99,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const setOpen = useAppStore((s) => s.setWorkflowEditorOpen)
   const setEditingId = useAppStore((s) => s.setEditingWorkflowId)
   const addWorkflow = useAppStore((s) => s.addWorkflow)
+  const connections = useConnections()
   const updateWorkflow = useAppStore((s) => s.updateWorkflow)
   const removeWorkflowFromStore = useAppStore((s) => s.removeWorkflow)
   const existingWorkflow = useAppStore((s) =>
@@ -576,6 +580,25 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     }
     handleClose()
   }, [editingId, removeWorkflowFromStore, handleClose])
+
+  // Saves first, so the file is what the canvas shows rather than the last save.
+  const handleExportFile = useCallback(async () => {
+    const workflow = persistWorkflow()
+    const projects = useAppStore.getState().config?.projects ?? []
+    const project = projectForWorkflow(workflow, projects)
+    const file = fileFromWorkflow(workflow, project?.path ?? '', connections)
+    const saved = await window.api.saveTextFile({
+      defaultName: file.name,
+      contents: file.contents,
+      title: 'Export workflow'
+    })
+    if (!saved) return
+    if (file.residual.length > 0) {
+      toast.error(`Exported, but these still name this machine: ${file.residual.join(', ')}`)
+    } else {
+      toast.success(`Exported "${workflow.name}"`)
+    }
+  }, [persistWorkflow, connections])
 
   const createNodeWithUniqueSlug = useCallback(
     (type: AddableNodeType, excludeNodeId?: string) => {
@@ -1209,6 +1232,17 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
                 </button>
                 {editingId && (
                   <>
+                    <button
+                      onClick={() => {
+                        setShowOverflowMenu(false)
+                        void handleExportFile()
+                      }}
+                      className="w-full px-3 py-2 text-left text-[12px] text-gray-300 hover:text-white
+                                 hover:bg-white/[0.06] flex items-center gap-2 transition-colors"
+                    >
+                      <Upload size={12} strokeWidth={1.5} />
+                      Export as file…
+                    </button>
                     <div className="my-1 border-t border-white/[0.06]" />
                     <button
                       onClick={() => {

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -677,8 +677,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   // Saves first, so the file is what the canvas shows rather than the last save.
   const handleExportFile = useCallback(async () => {
     const workflow = persistWorkflow()
-    const projects = useAppStore.getState().config?.projects ?? []
-    const project = projectForWorkflow(workflow, projects)
+    const state = useAppStore.getState()
+    const projects = state.config?.projects ?? []
+    const project = projectForWorkflow(workflow, projects, state.activeProject)
     const file = fileFromWorkflow(workflow, project?.path ?? '', connections)
     const saved = await window.api.saveTextFile?.({
       defaultName: file.name,

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -29,6 +29,7 @@ import {
   WorkflowNodeErrorPolicy,
   WorkflowEdge,
   WorkflowTemplate,
+  ConnectorManifest,
   NodeExecutionStatus,
   WorkflowExecution,
   TriggerConfig,
@@ -82,7 +83,11 @@ import {
 import { toast } from '../Toast'
 import { useConnections } from '../../lib/use-connections'
 import { describeRequirement, fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
-import { templateSeed } from '../../lib/template-requirements'
+import {
+  connectorSuggestions,
+  templateSeed,
+  type ConnectorSuggestion
+} from '../../lib/template-requirements'
 import { StartFromPanel } from './panels/StartFromPanel'
 import {
   slugify,
@@ -126,6 +131,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const [showRunHistory, setShowRunHistory] = useState(false)
   const [showStartFrom, setShowStartFrom] = useState(true)
   const [templates, setTemplates] = useState<WorkflowTemplate[]>([])
+  const [connectors, setConnectors] = useState<
+    Array<{ id: string; manifest: ConnectorManifest }>
+  >([])
   const [launchingSince, setLaunchingSince] = useState<number | null>(null)
   const [followRunId, setFollowRunId] = useState<string | null>(null)
   const followArmRef = useRef(false)
@@ -595,6 +603,37 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       .then((snapshot) => setTemplates(snapshot.templates ?? []))
       .catch(() => setTemplates([]))
   }, [editingId, templates.length])
+
+  useEffect(() => {
+    if (editingId) return
+    void window.api
+      .listConnectors()
+      .then(setConnectors)
+      .catch(() => setConnectors([]))
+  }, [editingId])
+
+  const suggestions = useMemo(
+    () => connectorSuggestions(connections, connectors),
+    [connections, connectors]
+  )
+
+  /** The server builds these from the connector's own manifest, and repeats are the same workflow. */
+  const handlePickSuggestion = useCallback(
+    async (suggestion: ConnectorSuggestion) => {
+      try {
+        const { workflowId } = await window.api.seedConnectorWorkflow(
+          suggestion.connectionId,
+          suggestion.event
+        )
+        setShowStartFrom(false)
+        setEditingId(workflowId)
+        toast.success(`Started "${suggestion.name}"`)
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : String(err))
+      }
+    },
+    [setEditingId]
+  )
 
   const handlePickTemplate = useCallback(
     (template: WorkflowTemplate) => {
@@ -1333,8 +1372,10 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           <StartFromPanel
             templates={templates}
             connections={connections}
+            suggestions={suggestions}
             onPickBlank={() => setShowStartFrom(false)}
             onPickTemplate={handlePickTemplate}
+            onPickSuggestion={(suggestion) => void handlePickSuggestion(suggestion)}
             onClose={() => setShowStartFrom(false)}
           />
         )}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -131,9 +131,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const [showRunHistory, setShowRunHistory] = useState(false)
   const [showStartFrom, setShowStartFrom] = useState(true)
   const [templates, setTemplates] = useState<WorkflowTemplate[]>([])
-  const [connectors, setConnectors] = useState<
-    Array<{ id: string; manifest: ConnectorManifest }>
-  >([])
+  const [connectors, setConnectors] = useState<Array<{ id: string; manifest: ConnectorManifest }>>(
+    []
+  )
   const [launchingSince, setLaunchingSince] = useState<number | null>(null)
   const [followRunId, setFollowRunId] = useState<string | null>(null)
   const followArmRef = useRef(false)

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -432,6 +432,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setSelectedNodeId(null)
       setPendingInsert(null)
       setShowRunHistory(false)
+      // Dismissing it answered the last workflow's question, not this one's.
+      setShowStartFrom(true)
       // Run feedback belongs to the workflow that launched it.
       setFollowRunId(null)
       setLaunchingSince(null)

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -28,6 +28,7 @@ import {
   WorkflowNode,
   WorkflowNodeErrorPolicy,
   WorkflowEdge,
+  WorkflowTemplate,
   NodeExecutionStatus,
   WorkflowExecution,
   TriggerConfig,
@@ -80,7 +81,9 @@ import {
 } from '../../lib/workflow-execution'
 import { toast } from '../Toast'
 import { useConnections } from '../../lib/use-connections'
-import { fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
+import { describeRequirement, fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
+import { templateSeed } from '../../lib/template-requirements'
+import { StartFromPanel } from './panels/StartFromPanel'
 import {
   slugify,
   ensureUniqueSlug,
@@ -121,6 +124,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
   const [pendingInsert, setPendingInsert] = useState<InsertAnchor | null>(null)
   const [showRunHistory, setShowRunHistory] = useState(false)
+  const [showStartFrom, setShowStartFrom] = useState(true)
+  const [templates, setTemplates] = useState<WorkflowTemplate[]>([])
   const [launchingSince, setLaunchingSince] = useState<number | null>(null)
   const [followRunId, setFollowRunId] = useState<string | null>(null)
   const followArmRef = useRef(false)
@@ -385,7 +390,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setStaggerDelayMs(existingWorkflow.staggerDelayMs)
       setAutoCleanupWorktrees(existingWorkflow.autoCleanupWorktrees ?? false)
     } else if (!editingId) {
-      // New workflow — an empty canvas whose first pick is the trigger.
+      // New workflow — an empty canvas, offered a template before the first pick.
       setName('New Workflow')
       setIcon('Workflow')
       setIconColor('#3b82f6')
@@ -393,6 +398,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       setEdges([])
       setEnabled(true)
       setStaggerDelayMs(undefined)
+      setShowStartFrom(true)
     }
     // Saving hands back a new workflow object; only an actual switch resets the panels.
     if (loadedEditorIdRef.current !== editingId) {
@@ -580,6 +586,35 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     }
     handleClose()
   }, [editingId, removeWorkflowFromStore, handleClose])
+
+  // Only fetched when there is an empty canvas to offer them for.
+  useEffect(() => {
+    if (editingId || templates.length > 0) return
+    void window.api
+      .listConnectorCatalog()
+      .then((snapshot) => setTemplates(snapshot.templates ?? []))
+      .catch(() => setTemplates([]))
+  }, [editingId, templates.length])
+
+  const handlePickTemplate = useCallback(
+    (template: WorkflowTemplate) => {
+      const state = useAppStore.getState()
+      const projects = state.config?.projects ?? []
+      const project = projects.find((p) => p.name === state.activeProject) ?? projects[0]
+      const seed = templateSeed(template, project, connections)
+
+      setName(seed.name)
+      if (seed.icon) setIcon(seed.icon)
+      if (seed.iconColor) setIconColor(seed.iconColor)
+      setNodes(seed.nodes)
+      setEdges(seed.edges)
+      setShowStartFrom(false)
+
+      const pending = seed.unresolved.map(describeRequirement).join(', ')
+      if (pending) toast.warning(`Started from "${template.name}" — still needs ${pending}`)
+    },
+    [connections]
+  )
 
   // Saves first, so the file is what the canvas shows rather than the last save.
   const handleExportFile = useCallback(async () => {
@@ -1291,6 +1326,16 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             }}
             onPick={handleLibraryPick}
             onClose={() => setPendingInsert(null)}
+          />
+        )}
+
+        {!editingId && nodes.length === 0 && showStartFrom && !pendingInsert && (
+          <StartFromPanel
+            templates={templates}
+            connections={connections}
+            onPickBlank={() => setShowStartFrom(false)}
+            onPickTemplate={handlePickTemplate}
+            onClose={() => setShowStartFrom(false)}
           />
         )}
 

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -595,20 +595,19 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     handleClose()
   }, [editingId, removeWorkflowFromStore, handleClose])
 
-  // Only fetched when there is an empty canvas to offer them for.
+  // Only fetched when there is an empty canvas to offer them for. Optional
+  // calls: a build without a catalog costs the offer, never the editor.
   useEffect(() => {
     if (editingId || templates.length > 0) return
-    void window.api
-      .listConnectorCatalog()
-      .then((snapshot) => setTemplates(snapshot.templates ?? []))
+    void Promise.resolve(window.api?.listConnectorCatalog?.())
+      .then((snapshot) => setTemplates(snapshot?.templates ?? []))
       .catch(() => setTemplates([]))
   }, [editingId, templates.length])
 
   useEffect(() => {
     if (editingId) return
-    void window.api
-      .listConnectors()
-      .then(setConnectors)
+    void Promise.resolve(window.api?.listConnectors?.())
+      .then((list) => setConnectors(list ?? []))
       .catch(() => setConnectors([]))
   }, [editingId])
 
@@ -661,7 +660,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     const projects = useAppStore.getState().config?.projects ?? []
     const project = projectForWorkflow(workflow, projects)
     const file = fileFromWorkflow(workflow, project?.path ?? '', connections)
-    const saved = await window.api.saveTextFile({
+    const saved = await window.api.saveTextFile?.({
       defaultName: file.name,
       contents: file.contents,
       title: 'Export workflow'

--- a/src/renderer/components/workflow-editor/panels/StartFromPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/StartFromPanel.tsx
@@ -1,0 +1,132 @@
+import { X, FilePlus2, Check } from 'lucide-react'
+import type { SourceConnection, WorkflowTemplate } from '../../../../shared/types'
+import { templateRequirements } from '../../../lib/template-requirements'
+import { describeRequirement } from '../../../lib/workflow-files'
+
+/**
+ * What a new workflow can start from, before the canvas is anything.
+ *
+ * Blank comes first because a template is an offer, not a gate. Each row says
+ * what its steps are and what it still wants connected, so the choice is made
+ * before the canvas fills rather than after.
+ */
+export function StartFromPanel({
+  templates,
+  connections,
+  onPickBlank,
+  onPickTemplate,
+  onClose
+}: {
+  templates: WorkflowTemplate[]
+  connections: SourceConnection[]
+  onPickBlank: () => void
+  onPickTemplate: (template: WorkflowTemplate) => void
+  onClose: () => void
+}) {
+  return (
+    <div
+      data-start-from
+      className="w-[280px] border-l border-white/[0.08] bg-surface-node flex flex-col h-full overflow-hidden titlebar-no-drag"
+      onKeyDown={(e) => {
+        if (e.key !== 'Escape') return
+        e.stopPropagation()
+        onClose()
+      }}
+    >
+      <div className="px-4 py-3 border-b border-white/[0.08] flex items-center justify-between">
+        <span className="text-[13px] font-medium text-white">Start from</span>
+        <button
+          aria-label="Close"
+          onClick={onClose}
+          className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-2">
+        <button
+          onClick={onPickBlank}
+          className="w-full text-left px-2.5 py-2 rounded-md flex items-start gap-2.5
+                     text-gray-300 hover:text-white hover:bg-white/[0.06] transition-colors"
+        >
+          <FilePlus2 size={14} strokeWidth={1.5} className="shrink-0 mt-0.5 text-gray-500" />
+          <span className="min-w-0">
+            <span className="block text-[12px] font-medium">Blank canvas</span>
+            <span className="block text-[11px] text-gray-500">Pick your own trigger</span>
+          </span>
+        </button>
+
+        {templates.length > 0 && (
+          <div className="px-2 pt-3 pb-1 text-[10px] font-mono uppercase tracking-wider text-gray-600">
+            Templates
+          </div>
+        )}
+
+        {templates.map((template) => (
+          <TemplateRow
+            key={template.id}
+            template={template}
+            connections={connections}
+            onPick={() => onPickTemplate(template)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function TemplateRow({
+  template,
+  connections,
+  onPick
+}: {
+  template: WorkflowTemplate
+  connections: SourceConnection[]
+  onPick: () => void
+}) {
+  const requirements = templateRequirements(template, connections)
+  const pending = requirements.filter((entry) => entry.connectionId === undefined)
+
+  return (
+    <button
+      onClick={onPick}
+      className="w-full text-left px-2.5 py-2 rounded-md flex items-start gap-2.5
+                 text-gray-300 hover:text-white hover:bg-white/[0.06] transition-colors"
+    >
+      <StepStrip count={template.portable.nodes.length} />
+      <span className="min-w-0 flex-1">
+        <span className="block text-[12px] font-medium truncate">{template.name}</span>
+        <span className="block text-[11px] text-gray-500 truncate">
+          {template.steps.join(' · ')}
+        </span>
+        {pending.length > 0 ? (
+          <span className="block text-[11px] text-bronzo truncate">
+            Needs {pending.map((entry) => describeRequirement(entry.requirement)).join(', ')}
+          </span>
+        ) : (
+          requirements.length > 0 && (
+            <span className="flex items-center gap-1 text-[11px] text-status-sage">
+              <Check size={10} strokeWidth={2} />
+              Connected
+            </span>
+          )
+        )}
+      </span>
+    </button>
+  )
+}
+
+/** The shape of the flow, drawn rather than counted. */
+function StepStrip({ count }: { count: number }) {
+  return (
+    <span
+      aria-hidden
+      className="shrink-0 mt-0.5 w-[22px] flex flex-col items-center gap-[3px] opacity-70"
+    >
+      {Array.from({ length: Math.min(count, 4) }).map((_, i) => (
+        <span key={i} className="w-full h-[3px] rounded-[1px] bg-white/[0.18]" />
+      ))}
+    </span>
+  )
+}

--- a/src/renderer/components/workflow-editor/panels/StartFromPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/StartFromPanel.tsx
@@ -1,6 +1,9 @@
-import { X, FilePlus2, Check } from 'lucide-react'
+import { X, FilePlus2, Check, Plug } from 'lucide-react'
 import type { SourceConnection, WorkflowTemplate } from '../../../../shared/types'
-import { templateRequirements } from '../../../lib/template-requirements'
+import {
+  templateRequirements,
+  type ConnectorSuggestion
+} from '../../../lib/template-requirements'
 import { describeRequirement } from '../../../lib/workflow-files'
 
 /**
@@ -13,14 +16,18 @@ import { describeRequirement } from '../../../lib/workflow-files'
 export function StartFromPanel({
   templates,
   connections,
+  suggestions = [],
   onPickBlank,
   onPickTemplate,
+  onPickSuggestion,
   onClose
 }: {
   templates: WorkflowTemplate[]
   connections: SourceConnection[]
+  suggestions?: ConnectorSuggestion[]
   onPickBlank: () => void
   onPickTemplate: (template: WorkflowTemplate) => void
+  onPickSuggestion?: (suggestion: ConnectorSuggestion) => void
   onClose: () => void
 }) {
   return (
@@ -70,6 +77,29 @@ export function StartFromPanel({
             connections={connections}
             onPick={() => onPickTemplate(template)}
           />
+        ))}
+
+        {suggestions.length > 0 && (
+          <div className="px-2 pt-3 pb-1 text-[10px] font-mono uppercase tracking-wider text-gray-600">
+            From your connections
+          </div>
+        )}
+
+        {suggestions.map((suggestion) => (
+          <button
+            key={suggestion.key}
+            onClick={() => onPickSuggestion?.(suggestion)}
+            className="w-full text-left px-2.5 py-2 rounded-md flex items-start gap-2.5
+                       text-gray-300 hover:text-white hover:bg-white/[0.06] transition-colors"
+          >
+            <Plug size={14} strokeWidth={1.5} className="shrink-0 mt-0.5 text-gray-500" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-[12px] font-medium truncate">{suggestion.name}</span>
+              <span className="block text-[11px] text-gray-500 truncate">
+                {suggestion.connectionName}
+              </span>
+            </span>
+          </button>
         ))}
       </div>
     </div>

--- a/src/renderer/components/workflow-editor/panels/StartFromPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/StartFromPanel.tsx
@@ -1,9 +1,6 @@
 import { X, FilePlus2, Check, Plug } from 'lucide-react'
 import type { SourceConnection, WorkflowTemplate } from '../../../../shared/types'
-import {
-  templateRequirements,
-  type ConnectorSuggestion
-} from '../../../lib/template-requirements'
+import { templateRequirements, type ConnectorSuggestion } from '../../../lib/template-requirements'
 import { describeRequirement } from '../../../lib/workflow-files'
 
 /**

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -1,6 +1,7 @@
 import type {
   ConnectorCatalogItem,
   InstalledConnectorPack,
+  McpServerCatalogEntry,
   SdkConnectorIcon,
   SourceConnection
 } from '../../shared/types'
@@ -23,7 +24,9 @@ export interface ConnectorListing {
   capabilities: string[]
   category: string
   /** `installed` is a pack the catalog does not carry; it brings its own manifest. */
-  source: 'builtin' | 'catalog' | 'installed'
+  source: 'builtin' | 'catalog' | 'installed' | 'mcp'
+  /** Set for an MCP server, which is a launch line rather than a package. */
+  mcpServer?: McpServerCatalogEntry
   /** Extra search terms, so a connector is findable by what it talks to. */
   keywords: string[]
   connectedCount: number
@@ -154,7 +157,8 @@ export function buildConnectorListings(
   builtIns: BuiltInConnector[],
   catalog: ConnectorCatalogItem[],
   connections: SourceConnection[],
-  packs: InstalledConnectorPack[] = []
+  packs: InstalledConnectorPack[] = [],
+  mcpServers: McpServerCatalogEntry[] = []
 ): ConnectorListing[] {
   const countFor = (id: string) =>
     connections.filter((conn) => connectionConnectorId(conn) === id).length
@@ -205,7 +209,21 @@ export function buildConnectorListings(
         connectedCount: countFor(pack.id),
         ...(pack.icon !== undefined && { icon: pack.icon }),
         pack
-      }))
+      })),
+    // A server Vorn starts and speaks MCP to; its connections are stored as
+    // `mcp` ones, so they are counted against the server's own id, never shared.
+    ...mcpServers.map((server) => ({
+      key: `mcp:${server.id}`,
+      id: server.id,
+      name: server.name,
+      ...(server.description !== undefined && { description: server.description }),
+      capabilities: ['actions'],
+      category: server.category ?? 'MCP servers',
+      source: 'mcp' as const,
+      keywords: server.keywords ?? [],
+      connectedCount: countFor(server.id),
+      mcpServer: server
+    }))
   ]
 
   return listings.sort((a, b) => {

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -210,8 +210,8 @@ export function buildConnectorListings(
         ...(pack.icon !== undefined && { icon: pack.icon }),
         pack
       })),
-    // A server Vorn starts and speaks MCP to; its connections are stored as
-    // `mcp` ones, so they are counted against the server's own id, never shared.
+    // A server Vorn starts and speaks MCP to. Its connections are `mcp` rows
+    // stamped with the server's id, which is what this counts against.
     ...mcpServers.map((server) => ({
       key: `mcp:${server.id}`,
       id: server.id,

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -173,6 +173,8 @@ export function canAddConnection(
   route: { source: string; hasLegacyLaunch?: boolean }
 ): boolean {
   if (route.source === 'builtin') return true
+  // An MCP server is a command, so there is nothing to install before connecting.
+  if (route.source === 'mcp') return true
   if (state.kind === 'installed') return true
   return route.hasLegacyLaunch === true
 }

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -109,7 +109,9 @@ export function templateSeed(
 
   const nodes = definition.nodes.map((node) => {
     const config = node.config as Record<string, unknown>
-    if (config.triggerType !== 'webhook' || config.token) return node
+    if (config.triggerType !== 'webhook') return node
+    // Always this machine's own token: one the catalog carried would be a
+    // secret shared with everyone who ever used the template.
     return { ...node, config: { ...config, token: mintToken() } } as WorkflowNode
   })
 

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -1,9 +1,11 @@
 import type {
+  ConnectorManifest,
   SourceConnection,
   WorkflowEdge,
   WorkflowNode,
   WorkflowTemplate
 } from '../../shared/types'
+import { connectionConnectorId } from '../../shared/types'
 import {
   fromPortable,
   resolveRequirement,
@@ -33,6 +35,39 @@ export interface TemplateSeed {
   edges: WorkflowEdge[]
   /** Steps that landed unbound, so the editor can say what is still wanted. */
   unresolved: PortableRequirement[]
+}
+
+/** A workflow a connected connector already knows how to build. */
+export interface ConnectorSuggestion {
+  key: string
+  connectionId: string
+  connectionName: string
+  event: string
+  name: string
+}
+
+/**
+ * The workflows this machine's connections ship with.
+ *
+ * These are not templates: the server builds them from the connector's own
+ * manifest against a connection that already exists, so they are offered
+ * beside the templates and taken by a different route.
+ */
+export function connectorSuggestions(
+  connections: SourceConnection[],
+  connectors: Array<{ id: string; manifest: ConnectorManifest }>
+): ConnectorSuggestion[] {
+  const manifests = new Map(connectors.map((connector) => [connector.id, connector.manifest]))
+  return connections.flatMap((connection) => {
+    const manifest = manifests.get(connectionConnectorId(connection))
+    return (manifest?.defaultWorkflows ?? []).map((seeded) => ({
+      key: `${connection.id}:${seeded.event}`,
+      connectionId: connection.id,
+      connectionName: connection.name,
+      event: seeded.event,
+      name: seeded.name
+    }))
+  })
 }
 
 export function templateRequirements(

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -1,0 +1,89 @@
+import type {
+  SourceConnection,
+  WorkflowEdge,
+  WorkflowNode,
+  WorkflowTemplate
+} from '../../shared/types'
+import {
+  fromPortable,
+  resolveRequirement,
+  unresolvedRequirements,
+  type PortableRequirement
+} from '../../shared/workflow-portability'
+
+/**
+ * What a template needs before it will run here, and what it becomes when used.
+ *
+ * Kept apart from the panel that draws it: whether a connection answers a
+ * requirement is a question about this machine's data, not about a list, and
+ * the answer decides both what the rows say and what lands on the canvas.
+ */
+
+export interface TemplateRequirement {
+  requirement: PortableRequirement
+  /** The connection this machine will bind, when it has exactly one answer. */
+  connectionId?: string
+}
+
+export interface TemplateSeed {
+  name: string
+  icon?: string
+  iconColor?: string
+  nodes: WorkflowNode[]
+  edges: WorkflowEdge[]
+  /** Steps that landed unbound, so the editor can say what is still wanted. */
+  unresolved: PortableRequirement[]
+}
+
+export function templateRequirements(
+  template: WorkflowTemplate,
+  connections: SourceConnection[]
+): TemplateRequirement[] {
+  return (template.portable.requires ?? []).map((requirement) => {
+    const connectionId = resolveRequirement(requirement, connections)
+    return connectionId === undefined ? { requirement } : { requirement, connectionId }
+  })
+}
+
+/** Whether every connection this template names is already answered here. */
+export function templateIsReady(
+  template: WorkflowTemplate,
+  connections: SourceConnection[]
+): boolean {
+  return unresolvedRequirements(template.portable, connections).length === 0
+}
+
+/**
+ * The canvas a template starts you with.
+ *
+ * A published token would be the same secret on every machine that ever used
+ * the template, so a webhook trigger is given its own here instead.
+ */
+export function templateSeed(
+  template: WorkflowTemplate,
+  project: { name: string; path: string } | undefined,
+  connections: SourceConnection[],
+  mintToken: () => string = () => crypto.randomUUID()
+): TemplateSeed {
+  const definition = fromPortable(
+    template.portable,
+    'template',
+    project ?? { name: '', path: '' },
+    connections
+  )
+
+  const nodes = definition.nodes.map((node) => {
+    const config = node.config as Record<string, unknown>
+    if (config.triggerType !== 'webhook' || config.token) return node
+    return { ...node, config: { ...config, token: mintToken() } } as WorkflowNode
+  })
+
+  return {
+    name: template.name,
+    ...(definition.icon && { icon: definition.icon }),
+    ...(definition.iconColor && { iconColor: definition.iconColor }),
+    nodes,
+    edges: definition.edges,
+    unresolved: unresolvedRequirements(template.portable, connections)
+  }
+}

--- a/src/renderer/lib/workflow-files.ts
+++ b/src/renderer/lib/workflow-files.ts
@@ -2,6 +2,7 @@ import type { SourceConnection, WorkflowDefinition } from '../../shared/types'
 import {
   toPortable,
   fromPortable,
+  importedWorkflowIdFor,
   residualAbsolutePaths,
   unresolvedRequirements,
   slugify,
@@ -26,15 +27,25 @@ export type ImportedWorkflowFile =
   | { ok: true; definition: WorkflowDefinition; unresolved: PortableRequirement[] }
   | { ok: false; error: string }
 
-/** The project a workflow's own steps point at, which its paths are relative to. */
+/**
+ * The project a workflow's paths are relative to.
+ *
+ * Its own steps answer first. A workflow that names none still has paths worth
+ * tokenizing — a script step carries a `cwd` without a `projectName` — so the
+ * project in view stands in rather than leaving the export machine-specific.
+ */
 export function projectForWorkflow(
   workflow: WorkflowDefinition,
-  projects: { name: string; path: string }[]
+  projects: { name: string; path: string }[],
+  activeProject?: string | null
 ): { name: string; path: string } | undefined {
   const named = workflow.nodes
     .map((node) => (node.config as Record<string, unknown>).projectName)
     .find((name): name is string => typeof name === 'string' && name.length > 0)
-  return projects.find((project) => project.name === named)
+  return (
+    projects.find((project) => project.name === named) ??
+    projects.find((project) => project.name === activeProject)
+  )
 }
 
 export function workflowFileName(workflow: WorkflowDefinition): string {
@@ -55,13 +66,21 @@ export function fileFromWorkflow(
   }
 }
 
+/** As much text as a workflow can reasonably be, matching what an agent may hand in. */
+export const MAX_WORKFLOW_FILE_BYTES = 500_000
+
 /** Read a file back into a workflow for this machine, or say why it cannot be. */
 export function definitionFromFile(
   text: string,
   project: { name: string; path: string },
   bundle: string,
-  connections: SourceConnection[]
+  connections: SourceConnection[],
+  existingWorkflows: Array<{ id: string; name: string }> = []
 ): ImportedWorkflowFile {
+  if (text.length > MAX_WORKFLOW_FILE_BYTES) {
+    return { ok: false, error: 'That file is too large to be a workflow' }
+  }
+
   let parsed: PortableWorkflow
   try {
     parsed = JSON.parse(text)
@@ -79,21 +98,67 @@ export function definitionFromFile(
     return { ok: false, error: 'That file is missing a name, nodes or edges' }
   }
 
+  const graph = graphComplaint(parsed)
+  if (graph) return { ok: false, error: graph }
+
   const portable = { ...parsed, slug: parsed.slug ?? slugify(parsed.name) }
+  const definition = fromPortable(portable, bundle, project, connections)
   return {
     ok: true,
-    definition: fromPortable(portable, bundle, project, connections),
+    definition: {
+      ...definition,
+      id: importedWorkflowIdFor(bundle, portable.slug, portable.name, existingWorkflows)
+    },
     unresolved: unresolvedRequirements(portable, connections)
   }
 }
 
-/** Keep a re-imported workflow where it already lived; a new one joins the workspace in view. */
+/**
+ * What is wrong with the graph, if anything.
+ *
+ * Array-ness alone is not a graph: `nodes: ["oops"]` reaches the canvas and the
+ * engine as something neither can read, and an edge naming a node that is not
+ * in the file draws from nowhere.
+ */
+function graphComplaint(portable: PortableWorkflow): string | null {
+  const ids = new Set<string>()
+  for (const node of portable.nodes) {
+    const candidate = node as { id?: unknown; type?: unknown } | null
+    if (typeof candidate?.id !== 'string' || typeof candidate.type !== 'string') {
+      return 'That file has a step this build cannot read'
+    }
+    ids.add(candidate.id)
+  }
+
+  for (const edge of portable.edges) {
+    const candidate = edge as { source?: unknown; target?: unknown } | null
+    if (typeof candidate?.source !== 'string' || typeof candidate.target !== 'string') {
+      return 'That file has a connection this build cannot read'
+    }
+    if (!ids.has(candidate.source) || !ids.has(candidate.target)) {
+      return 'That file connects a step it does not carry'
+    }
+  }
+
+  return null
+}
+
+/**
+ * Keep a re-imported workflow where it already lived, and as it was left.
+ *
+ * A workflow that was running keeps running; one arriving for the first time
+ * stays off, because a file is a description rather than a decision to run.
+ */
 export function placeImportedWorkflow(
   definition: WorkflowDefinition,
   existing: WorkflowDefinition | undefined,
   activeWorkspace: string
 ): WorkflowDefinition {
-  return { ...definition, workspaceId: existing?.workspaceId ?? activeWorkspace }
+  return {
+    ...definition,
+    enabled: existing ? existing.enabled : definition.enabled,
+    workspaceId: existing?.workspaceId ?? activeWorkspace
+  }
 }
 
 /** What an unbound step is still waiting for, in a sentence a person can act on. */
@@ -111,7 +176,11 @@ function isWorkflowFile(file: File): boolean {
   return file.name.toLowerCase().endsWith('.json')
 }
 
+/** Refuses by size before reading, so a huge file is never held in memory. */
 async function readFile(file: File): Promise<{ name: string; contents: string }> {
+  if (file.size > MAX_WORKFLOW_FILE_BYTES) {
+    throw new Error('That file is too large to be a workflow')
+  }
   return { name: file.name, contents: await file.text() }
 }
 
@@ -131,7 +200,7 @@ export async function readDroppedWorkflowFile(
  * give back the contents, which is the thing that gets imported.
  */
 export function pickWorkflowFile(): Promise<{ name: string; contents: string } | null> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const input = document.createElement('input')
     input.type = 'file'
     input.accept = '.json,application/json'
@@ -139,19 +208,35 @@ export function pickWorkflowFile(): Promise<{ name: string; contents: string } |
     document.body.appendChild(input)
 
     let settled = false
-    const finish = (value: { name: string; contents: string } | null): void => {
-      if (settled) return
+    const done = (): boolean => {
+      if (settled) return true
       settled = true
       input.remove()
-      resolve(value)
+      window.removeEventListener('focus', onFocus)
+      return false
+    }
+    const finish = (value: { name: string; contents: string } | null): void => {
+      if (!done()) resolve(value)
+    }
+    const fail = (err: unknown): void => {
+      if (!done()) reject(err)
+    }
+
+    // Not every browser fires `cancel`, and a picker that closed with nothing
+    // chosen would otherwise leave this promise — and the input — hanging.
+    function onFocus(): void {
+      setTimeout(() => {
+        if (!input.files?.length) finish(null)
+      }, 300)
     }
 
     input.addEventListener('change', () => {
       const file = input.files?.[0]
       if (!file) return finish(null)
-      void readFile(file).then(finish, () => finish(null))
+      void readFile(file).then(finish, fail)
     })
     input.addEventListener('cancel', () => finish(null))
+    window.addEventListener('focus', onFocus)
     input.click()
   })
 }

--- a/src/renderer/lib/workflow-files.ts
+++ b/src/renderer/lib/workflow-files.ts
@@ -1,0 +1,157 @@
+import type { SourceConnection, WorkflowDefinition } from '../../shared/types'
+import {
+  toPortable,
+  fromPortable,
+  residualAbsolutePaths,
+  unresolvedRequirements,
+  slugify,
+  PORTABLE_FORMAT_VERSION,
+  type PortableRequirement,
+  type PortableWorkflow
+} from '../../shared/workflow-portability'
+
+/**
+ * A workflow as a file, on the way out and on the way back.
+ *
+ * The reading and writing are deliberately split from the dialogs around them:
+ * everything a person can get wrong — a file that is not JSON, a version this
+ * build does not read, a connection this machine does not have — is decided by
+ * a plain function a test can call, and only the file handles need a browser.
+ */
+
+/** Names the file for what it is, so a directory of them reads. */
+export const WORKFLOW_FILE_SUFFIX = '.vorn-workflow.json'
+
+export type ImportedWorkflowFile =
+  | { ok: true; definition: WorkflowDefinition; unresolved: PortableRequirement[] }
+  | { ok: false; error: string }
+
+/** The project a workflow's own steps point at, which its paths are relative to. */
+export function projectForWorkflow(
+  workflow: WorkflowDefinition,
+  projects: { name: string; path: string }[]
+): { name: string; path: string } | undefined {
+  const named = workflow.nodes
+    .map((node) => (node.config as Record<string, unknown>).projectName)
+    .find((name): name is string => typeof name === 'string' && name.length > 0)
+  return projects.find((project) => project.name === named)
+}
+
+export function workflowFileName(workflow: WorkflowDefinition): string {
+  return `${slugify(workflow.name)}${WORKFLOW_FILE_SUFFIX}`
+}
+
+/** The bytes to write, plus whatever refused to become portable. */
+export function fileFromWorkflow(
+  workflow: WorkflowDefinition,
+  projectPath: string,
+  connections: SourceConnection[]
+): { name: string; contents: string; residual: string[] } {
+  const portable = toPortable(workflow, projectPath, connections)
+  return {
+    name: workflowFileName(workflow),
+    contents: `${JSON.stringify(portable, null, 2)}\n`,
+    residual: residualAbsolutePaths(portable)
+  }
+}
+
+/** Read a file back into a workflow for this machine, or say why it cannot be. */
+export function definitionFromFile(
+  text: string,
+  project: { name: string; path: string },
+  bundle: string,
+  connections: SourceConnection[]
+): ImportedWorkflowFile {
+  let parsed: PortableWorkflow
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return { ok: false, error: 'That file is not valid JSON' }
+  }
+
+  if (parsed?.version !== PORTABLE_FORMAT_VERSION) {
+    return {
+      ok: false,
+      error: `That file is version ${parsed?.version ?? 'unknown'}; this build reads version ${PORTABLE_FORMAT_VERSION}`
+    }
+  }
+  if (!parsed.name || !Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
+    return { ok: false, error: 'That file is missing a name, nodes or edges' }
+  }
+
+  const portable = { ...parsed, slug: parsed.slug ?? slugify(parsed.name) }
+  return {
+    ok: true,
+    definition: fromPortable(portable, bundle, project, connections),
+    unresolved: unresolvedRequirements(portable, connections)
+  }
+}
+
+/** Keep a re-imported workflow where it already lived; a new one joins the workspace in view. */
+export function placeImportedWorkflow(
+  definition: WorkflowDefinition,
+  existing: WorkflowDefinition | undefined,
+  activeWorkspace: string
+): WorkflowDefinition {
+  return { ...definition, workspaceId: existing?.workspaceId ?? activeWorkspace }
+}
+
+/** What an unbound step is still waiting for, in a sentence a person can act on. */
+export function describeRequirement(requirement: PortableRequirement): string {
+  if (requirement.kind === 'httpProfile') {
+    return requirement.name ? `an HTTP profile like "${requirement.name}"` : 'an HTTP profile'
+  }
+  const connector = requirement.connectorId || 'connector'
+  return requirement.name
+    ? `a ${connector} connection like "${requirement.name}"`
+    : `a ${connector} connection`
+}
+
+function isWorkflowFile(file: File): boolean {
+  return file.name.toLowerCase().endsWith('.json')
+}
+
+async function readFile(file: File): Promise<{ name: string; contents: string }> {
+  return { name: file.name, contents: await file.text() }
+}
+
+/** The first workflow file in a drop, ignoring anything else that came with it. */
+export async function readDroppedWorkflowFile(
+  files: FileList | null
+): Promise<{ name: string; contents: string } | null> {
+  const file = Array.from(files ?? []).find(isWorkflowFile)
+  return file ? readFile(file) : null
+}
+
+/**
+ * Ask for a file and hand back its text.
+ *
+ * A renderer file input rather than a dialog channel: it opens the native
+ * picker in the desktop app and the browser's own in server mode, and both
+ * give back the contents, which is the thing that gets imported.
+ */
+export function pickWorkflowFile(): Promise<{ name: string; contents: string } | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = '.json,application/json'
+    input.style.display = 'none'
+    document.body.appendChild(input)
+
+    let settled = false
+    const finish = (value: { name: string; contents: string } | null): void => {
+      if (settled) return
+      settled = true
+      input.remove()
+      resolve(value)
+    }
+
+    input.addEventListener('change', () => {
+      const file = input.files?.[0]
+      if (!file) return finish(null)
+      void readFile(file).then(finish, () => finish(null))
+    })
+    input.addEventListener('cancel', () => finish(null))
+    input.click()
+  })
+}

--- a/src/renderer/lib/workflow-files.ts
+++ b/src/renderer/lib/workflow-files.ts
@@ -127,6 +127,7 @@ function graphComplaint(portable: PortableWorkflow): string | null {
     if (typeof candidate?.id !== 'string' || typeof candidate.type !== 'string') {
       return 'That file has a step this build cannot read'
     }
+    if (ids.has(candidate.id)) return 'That file carries the same step twice'
     ids.add(candidate.id)
   }
 

--- a/src/shared/workflow-portability.ts
+++ b/src/shared/workflow-portability.ts
@@ -1,0 +1,1 @@
+export * from '@vornrun/shared/workflow-portability'

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -65,6 +65,25 @@ describe('the connector list', () => {
     return { ...utils, onSelect, onAdd }
   }
 
+  it('calls connecting to an MCP server adding a server, and offers no install', () => {
+    const server = { id: 'playwright', name: 'Playwright', command: 'npx', args: [] }
+    const onAdd = vi.fn()
+    const { getByText, queryByText } = render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [], [], [], [server])}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={onAdd}
+        onInstall={vi.fn()}
+      />
+    )
+
+    // There is no pack behind a server, so an Install button would be a lie.
+    expect(queryByText('Install')).not.toBeInTheDocument()
+    fireEvent.click(getByText('Add server'))
+    expect(onAdd).toHaveBeenCalled()
+  })
+
   it('says what a connector offers, and what would be installed, in one line', () => {
     // A name and a blurb cannot answer "will this do what I need", and both
     // blurbs here start with the same four words.

--- a/tests/connector-launch-precedence.test.ts
+++ b/tests/connector-launch-precedence.test.ts
@@ -78,11 +78,16 @@ describe('catalogLaunchSpec', () => {
 
 describe('resolveLaunch precedence', () => {
   const packsRoot = { current: '' }
+  const packsBehavior = { throwUnresolved: false }
 
   beforeEach(() => {
     packsRoot.current = tempDir()
+    packsBehavior.throwUnresolved = false
     vi.doMock('../packages/server/src/connectors/packs', () => ({
       installedLaunch: (id: string) => {
+        if (packsBehavior.throwUnresolved) {
+          throw new Error('Data directory not resolved. Call initDatabase() first.')
+        }
         if (id !== 'acme' || packsRoot.current === '') return undefined
         return { command: 'node', args: [join(packsRoot.current, 'acme', '2.0.0', 'index.js')] }
       }
@@ -136,12 +141,7 @@ describe('resolveLaunch precedence', () => {
   })
 
   it('treats an unresolved data directory as nothing installed', async () => {
-    vi.doMock('../packages/server/src/connectors/packs', () => ({
-      installedLaunch: () => {
-        throw new Error('Data directory not resolved. Call initDatabase() first.')
-      }
-    }))
-    vi.resetModules()
+    packsBehavior.throwUnresolved = true
     const { resolveLaunch } = await load()
     expect(
       resolveLaunch(connection({ sdkConnectorId: 'acme', command: 'npx', args: '[]' }))

--- a/tests/mcp-server-add.test.tsx
+++ b/tests/mcp-server-add.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ConnectorManifest, McpServerCatalogEntry } from '../src/shared/types'
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({ config: { workflows: [], projects: [] } }),
+    { getState: () => ({}) }
+  )
+}))
+
+const { ConnectorSettings } = await import('../src/renderer/components/settings/ConnectorSettings')
+
+const SERVER: McpServerCatalogEntry = {
+  id: 'playwright',
+  name: 'Playwright',
+  description: 'Drive a browser',
+  command: 'npx',
+  args: ['-y', '@playwright/mcp']
+}
+
+/** The built-in the generic stdio form is rendered against. */
+const MCP_CONNECTOR = {
+  id: 'mcp',
+  name: 'MCP Server',
+  icon: 'plug',
+  capabilities: ['actions'],
+  manifest: {
+    id: 'mcp',
+    name: 'MCP Server',
+    auth: [
+      { key: 'command', label: 'Command', type: 'text', required: true },
+      { key: 'args', label: 'Arguments', type: 'text' }
+    ],
+    triggers: [],
+    actions: []
+  } as unknown as ConnectorManifest
+}
+
+const createConnection = vi.fn()
+
+function stubApi(connectors: unknown[]): void {
+  ;(window as unknown as { api: unknown }).api = {
+    listConnectors: vi.fn().mockResolvedValue(connectors),
+    listConnections: vi.fn().mockResolvedValue([]),
+    getConnectorStatus: vi.fn().mockResolvedValue([]),
+    listConnectorCatalog: vi.fn().mockResolvedValue({
+      items: [],
+      templates: [],
+      mcpServers: [SERVER],
+      fetchedAt: Date.now()
+    }),
+    listConnectorPacks: vi.fn().mockResolvedValue([]),
+    onConnectorInstallProgress: vi.fn().mockReturnValue(() => {}),
+    encryptString: vi.fn().mockResolvedValue('sealed'),
+    createConnection
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  createConnection.mockResolvedValue(undefined)
+  stubApi([MCP_CONNECTOR])
+})
+
+/** With no connections yet the directory leads, so the row is already there. */
+async function pressAddServer(): Promise<void> {
+  render(<ConnectorSettings />)
+  fireEvent.click(await screen.findByRole('button', { name: /Add server/ }))
+}
+
+describe('adding a listed MCP server', () => {
+  it('arrives at the manual form with the launch line already written', async () => {
+    await pressAddServer()
+
+    const command = (await screen.findByDisplayValue('npx')) as HTMLInputElement
+    expect(command).toBeInTheDocument()
+    expect(screen.getByDisplayValue('["-y","@playwright/mcp"]')).toBeInTheDocument()
+  })
+
+  it('stamps the server it belongs to, so its row can count the connection', async () => {
+    await pressAddServer()
+    await screen.findByDisplayValue('npx')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    await waitFor(() => expect(createConnection).toHaveBeenCalledTimes(1))
+    const created = createConnection.mock.calls[0][0]
+    expect(created.connectorId).toBe('mcp')
+    // Without this the row shows no connections and never says "Add another".
+    expect(created.filters.sdkConnectorId).toBe('playwright')
+  })
+
+  it('says so rather than showing nothing when the MCP connector is missing', async () => {
+    stubApi([])
+    await pressAddServer()
+
+    expect(await screen.findByText(/MCP connector is not available/)).toBeInTheDocument()
+  })
+})

--- a/tests/mcp-server-listings.test.ts
+++ b/tests/mcp-server-listings.test.ts
@@ -61,6 +61,14 @@ describe('MCP servers in the directory', () => {
     expect(canAddConnection({ kind: 'absent' }, { source: 'mcp' })).toBe(true)
   })
 
+  it('lists a bare entry without inventing anything for it', () => {
+    const bare = { id: 'tiny', name: 'Tiny', command: 'tiny-mcp', args: [] }
+    const [listing] = buildConnectorListings([], [], [], [], [bare])
+    expect(listing.keywords).toEqual([])
+    expect(listing.category).toBe('MCP servers')
+    expect(listing).not.toHaveProperty('description')
+  })
+
   it('lists nothing when the catalog publishes no servers', () => {
     expect(buildConnectorListings([], [], [], [], [])).toEqual([])
   })

--- a/tests/mcp-server-listings.test.ts
+++ b/tests/mcp-server-listings.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { buildConnectorListings } from '../src/renderer/lib/connector-browse'
+import { canAddConnection } from '../src/renderer/lib/pack-status'
+import type { McpServerCatalogEntry, SourceConnection } from '../packages/shared/src/types'
+
+const SERVER: McpServerCatalogEntry = {
+  id: 'playwright',
+  name: 'Playwright',
+  description: 'Drive a browser',
+  command: 'npx',
+  args: ['-y', '@playwright/mcp'],
+  keywords: ['browser']
+}
+
+function connection(overrides: Partial<SourceConnection> = {}): SourceConnection {
+  return {
+    id: 'conn-1',
+    name: 'Playwright',
+    connectorId: 'mcp',
+    filters: {},
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-09-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('MCP servers in the directory', () => {
+  it('lists a published server beside the connectors', () => {
+    const [listing] = buildConnectorListings([], [], [], [], [SERVER])
+    expect(listing).toMatchObject({
+      key: 'mcp:playwright',
+      id: 'playwright',
+      name: 'Playwright',
+      source: 'mcp',
+      category: 'MCP servers',
+      keywords: ['browser'],
+      connectedCount: 0
+    })
+    expect(listing.mcpServer).toEqual(SERVER)
+  })
+
+  it('keeps the published category when one is given', () => {
+    const [listing] = buildConnectorListings([], [], [], [], [{ ...SERVER, category: 'Testing' }])
+    expect(listing.category).toBe('Testing')
+  })
+
+  it('counts only the connections made to that server', () => {
+    const listings = buildConnectorListings(
+      [],
+      [],
+      [connection({ filters: { sdkConnectorId: 'playwright' } }), connection({ id: 'other' })],
+      [],
+      [SERVER]
+    )
+    const server = listings.find((l) => l.source === 'mcp')!
+    expect(server.connectedCount).toBe(1)
+  })
+
+  it('can be connected to without installing anything first', () => {
+    expect(canAddConnection({ kind: 'absent' }, { source: 'mcp' })).toBe(true)
+  })
+
+  it('lists nothing when the catalog publishes no servers', () => {
+    expect(buildConnectorListings([], [], [], [], [])).toEqual([])
+  })
+})

--- a/tests/start-from-degrades.test.tsx
+++ b/tests/start-from-degrades.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowDefinition } from '../src/shared/types'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', () => ({
+  WorkflowCanvas: () => <div data-testid="canvas" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/StepLibrary', () => ({
+  StepLibrary: () => <div data-testid="step-library" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/NodeConfigPanel', () => ({
+  NodeConfigPanel: () => <div data-testid="node-config" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/RunHistoryPanel', () => ({
+  RunHistoryPanel: () => <div data-testid="run-history" />
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel', () => ({
+  WorkflowPropertiesPanel: () => <div data-testid="properties-panel" />
+}))
+
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: vi.fn().mockResolvedValue(undefined)
+}))
+
+const mockState = {
+  isWorkflowEditorOpen: true,
+  editingWorkflowId: null as string | null,
+  setWorkflowEditorOpen: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  addWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  removeWorkflow: vi.fn(),
+  config: { workflows: [] as WorkflowDefinition[], tasks: [], projects: [], defaults: {} },
+  setPendingWorkflowRun: vi.fn(),
+  addTerminal: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  setSelectedTaskId: vi.fn(),
+  activeWorkspace: 'personal',
+  workflowExecutions: new Map<string, unknown>()
+}
+
+vi.mock('../src/renderer/stores', () => {
+  const useAppStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+  useAppStore.getState = () => mockState
+  return { useAppStore }
+})
+
+// An older build, or any host that never learned the catalog methods.
+;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  api: {
+    listWorkflowRuns: vi.fn().mockResolvedValue([]),
+    isWindowMaximized: vi.fn().mockResolvedValue(false),
+    onWindowMaximizedChange: vi.fn(() => () => {})
+  }
+}
+
+const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
+
+describe('an editor whose host cannot answer about templates', () => {
+  it('still renders, because the offer is worth less than the editor', () => {
+    const { getByTestId } = render(<WorkflowEditor />)
+    expect(getByTestId('canvas')).toBeInTheDocument()
+  })
+
+  it('shows the start-from panel with nothing but the blank canvas in it', () => {
+    const { container, getByText } = render(<WorkflowEditor />)
+    expect(container.querySelector('[data-start-from]')).toBeTruthy()
+    expect(getByText('Blank canvas')).toBeInTheDocument()
+    expect(container.textContent).not.toContain('Templates')
+  })
+})

--- a/tests/start-from-panel.test.tsx
+++ b/tests/start-from-panel.test.tsx
@@ -71,4 +71,31 @@ describe('StartFromPanel', () => {
     fireEvent.click(screen.getByText('Blank canvas'))
     expect(onPickBlank).toHaveBeenCalledTimes(1)
   })
+
+  it('offers what a connection already knows how to build, and names it', () => {
+    const onPickSuggestion = vi.fn()
+    const suggestion = {
+      key: 'c1:issueCreated',
+      connectionId: 'c1',
+      connectionName: 'workspace-eng',
+      event: 'issueCreated',
+      name: 'New issues to tasks'
+    }
+    render(
+      <StartFromPanel
+        templates={[]}
+        connections={[]}
+        suggestions={[suggestion]}
+        onPickBlank={vi.fn()}
+        onPickTemplate={vi.fn()}
+        onPickSuggestion={onPickSuggestion}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('From your connections')).toBeInTheDocument()
+    expect(screen.getByText('workspace-eng')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('New issues to tasks'))
+    expect(onPickSuggestion).toHaveBeenCalledWith(suggestion)
+  })
 })

--- a/tests/start-from-panel.test.tsx
+++ b/tests/start-from-panel.test.tsx
@@ -61,9 +61,7 @@ describe('StartFromPanel', () => {
     const onPickTemplate = vi.fn()
     panel([], onPickTemplate)
     fireEvent.click(screen.getByText('Morning digest'))
-    expect(onPickTemplate).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'morning-digest' })
-    )
+    expect(onPickTemplate).toHaveBeenCalledWith(expect.objectContaining({ id: 'morning-digest' }))
   })
 
   it('takes the blank canvas as an answer too', () => {

--- a/tests/start-from-panel.test.tsx
+++ b/tests/start-from-panel.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { StartFromPanel } from '../src/renderer/components/workflow-editor/panels/StartFromPanel'
+import { TEMPLATE_SEED } from '../packages/server/src/connectors/template-seed'
+import type { SourceConnection } from '../packages/shared/src/types'
+
+function connection(overrides: Partial<SourceConnection> = {}): SourceConnection {
+  return {
+    id: 'conn-1',
+    name: 'reporting API',
+    connectorId: 'http',
+    filters: {},
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-09-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+function panel(connections: SourceConnection[] = [], onPickTemplate = vi.fn()) {
+  const onPickBlank = vi.fn()
+  render(
+    <StartFromPanel
+      templates={TEMPLATE_SEED}
+      connections={connections}
+      onPickBlank={onPickBlank}
+      onPickTemplate={onPickTemplate}
+      onClose={vi.fn()}
+    />
+  )
+  return { onPickBlank, onPickTemplate }
+}
+
+describe('StartFromPanel', () => {
+  it('offers a blank canvas before any template', () => {
+    panel()
+    const options = screen.getAllByRole('button').map((b) => b.textContent)
+    expect(options[1]).toContain('Blank canvas')
+    expect(options.slice(2).join(' ')).toContain('Webhook to report')
+  })
+
+  it('names each template by the steps it draws', () => {
+    panel()
+    expect(screen.getByText('Webhook · Condition · HTTP request')).toBeInTheDocument()
+  })
+
+  it('says what a template still needs here', () => {
+    panel()
+    expect(screen.getByText(/Needs an HTTP profile like "reporting API"/)).toBeInTheDocument()
+  })
+
+  it('says a template is connected once this machine can answer it', () => {
+    panel([connection()])
+    expect(screen.queryByText(/Needs an HTTP profile/)).not.toBeInTheDocument()
+    expect(screen.getByText('Connected')).toBeInTheDocument()
+  })
+
+  it('hands back the template that was picked', () => {
+    const onPickTemplate = vi.fn()
+    panel([], onPickTemplate)
+    fireEvent.click(screen.getByText('Morning digest'))
+    expect(onPickTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'morning-digest' })
+    )
+  })
+
+  it('takes the blank canvas as an answer too', () => {
+    const { onPickBlank } = panel()
+    fireEvent.click(screen.getByText('Blank canvas'))
+    expect(onPickBlank).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -89,9 +89,10 @@ describe('what a connection already knows how to build', () => {
 
   it('offers nothing for a connector that ships no workflow', () => {
     expect(
-      connectorSuggestions([connection({ connectorId: 'github' })], [
-        { id: 'github', manifest: manifest() }
-      ])
+      connectorSuggestions(
+        [connection({ connectorId: 'github' })],
+        [{ id: 'github', manifest: manifest() }]
+      )
     ).toEqual([])
   })
 

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -133,6 +133,30 @@ describe('what a template puts on the canvas', () => {
     expect(tokenOf(second)).toBe('token-2')
   })
 
+  it('replaces a token the catalog carried rather than trusting it', () => {
+    // A published token would be one secret shared by every install that used
+    // the template, so what the file says is never what gets used.
+    const published = template('webhook-to-report')
+    const carried = {
+      ...published,
+      portable: {
+        ...published.portable,
+        nodes: published.portable.nodes.map((node) =>
+          node.id === 'trigger'
+            ? { ...node, config: { ...node.config, token: 'from-the-catalog' } }
+            : node
+        )
+      }
+    }
+
+    const seed = templateSeed(carried, PROJECT, [], () => 'mine')
+    const trigger = seed.nodes.find((node) => node.id === 'trigger')!.config as Record<
+      string,
+      unknown
+    >
+    expect(trigger.token).toBe('mine')
+  })
+
   it('binds the step when this machine can answer, and says so when it cannot', () => {
     const bound = templateSeed(template('webhook-to-report'), PROJECT, [connection()])
     const report = bound.nodes.find((n) => n.id === 'report')!.config as Record<string, unknown>

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -56,7 +56,14 @@ describe('what a connection already knows how to build', () => {
     return { defaultWorkflows: defaults } as ConnectorManifest
   }
 
-  const seeded = [{ name: 'New issues to tasks', event: 'issueCreated', defaultCronFromMinutes: 5 }]
+  const seeded = [
+    {
+      name: 'New issues to tasks',
+      event: 'issueCreated',
+      defaultCronFromMinutes: 5,
+      downstream: 'createTaskFromItem' as const
+    }
+  ]
 
   it('offers one row per workflow the connector ships', () => {
     const suggestions = connectorSuggestions(

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  templateRequirements,
+  templateIsReady,
+  templateSeed
+} from '../src/renderer/lib/template-requirements'
+import { TEMPLATE_SEED } from '../packages/server/src/connectors/template-seed'
+import type { SourceConnection, WorkflowTemplate } from '../packages/shared/src/types'
+
+function connection(overrides: Partial<SourceConnection> = {}): SourceConnection {
+  return {
+    id: 'conn-1',
+    name: 'reporting API',
+    connectorId: 'http',
+    filters: {},
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-09-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+function template(id: string): WorkflowTemplate {
+  return TEMPLATE_SEED.find((t) => t.id === id)!
+}
+
+const PROJECT = { name: 'Novum', path: '/Users/someone/dev/novum' }
+
+describe('what a template still needs', () => {
+  it('reports an unanswered requirement', () => {
+    const [entry] = templateRequirements(template('webhook-to-report'), [])
+    expect(entry.connectionId).toBeUndefined()
+    expect(entry.requirement).toMatchObject({ kind: 'httpProfile', name: 'reporting API' })
+    expect(templateIsReady(template('webhook-to-report'), [])).toBe(false)
+  })
+
+  it('answers it from the one profile this machine has', () => {
+    const [entry] = templateRequirements(template('webhook-to-report'), [connection()])
+    expect(entry.connectionId).toBe('conn-1')
+    expect(templateIsReady(template('webhook-to-report'), [connection()])).toBe(true)
+  })
+
+  it('calls a template with nothing to connect ready', () => {
+    expect(templateRequirements(template('morning-digest'), [])).toEqual([])
+    expect(templateIsReady(template('morning-digest'), [])).toBe(true)
+  })
+})
+
+describe('what a template puts on the canvas', () => {
+  it('resolves the project tokens against the project in view', () => {
+    const seed = templateSeed(template('morning-digest'), PROJECT, [])
+    const script = seed.nodes.find((n) => n.id === 'gather')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe(PROJECT.path)
+    expect(script.projectName).toBe('Novum')
+  })
+
+  it('leaves the project blank rather than literal when there is no project', () => {
+    const seed = templateSeed(template('morning-digest'), undefined, [])
+    const script = seed.nodes.find((n) => n.id === 'gather')!.config as Record<string, unknown>
+    expect(script.projectPath).toBe('')
+  })
+
+  it('mints a webhook token, so two installs never share one', () => {
+    let n = 0
+    const first = templateSeed(template('webhook-to-report'), PROJECT, [], () => `token-${++n}`)
+    const second = templateSeed(template('webhook-to-report'), PROJECT, [], () => `token-${++n}`)
+
+    const tokenOf = (seed: typeof first): unknown =>
+      (seed.nodes.find((node) => node.id === 'trigger')!.config as Record<string, unknown>).token
+    expect(tokenOf(first)).toBe('token-1')
+    expect(tokenOf(second)).toBe('token-2')
+  })
+
+  it('binds the step when this machine can answer, and says so when it cannot', () => {
+    const bound = templateSeed(template('webhook-to-report'), PROJECT, [connection()])
+    const report = bound.nodes.find((n) => n.id === 'report')!.config as Record<string, unknown>
+    expect(report.profileConnectionId).toBe('conn-1')
+    expect(bound.unresolved).toEqual([])
+
+    const unbound = templateSeed(template('webhook-to-report'), PROJECT, [])
+    expect(unbound.unresolved).toHaveLength(1)
+    expect(
+      (unbound.nodes.find((n) => n.id === 'report')!.config as Record<string, unknown>)
+        .profileConnectionId
+    ).toBeUndefined()
+  })
+
+  it('keeps the graph the template drew', () => {
+    const seed = templateSeed(template('webhook-to-report'), PROJECT, [])
+    expect(seed.nodes).toHaveLength(3)
+    expect(seed.edges.find((e) => e.conditionBranch === 'true')).toBeTruthy()
+    expect(seed.name).toBe('Webhook to report')
+  })
+})

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest'
 import {
+  connectorSuggestions,
   templateRequirements,
   templateIsReady,
   templateSeed
 } from '../src/renderer/lib/template-requirements'
 import { TEMPLATE_SEED } from '../packages/server/src/connectors/template-seed'
-import type { SourceConnection, WorkflowTemplate } from '../packages/shared/src/types'
+import type {
+  ConnectorManifest,
+  SourceConnection,
+  WorkflowTemplate
+} from '../packages/shared/src/types'
 
 function connection(overrides: Partial<SourceConnection> = {}): SourceConnection {
   return {
@@ -43,6 +48,55 @@ describe('what a template still needs', () => {
   it('calls a template with nothing to connect ready', () => {
     expect(templateRequirements(template('morning-digest'), [])).toEqual([])
     expect(templateIsReady(template('morning-digest'), [])).toBe(true)
+  })
+})
+
+describe('what a connection already knows how to build', () => {
+  function manifest(defaults?: ConnectorManifest['defaultWorkflows']): ConnectorManifest {
+    return { defaultWorkflows: defaults } as ConnectorManifest
+  }
+
+  const seeded = [{ name: 'New issues to tasks', event: 'issueCreated', defaultCronFromMinutes: 5 }]
+
+  it('offers one row per workflow the connector ships', () => {
+    const suggestions = connectorSuggestions(
+      [connection({ id: 'c1', name: 'workspace-eng', connectorId: 'github' })],
+      [{ id: 'github', manifest: manifest(seeded) }]
+    )
+    expect(suggestions).toEqual([
+      {
+        key: 'c1:issueCreated',
+        connectionId: 'c1',
+        connectionName: 'workspace-eng',
+        event: 'issueCreated',
+        name: 'New issues to tasks'
+      }
+    ])
+  })
+
+  it('finds a packaged connector by its manifest id rather than mcp', () => {
+    const packaged = connection({
+      id: 'c2',
+      connectorId: 'mcp',
+      filters: { sdkConnectorId: 'packdemo' }
+    })
+    const suggestions = connectorSuggestions(
+      [packaged],
+      [{ id: 'packdemo', manifest: manifest(seeded) }]
+    )
+    expect(suggestions.map((s) => s.connectionId)).toEqual(['c2'])
+  })
+
+  it('offers nothing for a connector that ships no workflow', () => {
+    expect(
+      connectorSuggestions([connection({ connectorId: 'github' })], [
+        { id: 'github', manifest: manifest() }
+      ])
+    ).toEqual([])
+  })
+
+  it('offers nothing for a connection whose connector is not installed', () => {
+    expect(connectorSuggestions([connection({ connectorId: 'github' })], [])).toEqual([])
   })
 })
 

--- a/tests/workflow-context-menu.test.tsx
+++ b/tests/workflow-context-menu.test.tsx
@@ -63,6 +63,39 @@ describe('WorkflowContextMenu', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it('offers export only when there is somewhere to send it', () => {
+    const { rerender } = render(
+      <WorkflowContextMenu onEdit={vi.fn()} onDelete={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(screen.queryByText('Export as file…')).not.toBeInTheDocument()
+
+    rerender(
+      <WorkflowContextMenu
+        onEdit={vi.fn()}
+        onExport={vi.fn()}
+        onDelete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Export as file…')).toBeInTheDocument()
+  })
+
+  it('calls onExport + onClose on export click', () => {
+    const onExport = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <WorkflowContextMenu
+        onEdit={vi.fn()}
+        onExport={onExport}
+        onDelete={vi.fn()}
+        onClose={onClose}
+      />
+    )
+    fireEvent.click(screen.getByText('Export as file…'))
+    expect(onExport).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it('calls onClose on click outside', () => {
     const onClose = vi.fn()
     render(

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -1,0 +1,280 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { WorkflowDefinition } from '../src/shared/types'
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    )
+  },
+  AnimatePresence: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('react-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-dom')>('react-dom')
+  return { ...actual, createPortal: (node: React.ReactNode) => node }
+})
+
+vi.mock('../src/renderer/components/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
+}))
+
+const captured = vi.hoisted(() => ({ canvasProps: null as Record<string, unknown> | null }))
+vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', () => ({
+  WorkflowCanvas: (props: Record<string, unknown>) => {
+    captured.canvasProps = props
+    return <div data-testid="canvas" />
+  }
+}))
+
+vi.mock('../src/renderer/components/workflow-editor/panels/StepLibrary', () => ({
+  StepLibrary: () => <div data-testid="step-library" />
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/NodeConfigPanel', () => ({
+  NodeConfigPanel: () => <div data-testid="node-config" />
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/RunHistoryPanel', () => ({
+  RunHistoryPanel: () => <div data-testid="run-history" />
+}))
+vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel', () => ({
+  WorkflowPropertiesPanel: () => <div data-testid="properties-panel" />
+}))
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: vi.fn().mockResolvedValue(undefined)
+}))
+
+const toasts = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+  loading: vi.fn(),
+  dismiss: vi.fn(),
+  update: vi.fn()
+}))
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: Object.assign(vi.fn(), toasts)
+}))
+
+const EXPORTABLE: WorkflowDefinition = {
+  id: 'wf-1',
+  name: 'Nightly digest',
+  icon: 'Zap',
+  iconColor: '#6366f1',
+  enabled: true,
+  nodes: [
+    {
+      id: 'trigger-1',
+      type: 'trigger',
+      label: 'Manual',
+      config: { triggerType: 'manual' },
+      position: { x: 0, y: 0 }
+    }
+  ],
+  edges: []
+}
+
+const mockState = {
+  isWorkflowEditorOpen: true,
+  editingWorkflowId: null as string | null,
+  setWorkflowEditorOpen: vi.fn(),
+  setEditingWorkflowId: vi.fn(),
+  addWorkflow: vi.fn(),
+  updateWorkflow: vi.fn(),
+  removeWorkflow: vi.fn(),
+  config: {
+    workflows: [EXPORTABLE],
+    tasks: [],
+    projects: [{ name: 'Novum', path: '/Users/someone/dev/novum', preferredAgents: [] }],
+    defaults: {}
+  },
+  activeProject: 'Novum',
+  setPendingWorkflowRun: vi.fn(),
+  addTerminal: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  setSelectedTaskId: vi.fn(),
+  activeWorkspace: 'personal',
+  workflowExecutions: new Map<string, unknown>()
+}
+
+vi.mock('../src/renderer/stores', () => {
+  const useAppStore = (selector?: (s: unknown) => unknown) =>
+    selector ? selector(mockState) : mockState
+  useAppStore.getState = () => mockState
+  return { useAppStore }
+})
+
+const seedConnectorWorkflow = vi.fn().mockResolvedValue({ workflowId: 'seeded-1', created: true })
+const saveTextFile = vi.fn().mockResolvedValue('/tmp/nightly-digest.vorn-workflow.json')
+
+const CONNECTION = {
+  id: 'conn-1',
+  name: 'workspace-eng',
+  connectorId: 'github',
+  filters: {},
+  syncIntervalMinutes: 5,
+  statusMapping: {},
+  createdAt: '2026-09-01T00:00:00Z'
+}
+
+;(global as unknown as { window: object }).window = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  api: {
+    listWorkflowRuns: vi.fn().mockResolvedValue([]),
+    isWindowMaximized: vi.fn().mockResolvedValue(false),
+    onWindowMaximizedChange: vi.fn(() => () => {}),
+    onConfigChanged: vi.fn(() => () => {}),
+    listConnections: vi.fn().mockResolvedValue([CONNECTION]),
+    listConnectorPacks: vi.fn().mockResolvedValue([]),
+    listConnectors: vi.fn().mockResolvedValue([
+      {
+        id: 'github',
+        name: 'GitHub',
+        manifest: {
+          defaultWorkflows: [
+            { name: 'New issues to tasks', event: 'issueCreated', defaultCronFromMinutes: 5 }
+          ]
+        }
+      }
+    ]),
+    listConnectorCatalog: vi.fn(),
+    seedConnectorWorkflow,
+    saveTextFile
+  }
+}
+
+const { TEMPLATE_SEED } = await import('../packages/server/src/connectors/template-seed')
+const { __resetConnectionsCacheForTests } = await import('../src/renderer/lib/use-connections')
+const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
+
+const api = (window as unknown as { api: Record<string, ReturnType<typeof vi.fn>> }).api
+
+beforeEach(() => {
+  __resetConnectionsCacheForTests()
+  vi.clearAllMocks()
+  api.listConnections.mockResolvedValue([CONNECTION])
+  api.listConnectorPacks.mockResolvedValue([])
+  api.listConnectorCatalog.mockResolvedValue({ items: [], templates: TEMPLATE_SEED, mcpServers: [] })
+  api.listConnectors.mockResolvedValue([
+    {
+      id: 'github',
+      name: 'GitHub',
+      manifest: {
+        defaultWorkflows: [
+          { name: 'New issues to tasks', event: 'issueCreated', defaultCronFromMinutes: 5 }
+        ]
+      }
+    }
+  ])
+  seedConnectorWorkflow.mockResolvedValue({ workflowId: 'seeded-1', created: true })
+  saveTextFile.mockResolvedValue('/tmp/nightly-digest.vorn-workflow.json')
+})
+
+afterEach(() => {
+  mockState.editingWorkflowId = null
+  captured.canvasProps = null
+})
+
+describe('starting a new workflow from a template', () => {
+  it('offers the published templates on an empty canvas', async () => {
+    render(<WorkflowEditor />)
+    expect(await screen.findByText('Webhook to report')).toBeInTheDocument()
+    expect(screen.getByText('Blank canvas')).toBeInTheDocument()
+  })
+
+  it('puts the template on the canvas and names the workflow after it', async () => {
+    const { container } = render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('Morning digest'))
+
+    await waitFor(() => {
+      expect((captured.canvasProps?.nodes as unknown[]).length).toBe(3)
+    })
+    const nameInput = container.querySelector(
+      'input[placeholder="Workflow name"]'
+    ) as HTMLInputElement
+    expect(nameInput.value).toBe('Morning digest')
+    // Picking answers the question the panel asked, so it goes away.
+    expect(screen.queryByText('Blank canvas')).not.toBeInTheDocument()
+  })
+
+  it('resolves the template against the project in view', async () => {
+    render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('Morning digest'))
+
+    await waitFor(() => expect(captured.canvasProps?.nodes).toBeTruthy())
+    const nodes = captured.canvasProps?.nodes as Array<{ id: string; config: Record<string, unknown> }>
+    expect(nodes.find((n) => n.id === 'gather')?.config.projectPath).toBe(
+      '/Users/someone/dev/novum'
+    )
+  })
+
+  it('warns about what the template still needs here', async () => {
+    render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('Webhook to report'))
+
+    await waitFor(() => expect(toasts.warning).toHaveBeenCalledTimes(1))
+    expect(toasts.warning.mock.calls[0][0]).toContain('HTTP profile')
+  })
+
+  it('leaves the canvas alone when the blank one is chosen', async () => {
+    render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('Blank canvas'))
+
+    await waitFor(() => expect(screen.queryByText('Blank canvas')).not.toBeInTheDocument())
+    expect((captured.canvasProps?.nodes as unknown[]).length).toBe(0)
+  })
+})
+
+describe('starting from what a connection already builds', () => {
+  it('asks the server for it and opens what comes back', async () => {
+    render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('New issues to tasks'))
+
+    await waitFor(() => expect(seedConnectorWorkflow).toHaveBeenCalledWith('conn-1', 'issueCreated'))
+    expect(mockState.setEditingWorkflowId).toHaveBeenCalledWith('seeded-1')
+    expect(toasts.success).toHaveBeenCalled()
+  })
+
+  it('says so when the server refuses', async () => {
+    seedConnectorWorkflow.mockRejectedValue(new Error('no such connection'))
+    render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('New issues to tasks'))
+
+    await waitFor(() => expect(toasts.error).toHaveBeenCalledWith('no such connection'))
+    expect(mockState.setEditingWorkflowId).not.toHaveBeenCalled()
+  })
+})
+
+describe('exporting the workflow being edited', () => {
+  async function openMenu(): Promise<void> {
+    mockState.editingWorkflowId = 'wf-1'
+    render(<WorkflowEditor />)
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('More options'))
+    })
+  }
+
+  it('writes the file the canvas describes', async () => {
+    await openMenu()
+    fireEvent.click(screen.getByText('Export as file…'))
+
+    await waitFor(() => expect(saveTextFile).toHaveBeenCalledTimes(1))
+    expect(saveTextFile.mock.calls[0][0].defaultName).toBe('nightly-digest.vorn-workflow.json')
+    expect(JSON.parse(saveTextFile.mock.calls[0][0].contents).name).toBe('Nightly digest')
+    expect(toasts.success).toHaveBeenCalledWith('Exported "Nightly digest"')
+  })
+
+  it('says nothing when the save is cancelled', async () => {
+    saveTextFile.mockResolvedValue(null)
+    await openMenu()
+    fireEvent.click(screen.getByText('Export as file…'))
+
+    await waitFor(() => expect(saveTextFile).toHaveBeenCalledTimes(1))
+    expect(toasts.success).not.toHaveBeenCalled()
+    expect(toasts.error).not.toHaveBeenCalled()
+  })
+})

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -48,7 +48,8 @@ vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPan
     return <div data-testid="properties-panel" />
   }
 }))
-vi.mock('../src/renderer/lib/workflow-execution', () => ({
+vi.mock('../src/renderer/lib/workflow-execution', async (importActual) => ({
+  ...(await importActual<Record<string, unknown>>()),
   executeWorkflow: vi.fn().mockResolvedValue(undefined)
 }))
 
@@ -145,6 +146,7 @@ const CONNECTION = {
     }
   ]),
   listConnectorCatalog: vi.fn(),
+  listConnectionActions: vi.fn().mockResolvedValue([]),
   seedConnectorWorkflow,
   saveTextFile
 }

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -22,7 +22,10 @@ vi.mock('../src/renderer/components/Tooltip', () => ({
   Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>
 }))
 
-const captured = vi.hoisted(() => ({ canvasProps: null as Record<string, unknown> | null }))
+const captured = vi.hoisted(() => ({
+  canvasProps: null as Record<string, unknown> | null,
+  propertiesProps: null as Record<string, unknown> | null
+}))
 vi.mock('../src/renderer/components/workflow-editor/WorkflowCanvas', () => ({
   WorkflowCanvas: (props: Record<string, unknown>) => {
     captured.canvasProps = props
@@ -40,7 +43,10 @@ vi.mock('../src/renderer/components/workflow-editor/panels/RunHistoryPanel', () 
   RunHistoryPanel: () => <div data-testid="run-history" />
 }))
 vi.mock('../src/renderer/components/workflow-editor/panels/WorkflowPropertiesPanel', () => ({
-  WorkflowPropertiesPanel: () => <div data-testid="properties-panel" />
+  WorkflowPropertiesPanel: (props: Record<string, unknown>) => {
+    captured.propertiesProps = props
+    return <div data-testid="properties-panel" />
+  }
 }))
 vi.mock('../src/renderer/lib/workflow-execution', () => ({
   executeWorkflow: vi.fn().mockResolvedValue(undefined)
@@ -152,6 +158,7 @@ const api = (window as unknown as { api: Record<string, ReturnType<typeof vi.fn>
 beforeEach(() => {
   __resetConnectionsCacheForTests()
   vi.clearAllMocks()
+  api.listWorkflowRuns.mockResolvedValue([])
   api.listConnections.mockResolvedValue([CONNECTION])
   api.listConnectorPacks.mockResolvedValue([])
   api.listConnectorCatalog.mockResolvedValue({
@@ -177,6 +184,76 @@ beforeEach(() => {
 afterEach(() => {
   mockState.editingWorkflowId = null
   captured.canvasProps = null
+  captured.propertiesProps = null
+})
+
+describe('the one panel a new workflow opens with', () => {
+  it('asks what to start from, and does not offer settings beside it', () => {
+    const { container, queryByTestId } = render(<WorkflowEditor />)
+    expect(container.querySelector('[data-start-from]')).toBeTruthy()
+    expect(queryByTestId('properties-panel')).not.toBeInTheDocument()
+  })
+
+  it('hands the slot to settings when they are asked for', async () => {
+    render(<WorkflowEditor />)
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('More options'))
+    })
+    fireEvent.click(screen.getByText('Workflow settings'))
+
+    expect(screen.getByTestId('properties-panel')).toBeInTheDocument()
+    expect(document.querySelector('[data-start-from]')).toBeNull()
+  })
+
+  it('gives the slot back to settings once the canvas has something on it', async () => {
+    const { container } = render(<WorkflowEditor />)
+    fireEvent.click(await screen.findByText('Morning digest'))
+
+    await waitFor(() => expect(container.querySelector('[data-start-from]')).toBeNull())
+    expect(screen.getByTestId('properties-panel')).toBeInTheDocument()
+  })
+})
+
+describe('a new workflow carries none of the last one', () => {
+  const RUN = {
+    runId: 'run-1',
+    workflowId: 'wf-1',
+    startedAt: '2026-09-01T08:00:00Z',
+    completedAt: '2026-09-01T08:01:00Z',
+    status: 'success' as const,
+    nodeStates: []
+  }
+
+  it('forgets the previous workflow runs when New is opened', async () => {
+    mockState.editingWorkflowId = 'wf-1'
+    api.listWorkflowRuns.mockResolvedValue([RUN])
+    const { rerender } = render(<WorkflowEditor />)
+    await waitFor(() => expect(captured.propertiesProps?.lastRun).toBeTruthy())
+
+    mockState.editingWorkflowId = null
+    rerender(<WorkflowEditor />)
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('More options'))
+    })
+    fireEvent.click(screen.getByText('Workflow settings'))
+
+    // The last run belonged to the workflow that was open, not to this one.
+    await waitFor(() => expect(captured.propertiesProps?.lastRun).toBeNull())
+  })
+
+  it('stops counting the previous workflow runs in the toolbar', async () => {
+    mockState.editingWorkflowId = 'wf-1'
+    api.listWorkflowRuns.mockResolvedValue([RUN])
+    const { rerender } = render(<WorkflowEditor />)
+    await screen.findByRole('button', { name: /Run history \(1\)/ })
+
+    mockState.editingWorkflowId = null
+    rerender(<WorkflowEditor />)
+
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Run history \(1\)/ })).toBeNull()
+    )
+  })
 })
 
 describe('starting a new workflow from a template', () => {

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -120,31 +120,27 @@ const CONNECTION = {
   createdAt: '2026-09-01T00:00:00Z'
 }
 
-;(global as unknown as { window: object }).window = {
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
-  api: {
-    listWorkflowRuns: vi.fn().mockResolvedValue([]),
-    isWindowMaximized: vi.fn().mockResolvedValue(false),
-    onWindowMaximizedChange: vi.fn(() => () => {}),
-    onConfigChanged: vi.fn(() => () => {}),
-    listConnections: vi.fn().mockResolvedValue([CONNECTION]),
-    listConnectorPacks: vi.fn().mockResolvedValue([]),
-    listConnectors: vi.fn().mockResolvedValue([
-      {
-        id: 'github',
-        name: 'GitHub',
-        manifest: {
-          defaultWorkflows: [
-            { name: 'New issues to tasks', event: 'issueCreated', defaultCronFromMinutes: 5 }
-          ]
-        }
+;(window as unknown as { api: object }).api = {
+  listWorkflowRuns: vi.fn().mockResolvedValue([]),
+  isWindowMaximized: vi.fn().mockResolvedValue(false),
+  onWindowMaximizedChange: vi.fn(() => () => {}),
+  onConfigChanged: vi.fn(() => () => {}),
+  listConnections: vi.fn().mockResolvedValue([CONNECTION]),
+  listConnectorPacks: vi.fn().mockResolvedValue([]),
+  listConnectors: vi.fn().mockResolvedValue([
+    {
+      id: 'github',
+      name: 'GitHub',
+      manifest: {
+        defaultWorkflows: [
+          { name: 'New issues to tasks', event: 'issueCreated', defaultCronFromMinutes: 5 }
+        ]
       }
-    ]),
-    listConnectorCatalog: vi.fn(),
-    seedConnectorWorkflow,
-    saveTextFile
-  }
+    }
+  ]),
+  listConnectorCatalog: vi.fn(),
+  seedConnectorWorkflow,
+  saveTextFile
 }
 
 const { TEMPLATE_SEED } = await import('../packages/server/src/connectors/template-seed')

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -158,7 +158,11 @@ beforeEach(() => {
   vi.clearAllMocks()
   api.listConnections.mockResolvedValue([CONNECTION])
   api.listConnectorPacks.mockResolvedValue([])
-  api.listConnectorCatalog.mockResolvedValue({ items: [], templates: TEMPLATE_SEED, mcpServers: [] })
+  api.listConnectorCatalog.mockResolvedValue({
+    items: [],
+    templates: TEMPLATE_SEED,
+    mcpServers: []
+  })
   api.listConnectors.mockResolvedValue([
     {
       id: 'github',
@@ -206,7 +210,10 @@ describe('starting a new workflow from a template', () => {
     fireEvent.click(await screen.findByText('Morning digest'))
 
     await waitFor(() => expect(captured.canvasProps?.nodes).toBeTruthy())
-    const nodes = captured.canvasProps?.nodes as Array<{ id: string; config: Record<string, unknown> }>
+    const nodes = captured.canvasProps?.nodes as Array<{
+      id: string
+      config: Record<string, unknown>
+    }>
     expect(nodes.find((n) => n.id === 'gather')?.config.projectPath).toBe(
       '/Users/someone/dev/novum'
     )
@@ -234,7 +241,9 @@ describe('starting from what a connection already builds', () => {
     render(<WorkflowEditor />)
     fireEvent.click(await screen.findByText('New issues to tasks'))
 
-    await waitFor(() => expect(seedConnectorWorkflow).toHaveBeenCalledWith('conn-1', 'issueCreated'))
+    await waitFor(() =>
+      expect(seedConnectorWorkflow).toHaveBeenCalledWith('conn-1', 'issueCreated')
+    )
     expect(mockState.setEditingWorkflowId).toHaveBeenCalledWith('seeded-1')
     expect(toasts.success).toHaveBeenCalled()
   })

--- a/tests/workflow-editor.test.tsx
+++ b/tests/workflow-editor.test.tsx
@@ -105,10 +105,20 @@ describe('WorkflowEditor', () => {
     mockState.editingWorkflowId = null
   })
 
-  it('renders the canvas and properties panel when open with no node selected', () => {
-    const { getByTestId } = render(<WorkflowEditor />)
+  it('opens a new workflow on the start-from panel rather than its settings', () => {
+    // Settings for a workflow that does not exist yet are not the question a
+    // blank canvas is asking, and two panels never share the slot.
+    const { getByTestId, queryByTestId, container } = render(<WorkflowEditor />)
     expect(getByTestId('canvas')).toBeInTheDocument()
+    expect(container.querySelector('[data-start-from]')).toBeTruthy()
+    expect(queryByTestId('properties-panel')).not.toBeInTheDocument()
+  })
+
+  it('shows the properties panel for a workflow that exists', () => {
+    mockState.editingWorkflowId = 'w1'
+    const { getByTestId, container } = render(<WorkflowEditor />)
     expect(getByTestId('properties-panel')).toBeInTheDocument()
+    expect(container.querySelector('[data-start-from]')).toBeNull()
   })
 
   it('renders workflow name input', () => {

--- a/tests/workflow-file-handles.test.tsx
+++ b/tests/workflow-file-handles.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  pickWorkflowFile,
+  readDroppedWorkflowFile
+} from '../src/renderer/lib/workflow-files'
+
+const CONTENTS = '{"version":1,"slug":"x","name":"X","nodes":[],"edges":[]}'
+
+function jsonFile(name = 'x.vorn-workflow.json'): File {
+  return new File([CONTENTS], name, { type: 'application/json' })
+}
+
+/** Stand in for the native picker: the click is what opens it. */
+function whenPickerOpens(handler: (input: HTMLInputElement) => void) {
+  return vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(function (
+    this: HTMLInputElement
+  ) {
+    handler(this)
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('reading a dropped file', () => {
+  it('reads the workflow file out of the drop', async () => {
+    const picked = await readDroppedWorkflowFile([jsonFile()] as unknown as FileList)
+    expect(picked).toEqual({ name: 'x.vorn-workflow.json', contents: CONTENTS })
+  })
+
+  it('ignores what came alongside it', async () => {
+    const files = [
+      new File(['n'], 'notes.txt', { type: 'text/plain' }),
+      jsonFile('second.json')
+    ] as unknown as FileList
+    expect((await readDroppedWorkflowFile(files))?.name).toBe('second.json')
+  })
+
+  it('answers nothing for a drop with no workflow file in it', async () => {
+    const files = [new File(['n'], 'notes.txt')] as unknown as FileList
+    expect(await readDroppedWorkflowFile(files)).toBeNull()
+    expect(await readDroppedWorkflowFile(null)).toBeNull()
+  })
+})
+
+describe('asking for a file', () => {
+  it('hands back the text of the file that was chosen', async () => {
+    whenPickerOpens((input) => {
+      Object.defineProperty(input, 'files', { value: [jsonFile()] })
+      input.dispatchEvent(new Event('change'))
+    })
+
+    expect(await pickWorkflowFile()).toEqual({
+      name: 'x.vorn-workflow.json',
+      contents: CONTENTS
+    })
+  })
+
+  it('answers nothing when the picker is dismissed', async () => {
+    whenPickerOpens((input) => input.dispatchEvent(new Event('cancel')))
+    expect(await pickWorkflowFile()).toBeNull()
+  })
+
+  it('answers nothing when the picker closes with no file', async () => {
+    whenPickerOpens((input) => {
+      Object.defineProperty(input, 'files', { value: [] })
+      input.dispatchEvent(new Event('change'))
+    })
+    expect(await pickWorkflowFile()).toBeNull()
+  })
+
+  it('leaves no input behind in the document', async () => {
+    whenPickerOpens((input) => {
+      Object.defineProperty(input, 'files', { value: [jsonFile()] })
+      input.dispatchEvent(new Event('change'))
+    })
+
+    await pickWorkflowFile()
+    expect(document.querySelectorAll('input[type="file"]')).toHaveLength(0)
+  })
+})

--- a/tests/workflow-file-handles.test.tsx
+++ b/tests/workflow-file-handles.test.tsx
@@ -68,6 +68,53 @@ describe('asking for a file', () => {
     expect(await pickWorkflowFile()).toBeNull()
   })
 
+  it('settles on the window coming back, for pickers that never say cancel', async () => {
+    vi.useFakeTimers()
+    whenPickerOpens(() => {})
+
+    const pending = pickWorkflowFile()
+    window.dispatchEvent(new Event('focus'))
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(await pending).toBeNull()
+    expect(document.querySelectorAll('input[type="file"]')).toHaveLength(0)
+    vi.useRealTimers()
+  })
+
+  it('does not settle on focus when a file was chosen', async () => {
+    vi.useFakeTimers()
+    whenPickerOpens((input) => {
+      Object.defineProperty(input, 'files', { value: [jsonFile()] })
+      input.dispatchEvent(new Event('change'))
+    })
+
+    const pending = pickWorkflowFile()
+    window.dispatchEvent(new Event('focus'))
+    await vi.advanceTimersByTimeAsync(400)
+
+    expect(await pending).toMatchObject({ name: 'x.vorn-workflow.json' })
+    vi.useRealTimers()
+  })
+
+  it('refuses a file too large to be a workflow', async () => {
+    const huge = new File(['x'], 'huge.json', { type: 'application/json' })
+    Object.defineProperty(huge, 'size', { value: 600_000 })
+    whenPickerOpens((input) => {
+      Object.defineProperty(input, 'files', { value: [huge] })
+      input.dispatchEvent(new Event('change'))
+    })
+
+    await expect(pickWorkflowFile()).rejects.toThrow(/too large/)
+  })
+
+  it('refuses a dropped file too large to be a workflow', async () => {
+    const huge = new File(['x'], 'huge.json', { type: 'application/json' })
+    Object.defineProperty(huge, 'size', { value: 600_000 })
+    await expect(readDroppedWorkflowFile([huge] as unknown as FileList)).rejects.toThrow(
+      /too large/
+    )
+  })
+
   it('leaves no input behind in the document', async () => {
     whenPickerOpens((input) => {
       Object.defineProperty(input, 'files', { value: [jsonFile()] })

--- a/tests/workflow-file-handles.test.tsx
+++ b/tests/workflow-file-handles.test.tsx
@@ -1,9 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import {
-  pickWorkflowFile,
-  readDroppedWorkflowFile
-} from '../src/renderer/lib/workflow-files'
+import { pickWorkflowFile, readDroppedWorkflowFile } from '../src/renderer/lib/workflow-files'
 
 const CONTENTS = '{"version":1,"slug":"x","name":"X","nodes":[],"edges":[]}'
 

--- a/tests/workflow-file-ui.test.tsx
+++ b/tests/workflow-file-ui.test.tsx
@@ -124,6 +124,38 @@ describe('bringing a workflow file in', () => {
     expect(addWorkflow).not.toHaveBeenCalled()
   })
 
+  it('says where to drop while a file is over the list', () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+    const list = screen.getByLabelText('All runs')
+
+    fireEvent.dragOver(list, { dataTransfer: { types: ['Files'] } })
+    expect(screen.getByText('Drop to import a workflow file')).toBeInTheDocument()
+
+    fireEvent.dragLeave(list, { relatedTarget: document.body })
+    expect(screen.queryByText('Drop to import a workflow file')).not.toBeInTheDocument()
+  })
+
+  it('stays quiet while a row is being dragged to reorder', () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+    fireEvent.dragOver(screen.getByLabelText('All runs'), {
+      dataTransfer: { types: ['text/plain'] }
+    })
+    expect(screen.queryByText('Drop to import a workflow file')).not.toBeInTheDocument()
+  })
+
+  it('refuses to import when there is no project to resolve against', async () => {
+    act(() => {
+      useAppStore.setState({
+        config: { ...(useAppStore.getState().config as AppConfig), projects: [] } as AppConfig
+      })
+    })
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+
+    dropFile(fileFromWorkflow(workflow(), PROJECT.path, []).contents)
+
+    await waitFor(() => expect(addWorkflow).not.toHaveBeenCalled())
+  })
+
   it('ignores a drop carrying no file it can read', async () => {
     render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
 
@@ -133,5 +165,32 @@ describe('bringing a workflow file in', () => {
     })
 
     await waitFor(() => expect(addWorkflow).not.toHaveBeenCalled())
+  })
+})
+
+describe('sending a workflow out to a file', () => {
+  const saveTextFile = () =>
+    (window as unknown as { api: { saveTextFile: ReturnType<typeof vi.fn> } }).api.saveTextFile
+
+  async function exportFromMenu(): Promise<void> {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+    fireEvent.contextMenu(screen.getByText('Nightly digest'))
+    fireEvent.click(await screen.findByText('Export as file…'))
+  }
+
+  it('writes the workflow the row names', async () => {
+    await exportFromMenu()
+
+    await waitFor(() => expect(saveTextFile()).toHaveBeenCalledTimes(1))
+    const written = saveTextFile().mock.calls[0][0]
+    expect(written.defaultName).toBe('nightly-digest.vorn-workflow.json')
+    expect(JSON.parse(written.contents)).toMatchObject({ name: 'Nightly digest', version: 1 })
+  })
+
+  it('closes the menu whether or not a file was written', async () => {
+    saveTextFile().mockResolvedValue(null)
+    await exportFromMenu()
+
+    await waitFor(() => expect(screen.queryByText('Export as file…')).not.toBeInTheDocument())
   })
 })

--- a/tests/workflow-file-ui.test.tsx
+++ b/tests/workflow-file-ui.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { useAppStore } from '../src/renderer/stores'
+import { WorkflowsSection } from '../src/renderer/components/project-sidebar/WorkflowsSection'
+import { __resetConnectionsCacheForTests } from '../src/renderer/lib/use-connections'
+import { fileFromWorkflow } from '../src/renderer/lib/workflow-files'
+import type { AppConfig, WorkflowDefinition } from '../packages/shared/src/types'
+
+const PROJECT = { name: 'Novum', path: '/Users/someone/dev/novum' }
+
+function workflow(): WorkflowDefinition {
+  return {
+    id: 'wf-1',
+    name: 'Nightly digest',
+    icon: 'Zap',
+    iconColor: '#6366f1',
+    enabled: true,
+    workspaceId: 'personal',
+    nodes: [
+      {
+        id: 'trigger-1',
+        type: 'trigger',
+        label: 'Manual',
+        config: { triggerType: 'manual' },
+        position: { x: 0, y: 0 }
+      }
+    ],
+    edges: []
+  }
+}
+
+const initialState = useAppStore.getState()
+const addWorkflow = vi.fn()
+const updateWorkflow = vi.fn()
+
+beforeEach(() => {
+  __resetConnectionsCacheForTests()
+  addWorkflow.mockClear()
+  updateWorkflow.mockClear()
+  ;(window as unknown as { api: unknown }).api = {
+    listConnections: vi.fn().mockResolvedValue([]),
+    onConfigChanged: vi.fn().mockReturnValue(() => {}),
+    saveTextFile: vi.fn().mockResolvedValue('/tmp/nightly-digest.vorn-workflow.json')
+  }
+  act(() => {
+    useAppStore.setState({
+      config: {
+        ...(initialState.config ?? {}),
+        projects: [{ ...PROJECT, preferredAgents: [] }],
+        workflows: [workflow()]
+      } as AppConfig,
+      activeProject: PROJECT.name,
+      activeWorkspace: 'personal',
+      addWorkflow,
+      updateWorkflow
+    })
+  })
+})
+
+afterEach(() => {
+  act(() => useAppStore.setState(initialState, true))
+})
+
+/** A file drop as the browser delivers one. */
+function dropFile(contents: string, name = 'nightly-digest.vorn-workflow.json'): void {
+  const file = new File([contents], name, { type: 'application/json' })
+  fireEvent.drop(screen.getByLabelText('All runs'), {
+    dataTransfer: { files: [file], types: ['Files'] }
+  })
+}
+
+describe('bringing a workflow file in', () => {
+  it('offers importing beside creating', () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+    expect(screen.getByLabelText('Import workflow file')).toBeInTheDocument()
+    expect(screen.getByLabelText('New workflow')).toBeInTheDocument()
+  })
+
+  it('adds the workflow a dropped file describes', async () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+    const exported = fileFromWorkflow(workflow(), PROJECT.path, []).contents
+
+    dropFile(exported)
+
+    await waitFor(() => expect(addWorkflow).toHaveBeenCalledTimes(1))
+    const added = addWorkflow.mock.calls[0][0] as WorkflowDefinition
+    expect(added.name).toBe('Nightly digest')
+    // Derived from the file, so dropping it again updates rather than duplicates.
+    expect(added.id).toBe('import:novum:nightly-digest')
+    expect(added.workspaceId).toBe('personal')
+  })
+
+  it('updates in place when that file has been dropped before', async () => {
+    const exported = fileFromWorkflow(workflow(), PROJECT.path, []).contents
+    const already = { ...workflow(), id: 'import:novum:nightly-digest', workspaceId: 'team' }
+    act(() => {
+      useAppStore.setState({
+        config: {
+          ...(useAppStore.getState().config as AppConfig),
+          workflows: [already]
+        } as AppConfig
+      })
+    })
+
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[already]} />)
+    dropFile(exported)
+
+    await waitFor(() => expect(updateWorkflow).toHaveBeenCalledTimes(1))
+    expect(addWorkflow).not.toHaveBeenCalled()
+    // Re-import must not move a workflow out of the workspace it lives in.
+    expect((updateWorkflow.mock.calls[0][1] as WorkflowDefinition).workspaceId).toBe('team')
+  })
+
+  it('says so rather than importing when the file is not a workflow', async () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+
+    dropFile('this is not json')
+
+    await waitFor(() => expect(screen.queryByText(/not valid JSON/)).toBeTruthy(), {
+      timeout: 1000
+    }).catch(() => {})
+    expect(addWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('ignores a drop carrying no file it can read', async () => {
+    render(<WorkflowsSection isCollapsed={false} workspaceWorkflows={[workflow()]} />)
+
+    const file = new File(['x'], 'notes.txt', { type: 'text/plain' })
+    fireEvent.drop(screen.getByLabelText('All runs'), {
+      dataTransfer: { files: [file], types: ['Files'] }
+    })
+
+    await waitFor(() => expect(addWorkflow).not.toHaveBeenCalled())
+  })
+})

--- a/tests/workflow-files.test.ts
+++ b/tests/workflow-files.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import {
+  definitionFromFile,
+  describeRequirement,
+  fileFromWorkflow,
+  placeImportedWorkflow,
+  projectForWorkflow,
+  workflowFileName,
+  WORKFLOW_FILE_SUFFIX
+} from '../src/renderer/lib/workflow-files'
+import type { SourceConnection, WorkflowDefinition } from '../packages/shared/src/types'
+
+const PROJECT = { name: 'Novum', path: '/Users/someone/dev/novum' }
+
+function workflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefinition {
+  return {
+    id: 'abc-123',
+    name: 'Nightly digest',
+    icon: 'Newspaper',
+    iconColor: '#c9a227',
+    enabled: true,
+    nodes: [
+      {
+        id: 'trigger-1',
+        type: 'trigger',
+        label: 'Manual',
+        config: { triggerType: 'manual' },
+        position: { x: 0, y: 0 }
+      },
+      {
+        id: 'run-1',
+        type: 'script',
+        label: 'Build',
+        config: {
+          scriptType: 'bash',
+          projectName: 'Novum',
+          projectPath: PROJECT.path,
+          scriptContent: 'make'
+        },
+        position: { x: 0, y: 110 }
+      }
+    ],
+    edges: [{ id: 'e1', source: 'trigger-1', target: 'run-1' }],
+    ...overrides
+  }
+}
+
+function connection(overrides: Partial<SourceConnection> = {}): SourceConnection {
+  return {
+    id: 'conn-1',
+    name: 'workspace-eng',
+    connectorId: 'github',
+    filters: {},
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-09-01T00:00:00Z',
+    ...overrides
+  }
+}
+
+describe('naming the file', () => {
+  it('names it for the workflow so a folder of them reads', () => {
+    expect(workflowFileName(workflow())).toBe(`nightly-digest${WORKFLOW_FILE_SUFFIX}`)
+  })
+})
+
+describe('projectForWorkflow', () => {
+  it('finds the project the workflow points at', () => {
+    expect(projectForWorkflow(workflow(), [PROJECT])).toEqual(PROJECT)
+  })
+
+  it('answers nothing when no registered project matches', () => {
+    expect(projectForWorkflow(workflow(), [{ name: 'Other', path: '/o' }])).toBeUndefined()
+  })
+})
+
+describe('fileFromWorkflow', () => {
+  it('writes readable JSON that ends in a newline', () => {
+    const file = fileFromWorkflow(workflow(), PROJECT.path, [])
+    expect(file.contents.endsWith('\n')).toBe(true)
+    expect(JSON.parse(file.contents).name).toBe('Nightly digest')
+  })
+
+  it('reports nothing machine-specific for a workflow inside its project', () => {
+    expect(fileFromWorkflow(workflow(), PROJECT.path, []).residual).toEqual([])
+  })
+
+  it('keeps paths intact when no project could be resolved', () => {
+    // An empty root must not rewrite every absolute path as if it sat inside it.
+    const file = fileFromWorkflow(workflow(), '', [])
+    const script = JSON.parse(file.contents).nodes[1].config
+    expect(script.projectPath).toBe(PROJECT.path)
+    expect(file.residual).toContain('run-1.projectPath')
+  })
+})
+
+describe('definitionFromFile', () => {
+  function exported(): string {
+    return fileFromWorkflow(workflow(), PROJECT.path, []).contents
+  }
+
+  it('resolves a file against the importing project', () => {
+    const result = definitionFromFile(exported(), { name: 'Other', path: '/o/code' }, 'novum', [])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const script = result.definition.nodes[1].config as Record<string, unknown>
+    expect(script.projectPath).toBe('/o/code')
+    expect(script.projectName).toBe('Other')
+  })
+
+  it('derives the same id every time, so a re-import updates in place', () => {
+    const a = definitionFromFile(exported(), PROJECT, 'novum', [])
+    const b = definitionFromFile(exported(), { name: 'X', path: '/x' }, 'novum', [])
+    expect(a.ok && b.ok && a.definition.id === b.definition.id).toBe(true)
+  })
+
+  it('refuses a file that is not JSON', () => {
+    const result = definitionFromFile('not json at all', PROJECT, 'novum', [])
+    expect(result).toEqual({ ok: false, error: 'That file is not valid JSON' })
+  })
+
+  it('refuses a version this build does not read', () => {
+    const bumped = JSON.stringify({ ...JSON.parse(exported()), version: 99 })
+    const result = definitionFromFile(bumped, PROJECT, 'novum', [])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('version 99')
+  })
+
+  it('refuses a file missing the graph', () => {
+    const gutted = JSON.stringify({ version: 1, name: 'X', slug: 'x' })
+    const result = definitionFromFile(gutted, PROJECT, 'novum', [])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('missing a name, nodes or edges')
+  })
+
+  it('reports what a connector step still needs here', () => {
+    const wf = workflow()
+    wf.nodes.push({
+      id: 'act-1',
+      type: 'callConnectorAction',
+      label: 'Create issue',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: 'conn-1',
+        action: 'createIssue',
+        args: {}
+      } as WorkflowDefinition['nodes'][number]['config'],
+      position: { x: 0, y: 220 }
+    })
+    const contents = fileFromWorkflow(wf, PROJECT.path, [connection()]).contents
+
+    const result = definitionFromFile(contents, PROJECT, 'novum', [])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.unresolved).toHaveLength(1)
+    expect(describeRequirement(result.unresolved[0])).toBe(
+      'a github connection like "workspace-eng"'
+    )
+  })
+
+  it('binds the step and says nothing is pending when this machine has the connector', () => {
+    const wf = workflow()
+    wf.nodes.push({
+      id: 'act-1',
+      type: 'callConnectorAction',
+      label: 'Create issue',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: 'conn-1',
+        action: 'createIssue',
+        args: {}
+      } as WorkflowDefinition['nodes'][number]['config'],
+      position: { x: 0, y: 220 }
+    })
+    const contents = fileFromWorkflow(wf, PROJECT.path, [connection()]).contents
+
+    const here = [connection({ id: 'mine', name: 'my-workspace' })]
+    const result = definitionFromFile(contents, PROJECT, 'novum', here)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const action = result.definition.nodes.find((n) => n.id === 'act-1')!.config as Record<
+      string,
+      unknown
+    >
+    expect(action.connectionId).toBe('mine')
+    expect(result.unresolved).toEqual([])
+  })
+})
+
+describe('describeRequirement', () => {
+  it('names an http profile without pretending to know its connector', () => {
+    expect(describeRequirement({ kind: 'httpProfile', nodeId: 'n', name: 'reporting API' })).toBe(
+      'an HTTP profile like "reporting API"'
+    )
+    expect(describeRequirement({ kind: 'httpProfile', nodeId: 'n', name: '' })).toBe(
+      'an HTTP profile'
+    )
+  })
+
+  it('falls back to a plain connection when the file named neither', () => {
+    expect(
+      describeRequirement({ kind: 'connection', nodeId: 'n', connectorId: '', name: '' })
+    ).toBe('a connector connection')
+  })
+})
+
+describe('placeImportedWorkflow', () => {
+  it('puts a new workflow in the workspace being viewed', () => {
+    expect(placeImportedWorkflow(workflow(), undefined, 'team').workspaceId).toBe('team')
+  })
+
+  it('leaves a re-imported workflow in the workspace it already lived in', () => {
+    const existing = workflow({ workspaceId: 'personal' })
+    expect(placeImportedWorkflow(workflow(), existing, 'team').workspaceId).toBe('personal')
+  })
+})

--- a/tests/workflow-files.test.ts
+++ b/tests/workflow-files.test.ts
@@ -6,6 +6,7 @@ import {
   placeImportedWorkflow,
   projectForWorkflow,
   workflowFileName,
+  MAX_WORKFLOW_FILE_BYTES,
   WORKFLOW_FILE_SUFFIX
 } from '../src/renderer/lib/workflow-files'
 import type { SourceConnection, WorkflowDefinition } from '../packages/shared/src/types'
@@ -71,6 +72,28 @@ describe('projectForWorkflow', () => {
 
   it('answers nothing when no registered project matches', () => {
     expect(projectForWorkflow(workflow(), [{ name: 'Other', path: '/o' }])).toBeUndefined()
+  })
+
+  it('falls back to the project in view when no step names one', () => {
+    // A script step carries a cwd without a projectName; without a project to
+    // be relative to, that path would travel as this machine's.
+    const nameless = workflow({
+      nodes: [
+        {
+          id: 'run-1',
+          type: 'script',
+          label: 'Build',
+          config: { scriptType: 'bash', scriptContent: 'make', cwd: `${PROJECT.path}/sub` },
+          position: { x: 0, y: 0 }
+        }
+      ]
+    })
+    expect(projectForWorkflow(nameless, [PROJECT], 'Novum')).toEqual(PROJECT)
+  })
+
+  it('prefers what the workflow names over what is in view', () => {
+    const other = { name: 'Other', path: '/o' }
+    expect(projectForWorkflow(workflow(), [PROJECT, other], 'Other')).toEqual(PROJECT)
   })
 })
 
@@ -186,6 +209,89 @@ describe('definitionFromFile', () => {
     >
     expect(action.connectionId).toBe('mine')
     expect(result.unresolved).toEqual([])
+  })
+})
+
+describe('refusing a file before it becomes a workflow', () => {
+  function exported(): string {
+    return fileFromWorkflow(workflow(), PROJECT.path, []).contents
+  }
+
+  it('refuses more text than a workflow could be', () => {
+    const huge = `${' '.repeat(MAX_WORKFLOW_FILE_BYTES)}${exported()}`
+    expect(definitionFromFile(huge, PROJECT, 'novum', [])).toEqual({
+      ok: false,
+      error: 'That file is too large to be a workflow'
+    })
+  })
+
+  it('refuses a step it cannot read, not merely a non-array', () => {
+    const gutted = JSON.stringify({ ...JSON.parse(exported()), nodes: ['oops'], edges: [] })
+    const result = definitionFromFile(gutted, PROJECT, 'novum', [])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('step this build cannot read')
+  })
+
+  it('refuses an edge that names a step the file does not carry', () => {
+    const parsed = JSON.parse(exported())
+    parsed.edges = [{ id: 'e9', source: 'trigger-1', target: 'ghost' }]
+    const result = definitionFromFile(JSON.stringify(parsed), PROJECT, 'novum', [])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('connects a step it does not carry')
+  })
+
+  it('refuses an edge with no endpoints at all', () => {
+    const parsed = JSON.parse(exported())
+    parsed.edges = [{ id: 'e9' }]
+    const result = definitionFromFile(JSON.stringify(parsed), PROJECT, 'novum', [])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain('connection this build cannot read')
+  })
+
+  it('still accepts the file it wrote', () => {
+    expect(definitionFromFile(exported(), PROJECT, 'novum', []).ok).toBe(true)
+  })
+})
+
+describe('an import lands switched off', () => {
+  function exported(): string {
+    return fileFromWorkflow(workflow(), PROJECT.path, []).contents
+  }
+
+  it('arrives disabled, whatever the file was exported from', () => {
+    const result = definitionFromFile(exported(), PROJECT, 'novum', [])
+    expect(result.ok && result.definition.enabled).toBe(false)
+  })
+
+  it('leaves a workflow that was already running alone', () => {
+    const result = definitionFromFile(exported(), PROJECT, 'novum', [])
+    if (!result.ok) throw new Error('expected a definition')
+    const already = workflow({ id: result.definition.id, enabled: true, workspaceId: 'team' })
+
+    expect(placeImportedWorkflow(result.definition, already, 'personal').enabled).toBe(true)
+  })
+
+  it('leaves a workflow that was switched off switched off', () => {
+    const result = definitionFromFile(exported(), PROJECT, 'novum', [])
+    if (!result.ok) throw new Error('expected a definition')
+    const already = workflow({ id: result.definition.id, enabled: false })
+
+    expect(placeImportedWorkflow(result.definition, already, 'personal').enabled).toBe(false)
+  })
+
+  it('steps aside from a workflow of another name holding its id', () => {
+    const held = [{ id: 'import:novum:nightly-digest', name: 'Something else' }]
+    const result = definitionFromFile(exported(), PROJECT, 'novum', [], held)
+    expect(result.ok && result.definition.id).toBe('import:novum:nightly-digest-2')
+  })
+
+  it('updates in place when the name matches', () => {
+    const held = [{ id: 'import:novum:nightly-digest', name: 'Nightly digest' }]
+    const result = definitionFromFile(exported(), PROJECT, 'novum', [], held)
+    expect(result.ok && result.definition.id).toBe('import:novum:nightly-digest')
   })
 })
 

--- a/tests/workflow-files.test.ts
+++ b/tests/workflow-files.test.ts
@@ -322,3 +322,24 @@ describe('placeImportedWorkflow', () => {
     expect(placeImportedWorkflow(workflow(), existing, 'team').workspaceId).toBe('personal')
   })
 })
+
+it('refuses a file that carries the same step twice', () => {
+  const dupe = {
+    version: 1,
+    name: 'Twice',
+    nodes: [
+      {
+        id: 'a',
+        type: 'trigger',
+        label: 'T',
+        config: { triggerType: 'manual' },
+        position: { x: 0, y: 0 }
+      },
+      { id: 'a', type: 'script', label: 'S', config: {}, position: { x: 0, y: 0 } }
+    ],
+    edges: []
+  }
+  const result = definitionFromFile(JSON.stringify(dupe), 'b', PROJECT, [])
+  expect(result.ok).toBe(false)
+  if (!result.ok) expect(result.error).toMatch(/same step twice/)
+})

--- a/tests/workflow-files.test.ts
+++ b/tests/workflow-files.test.ts
@@ -339,7 +339,7 @@ it('refuses a file that carries the same step twice', () => {
     ],
     edges: []
   }
-  const result = definitionFromFile(JSON.stringify(dupe), 'b', PROJECT, [])
+  const result = definitionFromFile(JSON.stringify(dupe), PROJECT, 'b', [])
   expect(result.ok).toBe(false)
   if (!result.ok) expect(result.error).toMatch(/same step twice/)
 })

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -2,13 +2,15 @@ import { describe, it, expect } from 'vitest'
 import {
   toPortable,
   fromPortable,
-  portabilityBlockers,
+  resolveRequirement,
+  unresolvedRequirements,
   residualAbsolutePaths,
   importedWorkflowId,
   parseImportedWorkflowId,
   slugify,
-  PROJECT_PATH_TOKEN
-} from '../packages/mcp/src/workflow-portability'
+  PROJECT_PATH_TOKEN,
+  type PortableConnection
+} from '../packages/shared/src/workflow-portability'
 import type { WorkflowDefinition } from '../packages/shared/src/types'
 
 const PROJECT = '/Users/someone/dev/novum'
@@ -63,6 +65,34 @@ function workflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefiniti
   }
 }
 
+function connection(overrides: Partial<PortableConnection> = {}): PortableConnection {
+  return { id: 'conn-1', name: 'workspace-eng', connectorId: 'github', ...overrides }
+}
+
+/** A workflow whose trigger polls a connector and whose step calls one. */
+function connectorWorkflow(): WorkflowDefinition {
+  const wf = workflow()
+  wf.nodes[0].config = {
+    triggerType: 'connectorPoll',
+    connectionId: 'conn-1',
+    event: 'issueCreated',
+    cron: '*/5 * * * *'
+  } as WorkflowDefinition['nodes'][number]['config']
+  wf.nodes.push({
+    id: 'act-1',
+    type: 'callConnectorAction',
+    label: 'Create issue',
+    config: {
+      nodeType: 'callConnectorAction',
+      connectionId: 'conn-1',
+      action: 'createIssue',
+      args: {}
+    } as WorkflowDefinition['nodes'][number]['config'],
+    position: { x: 0, y: 330 }
+  })
+  return wf
+}
+
 describe('toPortable', () => {
   it('replaces the project path everywhere it appears', () => {
     const p = toPortable(workflow(), PROJECT)
@@ -91,6 +121,10 @@ describe('toPortable', () => {
     const wf = workflow()
     toPortable(wf, PROJECT)
     expect((wf.nodes[1].config as Record<string, unknown>).projectPath).toBe(PROJECT)
+  })
+
+  it('says nothing about requirements when nothing is bound', () => {
+    expect(toPortable(workflow(), PROJECT).requires).toBeUndefined()
   })
 })
 
@@ -130,37 +164,111 @@ describe('round trip', () => {
   })
 })
 
-describe('portabilityBlockers', () => {
-  it('passes an ordinary workflow', () => {
-    expect(portabilityBlockers(workflow())).toEqual([])
+describe('connections travel as requirements', () => {
+  it('drops the local id and records what it stood for', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+
+    expect((p.nodes[0].config as Record<string, unknown>).connectionId).toBe('')
+    expect(p.requires).toEqual([
+      {
+        kind: 'connection',
+        nodeId: 'trigger-1',
+        connectorId: 'github',
+        name: 'workspace-eng',
+        event: 'issueCreated'
+      },
+      { kind: 'connection', nodeId: 'act-1', connectorId: 'github', name: 'workspace-eng' }
+    ])
   })
 
-  it('refuses a connector-poll trigger rather than exporting a broken file', () => {
-    const wf = workflow()
-    wf.nodes[0].config = {
-      triggerType: 'connectorPoll',
-      connectionId: 'local-uuid',
-      event: 'issue.created',
-      cron: '*/5 * * * *'
-    }
-    expect(portabilityBlockers(wf)[0]).toContain('connector connection')
+  it('names a packaged connector by its manifest id, not mcp', () => {
+    const packaged = connection({ connectorId: 'mcp', filters: { sdkConnectorId: 'packdemo' } })
+    const p = toPortable(connectorWorkflow(), PROJECT, [packaged])
+    expect((p.requires ?? [])[0]).toMatchObject({ connectorId: 'packdemo' })
   })
 
-  it('refuses a connector action step', () => {
+  it('unbinds an http profile even when the connection is unknown here', () => {
     const wf = workflow()
     wf.nodes.push({
-      id: 'act-1',
-      type: 'callConnectorAction',
-      label: 'Create issue',
+      id: 'http-1',
+      type: 'httpRequest',
+      label: 'Report',
       config: {
-        nodeType: 'callConnectorAction',
-        connectionId: 'local-uuid',
-        action: 'x',
-        args: {}
-      },
-      position: { x: 0, y: 330 }
+        nodeType: 'httpRequest',
+        method: 'POST',
+        url: '/report',
+        headers: {},
+        body: '',
+        profileConnectionId: 'gone'
+      } as WorkflowDefinition['nodes'][number]['config'],
+      position: { x: 0, y: 440 }
     })
-    expect(portabilityBlockers(wf).some((b) => b.includes('Create issue'))).toBe(true)
+
+    const p = toPortable(wf, PROJECT)
+    const http = p.nodes.find((n) => n.id === 'http-1')!.config as Record<string, unknown>
+    expect(http).not.toHaveProperty('profileConnectionId')
+    expect(p.requires).toEqual([{ kind: 'httpProfile', nodeId: 'http-1', name: '' }])
+  })
+
+  it('never lets a local id reach the file', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+    expect(JSON.stringify(p)).not.toContain('conn-1')
+  })
+
+  it('rebinds on import when this machine has one match', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+    const here = [connection({ id: 'other-uuid', name: 'their-workspace' })]
+
+    const imported = fromPortable(p, 'novum', { name: 'N', path: '/n' }, here)
+    const trigger = imported.nodes[0].config as Record<string, unknown>
+    const action = imported.nodes.find((n) => n.id === 'act-1')!.config as Record<string, unknown>
+    expect(trigger.connectionId).toBe('other-uuid')
+    expect(action.connectionId).toBe('other-uuid')
+  })
+
+  it('prefers the connection the file named when several could match', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+    const here = [
+      connection({ id: 'a', name: 'other-team' }),
+      connection({ id: 'b', name: 'workspace-eng' })
+    ]
+    const imported = fromPortable(p, 'novum', { name: 'N', path: '/n' }, here)
+    expect((imported.nodes[0].config as Record<string, unknown>).connectionId).toBe('b')
+  })
+
+  it('leaves the step unbound rather than guessing between two accounts', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+    const here = [connection({ id: 'a', name: 'one' }), connection({ id: 'b', name: 'two' })]
+
+    const imported = fromPortable(p, 'novum', { name: 'N', path: '/n' }, here)
+    expect((imported.nodes[0].config as Record<string, unknown>).connectionId).toBe('')
+    expect(unresolvedRequirements(p, here)).toHaveLength(2)
+  })
+
+  it('leaves the step unbound when nothing here is that connector', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+    const imported = fromPortable(p, 'novum', { name: 'N', path: '/n' }, [
+      connection({ id: 'z', connectorId: 'slack' })
+    ])
+    expect((imported.nodes[0].config as Record<string, unknown>).connectionId).toBe('')
+  })
+
+  it('matches an http profile by its connector, whatever it is called', () => {
+    const requirement = { kind: 'httpProfile', nodeId: 'http-1', name: 'reporting API' } as const
+    const profiles = [connection({ id: 'p1', name: 'anything', connectorId: 'http' })]
+    expect(resolveRequirement(requirement, profiles)).toBe('p1')
+  })
+
+  it('cannot rebind a requirement the exporter could not name', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT)
+    expect((p.requires ?? [])[0]).toMatchObject({ connectorId: '', name: '' })
+    expect(resolveRequirement((p.requires ?? [])[0], [connection()])).toBeUndefined()
+  })
+
+  it('ignores a requirement for a node the file no longer carries', () => {
+    const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
+    const trimmed = { ...p, nodes: p.nodes.filter((n) => n.id !== 'act-1') }
+    expect(unresolvedRequirements(trimmed, []).map((r) => r.nodeId)).toEqual(['trigger-1'])
   })
 })
 
@@ -258,49 +366,5 @@ describe('Windows paths', () => {
     const imported = fromPortable(p, 'novum', { name: 'N', path: '/Users/other/novum/' })
     const script = imported.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
     expect(script.projectPath).toBe('/Users/other/novum')
-  })
-})
-
-describe('import refuses what export refuses', () => {
-  // Export rejects a connector-bound workflow because its connectionId is
-  // local. Without the same check on the way in, a hand-written file walks
-  // past that contract and lands a workflow that fails at run time against a
-  // connection this machine never had.
-  it('detects a connector trigger in a resolved definition', () => {
-    const portable = toPortable(workflow(), PROJECT)
-    portable.nodes[0].config = {
-      triggerType: 'connectorPoll',
-      connectionId: 'from-another-machine',
-      event: 'issue.created',
-      cron: '*/5 * * * *'
-    } as never
-    const resolved = fromPortable(portable, 'novum', { name: 'N', path: '/tmp/n' })
-    expect(portabilityBlockers(resolved)).not.toEqual([])
-  })
-
-  it('detects a connector action step in a resolved definition', () => {
-    const portable = toPortable(workflow(), PROJECT)
-    portable.nodes.push({
-      id: 'act',
-      type: 'callConnectorAction',
-      label: 'Create issue',
-      config: {
-        nodeType: 'callConnectorAction',
-        connectionId: 'x',
-        action: 'a',
-        args: {}
-      } as never,
-      position: { x: 0, y: 0 }
-    })
-    const resolved = fromPortable(portable, 'novum', { name: 'N', path: '/tmp/n' })
-    expect(portabilityBlockers(resolved).some((b) => b.includes('Create issue'))).toBe(true)
-  })
-
-  it('passes an ordinary workflow through both directions', () => {
-    const resolved = fromPortable(toPortable(workflow(), PROJECT), 'novum', {
-      name: 'N',
-      path: '/tmp/n'
-    })
-    expect(portabilityBlockers(resolved)).toEqual([])
   })
 })

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -367,4 +367,45 @@ describe('Windows paths', () => {
     const script = imported.nodes.find((n) => n.id === 'fetch-1')!.config as Record<string, unknown>
     expect(script.projectPath).toBe('/Users/other/novum')
   })
+
+  describe('a webhook hook secret', () => {
+    const hooked = () =>
+      workflow({
+        nodes: [
+          {
+            id: 'trigger-1',
+            type: 'trigger',
+            label: 'Webhook',
+            config: { triggerType: 'webhook', method: 'POST', token: 'live-secret-token' },
+            position: { x: 0, y: 0 }
+          }
+        ],
+        edges: []
+      })
+
+    it('never travels in the file', () => {
+      const p = toPortable(hooked(), PROJECT)
+      const config = p.nodes[0].config as Record<string, unknown>
+      expect(config.token).toBe('')
+      expect(JSON.stringify(p)).not.toContain('live-secret-token')
+    })
+
+    it('is minted fresh for the machine importing it', () => {
+      const p = toPortable(hooked(), PROJECT)
+      const project = { name: 'N', path: '/Users/other/novum' }
+      const first = fromPortable(p, 'novum', project, [], () => 'token-a')
+      const second = fromPortable(p, 'novum', project, [], () => 'token-b')
+
+      expect((first.nodes[0].config as Record<string, unknown>).token).toBe('token-a')
+      expect((second.nodes[0].config as Record<string, unknown>).token).toBe('token-b')
+    })
+
+    it('leaves other triggers alone', () => {
+      const imported = fromPortable(toPortable(workflow(), PROJECT), 'novum', {
+        name: 'N',
+        path: '/Users/other/novum'
+      })
+      expect((imported.nodes[0].config as Record<string, unknown>).token).toBeUndefined()
+    })
+  })
 })

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -6,6 +6,7 @@ import {
   unresolvedRequirements,
   residualAbsolutePaths,
   importedWorkflowId,
+  importedWorkflowIdFor,
   parseImportedWorkflowId,
   slugify,
   PROJECT_PATH_TOKEN,
@@ -269,6 +270,42 @@ describe('connections travel as requirements', () => {
     const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
     const trimmed = { ...p, nodes: p.nodes.filter((n) => n.id !== 'act-1') }
     expect(unresolvedRequirements(trimmed, []).map((r) => r.nodeId)).toEqual(['trigger-1'])
+  })
+})
+
+describe('an imported workflow arrives switched off', () => {
+  it('does not start running because a file said it was', () => {
+    // A dropped cron workflow that arrived enabled would fire before anyone
+    // had read it.
+    const running = workflow({ enabled: true })
+    const imported = fromPortable(toPortable(running, PROJECT), 'novum', { name: 'N', path: '/n' })
+    expect(imported.enabled).toBe(false)
+  })
+})
+
+describe('two names that slugify alike', () => {
+  const existing = [{ id: 'import:novum:deploy', name: 'Deploy!' }]
+
+  it('updates in place when the same workflow comes back', () => {
+    expect(importedWorkflowIdFor('novum', 'deploy', 'Deploy!', existing)).toBe(
+      'import:novum:deploy'
+    )
+  })
+
+  it('steps aside rather than overwriting a different workflow', () => {
+    expect(importedWorkflowIdFor('novum', 'deploy', 'Deploy?', existing)).toBe(
+      'import:novum:deploy-2'
+    )
+  })
+
+  it('keeps stepping aside for a third', () => {
+    const two = [...existing, { id: 'import:novum:deploy-2', name: 'Deploy?' }]
+    expect(importedWorkflowIdFor('novum', 'deploy', 'Deploy…', two)).toBe('import:novum:deploy-3')
+    expect(importedWorkflowIdFor('novum', 'deploy', 'Deploy?', two)).toBe('import:novum:deploy-2')
+  })
+
+  it('takes the plain id when nothing holds it', () => {
+    expect(importedWorkflowIdFor('novum', 'deploy', 'Deploy!', [])).toBe('import:novum:deploy')
   })
 })
 

--- a/tests/workflow-templates-catalog.test.ts
+++ b/tests/workflow-templates-catalog.test.ts
@@ -4,7 +4,9 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import {
   parseTemplates,
+  parseMcpServers,
   catalogTemplates,
+  catalogMcpServers,
   catalogSnapshot,
   refreshCatalog,
   resetCatalogCache
@@ -131,6 +133,38 @@ describe('the bundled seed', () => {
   })
 })
 
+describe('parseMcpServers', () => {
+  const server = { id: 'playwright', name: 'Playwright', command: 'npx', args: ['-y', 'mcp'] }
+
+  it('reads what a catalog publishes', () => {
+    expect(parseMcpServers({ mcpServers: [server] })).toEqual([
+      { id: 'playwright', name: 'Playwright', command: 'npx', args: ['-y', 'mcp'] }
+    ])
+  })
+
+  it('treats a document with no servers as having none', () => {
+    expect(parseMcpServers({ version: 1, connectors: CONNECTORS })).toEqual([])
+    expect(parseMcpServers(null)).toEqual([])
+  })
+
+  it('refuses an entry with nothing to start', () => {
+    expect(parseMcpServers({ mcpServers: [{ id: 'x', name: 'X' }] })).toEqual([])
+    expect(parseMcpServers({ mcpServers: [{ ...server, command: '' }] })).toEqual([])
+  })
+
+  it('repairs a list where a string was published instead', () => {
+    const [entry] = parseMcpServers({
+      mcpServers: [{ ...server, args: 'not a list', keywords: ['browser', 7] }]
+    })
+    expect(entry).toMatchObject({ args: [], keywords: ['browser'] })
+  })
+
+  it('has no seed, because a server nobody published is not a suggestion', () => {
+    resetCatalogCache()
+    expect(catalogMcpServers({ ...offline(), cachePath: emptyCache() })).toEqual([])
+  })
+})
+
 describe('templates ride the catalog', () => {
   it('adopts published templates and caches them beside the connectors', async () => {
     resetCatalogCache()
@@ -162,5 +196,22 @@ describe('templates ride the catalog', () => {
     const snapshot = catalogSnapshot({ ...offline(), cachePath: emptyCache() })
     expect(snapshot.templates).toEqual(TEMPLATE_SEED)
     expect(Array.isArray(snapshot.items)).toBe(true)
+    expect(snapshot.mcpServers).toEqual([])
+  })
+
+  it('carries published servers through the cache too', async () => {
+    resetCatalogCache()
+    const cachePath = emptyCache()
+    const server = { id: 'playwright', name: 'Playwright', command: 'npx', args: [] }
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ version: 1, connectors: CONNECTORS, mcpServers: [server] })
+      )) as unknown as typeof fetch
+
+    expect(await refreshCatalog({ fetchImpl, cachePath, now: 7 })).toBe(true)
+    resetCatalogCache()
+    expect(catalogMcpServers({ ...offline(), cachePath, now: 7 }).map((s) => s.id)).toEqual([
+      'playwright'
+    ])
   })
 })

--- a/tests/workflow-templates-catalog.test.ts
+++ b/tests/workflow-templates-catalog.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  parseTemplates,
+  catalogTemplates,
+  catalogSnapshot,
+  refreshCatalog,
+  resetCatalogCache
+} from '../packages/server/src/connectors/catalog'
+import { TEMPLATE_SEED } from '../packages/server/src/connectors/template-seed'
+import { PORTABLE_FORMAT_VERSION } from '../packages/shared/src/workflow-portability'
+
+/** Nothing in these tests may touch the network or this machine's real cache. */
+function emptyCache(): string {
+  return join(mkdtempSync(join(tmpdir(), 'vorn-templates-')), 'catalog.json')
+}
+
+function offline() {
+  return {
+    fetchImpl: (async () => {
+      throw new Error('offline')
+    }) as unknown as typeof fetch
+  }
+}
+
+function published(id: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    name: `Template ${id}`,
+    description: 'Does a thing',
+    steps: ['Webhook', 'Script'],
+    portable: {
+      version: PORTABLE_FORMAT_VERSION,
+      slug: id,
+      name: `Template ${id}`,
+      nodes: [{ id: 'trigger', type: 'trigger', label: 'Webhook', config: {}, position: {} }],
+      edges: []
+    },
+    ...extra
+  }
+}
+
+const CONNECTORS = [{ id: 'c', name: 'C', packageName: '@vornrun/connector-c' }]
+
+describe('parseTemplates', () => {
+  it('reads what a catalog publishes', () => {
+    const templates = parseTemplates({ version: 1, connectors: [], templates: [published('a')] })
+    expect(templates.map((t) => t.id)).toEqual(['a'])
+    expect(templates[0].steps).toEqual(['Webhook', 'Script'])
+  })
+
+  it('treats a document with no templates as having none, not as broken', () => {
+    // Every catalog published so far carries connectors only.
+    expect(parseTemplates({ version: 1, connectors: CONNECTORS })).toEqual([])
+    expect(parseTemplates(null)).toEqual([])
+    expect(parseTemplates({ version: 1, connectors: [], templates: 'soon' })).toEqual([])
+  })
+
+  it('drops one unusable template rather than the whole list', () => {
+    const templates = parseTemplates({
+      templates: [published('good'), { id: 'nameless' }, published('also-good')]
+    })
+    expect(templates.map((t) => t.id)).toEqual(['good', 'also-good'])
+  })
+
+  it('refuses a template whose workflow this build cannot read', () => {
+    const future = published('future')
+    future.portable.version = 99
+    expect(parseTemplates({ templates: [future] })).toEqual([])
+  })
+
+  it('refuses a template carrying no steps to run', () => {
+    const empty = published('empty')
+    empty.portable.nodes = []
+    expect(parseTemplates({ templates: [empty] })).toEqual([])
+  })
+
+  it('repairs a template that is merely missing its blurb', () => {
+    const bare = published('bare')
+    delete (bare as Record<string, unknown>).description
+    delete (bare as Record<string, unknown>).steps
+    const [template] = parseTemplates({ templates: [bare] })
+    expect(template).toMatchObject({ id: 'bare', description: '', steps: [] })
+  })
+})
+
+describe('the bundled seed', () => {
+  it('offers somewhere to start before anything is fetched', () => {
+    resetCatalogCache()
+    const templates = catalogTemplates({ ...offline(), cachePath: emptyCache() })
+    expect(templates).toEqual(TEMPLATE_SEED)
+    expect(templates.length).toBeGreaterThan(0)
+  })
+
+  it('stays small, because publishing is how the list grows', () => {
+    expect(TEMPLATE_SEED.length).toBeLessThanOrEqual(5)
+  })
+
+  it('needs nothing installed, so a first run can use every one of them', () => {
+    const connectorBound = TEMPLATE_SEED.flatMap((template) =>
+      template.portable.nodes.filter(
+        (node) =>
+          node.type === 'callConnectorAction' ||
+          (node.config as { triggerType?: string }).triggerType === 'connectorPoll'
+      )
+    )
+    expect(connectorBound).toEqual([])
+  })
+
+  it('publishes no webhook token, which would be the same secret everywhere', () => {
+    const tokens = TEMPLATE_SEED.flatMap((template) =>
+      template.portable.nodes
+        .map((node) => node.config as { triggerType?: string; token?: string })
+        .filter((config) => config.triggerType === 'webhook')
+        .map((config) => config.token)
+    )
+    expect(tokens.length).toBeGreaterThan(0)
+    expect(tokens.every((token) => token === '')).toBe(true)
+  })
+
+  it('names every edge endpoint it draws', () => {
+    for (const template of TEMPLATE_SEED) {
+      const ids = new Set(template.portable.nodes.map((node) => node.id))
+      for (const edge of template.portable.edges) {
+        expect(ids.has(edge.source)).toBe(true)
+        expect(ids.has(edge.target)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('templates ride the catalog', () => {
+  it('adopts published templates and caches them beside the connectors', async () => {
+    resetCatalogCache()
+    const cachePath = emptyCache()
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({ version: 1, connectors: CONNECTORS, templates: [published('remote')] })
+      )) as unknown as typeof fetch
+
+    expect(await refreshCatalog({ fetchImpl, cachePath, now: 42 })).toBe(true)
+    expect(catalogTemplates({ ...offline(), cachePath }).map((t) => t.id)).toEqual(['remote'])
+
+    resetCatalogCache()
+    expect(catalogTemplates({ ...offline(), cachePath, now: 42 }).map((t) => t.id)).toEqual([
+      'remote'
+    ])
+  })
+
+  it('falls back to the seed for a cache written before templates existed', () => {
+    resetCatalogCache()
+    const cachePath = emptyCache()
+    writeFileSync(cachePath, JSON.stringify({ fetchedAt: 5000, connectors: CONNECTORS }))
+
+    expect(catalogTemplates({ ...offline(), now: 5000, cachePath })).toEqual(TEMPLATE_SEED)
+  })
+
+  it('hands the UI templates in the same answer as the connectors', () => {
+    resetCatalogCache()
+    const snapshot = catalogSnapshot({ ...offline(), cachePath: emptyCache() })
+    expect(snapshot.templates).toEqual(TEMPLATE_SEED)
+    expect(Array.isArray(snapshot.items)).toBe(true)
+  })
+})

--- a/tests/workflow-templates-catalog.test.ts
+++ b/tests/workflow-templates-catalog.test.ts
@@ -79,6 +79,38 @@ describe('parseTemplates', () => {
     expect(parseTemplates({ templates: [empty] })).toEqual([])
   })
 
+  it('refuses to carry requirements that are not a list', () => {
+    // Everything downstream walks this; a string here took the editor down.
+    const hostile = published('hostile')
+    ;(hostile.portable as Record<string, unknown>).requires = 'soon'
+    const [template] = parseTemplates({ templates: [hostile] })
+    expect(template.portable.requires).toEqual([])
+  })
+
+  it('drops requirement entries nothing could act on', () => {
+    const hostile = published('hostile')
+    ;(hostile.portable as Record<string, unknown>).requires = [
+      'not an object',
+      null,
+      { kind: 'connection', nodeId: 'ok', connectorId: 'github', name: 'eng' },
+      { kind: 'connection', nodeId: 42, connectorId: 'github', name: 'eng' },
+      { kind: 'connection', nodeId: 'no-connector', name: 'eng' },
+      { kind: 'httpProfile', nodeId: 'profile', name: 'reporting' },
+      { kind: 'httpProfile', nodeId: 'nameless' },
+      { kind: 'invented', nodeId: 'x', connectorId: 'y', name: 'z' }
+    ]
+    const [template] = parseTemplates({ templates: [hostile] })
+    expect(template.portable.requires).toEqual([
+      { kind: 'connection', nodeId: 'ok', connectorId: 'github', name: 'eng' },
+      { kind: 'httpProfile', nodeId: 'profile', name: 'reporting' }
+    ])
+  })
+
+  it('leaves a template that names no requirements alone', () => {
+    const [template] = parseTemplates({ templates: [published('plain')] })
+    expect(template.portable.requires).toBeUndefined()
+  })
+
   it('repairs a template that is merely missing its blurb', () => {
     const bare = published('bare')
     delete (bare as Record<string, unknown>).description


### PR DESCRIPTION
## What this adds

**A new workflow starts from a working example.** An empty canvas offers a Start-from panel: blank first, then published templates (name, step chain, and what each still needs), plus the workflows a connection already knows how to seed. Picking lands a wired, arranged, named canvas; anything unresolvable — a missing connection, an absent HTTP profile — lands as an unconfigured step carrying the app's existing "wants you" treatment, with a warning that names it.

**Any workflow travels as a file.** Export from a row's context menu or the editor's overflow menu; import by drop or picker. The file is the same portable bundle the MCP tools speak — machine paths become project tokens, connections and profiles travel as requirements re-resolved on arrival, webhook tokens are blanked on the way out and minted fresh on the way in, and nothing secret ever serializes. Re-importing a file updates the same workflow instead of duplicating it; a *different* workflow that merely shares a name gets its own id. Imported workflows land disabled — a dropped file never starts running by itself.

**Templates ship through the catalog.** The published connector document gains optional `templates` and `mcpServers` keys — same fetch, same cache, same repair-don't-reject parsing (a malformed published entry degrades instead of taking the editor down), with a three-template offline seed. MCP servers become directory rows whose "Add server" lands in the manual connection form pre-filled.

**Portability moved to shared.** The bundle logic left the MCP package for `packages/shared`, so the UI and the tools share one format; the connector-bound-step export refusal is gone, replaced by the requirements block.

## Review

Two independent passes before this PR; all thirteen confirmed findings are fixed with pinning tests — among them the hostile-`requires` crash, auto-enabled imports, unconditional token minting, import size caps and element validation, and slug-collision overwrites.

## Tests

Typecheck clean; full vitest 5243/5245 (the two known ambient-environment cases). Patch coverage 95% against the 80% gate; format check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)