### PR TITLE
Give keys a page of their own, and a script step a way to borrow one

### DIFF
--- a/packages/server/src/connectors/keys.ts
+++ b/packages/server/src/connectors/keys.ts
@@ -1,0 +1,121 @@
+/**
+ * The secrets this machine holds, read as one list.
+ *
+ * A key is not a record of its own: it is a password-typed field on some
+ * connection, and one value often serves several workflows. Reading them all
+ * through the same rule — the connector's own manifest says which of its
+ * fields are secret — means an HTTP profile's token, a packaged connector's
+ * env blob and a built-in's API key are the same kind of thing here, and
+ * rotating any of them takes one path instead of three.
+ */
+import type {
+  ConnectorConfigField,
+  ConnectorKey,
+  ConnectorKeyField,
+  SourceConnection,
+  WorkflowDefinition
+} from '@vornrun/shared/types'
+import { connectionConnectorId } from '@vornrun/shared/types'
+import { boundConnectionKey } from '@vornrun/shared/workflow-portability'
+
+/** The one field that carries a set of env vars rather than a single value. */
+export const SECRET_ENV_FIELD = 'secretEnv'
+
+/** Which of a connector's fields hold secrets, as the connector itself says. */
+export function passwordFields(auth: ConnectorConfigField[] | undefined): ConnectorConfigField[] {
+  return (auth ?? []).filter((field) => field.type === 'password')
+}
+
+/**
+ * Enough of a value to recognize it by, never enough to use it.
+ *
+ * The opening is how a person tells a live key from a test one; the tail is
+ * the part that would let someone reconstruct it, so only the head travels.
+ */
+export function maskSecret(value: string | undefined): string {
+  if (!value) return ''
+  if (value.length < 12) return '••••'
+  return `${value.slice(0, 7)}…`
+}
+
+/** The env names a packaged connector's blob carries, when it can be read. */
+export function envNamesOf(blob: string | undefined): string[] {
+  if (!blob) return []
+  try {
+    const parsed: unknown = JSON.parse(blob)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return []
+    return Object.keys(parsed as Record<string, unknown>).filter((name) => name !== '')
+  } catch {
+    return []
+  }
+}
+
+/**
+ * How many workflow steps run against a connection.
+ *
+ * Counted per step rather than per workflow: "used by 3 steps" is what tells
+ * someone what rotating this key is about to touch.
+ */
+export function usageCounts(workflows: WorkflowDefinition[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const workflow of workflows) {
+    for (const node of workflow.nodes) {
+      const config = (node.config ?? {}) as Record<string, unknown>
+      const key = boundConnectionKey(node, config)
+      if (key === null) continue
+      const bound = config[key]
+      if (typeof bound !== 'string' || bound === '') continue
+      counts.set(bound, (counts.get(bound) ?? 0) + 1)
+    }
+  }
+  return counts
+}
+
+/** What a stored field can say about itself, given what this build can read. */
+function describeField(
+  field: ConnectorConfigField,
+  stored: unknown,
+  decrypted: string | undefined
+): ConnectorKeyField | undefined {
+  // Nothing stored is not a key: an optional password nobody filled in has
+  // nothing to test and nothing to rotate.
+  if (typeof stored !== 'string' || stored === '') return undefined
+  const readable = decrypted !== undefined
+  if (field.key === SECRET_ENV_FIELD) {
+    const names = envNamesOf(decrypted)
+    return { key: field.key, label: field.label, readable, envNames: names }
+  }
+  return { key: field.key, label: field.label, readable, hint: maskSecret(decrypted) }
+}
+
+/**
+ * Every connection that holds a secret, with what it is worth to rotate.
+ *
+ * Connections with no stored secret are left out entirely rather than listed
+ * empty — this page answers "what am I holding", and a connector that needs
+ * no key is not an answer to it.
+ */
+export function listKeys(
+  connections: SourceConnection[],
+  authByConnector: Map<string, ConnectorConfigField[] | undefined>,
+  workflows: WorkflowDefinition[],
+  decryptedFor: (connectionId: string) => Record<string, string> | undefined
+): ConnectorKey[] {
+  const counts = usageCounts(workflows)
+  const keys: ConnectorKey[] = []
+  for (const connection of connections) {
+    const decrypted = decryptedFor(connection.id) ?? {}
+    const fields = passwordFields(authByConnector.get(connection.connectorId))
+      .map((field) => describeField(field, connection.filters[field.key], decrypted[field.key]))
+      .filter((field): field is ConnectorKeyField => field !== undefined)
+    if (fields.length === 0) continue
+    keys.push({
+      connectionId: connection.id,
+      name: connection.name,
+      connectorId: connectionConnectorId(connection),
+      fields,
+      usageCount: counts.get(connection.id) ?? 0
+    })
+  }
+  return keys.sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/packages/server/src/connectors/keys.ts
+++ b/packages/server/src/connectors/keys.ts
@@ -27,14 +27,7 @@ export function passwordFields(auth: ConnectorConfigField[] | undefined): Connec
   return (auth ?? []).filter((field) => field.type === 'password')
 }
 
-/**
- * The markers a key announces itself with.
- *
- * Published, documented openings rather than key material — showing one says
- * which service and which mode a value belongs to, which is the question this
- * page is asked. Anything not on this list is treated as key material and
- * hidden, because a fixed slice of an unknown token is a slice of the secret.
- */
+// Published key prefixes: naming one says which service a value belongs to without giving up the secret.
 const VENDOR_MARKERS = [
   'sk_live_',
   'sk_test_',
@@ -59,14 +52,7 @@ const VENDOR_MARKERS = [
   'ASIA'
 ]
 
-/**
- * Enough of a value to recognize it by, never enough to use it.
- *
- * The last four digits are how a person tells one key from another, the way a
- * card is quoted; the middle is never shown at any length. A known vendor
- * marker rides in front because it says which service and which mode the key
- * is for without giving up a character of the secret itself.
- */
+// A known marker plus the last four characters, the way a card is quoted; the middle is never shown.
 export function maskSecret(value: string | undefined): string {
   if (!value) return ''
   // Too short for a tail to be a hint rather than most of the value.

--- a/packages/server/src/connectors/keys.ts
+++ b/packages/server/src/connectors/keys.ts
@@ -28,15 +28,51 @@ export function passwordFields(auth: ConnectorConfigField[] | undefined): Connec
 }
 
 /**
+ * The markers a key announces itself with.
+ *
+ * Published, documented openings rather than key material — showing one says
+ * which service and which mode a value belongs to, which is the question this
+ * page is asked. Anything not on this list is treated as key material and
+ * hidden, because a fixed slice of an unknown token is a slice of the secret.
+ */
+const VENDOR_MARKERS = [
+  'sk_live_',
+  'sk_test_',
+  'pk_live_',
+  'pk_test_',
+  'rk_live_',
+  'whsec_',
+  'github_pat_',
+  'ghp_',
+  'gho_',
+  'ghs_',
+  'ghu_',
+  'glpat-',
+  'xoxb-',
+  'xoxp-',
+  'xoxa-',
+  'xapp-',
+  'shpat_',
+  'npm_',
+  'dop_v1_',
+  'AKIA',
+  'ASIA'
+]
+
+/**
  * Enough of a value to recognize it by, never enough to use it.
  *
- * The opening is how a person tells a live key from a test one; the tail is
- * the part that would let someone reconstruct it, so only the head travels.
+ * The last four digits are how a person tells one key from another, the way a
+ * card is quoted; the middle is never shown at any length. A known vendor
+ * marker rides in front because it says which service and which mode the key
+ * is for without giving up a character of the secret itself.
  */
 export function maskSecret(value: string | undefined): string {
   if (!value) return ''
+  // Too short for a tail to be a hint rather than most of the value.
   if (value.length < 12) return '••••'
-  return `${value.slice(0, 7)}…`
+  const marker = VENDOR_MARKERS.find((m) => value.startsWith(m)) ?? ''
+  return `${marker}••••${value.slice(-4)}`
 }
 
 /** The env names a packaged connector's blob carries, when it can be read. */

--- a/packages/server/src/connectors/keys.ts
+++ b/packages/server/src/connectors/keys.ts
@@ -61,13 +61,20 @@ export function maskSecret(value: string | undefined): string {
   return `${marker}••••${value.slice(-4)}`
 }
 
+const RESERVED_NAMES = new Set(['__proto__', 'constructor', 'prototype'])
+
+// A name a shell accepts and the prototype cannot be reached through.
+export function isEnvName(name: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) && !RESERVED_NAMES.has(name)
+}
+
 /** The env names a packaged connector's blob carries, when it can be read. */
 export function envNamesOf(blob: string | undefined): string[] {
   if (!blob) return []
   try {
     const parsed: unknown = JSON.parse(blob)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return []
-    return Object.keys(parsed as Record<string, unknown>).filter((name) => name !== '')
+    return Object.keys(parsed as Record<string, unknown>).filter(isEnvName)
   } catch {
     return []
   }

--- a/packages/server/src/connectors/keys.ts
+++ b/packages/server/src/connectors/keys.ts
@@ -13,7 +13,8 @@ import type {
   ConnectorKey,
   ConnectorKeyField,
   SourceConnection,
-  WorkflowDefinition
+  WorkflowDefinition,
+  WorkflowNode
 } from '@vornrun/shared/types'
 import { connectionConnectorId } from '@vornrun/shared/types'
 import { boundConnectionKey } from '@vornrun/shared/workflow-portability'
@@ -51,6 +52,23 @@ export function envNamesOf(blob: string | undefined): string[] {
 }
 
 /**
+ * Every connection a step names, whether it runs against it or borrows from it.
+ *
+ * `boundConnectionKey` answers a narrower question — which connection a step
+ * cannot run without — and a script's `secretsFrom` is deliberately not that:
+ * it is optional, so a script missing one is not an unmet requirement. It is
+ * still a real use of the key, and this page is asked what rotating one would
+ * touch, so it is counted here rather than widened there.
+ */
+function boundConnectionIds(node: WorkflowNode, config: Record<string, unknown>): string[] {
+  const ids: string[] = []
+  const required = boundConnectionKey(node, config)
+  if (required !== null) ids.push(String(config[required] ?? ''))
+  if (node.type === 'script') ids.push(String(config.secretsFrom ?? ''))
+  return ids.filter((id) => id !== '')
+}
+
+/**
  * How many workflow steps run against a connection.
  *
  * Counted per step rather than per workflow: "used by 3 steps" is what tells
@@ -61,11 +79,9 @@ export function usageCounts(workflows: WorkflowDefinition[]): Map<string, number
   for (const workflow of workflows) {
     for (const node of workflow.nodes) {
       const config = (node.config ?? {}) as Record<string, unknown>
-      const key = boundConnectionKey(node, config)
-      if (key === null) continue
-      const bound = config[key]
-      if (typeof bound !== 'string' || bound === '') continue
-      counts.set(bound, (counts.get(bound) ?? 0) + 1)
+      for (const id of boundConnectionIds(node, config)) {
+        counts.set(id, (counts.get(id) ?? 0) + 1)
+      }
     }
   }
   return counts

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1498,8 +1498,8 @@ export function registerAllMethods(): void {
   })
 
   registerMethod('connection:listKeys', () => {
-    const auth = new Map(
-      connectorRegistry.list().map((c) => [c.id, c.describe().auth as ConnectorConfigField[]])
+    const auth = new Map<string, ConnectorConfigField[] | undefined>(
+      connectorRegistry.list().map((c) => [c.id, c.describe().auth])
     )
     return listKeys(
       dbListSourceConnections().filter((c) => c.connectorId !== 'webhook'),

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -57,6 +57,7 @@ import type {
   SourceConnection,
   TaskConfig,
   TaskStatus,
+  ConnectorConfigField,
   ConnectorManifest,
   ExternalItem,
   ProjectConfig,
@@ -154,6 +155,7 @@ import {
   performHttpRequest
 } from './connectors/http'
 import { getDecryptedCreds } from './connectors/decrypted-creds'
+import { listKeys, passwordFields } from './connectors/keys'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import type { ConnectorPackSource } from '@vornrun/shared/types'
 import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
@@ -1493,6 +1495,44 @@ export function registerAllMethods(): void {
       profile = applyDecryptedCreds(conn)
     }
     return performHttpRequest(profile, { method, url, headers, body })
+  })
+
+  registerMethod('connection:listKeys', () => {
+    const auth = new Map(
+      connectorRegistry.list().map((c) => [c.id, c.describe().auth as ConnectorConfigField[]])
+    )
+    return listKeys(
+      dbListSourceConnections().filter((c) => c.connectorId !== 'webhook'),
+      auth,
+      dbListWorkflows(),
+      getDecryptedCreds
+    )
+  })
+
+  /**
+   * Replace one stored secret.
+   *
+   * The plaintext never reaches here: the desktop process encrypts with the
+   * keychain and hands over ciphertext. Forgetting the old plaintext and
+   * ending the child are both part of the write — a connector left running
+   * would keep serving the key that was just rotated away.
+   */
+  registerMethod('connection:rotateSecret', async ({ connectionId, field, value }) => {
+    const conn = dbGetSourceConnection(connectionId)
+    if (!conn) return { ok: false, error: `connection ${connectionId} not found` }
+    const connector = connectorRegistry.get(conn.connectorId)
+    const secret = passwordFields(connector?.describe().auth).some((f) => f.key === field)
+    if (!secret) return { ok: false, error: `${field} is not a secret on this connection` }
+
+    dbUpdateSourceConnection(connectionId, { filters: { ...conn.filters, [field]: value } })
+    clearDecryptedCreds(connectionId)
+    await stopMcpClient(connectionId).catch((err) => log.warn(`[mcp] stopClient failed: ${err}`))
+    dbSignalChange()
+    // Notified, not just signalled: the decrypted store is repopulated by the
+    // desktop process on this broadcast, and until it lands the new secret
+    // exists only as ciphertext nothing can read.
+    configManager.notifyChanged()
+    return { ok: true }
   })
 
   registerMethod('connection:executeAction', async ({ connectionId, action, args }) => {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1512,25 +1512,33 @@ export function registerAllMethods(): void {
   /**
    * Replace one stored secret.
    *
-   * The plaintext never reaches here: the desktop process encrypts with the
-   * keychain and hands over ciphertext. Forgetting the old plaintext and
-   * ending the child are both part of the write — a connector left running
-   * would keep serving the key that was just rotated away.
+   * The ciphertext is what persists; the plaintext is adopted in the same call
+   * rather than waited for. Clearing and letting the desktop process push the
+   * new value back left a window — brief, but long enough for a poll or an
+   * action to run against a connection whose key had become unreadable.
+   * Ending the child is part of the write too: one left running would keep
+   * serving the key that was just rotated away.
    */
-  registerMethod('connection:rotateSecret', async ({ connectionId, field, value }) => {
+  registerMethod('connection:rotateSecret', async ({ connectionId, field, value, plaintext }) => {
     const conn = dbGetSourceConnection(connectionId)
     if (!conn) return { ok: false, error: `connection ${connectionId} not found` }
     const connector = connectorRegistry.get(conn.connectorId)
     const secret = passwordFields(connector?.describe().auth).some((f) => f.key === field)
     if (!secret) return { ok: false, error: `${field} is not a secret on this connection` }
+    // A blank replacement is a mistake rather than an intent to unset: it would
+    // leave every workflow bound to this key failing with nothing said.
+    if (value === '' || plaintext.trim() === '') {
+      return { ok: false, error: 'A replacement value is required' }
+    }
 
     dbUpdateSourceConnection(connectionId, { filters: { ...conn.filters, [field]: value } })
-    clearDecryptedCreds(connectionId)
+    // Merged, not replaced: a connection can hold more than one secret, and the
+    // others are still live.
+    setDecryptedCreds(connectionId, { ...getDecryptedCreds(connectionId), [field]: plaintext })
     await stopMcpClient(connectionId).catch((err) => log.warn(`[mcp] stopClient failed: ${err}`))
     dbSignalChange()
-    // Notified, not just signalled: the decrypted store is repopulated by the
-    // desktop process on this broadcast, and until it lands the new secret
-    // exists only as ciphertext nothing can read.
+    // The desktop process re-derives the same value from the keychain on this
+    // broadcast, which is a confirmation rather than the thing being waited on.
     configManager.notifyChanged()
     return { ok: true }
   })

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -2,7 +2,48 @@ import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { ScriptConfig, IPC } from '@vornrun/shared/types'
 import { getLaunchEnv } from './process-utils'
+import { getDecryptedCreds } from './connectors/decrypted-creds'
+import { SECRET_ENV_FIELD } from './connectors/keys'
 import log from './logger'
+
+/** `apiKey` names the variable `API_KEY`, the way a connector's own env does. */
+function envNameFor(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase()
+}
+
+/**
+ * The environment a step's named connection contributes.
+ *
+ * A connector's env blob already speaks in variable names, so it is spread as
+ * written; a single-value field is named after itself. Nothing is read unless
+ * a step asked for it by connection id.
+ */
+export function secretEnvFor(
+  connectionId: string | undefined,
+  lookup: (id: string) => Record<string, string> | undefined = getDecryptedCreds
+): Record<string, string> {
+  if (!connectionId) return {}
+  const decrypted = lookup(connectionId)
+  if (!decrypted) return {}
+  const env: Record<string, string> = {}
+  for (const [key, value] of Object.entries(decrypted)) {
+    if (key !== SECRET_ENV_FIELD) {
+      env[envNameFor(key)] = value
+      continue
+    }
+    try {
+      const parsed: unknown = JSON.parse(value)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
+      for (const [name, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'string') env[name] = v
+      }
+    } catch {
+      // A blob this build cannot read contributes nothing, and the step runs
+      // without it rather than failing on a value nobody can see.
+    }
+  }
+  return env
+}
 
 export interface ScriptExecutionResult {
   success: boolean
@@ -60,7 +101,9 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
     const child = spawn(command, args, {
       cwd,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: getLaunchEnv(),
+      // Only this child sees them: the secrets are read here rather than held
+      // anywhere the definition, a run record or an export could reach.
+      env: { ...getLaunchEnv(), ...secretEnvFor(config.secretsFrom) },
       windowsHide: true
     })
 

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -18,6 +18,9 @@ function envNameFor(key: string): string {
  * written; a single-value field is named after itself. Nothing is read unless
  * a step asked for it by connection id.
  */
+// Only a name a shell would accept becomes a variable; anything else in a blob is dropped.
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
+
 export function secretEnvFor(
   connectionId: string | undefined,
   lookup: (id: string) => Record<string, string> | undefined = getDecryptedCreds
@@ -25,7 +28,7 @@ export function secretEnvFor(
   if (!connectionId) return {}
   const decrypted = lookup(connectionId)
   if (!decrypted) return {}
-  const env: Record<string, string> = {}
+  const env: Record<string, string> = Object.create(null)
   for (const [key, value] of Object.entries(decrypted)) {
     if (key !== SECRET_ENV_FIELD) {
       env[envNameFor(key)] = value
@@ -35,14 +38,14 @@ export function secretEnvFor(
       const parsed: unknown = JSON.parse(value)
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
       for (const [name, v] of Object.entries(parsed as Record<string, unknown>)) {
-        if (typeof v === 'string') env[name] = v
+        if (typeof v === 'string' && ENV_NAME.test(name)) env[name] = v
       }
     } catch {
       // A blob this build cannot read contributes nothing, and the step runs
       // without it rather than failing on a value nobody can see.
     }
   }
-  return env
+  return { ...env }
 }
 
 export interface ScriptExecutionResult {

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 import { ScriptConfig, IPC } from '@vornrun/shared/types'
 import { getLaunchEnv } from './process-utils'
 import { getDecryptedCreds } from './connectors/decrypted-creds'
-import { SECRET_ENV_FIELD } from './connectors/keys'
+import { SECRET_ENV_FIELD, isEnvName } from './connectors/keys'
 import log from './logger'
 
 /** `apiKey` names the variable `API_KEY`, the way a connector's own env does. */
@@ -18,9 +18,6 @@ function envNameFor(key: string): string {
  * written; a single-value field is named after itself. Nothing is read unless
  * a step asked for it by connection id.
  */
-// Only a name a shell would accept becomes a variable; anything else in a blob is dropped.
-const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/
-
 export function secretEnvFor(
   connectionId: string | undefined,
   lookup: (id: string) => Record<string, string> | undefined = getDecryptedCreds
@@ -38,7 +35,7 @@ export function secretEnvFor(
       const parsed: unknown = JSON.parse(value)
       if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
       for (const [name, v] of Object.entries(parsed as Record<string, unknown>)) {
-        if (typeof v === 'string' && ENV_NAME.test(name)) env[name] = v
+        if (typeof v === 'string' && isEnvName(name)) env[name] = v
       }
     } catch {
       // A blob this build cannot read contributes nothing, and the step runs

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -22,6 +22,7 @@ import type {
   SessionEventType,
   SourceConnection,
   TaskSourceLink,
+  ConnectorKey,
   ConnectorManifest,
   ConnectorItemContext,
   TaskConfig,
@@ -806,6 +807,17 @@ export interface RequestMethods {
   'connection:preflight': {
     params: string
     result: { ok: boolean | null; message?: string }
+  }
+  /** Every connection holding a secret, described without disclosing one. */
+  'connection:listKeys': {
+    params: void
+    result: ConnectorKey[]
+  }
+  /** Replace one stored secret. `value` arrives already encrypted, because
+   *  only the desktop process holds the keychain that can encrypt it. */
+  'connection:rotateSecret': {
+    params: { connectionId: string; field: string; value: string }
+    result: { ok: boolean; error?: string }
   }
   /** Main→server push of decrypted credential fields. Called after main
    *  decrypts values (via Electron safeStorage) on boot and on config

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -813,10 +813,13 @@ export interface RequestMethods {
     params: void
     result: ConnectorKey[]
   }
-  /** Replace one stored secret. `value` arrives already encrypted, because
-   *  only the desktop process holds the keychain that can encrypt it. */
+  /** Replace one stored secret. `value` is the ciphertext to persist, sealed
+   *  by the desktop process because only it holds the keychain. `plaintext` is
+   *  the same secret in the clear, handed over so the running server can serve
+   *  it immediately rather than leaving a window in which the key is stored
+   *  but unusable — the same trust boundary `credentials:setDecrypted` uses. */
   'connection:rotateSecret': {
-    params: { connectionId: string; field: string; value: string }
+    params: { connectionId: string; field: string; value: string; plaintext: string }
     result: { ok: boolean; error?: string }
   }
   /** Main→server push of decrypted credential fields. Called after main

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -476,6 +476,29 @@ export interface SourceConnection {
   createdAt: string
 }
 
+/** One stored secret on a connection, described without being disclosed. */
+export interface ConnectorKeyField {
+  key: string
+  label: string
+  /** False when the ciphertext is there but this machine cannot read it. */
+  readable: boolean
+  /** Enough of the value to recognize it by, for a single-value field. */
+  hint?: string
+  /** The env names carried, for a field that holds a set of them. */
+  envNames?: string[]
+}
+
+/** A connection seen as what it holds, rather than as what it connects to. */
+export interface ConnectorKey {
+  connectionId: string
+  name: string
+  /** The real connector id, unwrapped from the `mcp` a package is stored as. */
+  connectorId: string
+  fields: ConnectorKeyField[]
+  /** Workflow steps that run against this connection. */
+  usageCount: number
+}
+
 /**
  * Where a packaged connector records itself on the connection that runs it.
  *
@@ -1671,6 +1694,8 @@ export const IPC = {
   WEBHOOK_INFO: 'webhook:info',
   HTTP_REQUEST: 'http:request',
   CONNECTION_PREFLIGHT: 'connection:preflight',
+  CONNECTION_LIST_KEYS: 'connection:listKeys',
+  CONNECTION_ROTATE_SECRET: 'connection:rotateSecret',
   CONNECTION_LIST_MCP_TOOLS: 'connection:listMcpTools',
   CONNECTION_REFRESH_MCP_TOOLS: 'connection:refreshMcpTools',
   CONNECTOR_PROBE_SDK: 'connector:probeSdk',

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -782,6 +782,15 @@ export interface ScriptConfig {
    *  When set, the runner emits SCRIPT_DATA/SCRIPT_EXIT with this id so the
    *  renderer can show output live in Run History. */
   runId?: string
+  /**
+   * A connection whose secrets this step runs with, named rather than carried.
+   *
+   * The id is all the definition holds; the values are read from the server's
+   * decrypted store at spawn time and reach this one child's environment only.
+   * A workflow that needs a key to talk to a service therefore stays a file
+   * anyone can read.
+   */
+  secretsFrom?: string
 }
 
 export type ConditionOperator =

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -126,7 +126,10 @@ function connectorOf(connection: PortableConnection): string {
 }
 
 /** Whether this node runs against a connector connection. */
-function boundConnectionKey(node: WorkflowNode, config: Record<string, unknown>): string | null {
+export function boundConnectionKey(
+  node: WorkflowNode,
+  config: Record<string, unknown>
+): string | null {
   if (node.type === 'trigger' && config.triggerType === 'connectorPoll') return 'connectionId'
   if (node.type === 'callConnectorAction') return 'connectionId'
   if (node.type === 'httpRequest') return 'profileConnectionId'

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -286,6 +286,12 @@ export function fromPortable(
   const nodes = portable.nodes.map((node) => {
     const config = { ...(node.config as Record<string, unknown>) }
 
+    // Export strips this, so a file carrying one was hand-written or came from
+    // a build that did not. Either way the id names a row in the writer's
+    // table, and honouring it here would hand a step whichever key happens to
+    // hold that id on this machine.
+    delete config.secretsFrom
+
     for (const [key, value] of Object.entries(config)) {
       if (typeof value !== 'string') continue
       config[key] = value

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -190,6 +190,10 @@ export function toPortable(
       // id means nothing elsewhere, so the import runs locally rather than
       // against a host the importer never configured.
       delete config.remoteHostId
+      // Names a connection in this install's own table. Elsewhere it would
+      // bind a step to whatever happened to take that id, so the import asks
+      // for a key rather than inheriting one.
+      delete config.secretsFrom
     }
 
     const key = boundConnectionKey(node, config)

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -731,6 +731,9 @@ export function createApiShim(wsUrl: string) {
       body?: string
     }) => rpc.invoke('http:request', params),
     preflightConnection: (connectionId: string) => rpc.invoke('connection:preflight', connectionId),
+    listConnectorKeys: () => rpc.invoke('connection:listKeys', undefined),
+    rotateConnectionSecret: (params: { connectionId: string; field: string; value: string }) =>
+      rpc.invoke('connection:rotateSecret', params),
     executeConnectorAction: (params: {
       connectionId: string
       action: string

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -732,8 +732,12 @@ export function createApiShim(wsUrl: string) {
     }) => rpc.invoke('http:request', params),
     preflightConnection: (connectionId: string) => rpc.invoke('connection:preflight', connectionId),
     listConnectorKeys: () => rpc.invoke('connection:listKeys', undefined),
-    rotateConnectionSecret: (params: { connectionId: string; field: string; value: string }) =>
-      rpc.invoke('connection:rotateSecret', params),
+    rotateConnectionSecret: (params: {
+      connectionId: string
+      field: string
+      value: string
+      plaintext: string
+    }) => rpc.invoke('connection:rotateSecret', params),
     executeConnectorAction: (params: {
       connectionId: string
       action: string

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -351,6 +351,12 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.CONNECTION_PREFLIGHT, (_e, connectionId) =>
     requireBridge().request(IPC.CONNECTION_PREFLIGHT, connectionId)
   )
+  safeHandle(IPC.CONNECTION_LIST_KEYS, () =>
+    requireBridge().request(IPC.CONNECTION_LIST_KEYS, undefined)
+  )
+  safeHandle(IPC.CONNECTION_ROTATE_SECRET, (_e, params) =>
+    requireBridge().request(IPC.CONNECTION_ROTATE_SECRET, params)
+  )
   safeHandle(IPC.CONNECTION_LIST_ACTIONS, (_, connectionId) =>
     requireBridge().request(IPC.CONNECTION_LIST_ACTIONS, connectionId)
   )

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,7 @@ import {
   FileEntry,
   SourceConnection,
   TaskSourceLink,
+  ConnectorKey,
   ConnectorManifest,
   ConnectorActionDef,
   InstalledShell,
@@ -866,6 +867,13 @@ const api = {
     ipcRenderer.invoke(IPC.HTTP_REQUEST, params),
   preflightConnection: (connectionId: string): Promise<{ ok: boolean | null; message?: string }> =>
     ipcRenderer.invoke(IPC.CONNECTION_PREFLIGHT, connectionId),
+  listConnectorKeys: (): Promise<ConnectorKey[]> => ipcRenderer.invoke(IPC.CONNECTION_LIST_KEYS),
+  rotateConnectionSecret: (params: {
+    connectionId: string
+    field: string
+    value: string
+  }): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke(IPC.CONNECTION_ROTATE_SECRET, params),
 
   listMcpTools: (
     connectionId: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -872,6 +872,7 @@ const api = {
     connectionId: string
     field: string
     value: string
+    plaintext: string
   }): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke(IPC.CONNECTION_ROTATE_SECRET, params),
 

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { AgentSettings } from './settings/AgentSettings'
 import { SSHSettings } from './settings/SSHSettings'
 import { McpSettings } from './settings/McpSettings'
 import { ConnectorSettings } from './settings/ConnectorSettings'
+import { KeysSettings } from './settings/KeysSettings'
 import { NetworkSettings } from './settings/NetworkSettings'
 import { AboutSettings } from './settings/AboutSettings'
 
@@ -189,6 +190,24 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
         )
       },
       {
+        key: 'keys',
+        label: 'Keys',
+        icon: (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <circle cx="8" cy="12" r="4" />
+            <line x1="12" y1="12" x2="21" y2="12" />
+            <line x1="18" y1="12" x2="18" y2="16" />
+          </svg>
+        )
+      },
+      {
         key: 'network',
         label: 'Remote Access',
         icon: (
@@ -325,6 +344,7 @@ export function SettingsPage() {
           {settingsCategory === 'ssh' && <SSHSettings />}
           {settingsCategory === 'mcp' && <McpSettings />}
           {settingsCategory === 'connectors' && <ConnectorSettings />}
+          {settingsCategory === 'keys' && <KeysSettings />}
           {settingsCategory === 'network' && <NetworkSettings />}
           {settingsCategory === 'about' && <AboutSettings />}
         </div>

--- a/src/renderer/components/settings/KeysSettings.tsx
+++ b/src/renderer/components/settings/KeysSettings.tsx
@@ -200,7 +200,7 @@ export function KeysSettings() {
     let cancelled = false
     window.api
       .isSafeStorageAvailable?.()
-      .then((available) => {
+      ?.then((available) => {
         if (!cancelled) setSafeStorageAvailable(available)
       })
       .catch(() => {})

--- a/src/renderer/components/settings/KeysSettings.tsx
+++ b/src/renderer/components/settings/KeysSettings.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { KeyRound, RefreshCw } from 'lucide-react'
 import type { ConnectorKey, ConnectorKeyField } from '../../../shared/types'
 import { ConnectorIcon } from '../ConnectorIcon'
+import { useConnectorLook } from '../../lib/use-connections'
 
 /** What a key's stored value can be said to be, without saying what it is. */
 function describeField(field: ConnectorKeyField): string {
@@ -18,7 +19,22 @@ function describeUsage(count: number): string {
   return count === 1 ? 'used by 1 step' : `used by ${count} steps`
 }
 
-function KeyRow({ entry, onRotated }: { entry: ConnectorKey; onRotated: () => void }) {
+function KeyRow({
+  entry,
+  canSeal,
+  onRotated
+}: {
+  entry: ConnectorKey
+  /** The keychain can seal a replacement, so rotating is worth offering. */
+  canSeal: boolean
+  onRotated: () => void
+}) {
+  // The same resolution the run surfaces use, so a packaged connector shows
+  // its own mark here rather than the generic one.
+  const look = useConnectorLook(entry.connectionId)
+  // Only an HTTP profile answers a preflight today; Lane B adds the SDK branch
+  // that lets a packaged connection answer one too.
+  const canTest = entry.connectorId === 'http'
   const [testing, setTesting] = useState(false)
   const [result, setResult] = useState<{ ok: boolean | null; message?: string } | null>(null)
   const [rotating, setRotating] = useState<string | null>(null)
@@ -71,7 +87,13 @@ function KeyRow({ entry, onRotated }: { entry: ConnectorKey; onRotated: () => vo
   return (
     <div className="px-4 py-2.5 bg-white/[0.03] border border-white/[0.06] rounded-sm">
       <div className="flex items-center gap-3">
-        <ConnectorIcon connectorId={entry.connectorId} size={14} className="text-gray-400" />
+        <ConnectorIcon
+          connectorId={look?.connectorId ?? entry.connectorId}
+          {...(look?.icon && { icon: look.icon })}
+          packaged={look?.packaged ?? false}
+          size={14}
+          className="text-gray-400"
+        />
         <div className="min-w-0 flex-1">
           <div className="text-[13px] text-gray-200 truncate">{entry.name}</div>
           <div className="text-[11px] text-gray-500 truncate">
@@ -86,18 +108,22 @@ function KeyRow({ entry, onRotated }: { entry: ConnectorKey; onRotated: () => vo
             }`}
           />
         )}
-        <button
-          onClick={runTest}
-          disabled={testing}
-          className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm disabled:opacity-50"
-        >
-          {testing ? 'Testing…' : 'Test'}
-        </button>
+        {canTest && (
+          <button
+            onClick={runTest}
+            disabled={testing}
+            className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm disabled:opacity-50"
+          >
+            {testing ? 'Testing…' : 'Test'}
+          </button>
+        )}
         {entry.fields.map((field) => (
           <button
             key={field.key}
             onClick={() => setRotating(rotating === field.key ? null : field.key)}
-            className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm flex items-center gap-1"
+            disabled={!canSeal}
+            title={canSeal ? undefined : 'The keychain cannot seal a replacement on this system'}
+            className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm flex items-center gap-1 disabled:opacity-50"
           >
             <RefreshCw size={11} />
             {entry.fields.length > 1 ? `Rotate ${field.label}` : 'Rotate'}
@@ -131,7 +157,7 @@ function KeyRow({ entry, onRotated }: { entry: ConnectorKey; onRotated: () => vo
           />
           <button
             onClick={() => save(rotating)}
-            disabled={saving || value === ''}
+            disabled={saving || value === '' || !canSeal}
             className="text-[11px] text-gray-200 px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] disabled:opacity-50"
           >
             {saving ? 'Saving…' : 'Save'}
@@ -208,7 +234,12 @@ export function KeysSettings() {
 
       <div className="space-y-2">
         {keys.map((entry) => (
-          <KeyRow key={entry.connectionId} entry={entry} onRotated={load} />
+          <KeyRow
+            key={entry.connectionId}
+            entry={entry}
+            canSeal={safeStorageAvailable}
+            onRotated={load}
+          />
         ))}
       </div>
 

--- a/src/renderer/components/settings/KeysSettings.tsx
+++ b/src/renderer/components/settings/KeysSettings.tsx
@@ -58,15 +58,12 @@ function KeyRow({
     setSaving(true)
     setError(null)
     try {
-      // Encrypted here: the keychain that can seal it lives in this process,
-      // and the server is only ever handed ciphertext.
+      // Sealed here because the keychain lives in this process; the plaintext rides along for immediate use.
       const sealed = await window.api.encryptString(value)
       const outcome = await window.api.rotateConnectionSecret({
         connectionId: entry.connectionId,
         field,
         value: sealed,
-        // Handed over as well as sealed, so the key works the moment it is
-        // stored rather than once the keychain has been read back.
         plaintext: value
       })
       if (!outcome.ok) {
@@ -120,7 +117,11 @@ function KeyRow({
         {entry.fields.map((field) => (
           <button
             key={field.key}
-            onClick={() => setRotating(rotating === field.key ? null : field.key)}
+            onClick={() => {
+              setRotating(rotating === field.key ? null : field.key)
+              setValue('')
+              setError(null)
+            }}
             disabled={!canSeal}
             title={canSeal ? undefined : 'The keychain cannot seal a replacement on this system'}
             className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm flex items-center gap-1 disabled:opacity-50"
@@ -157,7 +158,7 @@ function KeyRow({
           />
           <button
             onClick={() => save(rotating)}
-            disabled={saving || value === '' || !canSeal}
+            disabled={saving || value.trim() === '' || !canSeal}
             className="text-[11px] text-gray-200 px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] disabled:opacity-50"
           >
             {saving ? 'Saving…' : 'Save'}
@@ -195,7 +196,7 @@ export function KeysSettings() {
   }, [])
 
   useEffect(() => {
-    void load()
+    void Promise.resolve().then(load)
     let cancelled = false
     window.api
       .isSafeStorageAvailable?.()
@@ -203,9 +204,7 @@ export function KeysSettings() {
         if (!cancelled) setSafeStorageAvailable(available)
       })
       .catch(() => {})
-    // A key can change from outside this page — a connection added, a secret
-    // rotated in another window — and a list read once would keep describing
-    // what used to be held.
+    // A key can change from another window; a list read once would go stale.
     const unsubscribe = window.api.onConfigChanged?.(() => {
       void load()
     })

--- a/src/renderer/components/settings/KeysSettings.tsx
+++ b/src/renderer/components/settings/KeysSettings.tsx
@@ -48,7 +48,10 @@ function KeyRow({ entry, onRotated }: { entry: ConnectorKey; onRotated: () => vo
       const outcome = await window.api.rotateConnectionSecret({
         connectionId: entry.connectionId,
         field,
-        value: sealed
+        value: sealed,
+        // Handed over as well as sealed, so the key works the moment it is
+        // stored rather than once the keychain has been read back.
+        plaintext: value
       })
       if (!outcome.ok) {
         setError(outcome.error ?? 'The key could not be replaced')
@@ -174,8 +177,15 @@ export function KeysSettings() {
         if (!cancelled) setSafeStorageAvailable(available)
       })
       .catch(() => {})
+    // A key can change from outside this page — a connection added, a secret
+    // rotated in another window — and a list read once would keep describing
+    // what used to be held.
+    const unsubscribe = window.api.onConfigChanged?.(() => {
+      void load()
+    })
     return () => {
       cancelled = true
+      unsubscribe?.()
     }
   }, [load])
 

--- a/src/renderer/components/settings/KeysSettings.tsx
+++ b/src/renderer/components/settings/KeysSettings.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from 'react'
+import { KeyRound, RefreshCw } from 'lucide-react'
+import type { ConnectorKey, ConnectorKeyField } from '../../../shared/types'
+import { ConnectorIcon } from '../ConnectorIcon'
+
+/** What a key's stored value can be said to be, without saying what it is. */
+function describeField(field: ConnectorKeyField): string {
+  if (!field.readable) return 'Locked — this machine cannot read it'
+  if (field.envNames) {
+    return field.envNames.length > 0 ? field.envNames.join(' · ') : 'No variables set'
+  }
+  return field.hint || 'Set'
+}
+
+/** "used by 2 steps" is what says what rotating this is about to touch. */
+function describeUsage(count: number): string {
+  if (count === 0) return 'unused'
+  return count === 1 ? 'used by 1 step' : `used by ${count} steps`
+}
+
+function KeyRow({ entry, onRotated }: { entry: ConnectorKey; onRotated: () => void }) {
+  const [testing, setTesting] = useState(false)
+  const [result, setResult] = useState<{ ok: boolean | null; message?: string } | null>(null)
+  const [rotating, setRotating] = useState<string | null>(null)
+  const [value, setValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const runTest = async () => {
+    setTesting(true)
+    setResult(null)
+    try {
+      setResult(await window.api.preflightConnection(entry.connectionId))
+    } catch (err) {
+      setResult({ ok: false, message: err instanceof Error ? err.message : String(err) })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const save = async (field: string) => {
+    setSaving(true)
+    setError(null)
+    try {
+      // Encrypted here: the keychain that can seal it lives in this process,
+      // and the server is only ever handed ciphertext.
+      const sealed = await window.api.encryptString(value)
+      const outcome = await window.api.rotateConnectionSecret({
+        connectionId: entry.connectionId,
+        field,
+        value: sealed
+      })
+      if (!outcome.ok) {
+        setError(outcome.error ?? 'The key could not be replaced')
+        return
+      }
+      setRotating(null)
+      setValue('')
+      setResult(null)
+      onRotated()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="px-4 py-2.5 bg-white/[0.03] border border-white/[0.06] rounded-sm">
+      <div className="flex items-center gap-3">
+        <ConnectorIcon connectorId={entry.connectorId} size={14} className="text-gray-400" />
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] text-gray-200 truncate">{entry.name}</div>
+          <div className="text-[11px] text-gray-500 truncate">
+            {entry.fields.map(describeField).join(' · ')} · {describeUsage(entry.usageCount)}
+          </div>
+        </div>
+        {result && (
+          <span
+            aria-hidden
+            className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+              result.ok === null ? 'bg-gray-600' : result.ok ? 'bg-status-sage' : 'bg-danger'
+            }`}
+          />
+        )}
+        <button
+          onClick={runTest}
+          disabled={testing}
+          className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm disabled:opacity-50"
+        >
+          {testing ? 'Testing…' : 'Test'}
+        </button>
+        {entry.fields.map((field) => (
+          <button
+            key={field.key}
+            onClick={() => setRotating(rotating === field.key ? null : field.key)}
+            className="text-[11px] text-gray-400 hover:text-gray-200 px-2 py-1 border border-white/[0.1] rounded-sm flex items-center gap-1"
+          >
+            <RefreshCw size={11} />
+            {entry.fields.length > 1 ? `Rotate ${field.label}` : 'Rotate'}
+          </button>
+        ))}
+      </div>
+
+      {result && (
+        <div
+          className={`mt-1.5 text-[11px] ${result.ok === false ? 'text-danger' : 'text-gray-500'}`}
+        >
+          {result.ok === null
+            ? 'This connector has nothing to check'
+            : (result.message ?? (result.ok ? 'Reached it' : 'Could not reach it'))}
+        </div>
+      )}
+
+      {rotating && (
+        <div className="mt-2 flex items-center gap-2">
+          <input
+            type="password"
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={
+              entry.fields.find((f) => f.key === rotating)?.envNames
+                ? '{"TOKEN": "…"}'
+                : 'The replacement value'
+            }
+            className="flex-1 px-2 py-1 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-200 outline-none focus:border-white/[0.2]"
+          />
+          <button
+            onClick={() => save(rotating)}
+            disabled={saving || value === ''}
+            className="text-[11px] text-gray-200 px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            onClick={() => {
+              setRotating(null)
+              setValue('')
+              setError(null)
+            }}
+            className="text-[11px] text-gray-500 hover:text-gray-300 px-2 py-1"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+      {error && <div className="mt-1.5 text-[11px] text-danger">{error}</div>}
+    </div>
+  )
+}
+
+export function KeysSettings() {
+  const [keys, setKeys] = useState<ConnectorKey[]>([])
+  const [safeStorageAvailable, setSafeStorageAvailable] = useState(true)
+  const [loaded, setLoaded] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      setKeys((await window.api.listConnectorKeys?.()) ?? [])
+    } catch {
+      setKeys([])
+    } finally {
+      setLoaded(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+    let cancelled = false
+    window.api
+      .isSafeStorageAvailable?.()
+      .then((available) => {
+        if (!cancelled) setSafeStorageAvailable(available)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [load])
+
+  return (
+    <div data-testid="keys-panel">
+      <h2 className="text-xl font-semibold text-white mb-1">Keys</h2>
+      <p className="text-sm text-gray-500 mb-6">
+        The secrets your connections hold, stored encrypted with your OS keychain
+      </p>
+
+      {!safeStorageAvailable && (
+        <div
+          className="mb-4 px-4 py-3 rounded-sm border border-amber-500/30 text-sm text-amber-400"
+          style={{ background: 'rgba(245, 158, 11, 0.08)' }}
+        >
+          Keychain encryption is not available on this system, so a key cannot be replaced from
+          here.
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {keys.map((entry) => (
+          <KeyRow key={entry.connectionId} entry={entry} onRotated={load} />
+        ))}
+      </div>
+
+      {loaded && keys.length === 0 && (
+        <div className="px-4 py-6 border border-white/[0.06] rounded-sm text-center">
+          <KeyRound size={16} className="mx-auto text-gray-600 mb-2" />
+          <div className="text-sm text-gray-400">No keys yet</div>
+          <div className="text-[11px] text-gray-600 mt-1">
+            A connection that signs in with a key or a token shows up here.
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -304,6 +304,7 @@ export type SettingsCategory =
   | 'ssh'
   | 'mcp'
   | 'connectors'
+  | 'keys'
   | 'network'
   | 'about'
 

--- a/tests/connection-rotate-secret.test.ts
+++ b/tests/connection-rotate-secret.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  clearDecryptedCreds,
+  getDecryptedCreds,
+  setDecryptedCreds
+} from '../packages/server/src/connectors/decrypted-creds'
+import { secretEnvFor } from '../packages/server/src/script-runner'
+
+/**
+ * The rotate handler itself needs a database and a live server, which no unit
+ * test here stands up. What it promises that a caller can observe is the state
+ * it leaves behind: the new secret readable at once, merged with whatever else
+ * the connection holds. That is what these pin, against the same store the
+ * handler writes and every consumer reads.
+ */
+function rotateInto(connectionId: string, field: string, plaintext: string): void {
+  setDecryptedCreds(connectionId, { ...getDecryptedCreds(connectionId), [field]: plaintext })
+}
+
+beforeEach(() => {
+  clearDecryptedCreds('conn-1')
+  clearDecryptedCreds('conn-2')
+})
+
+describe('what a rotation leaves behind', () => {
+  it('serves the new secret immediately, with no window where none is readable', () => {
+    setDecryptedCreds('conn-1', { secret: 'sk_live_old' })
+    rotateInto('conn-1', 'secret', 'sk_live_new')
+
+    // Read the way a poll or an action reads it, with no resync in between.
+    expect(getDecryptedCreds('conn-1')).toEqual({ secret: 'sk_live_new' })
+  })
+
+  it('leaves the connection’s other secrets alone', () => {
+    setDecryptedCreds('conn-2', { apiKey: 'keep-me', secretEnv: '{"TOKEN":"old"}' })
+    rotateInto('conn-2', 'secretEnv', '{"TOKEN":"new"}')
+
+    expect(getDecryptedCreds('conn-2')).toEqual({
+      apiKey: 'keep-me',
+      secretEnv: '{"TOKEN":"new"}'
+    })
+  })
+
+  it('hands a step spawned right after the rotation the new value', () => {
+    setDecryptedCreds('conn-2', { secretEnv: '{"TOKEN":"old"}' })
+    rotateInto('conn-2', 'secretEnv', '{"TOKEN":"new"}')
+
+    expect(secretEnvFor('conn-2')).toEqual({ TOKEN: 'new' })
+  })
+
+  it('is the first thing a connection knows, when it held nothing before', () => {
+    rotateInto('conn-1', 'secret', 'sk_live_first')
+    expect(getDecryptedCreds('conn-1')).toEqual({ secret: 'sk_live_first' })
+  })
+})

--- a/tests/connector-keys.test.ts
+++ b/tests/connector-keys.test.ts
@@ -109,6 +109,23 @@ describe('what rotating a key would touch', () => {
     const counts = usageCounts([workflow('wf-3', [node('a', 'callConnectorAction', {})])])
     expect(counts.size).toBe(0)
   })
+
+  it('counts a script that borrows a key, which is a use like any other', () => {
+    const counts = usageCounts([
+      workflow('wf-4', [
+        node('smoke', 'script', { scriptContent: '', secretsFrom: 'conn-1' }),
+        node('plain', 'script', { scriptContent: '' })
+      ])
+    ])
+    expect(counts.get('conn-1')).toBe(1)
+  })
+
+  it('counts a step that both runs against a connection and borrows another', () => {
+    const counts = usageCounts([
+      workflow('wf-5', [node('a', 'script', { scriptContent: '', secretsFrom: 'conn-2' })])
+    ])
+    expect(counts.get('conn-2')).toBe(1)
+  })
 })
 
 describe('the keys this machine holds', () => {

--- a/tests/connector-keys.test.ts
+++ b/tests/connector-keys.test.ts
@@ -57,16 +57,28 @@ describe('which fields are secrets', () => {
 })
 
 describe('how much of a secret travels', () => {
-  it('shows the opening a person recognizes it by', () => {
-    expect(maskSecret('sk_live_51abcdefghijkl')).toBe('sk_live…')
+  it('names the service and the mode, then the last four to tell keys apart', () => {
+    expect(maskSecret('sk_live_51abcdefgh4242')).toBe('sk_live_••••4242')
+    expect(maskSecret('xoxb-1111-2222-abcd')).toBe('xoxb-••••abcd')
   })
 
-  it('shows nothing at all of a short value, which is mostly opening', () => {
+  it('gives up no opening at all for a token it does not recognize', () => {
+    // A fixed slice of an unknown key is a slice of the secret.
+    expect(maskSecret('a1b2c3d4e5f6g7h8')).toBe('••••g7h8')
+  })
+
+  it('shows nothing of a short value, which a tail would mostly give away', () => {
     expect(maskSecret('short')).toBe('••••')
+    expect(maskSecret('sk_live_abc')).toBe('••••')
   })
 
   it('says nothing when there is nothing to read', () => {
     expect(maskSecret(undefined)).toBe('')
+  })
+
+  it('never carries the middle of a key, whatever the key looks like', () => {
+    const secret = 'sk_live_MIDDLEPARTffff'
+    expect(maskSecret(secret)).not.toContain('MIDDLEPART')
   })
 })
 
@@ -139,7 +151,7 @@ describe('the keys this machine holds', () => {
       [connection()],
       auth,
       [workflow('wf-1', [node('a', 'httpRequest', { profileConnectionId: 'conn-1' })])],
-      () => ({ secret: 'sk_live_51abcdefg' })
+      () => ({ secret: 'sk_live_51abcdefgh4242' })
     )
     expect(keys).toEqual([
       {
@@ -147,7 +159,7 @@ describe('the keys this machine holds', () => {
         name: 'reporting API',
         connectorId: 'http',
         usageCount: 1,
-        fields: [{ key: 'secret', label: 'secret', readable: true, hint: 'sk_live…' }]
+        fields: [{ key: 'secret', label: 'secret', readable: true, hint: 'sk_live_••••4242' }]
       }
     ])
   })

--- a/tests/connector-keys.test.ts
+++ b/tests/connector-keys.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import type {
+  ConnectorConfigField,
+  SourceConnection,
+  WorkflowDefinition,
+  WorkflowNode
+} from '../packages/shared/src/types'
+import {
+  envNamesOf,
+  listKeys,
+  maskSecret,
+  passwordFields,
+  usageCounts
+} from '../packages/server/src/connectors/keys'
+
+const field = (key: string, type: ConnectorConfigField['type']): ConnectorConfigField => ({
+  key,
+  label: key,
+  type
+})
+
+const connection = (over: Partial<SourceConnection> = {}): SourceConnection => ({
+  id: 'conn-1',
+  connectorId: 'http',
+  name: 'reporting API',
+  filters: { secret: 'ciphertext' },
+  syncIntervalMinutes: 5,
+  statusMapping: {},
+  createdAt: '2026-09-02T00:00:00Z',
+  ...over
+})
+
+const node = (
+  id: string,
+  type: WorkflowNode['type'],
+  config: Record<string, unknown>
+): WorkflowNode =>
+  ({ id, type, label: id, config, position: { x: 0, y: 0 } }) as unknown as WorkflowNode
+
+const workflow = (id: string, nodes: WorkflowNode[]): WorkflowDefinition =>
+  ({
+    id,
+    name: id,
+    icon: 'Zap',
+    iconColor: '#fff',
+    enabled: true,
+    nodes,
+    edges: []
+  }) as unknown as WorkflowDefinition
+
+describe('which fields are secrets', () => {
+  it('takes the connector at its word, and nothing else', () => {
+    const auth = [field('baseUrl', 'text'), field('secret', 'password')]
+    expect(passwordFields(auth).map((f) => f.key)).toEqual(['secret'])
+    expect(passwordFields(undefined)).toEqual([])
+  })
+})
+
+describe('how much of a secret travels', () => {
+  it('shows the opening a person recognizes it by', () => {
+    expect(maskSecret('sk_live_51abcdefghijkl')).toBe('sk_live…')
+  })
+
+  it('shows nothing at all of a short value, which is mostly opening', () => {
+    expect(maskSecret('short')).toBe('••••')
+  })
+
+  it('says nothing when there is nothing to read', () => {
+    expect(maskSecret(undefined)).toBe('')
+  })
+})
+
+describe('the env a blob carries', () => {
+  it('names them without disclosing their values', () => {
+    expect(envNamesOf('{"SLACK_BOT_TOKEN":"xoxb-secret","PORT":"1"}')).toEqual([
+      'SLACK_BOT_TOKEN',
+      'PORT'
+    ])
+  })
+
+  it('answers nothing for a blob it cannot read', () => {
+    expect(envNamesOf('not json')).toEqual([])
+    expect(envNamesOf(undefined)).toEqual([])
+    expect(envNamesOf('[1,2]')).toEqual([])
+  })
+})
+
+describe('what rotating a key would touch', () => {
+  const workflows = [
+    workflow('wf-1', [
+      node('a', 'callConnectorAction', { connectionId: 'conn-1' }),
+      node('b', 'httpRequest', { profileConnectionId: 'conn-1' }),
+      node('c', 'script', { scriptContent: '' })
+    ]),
+    workflow('wf-2', [
+      node('d', 'trigger', { triggerType: 'connectorPoll', connectionId: 'conn-2' }),
+      // A trigger that runs on nothing external names no connection.
+      node('e', 'trigger', { triggerType: 'manual' })
+    ])
+  ]
+
+  it('counts the steps, not the workflows', () => {
+    const counts = usageCounts(workflows)
+    expect(counts.get('conn-1')).toBe(2)
+    expect(counts.get('conn-2')).toBe(1)
+  })
+
+  it('ignores a step whose connection was never chosen', () => {
+    const counts = usageCounts([workflow('wf-3', [node('a', 'callConnectorAction', {})])])
+    expect(counts.size).toBe(0)
+  })
+})
+
+describe('the keys this machine holds', () => {
+  const auth = new Map([
+    ['http', [field('baseUrl', 'text'), field('secret', 'password')]],
+    ['mcp', [field('command', 'text'), field('secretEnv', 'password')]]
+  ])
+
+  it('describes a single-value key by its opening and its use', () => {
+    const keys = listKeys(
+      [connection()],
+      auth,
+      [workflow('wf-1', [node('a', 'httpRequest', { profileConnectionId: 'conn-1' })])],
+      () => ({ secret: 'sk_live_51abcdefg' })
+    )
+    expect(keys).toEqual([
+      {
+        connectionId: 'conn-1',
+        name: 'reporting API',
+        connectorId: 'http',
+        usageCount: 1,
+        fields: [{ key: 'secret', label: 'secret', readable: true, hint: 'sk_live…' }]
+      }
+    ])
+  })
+
+  it('describes a packaged connector by the env it carries, under its own id', () => {
+    const packaged = connection({
+      id: 'conn-2',
+      connectorId: 'mcp',
+      name: 'Slack',
+      filters: { secretEnv: 'ciphertext', sdkConnectorId: 'slack' }
+    })
+    const keys = listKeys([packaged], auth, [], () => ({
+      secretEnv: '{"SLACK_BOT_TOKEN":"xoxb-secret"}'
+    }))
+    expect(keys[0]).toMatchObject({
+      connectorId: 'slack',
+      usageCount: 0,
+      fields: [{ key: 'secretEnv', readable: true, envNames: ['SLACK_BOT_TOKEN'] }]
+    })
+    // The value itself must never be part of the answer.
+    expect(JSON.stringify(keys)).not.toContain('xoxb-secret')
+  })
+
+  it('lists a key this build cannot read, because it is still one to rotate', () => {
+    const keys = listKeys([connection()], auth, [], () => undefined)
+    expect(keys[0].fields[0]).toEqual({
+      key: 'secret',
+      label: 'secret',
+      readable: false,
+      hint: ''
+    })
+  })
+
+  it('leaves out a connection holding no secret at all', () => {
+    const empty = connection({ id: 'conn-3', filters: { baseUrl: 'https://x.test' } })
+    expect(listKeys([empty], auth, [], () => ({}))).toEqual([])
+  })
+
+  it('leaves out a connector that declares no secret field', () => {
+    const builtIn = connection({ id: 'conn-4', connectorId: 'github', filters: { repo: 'x/y' } })
+    expect(listKeys([builtIn], auth, [], () => ({}))).toEqual([])
+  })
+})

--- a/tests/connector-keys.test.ts
+++ b/tests/connector-keys.test.ts
@@ -92,6 +92,7 @@ describe('the env a blob carries', () => {
 
   it('answers nothing for a blob it cannot read', () => {
     expect(envNamesOf('not json')).toEqual([])
+    expect(envNamesOf('{"":"a","BAD-NAME":"b","__proto__":"c","OK":"d"}')).toEqual(['OK'])
     expect(envNamesOf(undefined)).toEqual([])
     expect(envNamesOf('[1,2]')).toEqual([])
   })

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -10,7 +10,7 @@ const PROFILE: ConnectorKey = {
   name: 'reporting API',
   connectorId: 'http',
   usageCount: 2,
-  fields: [{ key: 'secret', label: 'secret', readable: true, hint: 'sk_live…' }]
+  fields: [{ key: 'secret', label: 'secret', readable: true, hint: 'sk_live_••••4242' }]
 }
 
 const PACKAGED: ConnectorKey = {
@@ -50,7 +50,7 @@ describe('the keys this machine holds', () => {
     render(<KeysSettings />)
 
     expect(await screen.findByText('reporting API')).toBeInTheDocument()
-    expect(screen.getByText(/sk_live… · used by 2 steps/)).toBeInTheDocument()
+    expect(screen.getByText(/sk_live_••••4242 · used by 2 steps/)).toBeInTheDocument()
     // A blob is named by the variables it carries, never by their values.
     expect(screen.getByText(/SLACK_BOT_TOKEN · unused/)).toBeInTheDocument()
   })

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ConnectorKey } from '../src/shared/types'
+import { KeysSettings } from '../src/renderer/components/settings/KeysSettings'
+
+const PROFILE: ConnectorKey = {
+  connectionId: 'conn-1',
+  name: 'reporting API',
+  connectorId: 'http',
+  usageCount: 2,
+  fields: [{ key: 'secret', label: 'secret', readable: true, hint: 'sk_live…' }]
+}
+
+const PACKAGED: ConnectorKey = {
+  connectionId: 'conn-2',
+  name: 'Slack',
+  connectorId: 'slack',
+  usageCount: 0,
+  fields: [{ key: 'secretEnv', label: 'secretEnv', readable: true, envNames: ['SLACK_BOT_TOKEN'] }]
+}
+
+const api = {
+  listConnectorKeys: vi.fn(),
+  isSafeStorageAvailable: vi.fn(),
+  preflightConnection: vi.fn(),
+  encryptString: vi.fn(),
+  rotateConnectionSecret: vi.fn()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  api.listConnectorKeys.mockResolvedValue([PROFILE, PACKAGED])
+  api.isSafeStorageAvailable.mockResolvedValue(true)
+  api.preflightConnection.mockResolvedValue({ ok: true, message: 'HTTP 200' })
+  api.encryptString.mockResolvedValue('sealed')
+  api.rotateConnectionSecret.mockResolvedValue({ ok: true })
+  ;(window as unknown as { api: unknown }).api = api
+})
+
+describe('the keys this machine holds', () => {
+  it('says what each key is and what rotating it would touch', async () => {
+    render(<KeysSettings />)
+
+    expect(await screen.findByText('reporting API')).toBeInTheDocument()
+    expect(screen.getByText(/sk_live… · used by 2 steps/)).toBeInTheDocument()
+    // A blob is named by the variables it carries, never by their values.
+    expect(screen.getByText(/SLACK_BOT_TOKEN · unused/)).toBeInTheDocument()
+  })
+
+  it('offers nothing to do when no connection holds a secret', async () => {
+    api.listConnectorKeys.mockResolvedValue([])
+    render(<KeysSettings />)
+
+    expect(await screen.findByText('No keys yet')).toBeInTheDocument()
+  })
+
+  it('says a locked key is still there, rather than showing it as empty', async () => {
+    api.listConnectorKeys.mockResolvedValue([
+      { ...PROFILE, fields: [{ key: 'secret', label: 'secret', readable: false }] }
+    ])
+    render(<KeysSettings />)
+
+    expect(await screen.findByText(/Locked — this machine cannot read it/)).toBeInTheDocument()
+  })
+
+  it('warns when the keychain cannot seal a replacement', async () => {
+    api.isSafeStorageAvailable.mockResolvedValue(false)
+    render(<KeysSettings />)
+
+    expect(await screen.findByText(/Keychain encryption is not available/)).toBeInTheDocument()
+  })
+})
+
+describe('testing a key', () => {
+  it('reports what the connection answered', async () => {
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Test' }))[0])
+
+    expect(await screen.findByText('HTTP 200')).toBeInTheDocument()
+    expect(api.preflightConnection).toHaveBeenCalledWith('conn-1')
+  })
+
+  it('says so when the connector has nothing to check', async () => {
+    api.preflightConnection.mockResolvedValue({ ok: null })
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Test' }))[0])
+
+    expect(await screen.findByText('This connector has nothing to check')).toBeInTheDocument()
+  })
+
+  it('reports a rejected call rather than leaving the row silent', async () => {
+    api.preflightConnection.mockRejectedValue(new Error('the server went away'))
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: 'Test' }))[0])
+
+    expect(await screen.findByText('the server went away')).toBeInTheDocument()
+  })
+})
+
+describe('rotating a key', () => {
+  it('seals the new value before it leaves, and reloads what is held', async () => {
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[0])
+    fireEvent.change(screen.getByPlaceholderText('The replacement value'), {
+      target: { value: 'sk_live_new' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(api.rotateConnectionSecret).toHaveBeenCalled())
+    expect(api.encryptString).toHaveBeenCalledWith('sk_live_new')
+    // Ciphertext, never the value the person typed.
+    expect(api.rotateConnectionSecret).toHaveBeenCalledWith({
+      connectionId: 'conn-1',
+      field: 'secret',
+      value: 'sealed'
+    })
+    await waitFor(() => expect(api.listConnectorKeys).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps the field open and says why when the server refuses', async () => {
+    api.rotateConnectionSecret.mockResolvedValue({ ok: false, error: 'not a secret here' })
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[0])
+    fireEvent.change(screen.getByPlaceholderText('The replacement value'), {
+      target: { value: 'x' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('not a secret here')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('The replacement value')).toBeInTheDocument()
+  })
+
+  it('will not send an empty replacement', async () => {
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[0])
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+})

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -26,7 +26,10 @@ const api = {
   isSafeStorageAvailable: vi.fn(),
   preflightConnection: vi.fn(),
   encryptString: vi.fn(),
-  rotateConnectionSecret: vi.fn()
+  rotateConnectionSecret: vi.fn(),
+  onConfigChanged: vi.fn(() => () => {}),
+  listConnections: vi.fn(),
+  listConnectorPacks: vi.fn()
 }
 
 beforeEach(() => {
@@ -36,6 +39,9 @@ beforeEach(() => {
   api.preflightConnection.mockResolvedValue({ ok: true, message: 'HTTP 200' })
   api.encryptString.mockResolvedValue('sealed')
   api.rotateConnectionSecret.mockResolvedValue({ ok: true })
+  api.onConfigChanged.mockReturnValue(() => {})
+  api.listConnections.mockResolvedValue([])
+  api.listConnectorPacks.mockResolvedValue([])
   ;(window as unknown as { api: unknown }).api = api
 })
 
@@ -110,13 +116,36 @@ describe('rotating a key', () => {
 
     await waitFor(() => expect(api.rotateConnectionSecret).toHaveBeenCalled())
     expect(api.encryptString).toHaveBeenCalledWith('sk_live_new')
-    // Ciphertext, never the value the person typed.
+    // Ciphertext to store, and the value itself so the key works at once.
     expect(api.rotateConnectionSecret).toHaveBeenCalledWith({
       connectionId: 'conn-1',
       field: 'secret',
-      value: 'sealed'
+      value: 'sealed',
+      plaintext: 'sk_live_new'
     })
     await waitFor(() => expect(api.listConnectorKeys).toHaveBeenCalledTimes(2))
+  })
+
+  it('re-lists what is held when a key changes somewhere else', async () => {
+    render(<KeysSettings />)
+    await screen.findByText('reporting API')
+    expect(api.onConfigChanged).toHaveBeenCalled()
+
+    api.listConnectorKeys.mockResolvedValue([{ ...PROFILE, name: 'renamed API' }])
+    const notify = api.onConfigChanged.mock.calls[0][0] as () => void
+    notify()
+
+    expect(await screen.findByText('renamed API')).toBeInTheDocument()
+  })
+
+  it('stops listening when the page goes away', async () => {
+    const unsubscribe = vi.fn()
+    api.onConfigChanged.mockReturnValue(unsubscribe)
+    const { unmount } = render(<KeysSettings />)
+    await screen.findByText('reporting API')
+
+    unmount()
+    expect(unsubscribe).toHaveBeenCalled()
   })
 
   it('keeps the field open and says why when the server refuses', async () => {

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type { ConnectorKey } from '../src/shared/types'
 import { KeysSettings } from '../src/renderer/components/settings/KeysSettings'
+import { __resetConnectionsCacheForTests } from '../src/renderer/lib/use-connections'
 
 const PROFILE: ConnectorKey = {
   connectionId: 'conn-1',
@@ -34,6 +35,7 @@ const api = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  __resetConnectionsCacheForTests()
   api.listConnectorKeys.mockResolvedValue([PROFILE, PACKAGED])
   api.isSafeStorageAvailable.mockResolvedValue(true)
   api.preflightConnection.mockResolvedValue({ ok: true, message: 'HTTP 200' })
@@ -76,6 +78,47 @@ describe('the keys this machine holds', () => {
     render(<KeysSettings />)
 
     expect(await screen.findByText(/Keychain encryption is not available/)).toBeInTheDocument()
+  })
+
+  it('offers no rotation it could not carry out, rather than failing at Save', async () => {
+    api.isSafeStorageAvailable.mockResolvedValue(false)
+    render(<KeysSettings />)
+
+    await screen.findByText(/Keychain encryption is not available/)
+    for (const button of screen.getAllByRole('button', { name: /Rotate/ })) {
+      expect(button).toBeDisabled()
+    }
+  })
+
+  it('draws a packaged connector with the mark it ships', async () => {
+    api.listConnections.mockResolvedValue([
+      {
+        id: 'conn-2',
+        connectorId: 'mcp',
+        name: 'Slack',
+        filters: {
+          sdkConnectorId: 'slack',
+          sdkIcon: '{"viewBox":"0 0 24 24","paths":["M2 2h9v9z"]}'
+        },
+        syncIntervalMinutes: 5,
+        statusMapping: {},
+        createdAt: '2026-09-02T00:00:00Z'
+      }
+    ])
+    const { container } = render(<KeysSettings />)
+
+    await screen.findByText('Slack')
+    await waitFor(() => expect(container.querySelector('path[d="M2 2h9v9z"]')).not.toBeNull())
+  })
+})
+
+describe('what a key can be asked', () => {
+  it('offers Test where a preflight exists', async () => {
+    render(<KeysSettings />)
+    await screen.findByText('reporting API')
+
+    // One profile, one packaged connection: only the profile answers today.
+    expect(screen.getAllByRole('button', { name: 'Test' })).toHaveLength(1)
   })
 })
 

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -175,8 +175,11 @@ describe('rotating a key', () => {
     expect(api.onConfigChanged).toHaveBeenCalled()
 
     api.listConnectorKeys.mockResolvedValue([{ ...PROFILE, name: 'renamed API' }])
-    const notify = api.onConfigChanged.mock.calls[0][0] as () => void
-    notify()
+    // The connections cache subscribes too; which registered first is not the
+    // point of this test.
+    for (const [callback] of api.onConfigChanged.mock.calls) {
+      ;(callback as () => void)()
+    }
 
     expect(await screen.findByText('renamed API')).toBeInTheDocument()
   })

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -177,9 +177,8 @@ describe('rotating a key', () => {
     api.listConnectorKeys.mockResolvedValue([{ ...PROFILE, name: 'renamed API' }])
     // The connections cache subscribes too; which registered first is not the
     // point of this test.
-    for (const [callback] of api.onConfigChanged.mock.calls) {
-      ;(callback as () => void)()
-    }
+    const subscriptions = api.onConfigChanged.mock.calls as unknown as Array<[() => void]>
+    for (const [callback] of subscriptions) callback()
 
     expect(await screen.findByText('renamed API')).toBeInTheDocument()
   })

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -138,4 +138,35 @@ describe('rotating a key', () => {
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
+
+  it('asks for the whole set when the field carries a set of variables', async () => {
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[1])
+
+    expect(screen.getByPlaceholderText('{"TOKEN": "…"}')).toBeInTheDocument()
+  })
+
+  it('leaves the key alone when the replacement is abandoned', async () => {
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[0])
+    fireEvent.change(screen.getByPlaceholderText('The replacement value'), {
+      target: { value: 'typed' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByPlaceholderText('The replacement value')).not.toBeInTheDocument()
+    expect(api.rotateConnectionSecret).not.toHaveBeenCalled()
+  })
+
+  it('reports a rejected call rather than looking like it saved', async () => {
+    api.rotateConnectionSecret.mockRejectedValue(new Error('the server went away'))
+    render(<KeysSettings />)
+    fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[0])
+    fireEvent.change(screen.getByPlaceholderText('The replacement value'), {
+      target: { value: 'x' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('the server went away')).toBeInTheDocument()
+  })
 })

--- a/tests/keys-settings.test.tsx
+++ b/tests/keys-settings.test.tsx
@@ -211,6 +211,31 @@ describe('rotating a key', () => {
     fireEvent.click((await screen.findAllByRole('button', { name: /Rotate/ }))[0])
 
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('The replacement value'), {
+      target: { value: '   ' }
+    })
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+
+  it('forgets what was typed for one field when another field is picked', async () => {
+    api.listConnectorKeys.mockResolvedValue([
+      {
+        ...PROFILE,
+        fields: [
+          { key: 'secret', label: 'secret', readable: true },
+          { key: 'other', label: 'other', readable: true }
+        ]
+      }
+    ])
+    render(<KeysSettings />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Rotate secret' }))
+    fireEvent.change(screen.getByPlaceholderText('The replacement value'), {
+      target: { value: 'meant for secret' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Rotate other' }))
+
+    expect(screen.getByPlaceholderText('The replacement value')).toHaveValue('')
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled()
   })
 
   it('asks for the whole set when the field carries a set of variables', async () => {

--- a/tests/script-secrets.test.ts
+++ b/tests/script-secrets.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { secretEnvFor } from '../packages/server/src/script-runner'
+import { toPortable } from '../packages/shared/src/workflow-portability'
+import type { WorkflowDefinition } from '../packages/shared/src/types'
+
+describe('the environment a step borrows from a connection', () => {
+  const decrypted: Record<string, Record<string, string>> = {
+    'conn-http': { secret: 'sk_live_abc' },
+    'conn-slack': { secretEnv: '{"SLACK_BOT_TOKEN":"xoxb-abc","PORT":"1"}' },
+    'conn-mixed': { apiKey: 'k', secretEnv: '{"TOKEN":"t"}' }
+  }
+  const lookup = (id: string) => decrypted[id]
+
+  it('names a single value after the field that holds it', () => {
+    expect(secretEnvFor('conn-http', lookup)).toEqual({ SECRET: 'sk_live_abc' })
+  })
+
+  it('spreads a blob as the variables it already names', () => {
+    expect(secretEnvFor('conn-slack', lookup)).toEqual({
+      SLACK_BOT_TOKEN: 'xoxb-abc',
+      PORT: '1'
+    })
+  })
+
+  it('takes both kinds from one connection', () => {
+    expect(secretEnvFor('conn-mixed', lookup)).toEqual({ API_KEY: 'k', TOKEN: 't' })
+  })
+
+  it('gives a step that asked for nothing nothing at all', () => {
+    expect(secretEnvFor(undefined, lookup)).toEqual({})
+  })
+
+  it('gives nothing for a connection this machine cannot read', () => {
+    expect(secretEnvFor('conn-missing', lookup)).toEqual({})
+    expect(secretEnvFor('conn-bad', () => ({ secretEnv: 'not json' }))).toEqual({})
+  })
+})
+
+describe('what a workflow file says about the keys it needs', () => {
+  const withSecrets: WorkflowDefinition = {
+    id: 'wf-1',
+    name: 'Live smoke',
+    icon: 'Zap',
+    iconColor: '#6366f1',
+    enabled: true,
+    nodes: [
+      {
+        id: 'run',
+        type: 'script',
+        label: 'Smoke',
+        config: {
+          scriptType: 'bash',
+          scriptContent: 'echo "$SLACK_BOT_TOKEN"',
+          secretsFrom: 'conn-slack'
+        },
+        position: { x: 0, y: 0 }
+      }
+    ],
+    edges: []
+  } as unknown as WorkflowDefinition
+
+  it('names no connection of this machine, so the file asks rather than inherits', () => {
+    const portable = toPortable(withSecrets, '/Users/someone/dev/novum')
+    const config = portable.nodes[0].config as Record<string, unknown>
+    expect(config.secretsFrom).toBeUndefined()
+    // The script itself still travels; only the binding is local.
+    expect(config.scriptContent).toBe('echo "$SLACK_BOT_TOKEN"')
+  })
+})

--- a/tests/script-secrets.test.ts
+++ b/tests/script-secrets.test.ts
@@ -29,7 +29,7 @@ describe('the environment a step borrows from a connection', () => {
   it('drops blob names a shell would refuse, including ones that reach the prototype', () => {
     const env = secretEnvFor('conn-hostile', (id) =>
       id === 'conn-hostile'
-        ? { secretEnv: '{"":"a","__proto__":{"x":"y"},"BAD-NAME":"b","OK":"o"}' }
+        ? { secretEnv: '{"":"a","__proto__":{"x":"y"},"constructor":"c","BAD-NAME":"b","OK":"o"}' }
         : undefined
     )
     expect(env).toEqual({ OK: 'o' })

--- a/tests/script-secrets.test.ts
+++ b/tests/script-secrets.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { secretEnvFor } from '../packages/server/src/script-runner'
-import { toPortable } from '../packages/shared/src/workflow-portability'
+import { fromPortable, toPortable } from '../packages/shared/src/workflow-portability'
 import type { WorkflowDefinition } from '../packages/shared/src/types'
 
 describe('the environment a step borrows from a connection', () => {
@@ -65,5 +65,28 @@ describe('what a workflow file says about the keys it needs', () => {
     expect(config.secretsFrom).toBeUndefined()
     // The script itself still travels; only the binding is local.
     expect(config.scriptContent).toBe('echo "$SLACK_BOT_TOKEN"')
+  })
+
+  it('refuses one a file carries anyway, rather than binding to a stranger', () => {
+    const carried = {
+      version: 1,
+      name: 'Live smoke',
+      slug: 'live-smoke',
+      nodes: [
+        {
+          id: 'run',
+          type: 'script',
+          label: 'Smoke',
+          config: { scriptType: 'bash', scriptContent: 'x', secretsFrom: 'conn-elsewhere' },
+          position: { x: 0, y: 0 }
+        }
+      ],
+      edges: []
+    }
+    const definition = fromPortable(carried as never, 'bundle', {
+      name: 'Novum',
+      path: '/Users/someone/dev/novum'
+    })
+    expect((definition.nodes[0].config as Record<string, unknown>).secretsFrom).toBeUndefined()
   })
 })

--- a/tests/script-secrets.test.ts
+++ b/tests/script-secrets.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { secretEnvFor } from '../packages/server/src/script-runner'
-import { fromPortable, toPortable } from '../packages/shared/src/workflow-portability'
+import {
+  fromPortable,
+  toPortable,
+  type PortableWorkflow
+} from '../packages/shared/src/workflow-portability'
 import type { WorkflowDefinition } from '../packages/shared/src/types'
 
 describe('the environment a step borrows from a connection', () => {
@@ -83,7 +87,7 @@ describe('what a workflow file says about the keys it needs', () => {
       ],
       edges: []
     }
-    const definition = fromPortable(carried as never, 'bundle', {
+    const definition = fromPortable(carried as unknown as PortableWorkflow, 'bundle', {
       name: 'Novum',
       path: '/Users/someone/dev/novum'
     })

--- a/tests/script-secrets.test.ts
+++ b/tests/script-secrets.test.ts
@@ -26,6 +26,16 @@ describe('the environment a step borrows from a connection', () => {
     })
   })
 
+  it('drops blob names a shell would refuse, including ones that reach the prototype', () => {
+    const env = secretEnvFor('conn-hostile', (id) =>
+      id === 'conn-hostile'
+        ? { secretEnv: '{"":"a","__proto__":{"x":"y"},"BAD-NAME":"b","OK":"o"}' }
+        : undefined
+    )
+    expect(env).toEqual({ OK: 'o' })
+    expect(({} as { x?: string }).x).toBeUndefined()
+  })
+
   it('takes both kinds from one connection', () => {
     expect(secretEnvFor('conn-mixed', lookup)).toEqual({ API_KEY: 'k', TOKEN: 't' })
   })

--- a/tests/settings-page-updates.test.tsx
+++ b/tests/settings-page-updates.test.tsx
@@ -61,6 +61,9 @@ vi.mock('../src/renderer/components/settings/McpSettings', () => ({
 vi.mock('../src/renderer/components/settings/ConnectorSettings', () => ({
   ConnectorSettings: () => <div data-testid="connectors-panel" />
 }))
+vi.mock('../src/renderer/components/settings/KeysSettings', () => ({
+  KeysSettings: () => <div data-testid="keys-panel" />
+}))
 vi.mock('../src/renderer/components/settings/NetworkSettings', () => ({
   NetworkSettings: () => <div data-testid="network-panel" />
 }))
@@ -124,5 +127,18 @@ describe('SettingsPage', () => {
     mockStore.settingsCategory = 'about'
     render(<SettingsPage />)
     expect(screen.getByTestId('about-panel')).toBeInTheDocument()
+  })
+
+  it('offers Keys beside the other connection settings', () => {
+    render(<SettingsPage />)
+    expect(screen.getByRole('button', { name: 'Keys' })).toBeInTheDocument()
+  })
+
+  it('renders the Keys panel when that category is selected', () => {
+    mockStore.settingsCategory = 'keys'
+    render(<SettingsPage />)
+
+    expect(screen.getByTestId('keys-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('connectors-panel')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What this adds

**Settings › Keys.** One row per key-bearing connection — HTTP profiles, packaged connectors' secrets, built-ins' password fields — with a masked hint that never shows key material, the connector's own mark, how many steps use it (including script steps that borrow it), a status dot from the last Test, and **Test** / **Rotate**. Rotation seals the new value, hands it to the server in the same call (no window where a poll would find no secret), restarts the connector's child, and re-lists live.

**A script step can borrow a key.** `secretsFrom` names a connection whose decrypted secrets become that one child's environment — never the parent's, never a sibling's, never serialized: exported files drop it and imported files cannot smuggle it in. It is what the connector factory's live-smoke step uses for sandbox keys.

Two `connection:*` RPCs (`listKeys`, `rotateSecret`) wired across protocol, IPC, preload and the web shim; empty rotations refused at the boundary; Rotate disabled where the keychain is unavailable.

## Review

Two independent passes; all findings fixed with pinning tests — usage counts that saw the new binding, the symmetric import strip, the seamless rotation, the mask, the boundary checks, the page's glyphs.

## Tests

Typecheck clean; full vitest with only the two known ambient failures; patch coverage 97% against the 80% gate; format check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc