### PR TITLE
Let a connector be declared instead of written

### DIFF
--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -125,6 +125,13 @@ second one. Prefer `context.fetch` over the global one in a hand-written action.
 A `select` with fixed choices carries them; one whose choices only exist against
 a live connection names a set the connector serves.
 
+Choices are **suggestions, not a closed set**. Vorn draws a picker while the
+value is one of them and its template-aware input whenever it is not, because a
+step is entitled to compute the value from an earlier one — so the served tool
+schema keeps the argument a plain string and lists the choices in its
+description. Your action still receives whatever was finally sent, and it is
+the connector's job to refuse a value it cannot use.
+
 ```ts
 options: { channels: async ({ config, fetch }) => ['general', 'random'] },
 actions: [{
@@ -134,6 +141,12 @@ actions: [{
   request: { method: 'POST', url: '{{config.baseUrl}}/post/{{args.channel}}' }
 }]
 ```
+
+`loadOptions` is served today but not yet consumed: the SDK registers a
+`vorn_connector_options` tool and answers it, and the manifest carries the set's
+name, but the app does not fetch the list yet — such a field is edited as text
+until it does. Declaring it now is what makes it work then; a field whose
+choices are already known should use `options` instead.
 
 A `json` argument arrives parsed. `builderHint` on a field is a note for whoever
 writes the next connector, not for whoever runs this one.

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -84,6 +84,60 @@ await serveConnector(connector)
 
 Publish it like any other package (`"bin": { "acme-connector": "dist/bin.js" }`).
 
+`vorn-connector new acme` writes all of the above — package, entry, definition,
+a test that needs no network — already building, checking and packing.
+
+## Declare an action instead of writing one
+
+Most actions put arguments into a request and keep part of the answer. Say that
+and the SDK does the rest: `{{args.x}}` and `{{config.y}}` are filled in, an
+argument nobody supplied is left out, a failed status is raised with what the
+body said, and `postReceive` reshapes what came back.
+
+```ts
+{
+  type: 'createIssue',
+  label: 'Create issue',
+  idempotent: false,
+  inputs: [{ key: 'title', label: 'Title', required: true }],
+  request: {
+    method: 'POST',
+    url: '{{config.baseUrl}}/issues',
+    headers: { authorization: 'Bearer {{config.apiToken}}' },
+    body: { title: '{{args.title}}' }
+  },
+  // pick · rename · flatten · filter · map, applied left to right.
+  postReceive: [{ op: 'pick', keys: ['id', 'html_url'] }]
+}
+```
+
+Add `paginate` to follow every page rather than the first — `{ kind: 'cursor',
+cursorPath: 'next', param: 'cursor' }`, `{ kind: 'page', param: 'page' }` or
+`{ kind: 'link' }` — and the pages arrive concatenated.
+
+Retry, backoff and rate-limit handling are applied for you, to declared
+requests and to `context.fetch` alike. A read is always retried; a write only
+when the action declares `idempotent: true`, because repeating a create makes a
+second one. Prefer `context.fetch` over the global one in a hand-written action.
+
+## Offer a field the choices it has
+
+A `select` with fixed choices carries them; one whose choices only exist against
+a live connection names a set the connector serves.
+
+```ts
+options: { channels: async ({ config, fetch }) => ['general', 'random'] },
+actions: [{
+  type: 'post',
+  label: 'Post',
+  inputs: [{ key: 'channel', label: 'Channel', type: 'select', loadOptions: 'channels' }],
+  request: { method: 'POST', url: '{{config.baseUrl}}/post/{{args.channel}}' }
+}]
+```
+
+A `json` argument arrives parsed. `builderHint` on a field is a note for whoever
+writes the next connector, not for whoever runs this one.
+
 ## Poll a database instead of an API
 
 Nothing about a trigger is HTTP-specific — it just returns items. A SQL pull
@@ -301,6 +355,7 @@ text color instead of fighting the theme.
 ## CLI
 
 ```
+vorn-connector new <id>                   Scaffold a new connector, ready to build
 vorn-connector manifest <module>          Print the manifest as JSON
 vorn-connector setup <module> [trigger]   Print the Vorn connection settings
 vorn-connector poll <module> <trigger>    Run one poll against the environment
@@ -309,7 +364,8 @@ vorn-connector pack <module>              Build an installable .vorn.tgz pack
 vorn-connector serve <module>             Serve on stdio (what Vorn runs)
 ```
 
-`pack` accepts `--out <dir>`.
+`new` accepts `--out <dir>` and `--name "Display Name"`; `pack` accepts
+`--out <dir>`.
 
 `poll` accepts `--since <iso>` and `--limit <n>`, and reads the connector's
 declared config from your shell environment — the fastest way to confirm

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -11,7 +11,7 @@ import { connectionSetup, connectorManifest } from './setup'
 import { serveConnector } from './server'
 import type { Connector } from './types'
 
-const USAGE = `vorn-connector <command> <module> [options]
+const USAGE = `vorn-connector <command> <module | id> [options]
 
 Commands:
   new <id>                      Scaffold a new connector, ready to build

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url'
-import { resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { checkConnector, formatFindings } from './check'
 import { resolveConfig } from './define'
 import { packConnector, type BundleOutput, type BundleRequest } from './pack'
 import { runPoll } from './runtime'
+import { scaffoldFiles } from './scaffold'
 import { connectionSetup, connectorManifest } from './setup'
 import { serveConnector } from './server'
 import type { Connector } from './types'
@@ -12,6 +14,7 @@ import type { Connector } from './types'
 const USAGE = `vorn-connector <command> <module> [options]
 
 Commands:
+  new <id>                      Scaffold a new connector, ready to build
   manifest <module>             Print the connector manifest as JSON
   setup <module> [trigger]      Print the Vorn connection settings to paste
   check <module>                Verify the connector against Vorn's contract
@@ -23,7 +26,8 @@ Options:
   --since <iso>                 Lower bound passed to poll
   --limit <n>                   Maximum items to request
   --live                        Let check poll for real using the environment
-  --out <dir>                   Directory pack writes the archive to`
+  --out <dir>                   Directory new and pack write to
+  --name <name>                 Display name for a new connector`
 
 export interface CliDeps {
   load(modulePath: string): Promise<unknown>
@@ -33,6 +37,8 @@ export interface CliDeps {
   cwd?: string
   /** Replaced in tests so pack does not shell out to a bundler. */
   bundle?(request: BundleRequest): Promise<BundleOutput>
+  /** Replaced in tests so scaffolding writes nowhere. */
+  writeFile?(path: string, contents: string): Promise<void>
 }
 
 /** Flags that stand alone; everything else must be followed by a value. */
@@ -91,6 +97,27 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
   if (!modulePath) {
     deps.write(`Missing <module> argument\n\n${USAGE}`)
     return 1
+  }
+
+  // Handled before the module is loaded: there is nothing to load yet.
+  if (command === 'new') {
+    const { flags } = parseArgs(rest)
+    if (!deps.writeFile) {
+      deps.write('This build cannot write files')
+      return 1
+    }
+    const files = scaffoldFiles({
+      id: modulePath,
+      ...(flags.name !== undefined && { name: flags.name })
+    })
+    const root = join(flags.out ?? deps.cwd ?? '.', modulePath)
+    for (const file of files) {
+      await deps.writeFile(join(root, file.path), file.contents)
+    }
+    deps.write(`Created ${modulePath} in ${root}`)
+    for (const file of files) deps.write(`  ${file.path}`)
+    deps.write(`\nNext: cd ${root} && yarn install && yarn check`)
+    return 0
   }
 
   const connector = pickConnector(await deps.load(modulePath), modulePath)
@@ -198,7 +225,11 @@ if (invokedDirectly) {
           ? pathToFileURL(resolve(modulePath)).href
           : modulePath
       ),
-    write: (line) => process.stdout.write(`${line}\n`)
+    write: (line) => process.stdout.write(`${line}\n`),
+    writeFile: async (path, contents) => {
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, contents, { flag: 'wx' })
+    }
   })
     .then((code) => {
       process.exitCode = code

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -95,7 +95,7 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
     return command ? 0 : 1
   }
   if (!modulePath) {
-    deps.write(`Missing <module> argument\n\n${USAGE}`)
+    deps.write(`Missing <${command === 'new' ? 'id' : 'module'}> argument\n\n${USAGE}`)
     return 1
   }
 

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -197,7 +197,8 @@ export async function pollWithDedupe(
       config: context.config,
       ...(state && { lastItemId: state.id }),
       ...(context.limit !== undefined && { limit: context.limit }),
-      now: context.now
+      now: context.now,
+      fetch: context.fetch
     })
     return lastItemPoll(fetched, state, context, polledAt)
   }
@@ -210,7 +211,8 @@ export async function pollWithDedupe(
     config: context.config,
     ...(since !== undefined && { since }),
     ...(context.limit !== undefined && { limit: context.limit }),
-    now: context.now
+    now: context.now,
+    fetch: context.fetch
   })
   return timestampPoll(fetched, state, context, polledAt)
 }

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -180,6 +180,19 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
     if (!declared && loose.postReceive !== undefined) {
       throw new Error(`Action ${action.type} has postReceive but no request for it to reshape`)
     }
+    for (const input of action.inputs ?? []) {
+      // A field pointing at a set nobody serves draws an empty picker in the
+      // app, which reads as "this connection has none" rather than as a typo.
+      if (
+        input.loadOptions !== undefined &&
+        definition.options?.[input.loadOptions] === undefined
+      ) {
+        throw new Error(
+          `Action ${action.type} argument "${input.key}" loads options from ` +
+            `"${input.loadOptions}", which the connector does not serve`
+        )
+      }
+    }
   }
 
   assertUnique(

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -160,8 +160,25 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
     if (!KEY_PATTERN.test(action.type ?? '')) {
       throw new Error(`Action type "${action.type}" must start with a letter and be url-safe`)
     }
-    if (typeof action.run !== 'function') {
-      throw new Error(`Action ${action.type} is missing a run() implementation`)
+    // As with triggers, the union already rules these out for TypeScript
+    // authors; the checks stay for plain-JS connectors, where it buys nothing.
+    const loose = action as { run?: unknown; request?: unknown; postReceive?: unknown }
+    const written = typeof loose.run === 'function'
+    const declared = loose.request !== undefined
+    if (written && declared) {
+      throw new Error(`Action ${action.type} declares both run() and a request; pick one`)
+    }
+    if (!written && !declared) {
+      throw new Error(`Action ${action.type} is missing a run() implementation or a request`)
+    }
+    if (declared) {
+      const request = loose.request as { url?: unknown }
+      if (typeof request?.url !== 'string' || request.url.trim() === '') {
+        throw new Error(`Action ${action.type} declares a request with no URL`)
+      }
+    }
+    if (!declared && loose.postReceive !== undefined) {
+      throw new Error(`Action ${action.type} has postReceive but no request for it to reshape`)
     }
   }
 

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -21,6 +21,11 @@ const VIEW_BOX_PATTERN = /^-?[\d.]+\s+-?[\d.]+\s+-?[\d.]+\s+-?[\d.]+$/
 const DEDUPE_STRATEGIES: DedupeStrategy[] = ['timestamp', 'lastItem']
 const AUTH_RUNGS: AuthRung[] = ['none', 'cli', 'key', 'oauth']
 
+/** A declared request goes somewhere the connector named: a real URL, … */
+const ABSOLUTE_URL_PATTERN = /^https?:\/\//i
+/** … or one built on a value from its own settings. */
+const CONFIG_ROOTED_URL_PATTERN = /^\{\{\s*config\./
+
 function assertUnique(kind: string, keys: string[]): void {
   const seen = new Set<string>()
   for (const key of keys) {
@@ -175,6 +180,16 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
       const request = loose.request as { url?: unknown }
       if (typeof request?.url !== 'string' || request.url.trim() === '') {
         throw new Error(`Action ${action.type} declares a request with no URL`)
+      }
+      const url = request.url.trim()
+      // Where the call goes has to be the connector's decision. A URL built
+      // from an argument would let a step aim the connector's own credentials
+      // at a host of its choosing, and a relative one names no host at all.
+      if (!ABSOLUTE_URL_PATTERN.test(url) && !CONFIG_ROOTED_URL_PATTERN.test(url)) {
+        throw new Error(
+          `Action ${action.type} declares the request URL "${url}", which is neither absolute ` +
+            `nor rooted in a {{config.…}} value`
+        )
       }
     }
     if (!declared && loose.postReceive !== undefined) {

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -6,6 +6,10 @@ export interface HarnessOptions {
   config?: ConnectorConfig
   /** Fixed clock, so `updatedAt` defaults and cursors are deterministic. */
   now?: () => string
+  /** Answer the connector's calls from the test rather than the network. */
+  fetchImpl?: typeof fetch
+  /** Fake clock for backoff, so a retry test costs no real time. */
+  sleep?: (ms: number) => Promise<void>
 }
 
 export interface ConnectorHarness {
@@ -33,6 +37,8 @@ export function createConnectorHarness(
   const defaults = (options: RunPollOptions = {}): RunPollOptions => ({
     ...(harnessOptions.config && { config: harnessOptions.config }),
     ...(harnessOptions.now && { now: harnessOptions.now }),
+    ...(harnessOptions.fetchImpl && { fetchImpl: harnessOptions.fetchImpl }),
+    ...(harnessOptions.sleep && { sleep: harnessOptions.sleep }),
     ...options
   })
 
@@ -42,7 +48,9 @@ export function createConnectorHarness(
     execute: (actionType, args = {}) =>
       runAction(connector, actionType, args, {
         ...(harnessOptions.config && { config: harnessOptions.config }),
-        ...(harnessOptions.now && { now: harnessOptions.now })
+        ...(harnessOptions.now && { now: harnessOptions.now }),
+        ...(harnessOptions.fetchImpl && { fetchImpl: harnessOptions.fetchImpl }),
+        ...(harnessOptions.sleep && { sleep: harnessOptions.sleep })
       }),
     manifest: () => connectorManifest(connector),
     async pollTwice(triggerType, options) {

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -14,7 +14,7 @@ export {
   nextLink,
   MAX_REQUEST_PAGES
 } from './request'
-export type { RequestScope, ResolvedRequest } from './request'
+export type { RequestScope, ResolvedRequest, Substitution } from './request'
 export { resilientFetch, retryAfterMs, backoffMs } from './resilience'
 export type { RetryPolicy, ResilientFetchOptions } from './resilience'
 export {

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -5,6 +5,9 @@ export { pollWithDedupe } from './dedupe'
 export { normalizeItem, normalizeItems } from './normalize'
 export { runPoll, drainPoll, runAction, MAX_POLL_PAGES } from './runtime'
 export type { PollPage, RunPollOptions, RunActionOptions } from './runtime'
+export { applyPostReceive, valueAt } from './post-receive'
+export { resolveRequest, resolveTemplates, executeRequest, asOutput } from './request'
+export type { RequestScope, ResolvedRequest } from './request'
 export {
   connectionSetup,
   connectorManifest,
@@ -33,7 +36,10 @@ export type {
   ActionInputOption,
   ActionInputType,
   ActionOutputField,
+  ActionRequest,
   AuthRung,
+  PaginationStrategy,
+  PostReceiveOp,
   Connector,
   ConnectorAuth,
   ConnectorConfig,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -3,7 +3,7 @@ export { checkConnector, formatFindings } from './check'
 export type { CheckFinding, CheckOptions } from './check'
 export { pollWithDedupe } from './dedupe'
 export { normalizeItem, normalizeItems } from './normalize'
-export { runPoll, drainPoll, runAction, MAX_POLL_PAGES } from './runtime'
+export { runPoll, drainPoll, runAction, runOptions, MAX_POLL_PAGES } from './runtime'
 export type { PollPage, RunPollOptions, RunActionOptions } from './runtime'
 export { applyPostReceive, valueAt } from './post-receive'
 export {
@@ -22,6 +22,7 @@ export {
   connectorManifest,
   pollToolName,
   MANIFEST_TOOL,
+  OPTIONS_TOOL,
   PREFLIGHT_TOOL
 } from './setup'
 export type { ConnectionSetup, ConnectorManifest } from './setup'
@@ -59,6 +60,8 @@ export type {
   DedupeStrategy,
   FetchContext,
   NormalizedItem,
+  OptionsContext,
+  OptionsLoader,
   PollContext,
   PollOutcome,
   PreflightResult,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -6,8 +6,17 @@ export { normalizeItem, normalizeItems } from './normalize'
 export { runPoll, drainPoll, runAction, MAX_POLL_PAGES } from './runtime'
 export type { PollPage, RunPollOptions, RunActionOptions } from './runtime'
 export { applyPostReceive, valueAt } from './post-receive'
-export { resolveRequest, resolveTemplates, executeRequest, asOutput } from './request'
+export {
+  resolveRequest,
+  resolveTemplates,
+  executeRequest,
+  asOutput,
+  nextLink,
+  MAX_REQUEST_PAGES
+} from './request'
 export type { RequestScope, ResolvedRequest } from './request'
+export { resilientFetch, retryAfterMs, backoffMs } from './resilience'
+export type { RetryPolicy, ResilientFetchOptions } from './resilience'
 export {
   connectionSetup,
   connectorManifest,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -37,6 +37,8 @@ export {
 export type { PackOptions, PackResult, BundleRequest, BundleOutput } from './pack'
 export { createConnectorServer, serveConnector } from './server'
 export type { ConnectorServerOptions } from './server'
+export { scaffoldFiles, titleCase } from './scaffold'
+export type { ScaffoldOptions, ScaffoldFile } from './scaffold'
 export { createConnectorHarness } from './harness'
 export type { ConnectorHarness, HarnessOptions } from './harness'
 export type {

--- a/packages/connector-sdk/src/post-receive.ts
+++ b/packages/connector-sdk/src/post-receive.ts
@@ -1,0 +1,122 @@
+import type { PostReceiveOp } from './types'
+
+/**
+ * Reshaping a response, declaratively.
+ *
+ * Most connector actions differ from each other only in what they ask for and
+ * which part of the answer is worth keeping — an envelope to unwrap, a few
+ * fields to keep, a name to correct. Written by hand that is a page of
+ * defensive property access per action; written as these five ops it is a
+ * line each, and every one of them is a pure function this file can test
+ * without a network.
+ */
+
+/** Keys that would reach through an object into its prototype. */
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function segments(path: string): string[] {
+  return path
+    .split('.')
+    .map((part) => part.trim())
+    .filter((part) => part !== '')
+}
+
+/** The value at a dotted path, or undefined if any step is missing. */
+export function valueAt(value: unknown, path: string): unknown {
+  let current: unknown = value
+  for (const key of segments(path)) {
+    if (UNSAFE_KEYS.has(key)) return undefined
+    if (Array.isArray(current)) {
+      const index = Number(key)
+      if (!Number.isInteger(index)) return undefined
+      current = current[index]
+      continue
+    }
+    if (!isRecord(current)) return undefined
+    current = Object.prototype.hasOwnProperty.call(current, key) ? current[key] : undefined
+  }
+  return current
+}
+
+/** A copy of `value` with the dotted path replaced. Missing steps are created. */
+function withValueAt(value: unknown, path: string, next: unknown): unknown {
+  const keys = segments(path)
+  if (keys.length === 0) return next
+  const [head, ...rest] = keys
+  if (UNSAFE_KEYS.has(head)) return value
+
+  if (Array.isArray(value)) {
+    const index = Number(head)
+    if (!Number.isInteger(index)) return value
+    const copy = [...value]
+    copy[index] = rest.length === 0 ? next : withValueAt(copy[index], rest.join('.'), next)
+    return copy
+  }
+
+  const base = isRecord(value) ? value : {}
+  return {
+    ...base,
+    [head]: rest.length === 0 ? next : withValueAt(base[head], rest.join('.'), next)
+  }
+}
+
+function pick(value: unknown, keys: string[]): unknown {
+  if (Array.isArray(value)) return value.map((entry) => pick(entry, keys))
+  if (!isRecord(value)) return value
+  const out: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (UNSAFE_KEYS.has(key)) continue
+    if (Object.prototype.hasOwnProperty.call(value, key)) out[key] = value[key]
+  }
+  return out
+}
+
+function rename(value: unknown, from: string, to: string): unknown {
+  if (Array.isArray(value)) return value.map((entry) => rename(entry, from, to))
+  if (!isRecord(value)) return value
+  if (UNSAFE_KEYS.has(from) || UNSAFE_KEYS.has(to)) return value
+  if (!Object.prototype.hasOwnProperty.call(value, from)) return value
+  const out: Record<string, unknown> = {}
+  // Rebuilt in order so the renamed field keeps its place rather than moving
+  // to the end, which matters when the result is read by a person.
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === from) out[to] = entry
+    else if (key !== to) out[key] = entry
+  }
+  return out
+}
+
+/** Apply one op to the whole value, or to what lives at its `path`. */
+function applyOp(value: unknown, op: PostReceiveOp): unknown {
+  if (op.op === 'flatten') return valueAt(value, op.path)
+
+  const target = op.path === undefined ? value : valueAt(value, op.path)
+  // A path that names nothing leaves the value as it was, rather than adding
+  // the key it was looking for.
+  if (op.path !== undefined && target === undefined) return value
+  let next: unknown
+
+  if (op.op === 'pick') next = pick(target, op.keys)
+  else if (op.op === 'rename') next = rename(target, op.from, op.to)
+  else if (op.op === 'filter') {
+    // A filter on something that is not a list is a no-op rather than an
+    // error: an upstream that answered with one object instead of a page of
+    // them should not fail the step.
+    next = Array.isArray(target)
+      ? target.filter((entry) => isRecord(entry) && valueAt(entry, op.key) === op.equals)
+      : target
+  } else {
+    next = Array.isArray(target) ? target.map((entry) => applyPostReceive(entry, op.ops)) : target
+  }
+
+  return op.path === undefined ? next : withValueAt(value, op.path, next)
+}
+
+/** Run a response through the declared ops, left to right. */
+export function applyPostReceive(value: unknown, ops: PostReceiveOp[] | undefined): unknown {
+  return (ops ?? []).reduce<unknown>(applyOp, value)
+}

--- a/packages/connector-sdk/src/request.ts
+++ b/packages/connector-sdk/src/request.ts
@@ -28,6 +28,40 @@ function lookup(source: string, path: string, scope: RequestScope): unknown {
 }
 
 /**
+ * How a substituted value is written into its surroundings.
+ *
+ * A value's meaning depends on where it lands: a path segment has to be
+ * escaped, a header has characters it may not contain at all. Passing that
+ * decision in means the substitution is made safe once, here, instead of by
+ * every author who interpolates an argument.
+ */
+export type Substitution = (value: string, source: 'args' | 'config') => string
+
+/**
+ * Escape a substitution for a URL, but leave one that came from config alone.
+ *
+ * An argument is somebody else's input: `42?role=admin` or `../../admin` in one
+ * would otherwise rewrite the request the connector's own credentials are about
+ * to authenticate. Config is the connector's own setting — a base URL is a URL,
+ * and escaping it would break the request instead of protecting it.
+ */
+const intoUrl: Substitution = (value, source) =>
+  source === 'config' ? value : encodeURIComponent(value)
+
+/**
+ * A header value may not carry a line ending: one would end the header and
+ * start whatever the injected text says next.
+ */
+function intoHeader(name: string): Substitution {
+  return (value) => {
+    if (/[\r\n]/.test(value)) {
+      throw new Error(`Header "${name}" would carry a line ending, which is not allowed`)
+    }
+    return value
+  }
+}
+
+/**
  * Resolve `{{args.x}}` and `{{config.y}}` inside a value.
  *
  * A whole-string placeholder keeps the referenced value's own type, so a body
@@ -35,25 +69,53 @@ function lookup(source: string, path: string, scope: RequestScope): unknown {
  * into the string. An unset reference resolves to `undefined` on its own and to
  * the empty string when it is part of a larger one, which is what lets an
  * optional argument simply not appear.
+ *
+ * With a `substitute`, every resolved value passes through it — including a
+ * whole-string one, which then arrives as text rather than keeping its type,
+ * because a place that needs escaping is a place that holds a string.
  */
-export function resolveTemplates(value: unknown, scope: RequestScope): unknown {
+export function resolveTemplates(
+  value: unknown,
+  scope: RequestScope,
+  substitute?: Substitution
+): unknown {
   if (typeof value === 'string') {
     const whole = WHOLE_PLACEHOLDER.exec(value)
-    if (whole) return lookup(whole[1], whole[2], scope)
+    if (whole) {
+      const resolved = lookup(whole[1], whole[2], scope)
+      if (substitute === undefined || resolved === undefined || resolved === null) return resolved
+      return substitute(String(resolved), whole[1] as 'args' | 'config')
+    }
     return value.replace(PLACEHOLDER, (_match, source: string, path: string) => {
       const resolved = lookup(source, path, scope)
-      return resolved === undefined || resolved === null ? '' : String(resolved)
+      if (resolved === undefined || resolved === null) return ''
+      const text = String(resolved)
+      return substitute === undefined ? text : substitute(text, source as 'args' | 'config')
     })
   }
-  if (Array.isArray(value)) return value.map((entry) => resolveTemplates(entry, scope))
+  if (Array.isArray(value)) return value.map((entry) => resolveTemplates(entry, scope, substitute))
   if (typeof value === 'object' && value !== null) {
     const out: Record<string, unknown> = {}
     for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
-      out[key] = resolveTemplates(entry, scope)
+      out[key] = resolveTemplates(entry, scope, substitute)
     }
     return out
   }
   return value
+}
+
+/** Resolve each header on its own, so a refusal can name the one at fault. */
+function resolveHeaders(
+  raw: Record<string, string> | undefined,
+  scope: RequestScope
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [name, value] of Object.entries(raw ?? {})) {
+    const resolved = resolveTemplates(value, scope, intoHeader(name))
+    if (resolved === undefined || resolved === null || resolved === '') continue
+    out[name] = String(resolved)
+  }
+  return out
 }
 
 /** Drop entries whose value never resolved, and stringify the rest. */
@@ -77,17 +139,24 @@ export interface ResolvedRequest {
 /** Build the exact call a declared request makes, with its templates resolved. */
 export function resolveRequest(request: ActionRequest, scope: RequestScope): ResolvedRequest {
   const method = (request.method ?? 'GET').toUpperCase()
-  const rawUrl = resolveTemplates(request.url, scope)
+  const rawUrl = resolveTemplates(request.url, scope, intoUrl)
   if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
     throw new Error('Request has no URL once its templates are resolved')
   }
 
-  const url = new URL(rawUrl)
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    // Says what it actually tried to call: the declared template rarely names
+    // the problem, and the resolved string always does.
+    throw new Error(`Request URL is not a URL once its templates are resolved: "${rawUrl}"`)
+  }
   for (const [key, value] of Object.entries(stringMap(resolveTemplates(request.query, scope)))) {
     url.searchParams.set(key, value)
   }
 
-  const headers = stringMap(resolveTemplates(request.headers, scope))
+  const headers = resolveHeaders(request.headers, scope)
   const resolved: ResolvedRequest = { url: url.toString(), method, headers }
 
   if (request.body !== undefined && method !== 'GET' && method !== 'HEAD') {

--- a/packages/connector-sdk/src/request.ts
+++ b/packages/connector-sdk/src/request.ts
@@ -284,9 +284,20 @@ async function collectPages(
 
     const { response, body } = await sendRequest(resolved, options)
     const items = pageItems(body, strategy.itemsPath)
-    // A page that is not a list ends the walk: a source that answered with an
-    // object has nothing left to concatenate.
-    if (items === undefined) return collected
+    if (items === undefined) {
+      // On the first page this is the declaration being wrong, not the source
+      // running out — and answering "no items" would hide that for good.
+      if (index === 0) {
+        const where =
+          strategy.itemsPath === undefined
+            ? 'the response is not a list'
+            : `the response has no list at "${strategy.itemsPath}"`
+        throw new Error(`Cannot page through this request: ${where}`)
+      }
+      // Later on it is the end of the walk: a source that answered with an
+      // object has nothing left to concatenate.
+      return collected
+    }
     collected.push(...items)
     if (items.length === 0) return collected
 

--- a/packages/connector-sdk/src/request.ts
+++ b/packages/connector-sdk/src/request.ts
@@ -96,7 +96,8 @@ export function resolveRequest(request: ActionRequest, scope: RequestScope): Res
       resolved.body = typeof body === 'string' ? body : JSON.stringify(body)
       // Only defaulted: an author sending form-encoded or XML said so already.
       if (!Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
-        headers['content-type'] = typeof body === 'string' ? 'text/plain' : 'application/json'
+        resolved.headers['content-type'] =
+          typeof body === 'string' ? 'text/plain' : 'application/json'
       }
     }
   }

--- a/packages/connector-sdk/src/request.ts
+++ b/packages/connector-sdk/src/request.ts
@@ -1,5 +1,5 @@
 import { applyPostReceive, valueAt } from './post-receive'
-import type { ActionRequest, ConnectorConfig, PostReceiveOp } from './types'
+import type { ActionRequest, ConnectorConfig, PaginationStrategy, PostReceiveOp } from './types'
 
 /**
  * Turning a declared request into a real one.
@@ -157,13 +157,97 @@ export function asOutput(value: unknown): Record<string, unknown> {
   return value === undefined ? {} : { result: value }
 }
 
-/** Run a declared request end to end: resolve, send, reshape. */
+/** Longest chain of pages a declared request will follow before calling it a bug. */
+export const MAX_REQUEST_PAGES = 100
+
+const LINK_NEXT = /<([^>]+)>\s*;[^,]*\brel\s*=\s*"?next"?/i
+
+/** The URL of the next page, as a paged HTTP API states it in its `Link` header. */
+export function nextLink(header: string | null): string | undefined {
+  const match = header === null ? null : LINK_NEXT.exec(header)
+  return match ? match[1] : undefined
+}
+
+/** The list a page carries, at `itemsPath` or as the whole body. */
+function pageItems(body: unknown, itemsPath: string | undefined): unknown[] | undefined {
+  const value = itemsPath === undefined ? body : valueAt(body, itemsPath)
+  return Array.isArray(value) ? value : undefined
+}
+
+/**
+ * Follow a declared request to the end of its pages.
+ *
+ * Stops when the source runs out, when it stops moving — a cursor that repeats
+ * would otherwise loop forever — or at a bound, so a paging bug shows up as an
+ * error rather than as a step that never finishes.
+ */
+async function collectPages(
+  request: ActionRequest,
+  strategy: PaginationStrategy,
+  scope: RequestScope,
+  options: SendOptions
+): Promise<unknown[]> {
+  const collected: unknown[] = []
+  const seen = new Set<string>()
+  let page = strategy.kind === 'page' ? (strategy.startPage ?? 1) : 0
+  let cursor: string | undefined
+  let nextUrl: string | undefined
+
+  for (let index = 0; index < MAX_REQUEST_PAGES; index++) {
+    const resolved = resolveRequest(request, scope)
+    if (nextUrl !== undefined) resolved.url = nextUrl
+    if (strategy.kind === 'cursor' && cursor !== undefined) {
+      const url = new URL(resolved.url)
+      url.searchParams.set(strategy.param, cursor)
+      resolved.url = url.toString()
+    }
+    if (strategy.kind === 'page') {
+      const url = new URL(resolved.url)
+      url.searchParams.set(strategy.param, String(page))
+      resolved.url = url.toString()
+    }
+
+    if (seen.has(resolved.url)) {
+      throw new Error(`Request for ${request.url} asked for the same page twice`)
+    }
+    seen.add(resolved.url)
+
+    const { response, body } = await sendRequest(resolved, options)
+    const items = pageItems(body, strategy.itemsPath)
+    // A page that is not a list ends the walk: a source that answered with an
+    // object has nothing left to concatenate.
+    if (items === undefined) return collected
+    collected.push(...items)
+    if (items.length === 0) return collected
+
+    if (strategy.kind === 'cursor') {
+      const next = valueAt(body, strategy.cursorPath)
+      if (next === undefined || next === null || next === '') return collected
+      cursor = String(next)
+      continue
+    }
+    if (strategy.kind === 'link') {
+      nextUrl = nextLink(response.headers.get('link'))
+      if (nextUrl === undefined) return collected
+      continue
+    }
+    page += 1
+  }
+
+  throw new Error(`Request for ${request.url} exceeded ${MAX_REQUEST_PAGES} pages`)
+}
+
+/** Run a declared request end to end: resolve, send, follow its pages, reshape. */
 export async function executeRequest(
   request: ActionRequest,
   postReceive: PostReceiveOp[] | undefined,
   scope: RequestScope,
   options: SendOptions
 ): Promise<Record<string, unknown>> {
+  if (request.paginate) {
+    const items = await collectPages(request, request.paginate, scope, options)
+    return asOutput(applyPostReceive(items, postReceive))
+  }
   const { body } = await sendRequest(resolveRequest(request, scope), options)
   return asOutput(applyPostReceive(body, postReceive))
 }

--- a/packages/connector-sdk/src/request.ts
+++ b/packages/connector-sdk/src/request.ts
@@ -1,0 +1,169 @@
+import { applyPostReceive, valueAt } from './post-receive'
+import type { ActionRequest, ConnectorConfig, PostReceiveOp } from './types'
+
+/**
+ * Turning a declared request into a real one.
+ *
+ * A connector's actions are mostly the same shape — put these arguments into a
+ * URL, send them, keep part of the answer. Declaring that instead of writing it
+ * means the SDK owns the parts every author would otherwise re-implement: URL
+ * encoding, dropping arguments nobody supplied, reading the error body when the
+ * call fails.
+ */
+
+/** How much of a failed response to quote back. Enough to name the cause. */
+const MAX_ERROR_BODY = 500
+
+const PLACEHOLDER = /\{\{\s*(args|config)\.([A-Za-z0-9_.-]+)\s*\}\}/g
+/** A string that is nothing but one placeholder keeps the value's own type. */
+const WHOLE_PLACEHOLDER = /^\{\{\s*(args|config)\.([A-Za-z0-9_.-]+)\s*\}\}$/
+
+export interface RequestScope {
+  args: Record<string, unknown>
+  config: ConnectorConfig
+}
+
+function lookup(source: string, path: string, scope: RequestScope): unknown {
+  return valueAt(source === 'args' ? scope.args : scope.config, path)
+}
+
+/**
+ * Resolve `{{args.x}}` and `{{config.y}}` inside a value.
+ *
+ * A whole-string placeholder keeps the referenced value's own type, so a body
+ * can carry a number or an object; a placeholder among other text is rendered
+ * into the string. An unset reference resolves to `undefined` on its own and to
+ * the empty string when it is part of a larger one, which is what lets an
+ * optional argument simply not appear.
+ */
+export function resolveTemplates(value: unknown, scope: RequestScope): unknown {
+  if (typeof value === 'string') {
+    const whole = WHOLE_PLACEHOLDER.exec(value)
+    if (whole) return lookup(whole[1], whole[2], scope)
+    return value.replace(PLACEHOLDER, (_match, source: string, path: string) => {
+      const resolved = lookup(source, path, scope)
+      return resolved === undefined || resolved === null ? '' : String(resolved)
+    })
+  }
+  if (Array.isArray(value)) return value.map((entry) => resolveTemplates(entry, scope))
+  if (typeof value === 'object' && value !== null) {
+    const out: Record<string, unknown> = {}
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = resolveTemplates(entry, scope)
+    }
+    return out
+  }
+  return value
+}
+
+/** Drop entries whose value never resolved, and stringify the rest. */
+function stringMap(raw: unknown): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (typeof raw !== 'object' || raw === null) return out
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (value === undefined || value === null || value === '') continue
+    out[key] = String(value)
+  }
+  return out
+}
+
+export interface ResolvedRequest {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body?: string
+}
+
+/** Build the exact call a declared request makes, with its templates resolved. */
+export function resolveRequest(request: ActionRequest, scope: RequestScope): ResolvedRequest {
+  const method = (request.method ?? 'GET').toUpperCase()
+  const rawUrl = resolveTemplates(request.url, scope)
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    throw new Error('Request has no URL once its templates are resolved')
+  }
+
+  const url = new URL(rawUrl)
+  for (const [key, value] of Object.entries(stringMap(resolveTemplates(request.query, scope)))) {
+    url.searchParams.set(key, value)
+  }
+
+  const headers = stringMap(resolveTemplates(request.headers, scope))
+  const resolved: ResolvedRequest = { url: url.toString(), method, headers }
+
+  if (request.body !== undefined && method !== 'GET' && method !== 'HEAD') {
+    const body = resolveTemplates(request.body, scope)
+    if (body !== undefined) {
+      resolved.body = typeof body === 'string' ? body : JSON.stringify(body)
+      // Only defaulted: an author sending form-encoded or XML said so already.
+      if (!Object.keys(headers).some((key) => key.toLowerCase() === 'content-type')) {
+        headers['content-type'] = typeof body === 'string' ? 'text/plain' : 'application/json'
+      }
+    }
+  }
+
+  return resolved
+}
+
+/** Read a response as JSON when it says it is, and as text otherwise. */
+async function readBody(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (text === '') return undefined
+  const type = response.headers.get('content-type') ?? ''
+  if (!type.includes('json')) return text
+  try {
+    return JSON.parse(text)
+  } catch {
+    // A body that claims to be JSON and is not is the upstream's mistake, and
+    // the raw text says more about it than a parse error would.
+    return text
+  }
+}
+
+function describeFailure(response: Response, body: unknown): string {
+  const detail = typeof body === 'string' ? body : body === undefined ? '' : JSON.stringify(body)
+  const quoted = detail.length > MAX_ERROR_BODY ? `${detail.slice(0, MAX_ERROR_BODY)}…` : detail
+  return `Request failed with ${response.status} ${response.statusText}${quoted ? `: ${quoted}` : ''}`
+}
+
+export interface SendOptions {
+  fetchImpl: typeof fetch
+}
+
+/** Send one resolved request and read its body, throwing on a failed status. */
+export async function sendRequest(
+  resolved: ResolvedRequest,
+  options: SendOptions
+): Promise<{ response: Response; body: unknown }> {
+  const response = await options.fetchImpl(resolved.url, {
+    method: resolved.method,
+    headers: resolved.headers,
+    ...(resolved.body !== undefined && { body: resolved.body })
+  })
+  const body = await readBody(response)
+  if (!response.ok) throw new Error(describeFailure(response, body))
+  return { response, body }
+}
+
+/**
+ * The action's result, as Vorn stores it.
+ *
+ * A step's output is a record, so a response that is a list becomes `items` —
+ * the name the rest of this SDK already uses for one — and any other bare
+ * value becomes `result`.
+ */
+export function asOutput(value: unknown): Record<string, unknown> {
+  if (Array.isArray(value)) return { items: value }
+  if (typeof value === 'object' && value !== null) return value as Record<string, unknown>
+  return value === undefined ? {} : { result: value }
+}
+
+/** Run a declared request end to end: resolve, send, reshape. */
+export async function executeRequest(
+  request: ActionRequest,
+  postReceive: PostReceiveOp[] | undefined,
+  scope: RequestScope,
+  options: SendOptions
+): Promise<Record<string, unknown>> {
+  const { body } = await sendRequest(resolveRequest(request, scope), options)
+  return asOutput(applyPostReceive(body, postReceive))
+}

--- a/packages/connector-sdk/src/resilience.ts
+++ b/packages/connector-sdk/src/resilience.ts
@@ -1,0 +1,112 @@
+/**
+ * Surviving an upstream's bad minute.
+ *
+ * Every connector eventually meets the same three answers — a rate limit, a
+ * gateway that briefly forgot how to work, a socket that died mid-call — and
+ * every author writes the same retry loop for them, usually without the one
+ * part that matters: only repeating calls that are safe to repeat. Doing it
+ * here means a connector gets it by saying nothing at all.
+ */
+
+/** Statuses worth trying again. Anything else is an answer, not a hiccup. */
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504])
+
+export interface RetryPolicy {
+  /** Total tries, including the first. Defaults to 3. */
+  attempts?: number
+  /** First backoff step; each retry doubles it. Defaults to 250ms. */
+  baseDelayMs?: number
+  /** Ceiling for any single wait, including one the server asked for. */
+  maxDelayMs?: number
+}
+
+export interface ResilientFetchOptions {
+  fetchImpl: typeof fetch
+  /**
+   * Whether repeating the call is safe. A read always is; a write is only when
+   * the action said so, because retrying a `create` invents a second one.
+   */
+  retryable: boolean
+  retry?: RetryPolicy
+  /** Replaced in tests so backoff costs no real time. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+const DEFAULT_ATTEMPTS = 3
+const DEFAULT_BASE_DELAY_MS = 250
+const DEFAULT_MAX_DELAY_MS = 30_000
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+/**
+ * How long the server asked us to wait, in milliseconds.
+ *
+ * `Retry-After` is either a count of seconds or an HTTP date; both are common
+ * enough that reading only one of them is how a connector ends up hammering a
+ * rate limiter it was politely asked to back off from.
+ */
+export function retryAfterMs(header: string | null, now: number): number | undefined {
+  if (!header) return undefined
+  const trimmed = header.trim()
+  if (trimmed === '') return undefined
+
+  const seconds = Number(trimmed)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+
+  const at = Date.parse(trimmed)
+  if (Number.isNaN(at)) return undefined
+  return Math.max(0, at - now)
+}
+
+/** The wait before try number `attempt`, counting the first try as zero. */
+export function backoffMs(attempt: number, policy: RetryPolicy = {}): number {
+  const base = policy.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
+  const max = policy.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+  // Deliberately without jitter: a connector's tests should be able to say
+  // exactly how long it waited, and the fleet this serves is one machine's
+  // worth of calls rather than a thundering herd.
+  return Math.min(max, base * 2 ** attempt)
+}
+
+/**
+ * Wrap a fetch so it retries what is worth retrying.
+ *
+ * The wrapper is the value handed to actions as `context.fetch`, so a
+ * hand-written action and a declared request are equally protected.
+ */
+export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
+  const attempts = Math.max(1, options.retry?.attempts ?? DEFAULT_ATTEMPTS)
+  const sleep = options.sleep ?? wait
+
+  const ceiling = options.retry?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+
+  const send = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const last = attempt === attempts - 1
+      try {
+        const response = await options.fetchImpl(input, init)
+        if (!RETRYABLE_STATUS.has(response.status)) return response
+        // Out of tries, or not ours to repeat: the status is the answer.
+        if (!options.retryable || last) return response
+        // The server named its own wait; honour it over our backoff, because
+        // it knows when the limit resets and we are only guessing.
+        const asked = retryAfterMs(response.headers.get('retry-after'), Date.now())
+        await sleep(
+          asked === undefined ? backoffMs(attempt, options.retry) : Math.min(asked, ceiling)
+        )
+      } catch (error) {
+        // A thrown fetch is the network failing rather than the server
+        // answering, which is exactly the case a retry exists for.
+        if (!options.retryable || last) throw error
+        await sleep(backoffMs(attempt, options.retry))
+      }
+    }
+    // `attempts` is at least 1, so the loop always returns or throws first.
+    throw new Error('Request was never attempted')
+  }
+
+  return send as unknown as typeof fetch
+}

--- a/packages/connector-sdk/src/resilience.ts
+++ b/packages/connector-sdk/src/resilience.ts
@@ -36,6 +36,16 @@ const DEFAULT_ATTEMPTS = 3
 const DEFAULT_BASE_DELAY_MS = 250
 const DEFAULT_MAX_DELAY_MS = 30_000
 
+/**
+ * The bounds a connector cannot talk its way past.
+ *
+ * A policy is the connector's to set, but a step that waits forever is nobody's
+ * intention — an author who asks for fifty tries, or an upstream that keeps
+ * asking for another minute, would otherwise hold a run open indefinitely.
+ */
+const MAX_ATTEMPTS = 10
+const MAX_TOTAL_WAIT_MS = 120_000
+
 const wait = (ms: number): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(resolve, ms)
@@ -78,12 +88,21 @@ export function backoffMs(attempt: number, policy: RetryPolicy = {}): number {
  * hand-written action and a declared request are equally protected.
  */
 export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
-  const attempts = Math.max(1, options.retry?.attempts ?? DEFAULT_ATTEMPTS)
+  const attempts = Math.min(MAX_ATTEMPTS, Math.max(1, options.retry?.attempts ?? DEFAULT_ATTEMPTS))
   const sleep = options.sleep ?? wait
 
   const ceiling = options.retry?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
 
   const send = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    let waited = 0
+    /** Wait, unless doing so would spend more than one call is allowed. */
+    const pause = async (ms: number): Promise<boolean> => {
+      if (waited + ms > MAX_TOTAL_WAIT_MS) return false
+      waited += ms
+      await sleep(ms)
+      return true
+    }
+
     for (let attempt = 0; attempt < attempts; attempt++) {
       const last = attempt === attempts - 1
       try {
@@ -94,14 +113,15 @@ export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
         // The server named its own wait; honour it over our backoff, because
         // it knows when the limit resets and we are only guessing.
         const asked = retryAfterMs(response.headers.get('retry-after'), Date.now())
-        await sleep(
+        const delay =
           asked === undefined ? backoffMs(attempt, options.retry) : Math.min(asked, ceiling)
-        )
+        // Out of patience rather than out of tries; the status is still the answer.
+        if (!(await pause(delay))) return response
       } catch (error) {
         // A thrown fetch is the network failing rather than the server
         // answering, which is exactly the case a retry exists for.
         if (!options.retryable || last) throw error
-        await sleep(backoffMs(attempt, options.retry))
+        if (!(await pause(backoffMs(attempt, options.retry)))) throw error
       }
     }
     // `attempts` is at least 1, so the loop always returns or throws first.

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -156,18 +156,34 @@ export async function runOptions(
   )
 }
 
+/** How much of a bad value to quote back, so an error names it without a wall of text. */
+const MAX_QUOTED_VALUE = 80
+
+function quote(value: string): string {
+  return value.length > MAX_QUOTED_VALUE ? `${value.slice(0, MAX_QUOTED_VALUE)}…` : value
+}
+
 function coerceArg(value: unknown, type: string | undefined): unknown {
   if (typeof value !== 'string') return value
   if (type === 'number') {
     const parsed = Number(value)
-    if (Number.isNaN(parsed)) throw new Error(`Expected a number, got "${value}"`)
+    if (Number.isNaN(parsed)) throw new Error(`Expected a number, got "${quote(value)}"`)
     return parsed
   }
   if (type === 'boolean') {
     if (value === 'true') return true
     if (value === 'false') return false
-    throw new Error(`Expected a boolean, got "${value}"`)
+    throw new Error(`Expected a boolean, got "${quote(value)}"`)
   }
+  if (type === 'json') {
+    try {
+      return JSON.parse(value)
+    } catch {
+      throw new Error(`Expected JSON, got "${quote(value)}"`)
+    }
+  }
+  // `select` and `string` are both strings here: a select's value is one of
+  // its choices, which the served schema already states.
   return value
 }
 

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -236,20 +236,24 @@ export async function runAction(
     ...(options.sleep !== undefined && { sleep: options.sleep })
   })
 
-  if (typeof action.run === 'function') {
-    const output = await action.run(coerced, {
-      config,
-      now: options.now ?? (() => new Date().toISOString()),
-      fetch: fetchImpl
-    })
-    return output ?? {}
+  if (action.request !== undefined) {
+    return executeRequest(
+      action.request,
+      action.postReceive,
+      { args: coerced, config },
+      { fetchImpl }
+    )
+  }
+  // `defineConnector` rules this out; a connector hand-built in plain JS and
+  // passed straight here has not been through it.
+  if (typeof action.run !== 'function') {
+    throw new Error(`Action ${actionType} has neither a run() implementation nor a request`)
   }
 
-  // Declared rather than written: `defineConnector` guarantees one or the other.
-  return executeRequest(
-    action.request,
-    action.postReceive,
-    { args: coerced, config },
-    { fetchImpl }
-  )
+  const output = await action.run(coerced, {
+    config,
+    now: options.now ?? (() => new Date().toISOString()),
+    fetch: fetchImpl
+  })
+  return output ?? {}
 }

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -1,6 +1,7 @@
 import { pollWithDedupe } from './dedupe'
 import { normalizeItems } from './normalize'
 import { executeRequest } from './request'
+import { resilientFetch, type RetryPolicy } from './resilience'
 import type { Connector, ConnectorConfig, NormalizedItem, PollContext } from './types'
 
 export interface PollPage {
@@ -15,6 +16,11 @@ export interface RunPollOptions {
   cursor?: string
   limit?: number
   now?: () => string
+  /** Replaced by the harness and by tests; defaults to the global fetch. */
+  fetchImpl?: typeof fetch
+  retry?: RetryPolicy
+  /** Replaced in tests so backoff costs no real time. */
+  sleep?: (ms: number) => Promise<void>
 }
 
 /** Longest chain of pages `drainPoll` will follow before calling it a bug. */
@@ -41,7 +47,14 @@ export async function runPoll(
     ...(options.since !== undefined && { since: options.since }),
     ...(options.cursor !== undefined && { cursor: options.cursor }),
     ...(options.limit !== undefined && { limit: options.limit }),
-    now
+    now,
+    // A poll only reads, so every failure it meets is worth trying again.
+    fetch: resilientFetch({
+      fetchImpl: options.fetchImpl ?? globalThis.fetch,
+      retryable: true,
+      ...(options.retry !== undefined && { retry: options.retry }),
+      ...(options.sleep !== undefined && { sleep: options.sleep })
+    })
   }
 
   const outcome =
@@ -94,7 +107,13 @@ export interface RunActionOptions {
   now?: () => string
   /** Replaced by the harness and by tests; defaults to the global fetch. */
   fetchImpl?: typeof fetch
+  retry?: RetryPolicy
+  /** Replaced in tests so backoff costs no real time. */
+  sleep?: (ms: number) => Promise<void>
 }
+
+/** Methods that change nothing, so repeating one cannot do a thing twice. */
+const SAFE_METHODS = new Set(['GET', 'HEAD'])
 
 function coerceArg(value: unknown, type: string | undefined): unknown {
   if (typeof value !== 'string') return value
@@ -148,7 +167,17 @@ export async function runAction(
   }
 
   const config = options.config ?? {}
-  const fetchImpl = options.fetchImpl ?? globalThis.fetch
+  // Repeating a write invents a second one, so a retry needs the action's word
+  // that it is safe — except for a declared read, which says so by its method.
+  const method = (action.request?.method ?? 'GET').toUpperCase()
+  const retryable =
+    action.idempotent === true || (action.request !== undefined && SAFE_METHODS.has(method))
+  const fetchImpl = resilientFetch({
+    fetchImpl: options.fetchImpl ?? globalThis.fetch,
+    retryable,
+    ...(options.retry !== undefined && { retry: options.retry }),
+    ...(options.sleep !== undefined && { sleep: options.sleep })
+  })
 
   if (typeof action.run === 'function') {
     const output = await action.run(coerced, {

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -237,12 +237,21 @@ export async function runAction(
   })
 
   if (action.request !== undefined) {
-    return executeRequest(
-      action.request,
-      action.postReceive,
-      { args: coerced, config },
-      { fetchImpl }
-    )
+    try {
+      return await executeRequest(
+        action.request,
+        action.postReceive,
+        { args: coerced, config },
+        { fetchImpl }
+      )
+    } catch (error) {
+      // Which action failed is the first thing a reader needs; the message
+      // underneath already says what about it went wrong.
+      throw new Error(
+        `Action ${actionType}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      )
+    }
   }
   // `defineConnector` rules this out; a connector hand-built in plain JS and
   // passed straight here has not been through it.

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -2,7 +2,13 @@ import { pollWithDedupe } from './dedupe'
 import { normalizeItems } from './normalize'
 import { executeRequest } from './request'
 import { resilientFetch, type RetryPolicy } from './resilience'
-import type { Connector, ConnectorConfig, NormalizedItem, PollContext } from './types'
+import type {
+  ActionInputOption,
+  Connector,
+  ConnectorConfig,
+  NormalizedItem,
+  PollContext
+} from './types'
 
 export interface PollPage {
   items: NormalizedItem[]
@@ -114,6 +120,41 @@ export interface RunActionOptions {
 
 /** Methods that change nothing, so repeating one cannot do a thing twice. */
 const SAFE_METHODS = new Set(['GET', 'HEAD'])
+
+/**
+ * Ask a connector what one of its dynamic fields can be.
+ *
+ * Listing choices only reads, so it retries like a poll does. A bare string is
+ * taken as a choice that shows itself, which is the common case.
+ */
+export async function runOptions(
+  connector: Connector,
+  name: string,
+  options: RunActionOptions = {}
+): Promise<ActionInputOption[]> {
+  const loader = connector.options?.[name]
+  if (!loader) {
+    throw new Error(`Connector ${connector.id} serves no options set "${name}"`)
+  }
+
+  const loaded = await loader({
+    config: options.config ?? {},
+    now: options.now ?? (() => new Date().toISOString()),
+    fetch: resilientFetch({
+      fetchImpl: options.fetchImpl ?? globalThis.fetch,
+      retryable: true,
+      ...(options.retry !== undefined && { retry: options.retry }),
+      ...(options.sleep !== undefined && { sleep: options.sleep })
+    })
+  })
+
+  if (!Array.isArray(loaded)) {
+    throw new Error(`Options set "${name}" did not return an array`)
+  }
+  return loaded.map((entry) =>
+    typeof entry === 'string' ? { value: entry } : { ...entry, value: String(entry.value) }
+  )
+}
 
 function coerceArg(value: unknown, type: string | undefined): unknown {
   if (typeof value !== 'string') return value

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -1,5 +1,6 @@
 import { pollWithDedupe } from './dedupe'
 import { normalizeItems } from './normalize'
+import { executeRequest } from './request'
 import type { Connector, ConnectorConfig, NormalizedItem, PollContext } from './types'
 
 export interface PollPage {
@@ -91,6 +92,8 @@ export async function drainPoll(
 export interface RunActionOptions {
   config?: ConnectorConfig
   now?: () => string
+  /** Replaced by the harness and by tests; defaults to the global fetch. */
+  fetchImpl?: typeof fetch
 }
 
 function coerceArg(value: unknown, type: string | undefined): unknown {
@@ -144,9 +147,23 @@ export async function runAction(
     }
   }
 
-  const output = await action.run(coerced, {
-    config: options.config ?? {},
-    now: options.now ?? (() => new Date().toISOString())
-  })
-  return output ?? {}
+  const config = options.config ?? {}
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch
+
+  if (typeof action.run === 'function') {
+    const output = await action.run(coerced, {
+      config,
+      now: options.now ?? (() => new Date().toISOString()),
+      fetch: fetchImpl
+    })
+    return output ?? {}
+  }
+
+  // Declared rather than written: `defineConnector` guarantees one or the other.
+  return executeRequest(
+    action.request,
+    action.postReceive,
+    { args: coerced, config },
+    { fetchImpl }
+  )
 }

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -16,10 +16,11 @@ const ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 /**
  * What a scaffolded connector depends on.
  *
- * A range rather than the exact current version: a connector generated today
- * should still build against the next patch. Bumped with the SDK's own major.
+ * Names a prerelease on purpose. Only `0.7.0-beta.x` is published, and a bare
+ * `^0.7.0` matches no prerelease at all — a scaffold pinned to it installs
+ * nothing. Bumped with the SDK's own version until a stable one exists.
  */
-const SDK_DEPENDENCY_RANGE = '^0.7.0'
+const SDK_DEPENDENCY_RANGE = '^0.7.0-beta.8'
 
 export interface ScaffoldOptions {
   id: string

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -80,8 +80,8 @@ export const connector = defineConnector({
   id: '${id}',
   name: '${name}',
   description: '${description}',
-  // How this connector signs in. Prefer a login the machine already has:
-  // \`{ rung: 'cli', probe: { command: 'tool', args: ['auth', 'status'] } }\`.
+  version: '0.1.0',
+  // Prefer a login the machine already has: { rung: 'cli', probe: { command: 'tool', args: ['auth', 'status'] } }
   auth: { rung: 'key', keys: ['apiToken'] },
   config: [
     {
@@ -98,9 +98,7 @@ export const connector = defineConnector({
       type: 'itemCreated',
       label: 'Item created',
       description: 'Items created since the last poll',
-      // Declarative: return what is there and the SDK handles cursors and
-      // de-duplication. Use \`poll\` instead only if paging cannot be expressed
-      // as "give me everything since X".
+      // Return what is there; the SDK handles cursors and de-duplication.
       dedupe: 'timestamp',
       async fetch(context) {
         const url = new URL('/v1/items', context.config.baseUrl)
@@ -130,8 +128,7 @@ export const connector = defineConnector({
         { key: 'body', label: 'Body' }
       ],
       outputs: [{ key: 'id', type: 'string', description: 'The created item' }],
-      // Declared rather than written: the SDK fills the templates, sends it,
-      // and keeps what \`postReceive\` names.
+      // Declared, not written: the SDK fills the templates, sends it, and keeps what postReceive names.
       request: {
         method: 'POST',
         url: '{{config.baseUrl}}/v1/items',

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -77,9 +77,9 @@ function connectorSource(id: string, name: string, description: string): string 
   return `import { defineConnector } from '@vornrun/connector-sdk'
 
 export const connector = defineConnector({
-  id: '${id}',
-  name: '${name}',
-  description: '${description}',
+  id: ${JSON.stringify(id)},
+  name: ${JSON.stringify(name)},
+  description: ${JSON.stringify(description)},
   version: '0.1.0',
   // Prefer a login the machine already has: { rung: 'cli', probe: { command: 'tool', args: ['auth', 'status'] } }
   auth: { rung: 'key', keys: ['apiToken'] },
@@ -191,7 +191,7 @@ function fakeFetch(body: unknown) {
 
 const config = { apiToken: 'test-token', baseUrl: 'https://api.example.com' }
 
-describe('${name}', () => {
+describe(${JSON.stringify(name)}, () => {
   it('reports the items the source lists', async () => {
     const harness = createConnectorHarness(connector, {
       config,

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -1,0 +1,296 @@
+/**
+ * The files a new connector starts as.
+ *
+ * A connector is mostly boilerplate — a package that builds, an entry that
+ * serves, a definition, a test that proves it without a network — and getting
+ * that boilerplate right is the slowest part of writing the interesting bit.
+ * Generating it means every connector starts from the same shape, which is
+ * also the shape `check` and `pack` expect to find.
+ *
+ * The files are returned rather than written so the decision of what to write
+ * stays testable, and the writing stays in the CLI.
+ */
+
+const ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
+
+/**
+ * What a scaffolded connector depends on.
+ *
+ * A range rather than the exact current version: a connector generated today
+ * should still build against the next patch. Bumped with the SDK's own major.
+ */
+const SDK_DEPENDENCY_RANGE = '^0.7.0'
+
+export interface ScaffoldOptions {
+  id: string
+  /** Defaults to the id in title case. */
+  name?: string
+  description?: string
+}
+
+export interface ScaffoldFile {
+  /** Relative to the directory the connector is created in. */
+  path: string
+  contents: string
+}
+
+/** `acme-tickets` → `Acme Tickets`, so a generated name reads like a name. */
+export function titleCase(id: string): string {
+  return id
+    .split(/[-_]+/)
+    .filter((part) => part !== '')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function packageJson(id: string, description: string): string {
+  return `${JSON.stringify(
+    {
+      name: `vorn-connector-${id}`,
+      version: '0.1.0',
+      description,
+      type: 'module',
+      license: 'MIT',
+      bin: { [`vorn-connector-${id}`]: 'dist/index.js' },
+      main: './dist/index.js',
+      types: './dist/index.d.ts',
+      files: ['dist', 'README.md'],
+      scripts: {
+        build: 'tsup src/index.ts --format esm --target node22 --clean --dts',
+        check: 'vorn-connector check src/index.ts',
+        pack: 'vorn-connector pack src/index.ts',
+        test: 'vitest run',
+        typecheck: 'tsc --noEmit'
+      },
+      dependencies: { '@vornrun/connector-sdk': SDK_DEPENDENCY_RANGE },
+      devDependencies: { tsup: '^8.5.1', typescript: '^6.0.3', vitest: '^4.1.10' },
+      // Read by the catalog build: how this connector is filed and found.
+      vorn: { category: 'Other', keywords: [id] }
+    },
+    null,
+    2
+  )}\n`
+}
+
+function connectorSource(id: string, name: string, description: string): string {
+  return `import { defineConnector } from '@vornrun/connector-sdk'
+
+export const connector = defineConnector({
+  id: '${id}',
+  name: '${name}',
+  description: '${description}',
+  // How this connector signs in. Prefer a login the machine already has:
+  // \`{ rung: 'cli', probe: { command: 'tool', args: ['auth', 'status'] } }\`.
+  auth: { rung: 'key', keys: ['apiToken'] },
+  config: [
+    {
+      key: 'apiToken',
+      label: 'API token',
+      required: true,
+      secret: true,
+      builderHint: 'Say where a token is created and which scopes it needs'
+    },
+    { key: 'baseUrl', label: 'Base URL', default: 'https://api.example.com' }
+  ],
+  triggers: [
+    {
+      type: 'itemCreated',
+      label: 'Item created',
+      description: 'Items created since the last poll',
+      // Declarative: return what is there and the SDK handles cursors and
+      // de-duplication. Use \`poll\` instead only if paging cannot be expressed
+      // as "give me everything since X".
+      dedupe: 'timestamp',
+      async fetch(context) {
+        const url = new URL('/v1/items', context.config.baseUrl)
+        if (context.since) url.searchParams.set('updated_since', context.since)
+        // \`context.fetch\` retries and backs off; the global one does not.
+        const response = await context.fetch(url, {
+          headers: { authorization: 'Bearer ' + context.config.apiToken }
+        })
+        if (!response.ok) throw new Error('Listing items failed with ' + response.status)
+        const body = (await response.json()) as { items: Array<Record<string, string>> }
+        return body.items.map((item) => ({
+          externalId: item.id,
+          title: item.title,
+          url: item.html_url,
+          updatedAt: item.updated_at
+        }))
+      }
+    }
+  ],
+  actions: [
+    {
+      type: 'createItem',
+      label: 'Create item',
+      description: 'Create one item',
+      inputs: [
+        { key: 'title', label: 'Title', required: true },
+        { key: 'body', label: 'Body' }
+      ],
+      outputs: [{ key: 'id', type: 'string', description: 'The created item' }],
+      // Declared rather than written: the SDK fills the templates, sends it,
+      // and keeps what \`postReceive\` names.
+      request: {
+        method: 'POST',
+        url: '{{config.baseUrl}}/v1/items',
+        headers: { authorization: 'Bearer {{config.apiToken}}' },
+        body: { title: '{{args.title}}', body: '{{args.body}}' }
+      },
+      postReceive: [{ op: 'pick', keys: ['id'] }]
+    }
+  ]
+})
+`
+}
+
+function entrySource(): string {
+  return `import { realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { serveConnector } from '@vornrun/connector-sdk'
+import { connector } from './connector'
+
+/** True when this file was run directly rather than imported. */
+export function isEntryPoint(moduleUrl: string, argv = process.argv): boolean {
+  const invoked = argv[1]
+  if (invoked === undefined) return false
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(invoked)
+  } catch {
+    return false
+  }
+}
+
+/** Serve on stdio when run directly. This is what Vorn spawns. */
+export async function serveIfEntryPoint(moduleUrl: string): Promise<void> {
+  if (isEntryPoint(moduleUrl)) await serveConnector(connector)
+}
+`
+}
+
+function indexSource(): string {
+  return `import { connector } from './connector'
+import { serveIfEntryPoint } from './entry'
+
+export { connector }
+export default connector
+
+await serveIfEntryPoint(import.meta.url)
+`
+}
+
+function testSource(name: string): string {
+  return `import { describe, expect, it, vi } from 'vitest'
+import { createConnectorHarness } from '@vornrun/connector-sdk'
+import { connector } from './connector'
+
+/** Answers the connector's calls from here, so the test needs no network. */
+function fakeFetch(body: unknown) {
+  return vi.fn(async () =>
+    new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+  ) as unknown as typeof fetch
+}
+
+const config = { apiToken: 'test-token', baseUrl: 'https://api.example.com' }
+
+describe('${name}', () => {
+  it('reports the items the source lists', async () => {
+    const harness = createConnectorHarness(connector, {
+      config,
+      fetchImpl: fakeFetch({
+        items: [
+          {
+            id: '1',
+            title: 'First item',
+            html_url: 'https://example.com/1',
+            updated_at: '2026-01-01T00:00:00.000Z'
+          }
+        ]
+      })
+    })
+
+    const page = await harness.poll('itemCreated')
+
+    expect(page.items).toHaveLength(1)
+    expect(page.items[0].externalId).toBe('1')
+  })
+
+  it('does not deliver the same item twice', async () => {
+    const harness = createConnectorHarness(connector, {
+      config,
+      fetchImpl: fakeFetch({
+        items: [
+          {
+            id: '1',
+            title: 'First item',
+            html_url: 'https://example.com/1',
+            updated_at: '2026-01-01T00:00:00.000Z'
+          }
+        ]
+      })
+    })
+
+    expect(await harness.pollTwice('itemCreated')).toEqual([])
+  })
+
+  it('creates an item and keeps only its id', async () => {
+    const harness = createConnectorHarness(connector, {
+      config,
+      fetchImpl: fakeFetch({ id: '42', extra: 'ignored' })
+    })
+
+    expect(await harness.execute('createItem', { title: 'A title' })).toEqual({ id: '42' })
+  })
+})
+`
+}
+
+function readme(id: string, name: string, description: string): string {
+  return `# ${name}
+
+${description}
+
+## Build and check
+
+\`\`\`sh
+yarn install
+yarn build
+yarn check      # verifies the connector against Vorn's contract
+yarn test
+yarn pack       # writes ${id}-0.1.0.vorn.tgz, installable in Vorn
+\`\`\`
+
+## Settings
+
+| Setting | Environment | Required |
+| --- | --- | --- |
+| API token | \`API_TOKEN\` | yes |
+| Base URL | \`BASE_URL\` | no |
+
+## What it offers
+
+- **Item created** — polls for items created since the last run.
+- **Create item** — creates one item and returns its id.
+
+Rename the trigger, the action and the settings to whatever this connector
+really talks to; the shapes here are a starting point, not a rule.
+`
+}
+
+/** Every file a new connector starts with, ready to build, check and pack. */
+export function scaffoldFiles(options: ScaffoldOptions): ScaffoldFile[] {
+  if (!ID_PATTERN.test(options.id ?? '')) {
+    throw new Error(`Connector id "${options.id}" must start with a letter and be url-safe`)
+  }
+  const name = options.name?.trim() || titleCase(options.id)
+  const description = options.description?.trim() || `${name} connector for Vorn`
+
+  return [
+    { path: 'package.json', contents: packageJson(options.id, description) },
+    { path: 'src/connector.ts', contents: connectorSource(options.id, name, description) },
+    { path: 'src/entry.ts', contents: entrySource() },
+    { path: 'src/index.ts', contents: indexSource() },
+    { path: 'src/connector.test.ts', contents: testSource(name) },
+    { path: 'README.md', contents: readme(options.id, name, description) }
+  ]
+}

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -48,23 +48,23 @@ function describeInput(input: ActionInputField): string {
     return `${base}. Choices come from this connector's "${input.loadOptions}" list.`
   }
   if (input.type === 'json') return `${base}. Takes JSON.`
+  const choices = (input.options ?? [])
+    .map((option) => option.value)
+    .filter((value) => typeof value === 'string' && value !== '')
+  if (choices.length > 0) return `${base}. Suggested values: ${choices.join(', ')}.`
   return base
 }
 
 function inputShape(inputs: ActionInputField[]): Record<string, ZodTypeAny> {
   const shape: Record<string, ZodTypeAny> = {}
   for (const input of inputs) {
-    const choices = (input.options ?? [])
-      .map((option) => option.value)
-      .filter((value) => typeof value === 'string' && value !== '')
-    // Vorn renders action arguments from templates, so every value arrives as
-    // a string; the declared type is applied by `runAction` instead. Fixed
-    // choices are still stated, because a caller that knows them draws a
-    // picker instead of a text box.
-    const base =
-      choices.length > 0
-        ? z.enum(choices as [string, ...string[]]).describe(describeInput(input))
-        : z.string().describe(describeInput(input))
+    // Every value arrives as a string because Vorn renders action arguments
+    // from templates, and the declared type is applied by `runAction`. Choices
+    // stay in the description rather than becoming an enum: a step is entitled
+    // to compute this value, and a rendered template outside the list would
+    // otherwise be refused here — before the connector could say anything
+    // useful about it. The manifest carries `options` for the picker.
+    const base = z.string().describe(describeInput(input))
     shape[input.key] = input.required ? base : base.optional()
   }
   return shape

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -2,8 +2,14 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z, type ZodTypeAny } from 'zod'
 import { resolveConfig } from './define'
-import { runAction, runPoll } from './runtime'
-import { MANIFEST_TOOL, PREFLIGHT_TOOL, connectorManifest, pollToolName } from './setup'
+import { runAction, runOptions, runPoll } from './runtime'
+import {
+  MANIFEST_TOOL,
+  OPTIONS_TOOL,
+  PREFLIGHT_TOOL,
+  connectorManifest,
+  pollToolName
+} from './setup'
 import type { ActionInputField, ActionOutputField, Connector, ConnectorConfig } from './types'
 
 function json(value: Record<string, unknown>): {
@@ -29,12 +35,36 @@ function failure(error: unknown): {
   }
 }
 
+/**
+ * What the tool schema says a field is, in the words a caller reads.
+ *
+ * The manifest and the served schema describe the same `ActionInputField`, so
+ * they are generated from it together rather than drifting into two accounts
+ * of the same argument.
+ */
+function describeInput(input: ActionInputField): string {
+  const base = input.description ?? input.label
+  if (input.loadOptions !== undefined) {
+    return `${base}. Choices come from this connector's "${input.loadOptions}" list.`
+  }
+  if (input.type === 'json') return `${base}. Takes JSON.`
+  return base
+}
+
 function inputShape(inputs: ActionInputField[]): Record<string, ZodTypeAny> {
   const shape: Record<string, ZodTypeAny> = {}
   for (const input of inputs) {
+    const choices = (input.options ?? [])
+      .map((option) => option.value)
+      .filter((value) => typeof value === 'string' && value !== '')
     // Vorn renders action arguments from templates, so every value arrives as
-    // a string; the declared type is applied by `runAction` instead.
-    const base = z.string().describe(input.description ?? input.label)
+    // a string; the declared type is applied by `runAction` instead. Fixed
+    // choices are still stated, because a caller that knows them draws a
+    // picker instead of a text box.
+    const base =
+      choices.length > 0
+        ? z.enum(choices as [string, ...string[]]).describe(describeInput(input))
+        : z.string().describe(describeInput(input))
     shape[input.key] = input.required ? base : base.optional()
   }
   return shape
@@ -128,6 +158,38 @@ export function createConnectorServer(
             ok: false,
             message: error instanceof Error ? error.message : String(error)
           })
+        }
+      }
+    )
+  }
+
+  // Registered only when the connector serves a set, so its absence means
+  // "nothing here loads its choices" rather than "the list came back empty".
+  const optionSets = Object.keys(connector.options ?? {})
+  if (optionSets.length > 0) {
+    server.registerTool(
+      OPTIONS_TOOL,
+      {
+        description: `List what one of ${connector.name}'s fields can be set to`,
+        inputSchema: {
+          name: z.enum(optionSets as [string, ...string[]]).describe('Which options set to list')
+        },
+        outputSchema: z.looseObject({
+          options: z
+            .array(z.looseObject({ value: z.string(), label: z.string().optional() }))
+            .describe('The choices, each a value to send and words to show')
+        })
+      },
+      async (args) => {
+        try {
+          return json({
+            options: await runOptions(connector, args.name, {
+              config: config(),
+              ...(options.now && { now: options.now })
+            })
+          })
+        } catch (error) {
+          return failure(error)
         }
       }
     )

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -44,7 +44,14 @@ export interface ConnectionSetup {
     cursorPath: 'nextCursor'
   }
   /** Environment variable names the connector reads. */
-  env: Array<{ name: string; required: boolean; secret: boolean; description?: string }>
+  env: Array<{
+    name: string
+    required: boolean
+    secret: boolean
+    description?: string
+    /** For whoever is building a connector like this one, not for whoever runs it. */
+    builderHint?: string
+  }>
 }
 
 /**
@@ -78,7 +85,8 @@ export function connectionSetup(connector: Connector, triggerType: string): Conn
       name: envNameFor(field.key, field.env),
       required: field.required === true,
       secret: field.secret === true,
-      ...(field.description !== undefined && { description: field.description })
+      ...(field.description !== undefined && { description: field.description }),
+      ...(field.builderHint !== undefined && { builderHint: field.builderHint })
     }))
   }
 }
@@ -113,6 +121,8 @@ export interface ConnectorManifest {
       options?: ActionInputOption[]
       /** An options set the connector serves, resolved against a live connection. */
       loadOptions?: string
+      /** For whoever is building a connector like this one, not for whoever runs it. */
+      builderHint?: string
     }>
     /**
      * Fields the action is known to return. Absent when the connector declared
@@ -152,7 +162,8 @@ export function connectorManifest(connector: Connector): ConnectorManifest {
         type: input.type ?? 'string',
         required: input.required === true,
         ...(input.options !== undefined && { options: input.options }),
-        ...(input.loadOptions !== undefined && { loadOptions: input.loadOptions })
+        ...(input.loadOptions !== undefined && { loadOptions: input.loadOptions }),
+        ...(input.builderHint !== undefined && { builderHint: input.builderHint })
       })),
       ...(action.outputs !== undefined && { outputs: action.outputs })
     }))

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -23,6 +23,12 @@ export const MANIFEST_TOOL = 'vorn_connector_manifest'
  */
 export const PREFLIGHT_TOOL = 'vorn_connector_preflight'
 
+/**
+ * Tool that lists the choices for one dynamic field. Present only when the
+ * connector serves an options set, for the same reason preflight is.
+ */
+export const OPTIONS_TOOL = 'vorn_connector_options'
+
 export interface ConnectionSetup {
   connectorId: string
   triggerType: string

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -390,6 +390,24 @@ export interface ConnectorAuth {
   keys?: string[]
 }
 
+/** What an options set is given to work out its choices. */
+export interface OptionsContext {
+  config: ConnectorConfig
+  now(): string
+  /** Fetch with the SDK's retry and backoff applied. Listing choices is a read. */
+  fetch: typeof fetch
+}
+
+/**
+ * Answers the question "what can this field be?" against a live connection.
+ *
+ * A bare string is taken as a choice that shows itself; return the object form
+ * when the value a step should send and the words a person should read differ.
+ */
+export type OptionsLoader = (
+  context: OptionsContext
+) => Promise<Array<ActionInputOption | string>> | Array<ActionInputOption | string>
+
 export interface ConnectorDefinition {
   /** Stable connector id, e.g. `azure-devops`. */
   id: string
@@ -398,6 +416,12 @@ export interface ConnectorDefinition {
   description?: string
   icon?: ConnectorIcon
   config?: ConnectorConfigField[]
+  /**
+   * Named sets of choices an input can point at with `loadOptions`, for fields
+   * whose values only exist against a live connection — the channels in a
+   * workspace, the projects in an account.
+   */
+  options?: Record<string, OptionsLoader>
   /**
    * How this connector signs in. Absent means the app cannot say, which reads
    * as "a key, probably" — declare it rather than leave that to be guessed.

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -51,6 +51,13 @@ export interface ConnectorConfigField {
   secret?: boolean
   description?: string
   default?: string
+  /**
+   * A note for whoever is building this connector rather than using it: where
+   * the value is found, what a good one looks like. The factory's agent reads
+   * these, so a field that is easy to get wrong can say so once here instead of
+   * being got wrong in every connector that copies it.
+   */
+  builderHint?: string
 }
 
 export type ConnectorConfig = Record<string, string | undefined>
@@ -217,6 +224,8 @@ export interface ActionInputField {
    * the projects in an account.
    */
   loadOptions?: string
+  /** A note for whoever is building the connector, not for whoever runs it. */
+  builderHint?: string
 }
 
 /**

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -229,9 +229,63 @@ export interface ActionOutputField {
 export interface ActionContext {
   config: ConnectorConfig
   now(): string
+  /**
+   * Fetch, with the SDK's retry, backoff and rate-limit handling already
+   * applied. Prefer it over the global one: a hand-written action gets the
+   * same resilience a declared request does, and tests can replace it.
+   */
+  fetch: typeof fetch
 }
 
-export interface ActionDefinition {
+/**
+ * One step of reshaping a response.
+ *
+ * Each op reads the whole value, or just what lives at its dotted `path`, and
+ * leaves the rest alone. They compose left to right, which is enough to turn
+ * most envelopes into the record a workflow step wants.
+ */
+export type PostReceiveOp =
+  /** Keep only these keys, of the object or of every object in the list. */
+  | { op: 'pick'; keys: string[]; path?: string }
+  /** Give a key a better name, of the object or of every object in the list. */
+  | { op: 'rename'; from: string; to: string; path?: string }
+  /** Replace the whole value with what is at this path — unwrap the envelope. */
+  | { op: 'flatten'; path: string }
+  /** Keep the list entries whose `key` equals this value. */
+  | { op: 'filter'; key: string; equals: unknown; path?: string }
+  /** Run these ops against every entry of the list. */
+  | { op: 'map'; ops: PostReceiveOp[]; path?: string }
+
+/**
+ * How to ask for the page after this one.
+ *
+ * Declared rather than written because every source does the same three things
+ * — hand back a cursor, count pages, or put a link in a header — and following
+ * them by hand is where "only the first 100 items ever arrive" comes from.
+ */
+export type PaginationStrategy =
+  /** The response carries a cursor at `cursorPath`; send it back as `param`. */
+  | { kind: 'cursor'; cursorPath: string; param: string; itemsPath?: string }
+  /** Ask for page 1, 2, 3 … under `param`, until a page comes back short. */
+  | { kind: 'page'; param: string; startPage?: number; itemsPath?: string }
+  /** Follow the `Link` header's `rel="next"`, as paged HTTP APIs do. */
+  | { kind: 'link'; itemsPath?: string }
+
+/** An HTTP call an action makes, with `{{args.x}}` and `{{config.y}}` filled in. */
+export interface ActionRequest {
+  /** Defaults to GET. */
+  method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  url: string
+  headers?: Record<string, string>
+  /** Query parameters. An argument that resolves to nothing is left out. */
+  query?: Record<string, string>
+  /** Sent as JSON unless it is already a string, or a content type says otherwise. */
+  body?: unknown
+  /** Follow every page rather than returning only the first. */
+  paginate?: PaginationStrategy
+}
+
+interface ActionBase {
   /** Action key, e.g. `closeWorkItem`. Becomes an MCP tool of the same name. */
   type: string
   label: string
@@ -239,16 +293,37 @@ export interface ActionDefinition {
   /**
    * Whether repeating the call with the same arguments is safe. Surfaced in
    * the MCP tool description, because an agent retrying a failed step has no
-   * other way to know whether it is about to create a second issue.
+   * other way to know whether it is about to create a second issue — and it is
+   * what decides whether the SDK may retry the call itself.
    */
   idempotent?: boolean
   inputs?: ActionInputField[]
   outputs?: ActionOutputField[]
-  run(
-    args: Record<string, unknown>,
-    context: ActionContext
-  ): Promise<Record<string, unknown> | void> | Record<string, unknown> | void
 }
+
+/**
+ * An action is either declared or hand-written, never both — the same union
+ * shape triggers use, so the invalid combination is a type error while the
+ * connector is being written rather than a throw once it is installed.
+ */
+export type ActionDefinition = ActionBase &
+  (
+    | {
+        run(
+          args: Record<string, unknown>,
+          context: ActionContext
+        ): Promise<Record<string, unknown> | void> | Record<string, unknown> | void
+        request?: never
+        postReceive?: never
+      }
+    | {
+        /** The call to make. The SDK sends it and keeps the response. */
+        request: ActionRequest
+        /** How to reshape what came back, before the step sees it. */
+        postReceive?: PostReceiveOp[]
+        run?: never
+      }
+  )
 
 /**
  * A connector's own glyph, so an installed connector is recognizable in a list

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -69,6 +69,8 @@ export interface PollContext {
   limit?: number
   /** Injectable clock so tests are deterministic. */
   now(): string
+  /** Fetch with the SDK's retry and backoff applied. A poll is always a read. */
+  fetch: typeof fetch
 }
 
 export interface PollOutcome {
@@ -111,6 +113,8 @@ export interface FetchContext {
   limit?: number
   /** Injectable clock so tests are deterministic. */
   now(): string
+  /** Fetch with the SDK's retry and backoff applied. A fetch is always a read. */
+  fetch: typeof fetch
 }
 
 /**

--- a/packages/server/src/connectors/sdk-tools.ts
+++ b/packages/server/src/connectors/sdk-tools.ts
@@ -13,6 +13,9 @@ export const MANIFEST_TOOL = 'vorn_connector_manifest'
 /** Tool a packaged connector registers when it can report its own readiness. */
 export const PREFLIGHT_TOOL = 'vorn_connector_preflight'
 
+/** Tool a packaged connector registers when a field's choices need looking up. */
+export const OPTIONS_TOOL = 'vorn_connector_options'
+
 /** MCP tool name a trigger is served under. */
 export function pollToolName(triggerType: string): string {
   return `poll_${triggerType}`
@@ -26,7 +29,7 @@ export function pollToolName(triggerType: string): string {
  * is the fallback for callers that cannot say what the triggers are.
  */
 export function isReservedSdkTool(name: string, triggerTypes?: readonly string[]): boolean {
-  if (name === MANIFEST_TOOL || name === PREFLIGHT_TOOL) return true
+  if (name === MANIFEST_TOOL || name === PREFLIGHT_TOOL || name === OPTIONS_TOOL) return true
   return triggerTypes
     ? triggerTypes.some((type) => name === pollToolName(type))
     : name.startsWith(pollToolName(''))

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type {
   CallConnectorActionConfig,
   ConnectorActionDef,
+  ConnectorConfigField,
   TriggerConfig
 } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
@@ -16,6 +17,87 @@ interface Props {
   triggerType?: TriggerConfig['triggerType']
   inputVars?: TemplateVariable[]
   stepGroups?: StepVariableGroup[]
+}
+
+interface ArgumentFieldProps {
+  field: ConnectorConfigField
+  value: string
+  onChange: (value: string) => void
+  stepGroups: StepVariableGroup[]
+  contextVars: TemplateVariable[]
+}
+
+/**
+ * One argument's editor.
+ *
+ * A connector's listed choices are suggestions rather than a closed set: a step
+ * is entitled to compute this value from an earlier one, and the connector —
+ * not this form — is what finally judges it. So the picker is offered while the
+ * value is one of the choices, the template-aware input whenever it is not, and
+ * there is a way to move between them on purpose.
+ */
+function ArgumentField({
+  field,
+  value,
+  onChange,
+  stepGroups,
+  contextVars
+}: ArgumentFieldProps): React.JSX.Element {
+  const choices = field.options ?? []
+  const listed = choices.some((option) => option.value === value)
+  const [chosenFree, setChosenFree] = useState(false)
+  // Derived rather than stored, so a value that arrives already holding a
+  // template opens in the input that can edit it.
+  const free = chosenFree || (value !== '' && !listed)
+  const pickable = field.type === 'select' && choices.length > 0
+
+  if (pickable && !free) {
+    return (
+      <>
+        <SelectPicker
+          value={value}
+          options={choices.map((option) => ({ value: option.value, label: option.label }))}
+          onChange={onChange}
+          variant="form"
+          placeholder={field.placeholder ?? '—'}
+        />
+        <button
+          type="button"
+          onClick={() => setChosenFree(true)}
+          className="text-[10px] text-gray-500 hover:text-gray-300 mt-1 transition-colors"
+        >
+          Use a template instead
+        </button>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <VariableAutocomplete
+        value={value}
+        onChange={onChange}
+        placeholder={field.placeholder}
+        rows={field.type === 'textarea' ? 3 : 1}
+        stepGroups={stepGroups}
+        contextVars={contextVars}
+        mono
+      />
+      {pickable && (
+        <button
+          type="button"
+          onClick={() => {
+            setChosenFree(false)
+            // Cleared, because the list cannot show a value it does not hold.
+            if (!listed) onChange('')
+          }}
+          className="text-[10px] text-gray-500 hover:text-gray-300 mt-1 transition-colors"
+        >
+          Choose from the list
+        </button>
+      )}
+    </>
+  )
 }
 
 export function CallConnectorActionNodeForm({
@@ -156,31 +238,17 @@ export function CallConnectorActionNodeForm({
                   {field.label}
                   {field.required && <span className="text-danger ml-0.5">*</span>}
                 </label>
-                {field.type === 'select' ? (
-                  <SelectPicker
-                    value={fieldValue}
-                    options={(field.options ?? []).map((o) => ({
-                      value: o.value,
-                      label: o.label
-                    }))}
-                    onChange={setFieldValue}
-                    variant="form"
-                    placeholder={field.placeholder ?? '—'}
-                  />
-                ) : (
-                  // text / textarea / password / etc. all flow through the
-                  // template-aware autocomplete so users can reference
-                  // ancestor steps with `{{...}}`.
-                  <VariableAutocomplete
-                    value={fieldValue}
-                    onChange={setFieldValue}
-                    placeholder={field.placeholder}
-                    rows={field.type === 'textarea' ? 3 : 1}
-                    stepGroups={stepGroups}
-                    contextVars={contextVars}
-                    mono
-                  />
-                )}
+                {/* A picker when the choices fit, the template-aware input
+                    otherwise — text, textarea, and a select holding a value
+                    its list does not contain all reference ancestor steps
+                    with `{{...}}`. */}
+                <ArgumentField
+                  field={field}
+                  value={fieldValue}
+                  onChange={setFieldValue}
+                  stepGroups={stepGroups}
+                  contextVars={contextVars}
+                />
                 {field.description && (
                   <p className="text-[10px] text-gray-600 mt-0.5">{field.description}</p>
                 )}

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -27,21 +27,12 @@ interface ArgumentFieldProps {
   contextVars: TemplateVariable[]
 }
 
-/**
- * One argument's editor.
- *
- * A connector's listed choices are suggestions rather than a closed set: a step
- * is entitled to compute this value from an earlier one, and the connector —
- * not this form — is what finally judges it. So the picker is offered while the
- * value is one of the choices, the template-aware input whenever it is not, and
- * there is a way to move between them on purpose.
- */
+// Listed choices are suggestions: the picker while the value is one of them, the template input otherwise.
 function ArgumentField({ field, value, onChange, stepGroups, contextVars }: ArgumentFieldProps) {
   const choices = field.options ?? []
   const listed = choices.some((option) => option.value === value)
   const [chosenFree, setChosenFree] = useState(false)
-  // Derived rather than stored, so a value that arrives already holding a
-  // template opens in the input that can edit it.
+  const [parked, setParked] = useState('')
   const free = chosenFree || (value !== '' && !listed)
   const pickable = field.type === 'select' && choices.length > 0
 
@@ -57,7 +48,10 @@ function ArgumentField({ field, value, onChange, stepGroups, contextVars }: Argu
         />
         <button
           type="button"
-          onClick={() => setChosenFree(true)}
+          onClick={() => {
+            setChosenFree(true)
+            if (parked !== '') onChange(parked)
+          }}
           className="text-[10px] text-gray-500 hover:text-gray-300 mt-1 transition-colors"
         >
           Use a template instead
@@ -82,8 +76,11 @@ function ArgumentField({ field, value, onChange, stepGroups, contextVars }: Argu
           type="button"
           onClick={() => {
             setChosenFree(false)
-            // Cleared, because the list cannot show a value it does not hold.
-            if (!listed) onChange('')
+            // Parked, not lost: the list cannot show it, the template input can take it back.
+            if (!listed) {
+              setParked(value)
+              onChange('')
+            }
           }}
           className="text-[10px] text-gray-500 hover:text-gray-300 mt-1 transition-colors"
         >

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -36,13 +36,7 @@ interface ArgumentFieldProps {
  * value is one of the choices, the template-aware input whenever it is not, and
  * there is a way to move between them on purpose.
  */
-function ArgumentField({
-  field,
-  value,
-  onChange,
-  stepGroups,
-  contextVars
-}: ArgumentFieldProps): React.JSX.Element {
+function ArgumentField({ field, value, onChange, stepGroups, contextVars }: ArgumentFieldProps) {
   const choices = field.options ?? []
   const listed = choices.some((option) => option.value === value)
   const [chosenFree, setChosenFree] = useState(false)

--- a/tests/connector-action-catalog.test.ts
+++ b/tests/connector-action-catalog.test.ts
@@ -8,13 +8,14 @@ vi.mock('../packages/server/src/logger', () => ({
 
 const { mcpConnectionActions, mcpToolToConnectorAction } =
   await import('../packages/server/src/connectors/mcp')
-const { isReservedSdkTool, MANIFEST_TOOL, PREFLIGHT_TOOL, pollToolName } =
+const { isReservedSdkTool, MANIFEST_TOOL, OPTIONS_TOOL, PREFLIGHT_TOOL, pollToolName } =
   await import('../packages/server/src/connectors/sdk-tools')
 
 /** The tools a packed SDK connector with one trigger and one action really serves. */
 const PACK_TOOLS = [
   { name: MANIFEST_TOOL, description: 'Describe this connector' },
   { name: PREFLIGHT_TOOL, description: 'Report readiness' },
+  { name: OPTIONS_TOOL, description: 'List what a field can be set to' },
   { name: pollToolName('tick'), description: 'Poll Pack Demo for Tick' },
   { name: 'echo', title: 'Echo', description: 'Return the given message.' }
 ]
@@ -40,9 +41,12 @@ describe('reserved SDK tool names', () => {
     expect(isReservedSdkTool(MANIFEST_TOOL, ['tick'])).toBe(true)
   })
 
-  it('knows the three kinds of plumbing a connector serves', () => {
+  it('knows every kind of plumbing a connector serves', () => {
     expect(isReservedSdkTool(MANIFEST_TOOL)).toBe(true)
     expect(isReservedSdkTool(PREFLIGHT_TOOL)).toBe(true)
+    // Serves a field's choices, so it is Vorn's to call and never a step's.
+    expect(isReservedSdkTool(OPTIONS_TOOL)).toBe(true)
+    expect(isReservedSdkTool(OPTIONS_TOOL, ['tick'])).toBe(true)
     expect(isReservedSdkTool(pollToolName('tick'))).toBe(true)
     expect(isReservedSdkTool(pollToolName('issueCreated'))).toBe(true)
   })
@@ -74,6 +78,7 @@ describe('actions offered for a connection', () => {
     expect(actions.map((a) => a.type)).toEqual([
       MANIFEST_TOOL,
       PREFLIGHT_TOOL,
+      OPTIONS_TOOL,
       pollToolName('tick'),
       'echo'
     ])

--- a/tests/connector-form-panels.test.tsx
+++ b/tests/connector-form-panels.test.tsx
@@ -211,6 +211,67 @@ describe('CallConnectorActionNodeForm', () => {
     expect(await findByText('Comment')).toBeInTheDocument()
   })
 
+  /** An action whose one argument offers choices. */
+  const SELECT_MANIFEST: ConnectorManifest = {
+    auth: [],
+    triggers: [],
+    actions: [
+      {
+        type: 'post',
+        label: 'Post',
+        configFields: [
+          {
+            key: 'level',
+            label: 'Level',
+            type: 'select',
+            options: [
+              { value: 'high', label: 'High' },
+              { value: 'low', label: 'Low' }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+
+  const renderWithSelect = (level: string) => {
+    listConnectionsMock.mockResolvedValue([CONN])
+    listConnectionActionsMock.mockResolvedValue(SELECT_MANIFEST.actions ?? [])
+    return render(
+      <CallConnectorActionNodeForm
+        config={{ ...baseConfig, connectionId: 'conn-1', action: 'post', args: { level } }}
+        onChange={() => {}}
+      />
+    )
+  }
+
+  it('offers the picker while the value is one of the choices', async () => {
+    const { findByText, container } = renderWithSelect('high')
+    await findByText('Level')
+
+    expect(container.querySelector('textarea')).toBeNull()
+    expect(await findByText('Use a template instead')).toBeInTheDocument()
+  })
+
+  it('edits a value the choices do not hold in the template-aware input', async () => {
+    // A step is entitled to compute this, so the form must not lose it.
+    const { findByText, container } = renderWithSelect('{{steps.pick.level}}')
+    await findByText('Level')
+
+    const input = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe('{{steps.pick.level}}')
+    expect(await findByText('Choose from the list')).toBeInTheDocument()
+  })
+
+  it('swaps to the template input when asked, keeping the value it had', async () => {
+    const { findByText, container } = renderWithSelect('high')
+    fireEvent.click(await findByText('Use a template instead'))
+
+    const input = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(input.value).toBe('high')
+  })
+
   it('calls onChange when an argument value is edited', async () => {
     listConnectionsMock.mockResolvedValue([CONN])
     listConnectorsMock.mockResolvedValue([

--- a/tests/connector-form-panels.test.tsx
+++ b/tests/connector-form-panels.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useState } from 'react'
 import { render, waitFor, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type {
@@ -270,6 +271,27 @@ describe('CallConnectorActionNodeForm', () => {
 
     const input = container.querySelector('textarea') as HTMLTextAreaElement
     expect(input.value).toBe('high')
+  })
+
+  it('hands a template back after a trip through the list', async () => {
+    listConnectionsMock.mockResolvedValue([CONN])
+    listConnectionActionsMock.mockResolvedValue(SELECT_MANIFEST.actions ?? [])
+    function Stateful() {
+      const [level, setLevel] = useState('{{steps.pick.level}}')
+      return (
+        <CallConnectorActionNodeForm
+          config={{ ...baseConfig, connectionId: 'conn-1', action: 'post', args: { level } }}
+          onChange={(next) => setLevel((next.args as { level: string }).level)}
+        />
+      )
+    }
+    const { findByText, container } = render(<Stateful />)
+    fireEvent.click(await findByText('Choose from the list'))
+    expect(container.querySelector('textarea')).toBeNull()
+
+    fireEvent.click(await findByText('Use a template instead'))
+    const input = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(input.value).toBe('{{steps.pick.level}}')
   })
 
   it('calls onChange when an argument value is edited', async () => {

--- a/tests/connector-sdk-action-fields.test.ts
+++ b/tests/connector-sdk-action-fields.test.ts
@@ -7,6 +7,7 @@ const manifestFor = (action: Partial<ActionDefinition>) =>
     defineConnector({
       id: 'acme',
       name: 'Acme',
+      options: { channels: () => [] },
       actions: [{ type: 'post', label: 'Post', run: () => ({}), ...action } as ActionDefinition]
     })
   ).actions[0]

--- a/tests/connector-sdk-argument-types.test.ts
+++ b/tests/connector-sdk-argument-types.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { connectorManifest, defineConnector, runAction } from '../packages/connector-sdk/src/index'
+import type { ActionInputField, Connector } from '../packages/connector-sdk/src/types'
+
+/** Hands back exactly what `runAction` passed the action, after coercion. */
+const echo = (inputs: ActionInputField[]): Connector =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    actions: [{ type: 'take', label: 'Take', inputs, run: (args) => ({ ...args }) }]
+  })
+
+const take = (inputs: ActionInputField[], args: Record<string, unknown>) =>
+  runAction(echo(inputs), 'take', args)
+
+describe('the kinds of value an argument arrives as', () => {
+  it('parses a number and a boolean out of the text a template rendered', async () => {
+    const output = await take(
+      [
+        { key: 'count', label: 'Count', type: 'number' },
+        { key: 'draft', label: 'Draft', type: 'boolean' }
+      ],
+      { count: '7', draft: 'false' }
+    )
+    expect(output).toEqual({ count: 7, draft: false })
+  })
+
+  it('parses a json argument, so a step can send a structured value', async () => {
+    const output = await take([{ key: 'body', label: 'Body', type: 'json' }], {
+      body: '{"a":[1,2]}'
+    })
+    expect(output).toEqual({ body: { a: [1, 2] } })
+  })
+
+  it('says what it wanted when the json will not parse, quoting only a little', async () => {
+    await expect(
+      take([{ key: 'body', label: 'Body', type: 'json' }], { body: `{"a":${'9'.repeat(200)}` })
+    ).rejects.toThrow(/Expected JSON, got "\{"a":9+…"/)
+  })
+
+  it('leaves a select as the string it already is', async () => {
+    const output = await take(
+      [{ key: 'level', label: 'Level', type: 'select', options: [{ value: 'high' }] }],
+      { level: 'high' }
+    )
+    expect(output).toEqual({ level: 'high' })
+  })
+
+  it('still requires what is required, and drops what was left blank', async () => {
+    const inputs: ActionInputField[] = [
+      { key: 'id', label: 'Id', required: true },
+      { key: 'note', label: 'Note' }
+    ]
+    await expect(take(inputs, { id: '' })).rejects.toThrow(/requires "id"/)
+    expect(await take(inputs, { id: '1', note: '' })).toEqual({ id: '1' })
+  })
+})
+
+describe('a note left for whoever builds the next connector', () => {
+  it('reaches the manifest from a config field and from an argument', () => {
+    const manifest = connectorManifest(
+      defineConnector({
+        id: 'acme',
+        name: 'Acme',
+        config: [
+          {
+            key: 'token',
+            label: 'Token',
+            builderHint: 'Create one under Settings → Developer, scope read:items'
+          }
+        ],
+        actions: [
+          {
+            type: 'take',
+            label: 'Take',
+            inputs: [{ key: 'id', label: 'Id', builderHint: 'The numeric id, not the slug' }],
+            run: () => ({})
+          }
+        ],
+        triggers: [
+          {
+            type: 'made',
+            label: 'Made',
+            dedupe: 'timestamp',
+            fetch: () => []
+          }
+        ]
+      })
+    )
+
+    expect(manifest.actions[0].inputs[0].builderHint).toBe('The numeric id, not the slug')
+    expect(manifest.triggers[0].setup.env[0].builderHint).toContain('Settings → Developer')
+  })
+})

--- a/tests/connector-sdk-declarative-actions.test.ts
+++ b/tests/connector-sdk-declarative-actions.test.ts
@@ -101,6 +101,56 @@ describe('a request an action declares', () => {
   })
 })
 
+describe('an argument that tries to rewrite the request', () => {
+  const resolve = (url: string, args: Record<string, unknown>) =>
+    resolveRequest({ url }, { args, config: { baseUrl: 'https://api.test' } }).url
+
+  it('escapes a query string smuggled into a path segment', () => {
+    expect(resolve('https://api.test/things/{{args.id}}', { id: '42?role=admin' })).toBe(
+      'https://api.test/things/42%3Frole%3Dadmin'
+    )
+  })
+
+  it('escapes a fragment, so nothing after it is dropped', () => {
+    expect(resolve('https://api.test/things/{{args.id}}', { id: 'a#b' })).toBe(
+      'https://api.test/things/a%23b'
+    )
+  })
+
+  it('escapes traversal, so the path cannot climb out of where it was put', () => {
+    expect(resolve('https://api.test/things/{{args.id}}', { id: '../../admin' })).toBe(
+      'https://api.test/things/..%2F..%2Fadmin'
+    )
+  })
+
+  it('leaves the connector own settings alone, so a base URL stays a URL', () => {
+    expect(resolve('{{config.baseUrl}}/v1/items', {})).toBe('https://api.test/v1/items')
+    expect(resolve('{{config.baseUrl}}', {})).toBe('https://api.test/')
+  })
+
+  it('escapes a whole-placeholder argument too, so it cannot become the host', () => {
+    // Escaped, the borrowed URL is no longer a URL — which is the point.
+    expect(() => resolve('{{args.target}}', { target: 'https://elsewhere.test/x' })).toThrow(
+      /not a URL once its templates are resolved/
+    )
+  })
+
+  it('refuses a header value carrying a line ending, and names the header', () => {
+    expect(() =>
+      resolveRequest(
+        { url: 'https://api.test/t', headers: { 'x-note': 'note: {{args.note}}' } },
+        { args: { note: 'ok\r\nAuthorization: Bearer stolen' }, config: {} }
+      )
+    ).toThrow(/Header "x-note" would carry a line ending/)
+  })
+
+  it('still sends an ordinary argument unmangled', () => {
+    expect(resolve('https://api.test/rooms/{{args.room}}', { room: 'general' })).toBe(
+      'https://api.test/rooms/general'
+    )
+  })
+})
+
 describe('reshaping what came back', () => {
   const envelope = {
     data: [

--- a/tests/connector-sdk-declarative-actions.test.ts
+++ b/tests/connector-sdk-declarative-actions.test.ts
@@ -205,4 +205,21 @@ describe('what an action is allowed to be', () => {
     expect(() => build({ request: { url: '  ' } })).toThrow(/no URL/)
     expect(() => build({ run: () => ({}), postReceive: [] })).toThrow(/no request/)
   })
+
+  it('says so when one built in plain JS reaches the runtime as neither', async () => {
+    // `defineConnector` refuses this; a hand-built object passed straight to
+    // `runAction` has never been through it.
+    const handBuilt = {
+      id: 'acme',
+      name: 'Acme',
+      version: '0.0.0',
+      config: [],
+      triggers: [],
+      actions: [{ type: 'post', label: 'Post' }]
+    } as unknown as Parameters<typeof runAction>[0]
+
+    await expect(runAction(handBuilt, 'post', {})).rejects.toThrow(
+      /neither a run\(\) implementation nor a request/
+    )
+  })
 })

--- a/tests/connector-sdk-declarative-actions.test.ts
+++ b/tests/connector-sdk-declarative-actions.test.ts
@@ -256,6 +256,23 @@ describe('what an action is allowed to be', () => {
     expect(() => build({ run: () => ({}), postReceive: [] })).toThrow(/no request/)
   })
 
+  it('refuses a URL an argument could aim, or one that names no host', () => {
+    expect(() => build({ request: { url: '{{args.target}}' } })).toThrow(
+      /Action post declares the request URL "\{\{args.target\}\}", which is neither absolute/
+    )
+    expect(() => build({ request: { url: '/v1/items' } })).toThrow(/neither absolute nor rooted/)
+    // Absolute, or built on the connector's own setting: both are its decision.
+    expect(() => build({ request: { url: 'https://api.test/t' } })).not.toThrow()
+    expect(() => build({ request: { url: '{{config.baseUrl}}/t' } })).not.toThrow()
+  })
+
+  it('names the action when a request fails, not just what went wrong', async () => {
+    const { impl } = fakeFetch({ error: 'gone' }, { status: 410 })
+    await expect(runAction(declared({}), 'post', {}, { fetchImpl: impl })).rejects.toThrow(
+      /^Action post: Request failed with 410/
+    )
+  })
+
   it('says so when one built in plain JS reaches the runtime as neither', async () => {
     // `defineConnector` refuses this; a hand-built object passed straight to
     // `runAction` has never been through it.

--- a/tests/connector-sdk-declarative-actions.test.ts
+++ b/tests/connector-sdk-declarative-actions.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyPostReceive,
+  defineConnector,
+  resolveRequest,
+  runAction
+} from '../packages/connector-sdk/src/index'
+import type { ActionDefinition, PostReceiveOp } from '../packages/connector-sdk/src/types'
+
+/** A fetch that answers every call with the same JSON, and records the calls. */
+function fakeFetch(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {}
+) {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  const impl = vi.fn(async (url: string | URL | Request, requestInit?: RequestInit) => {
+    calls.push({ url: String(url), init: requestInit ?? {} })
+    return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+      status: init.status ?? 200,
+      headers: { 'content-type': 'application/json', ...init.headers }
+    })
+  })
+  return { calls, impl: impl as unknown as typeof fetch }
+}
+
+const declared = (action: Partial<ActionDefinition>) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    config: [{ key: 'token', label: 'Token' }],
+    actions: [
+      {
+        type: 'post',
+        label: 'Post',
+        request: { url: 'https://api.test/things' },
+        ...action
+      } as ActionDefinition
+    ]
+  })
+
+describe('a request an action declares', () => {
+  it('fills its URL, query and headers from the arguments and the config', () => {
+    const resolved = resolveRequest(
+      {
+        method: 'POST',
+        url: 'https://api.test/rooms/{{args.room}}/messages',
+        query: { limit: '{{args.limit}}', cursor: '{{args.cursor}}' },
+        headers: { authorization: 'Bearer {{config.token}}' }
+      },
+      { args: { room: 'general', limit: 10 }, config: { token: 'sk-1' } }
+    )
+
+    expect(resolved.url).toBe('https://api.test/rooms/general/messages?limit=10')
+    expect(resolved.headers.authorization).toBe('Bearer sk-1')
+    expect(resolved.method).toBe('POST')
+  })
+
+  it('keeps a whole-placeholder value as itself, so a body can carry a number', () => {
+    const resolved = resolveRequest(
+      { method: 'POST', url: 'https://api.test/t', body: { count: '{{args.count}}', to: 'x' } },
+      { args: { count: 7 }, config: {} }
+    )
+    expect(JSON.parse(resolved.body as string)).toEqual({ count: 7, to: 'x' })
+    expect(resolved.headers['content-type']).toBe('application/json')
+  })
+
+  it('leaves out an argument nobody supplied rather than sending an empty one', () => {
+    const resolved = resolveRequest(
+      { url: 'https://api.test/t', query: { after: '{{args.after}}', q: 'ok' } },
+      { args: {}, config: {} }
+    )
+    expect(resolved.url).toBe('https://api.test/t?q=ok')
+  })
+
+  it('sends the call and returns what came back', async () => {
+    const { calls, impl } = fakeFetch({ id: '1', ok: true })
+    const output = await runAction(
+      declared({ request: { method: 'POST', url: 'https://api.test/things' } }),
+      'post',
+      {},
+      { fetchImpl: impl }
+    )
+
+    expect(output).toEqual({ id: '1', ok: true })
+    expect(calls[0].init.method).toBe('POST')
+  })
+
+  it('reports a failed status with what the body said about it', async () => {
+    const { impl } = fakeFetch({ error: 'no such room' }, { status: 404 })
+    await expect(runAction(declared({}), 'post', {}, { fetchImpl: impl })).rejects.toThrow(
+      /404.*no such room/
+    )
+  })
+
+  it('names a list "items" and a bare value "result"', async () => {
+    const list = await runAction(declared({}), 'post', {}, { fetchImpl: fakeFetch([1, 2]).impl })
+    expect(list).toEqual({ items: [1, 2] })
+
+    const scalar = await runAction(declared({}), 'post', {}, { fetchImpl: fakeFetch('"hi"').impl })
+    expect(scalar).toEqual({ result: 'hi' })
+  })
+})
+
+describe('reshaping what came back', () => {
+  const envelope = {
+    data: [
+      { id: 1, name: 'One', kind: 'issue', noise: true },
+      { id: 2, name: 'Two', kind: 'note', noise: true }
+    ],
+    meta: { total: 2 }
+  }
+
+  const run = (ops: PostReceiveOp[]) => applyPostReceive(envelope, ops)
+
+  it('unwraps an envelope', () => {
+    expect(run([{ op: 'flatten', path: 'data' }])).toEqual(envelope.data)
+  })
+
+  it('keeps only the keys worth keeping, through a list', () => {
+    expect(run([{ op: 'pick', path: 'data', keys: ['id', 'name'] }])).toEqual({
+      ...envelope,
+      data: [
+        { id: 1, name: 'One' },
+        { id: 2, name: 'Two' }
+      ]
+    })
+  })
+
+  it('renames a key in place rather than moving it to the end', () => {
+    const renamed = run([{ op: 'rename', path: 'data', from: 'name', to: 'title' }]) as {
+      data: Array<Record<string, unknown>>
+    }
+    expect(Object.keys(renamed.data[0])).toEqual(['id', 'title', 'kind', 'noise'])
+  })
+
+  it('filters a list by a field', () => {
+    const filtered = run([{ op: 'filter', path: 'data', key: 'kind', equals: 'issue' }]) as {
+      data: unknown[]
+    }
+    expect(filtered.data).toHaveLength(1)
+  })
+
+  it('maps a sub-pipeline over every entry', () => {
+    const mapped = run([{ op: 'map', path: 'data', ops: [{ op: 'pick', keys: ['id'] }] }]) as {
+      data: unknown[]
+    }
+    expect(mapped.data).toEqual([{ id: 1 }, { id: 2 }])
+  })
+
+  it('composes left to right, which is how an envelope becomes a list of items', () => {
+    expect(
+      run([
+        { op: 'flatten', path: 'data' },
+        { op: 'filter', key: 'kind', equals: 'issue' },
+        { op: 'pick', keys: ['id', 'name'] },
+        { op: 'rename', from: 'name', to: 'title' }
+      ])
+    ).toEqual([{ id: 1, title: 'One' }])
+  })
+
+  it('leaves a value alone when the path names nothing, and refuses prototype keys', () => {
+    expect(applyPostReceive({ a: 1 }, [{ op: 'pick', path: 'nope', keys: ['x'] }])).toEqual({
+      a: 1
+    })
+    expect(applyPostReceive({ a: 1 }, [{ op: 'flatten', path: '__proto__' }])).toBeUndefined()
+  })
+
+  it('runs the ops a declared action carries', async () => {
+    const { impl } = fakeFetch(envelope)
+    const output = await runAction(
+      declared({
+        request: { url: 'https://api.test/things' },
+        postReceive: [
+          { op: 'flatten', path: 'data' },
+          { op: 'pick', keys: ['id'] }
+        ]
+      }),
+      'post',
+      {},
+      { fetchImpl: impl }
+    )
+    expect(output).toEqual({ items: [{ id: 1 }, { id: 2 }] })
+  })
+})
+
+describe('what an action is allowed to be', () => {
+  const build = (action: Record<string, unknown>) =>
+    defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      actions: [{ type: 'post', label: 'Post', ...action } as unknown as ActionDefinition]
+    })
+
+  it('refuses one that is both written and declared', () => {
+    expect(() => build({ run: () => ({}), request: { url: 'https://api.test' } })).toThrow(
+      /pick one/
+    )
+  })
+
+  it('refuses one that is neither', () => {
+    expect(() => build({})).toThrow(/missing a run\(\) implementation or a request/)
+  })
+
+  it('refuses a request with no URL, and postReceive with nothing to reshape', () => {
+    expect(() => build({ request: { url: '  ' } })).toThrow(/no URL/)
+    expect(() => build({ run: () => ({}), postReceive: [] })).toThrow(/no request/)
+  })
+})

--- a/tests/connector-sdk-options.test.ts
+++ b/tests/connector-sdk-options.test.ts
@@ -103,13 +103,29 @@ describe('choices a connection has to be asked for', () => {
 })
 
 describe('what the served schema says about an argument', () => {
-  it('states fixed choices, so a caller draws a picker rather than a text box', async () => {
+  it('suggests fixed choices without refusing anything else', async () => {
     const client = await connect(withOptions())
     const post = (await client.listTools()).tools.find((tool) => tool.name === 'post')
-    const properties = (post?.inputSchema as { properties: Record<string, { enum?: string[] }> })
-      .properties
+    const properties = (
+      post?.inputSchema as {
+        properties: Record<string, { enum?: string[]; description?: string; type?: string }>
+      }
+    ).properties
 
-    expect(properties.level.enum).toEqual(['high', 'low'])
+    // Not an enum: a step may compute this value, and a rendered template
+    // outside the list would otherwise be refused before the connector saw it.
+    expect(properties.level.enum).toBeUndefined()
+    expect(properties.level.type).toBe('string')
+    expect(properties.level.description).toContain('Suggested values: high, low')
+  })
+
+  it('accepts a value the list does not hold, and lets the connector judge it', async () => {
+    const client = await connect(withOptions())
+    const result = await client.callTool({
+      name: 'post',
+      arguments: { level: 'computed-elsewhere', channel: 'C1' }
+    })
+    expect(result.isError).not.toBe(true)
   })
 
   it('names the set a dynamic field loads from, since its choices are not known yet', async () => {

--- a/tests/connector-sdk-options.test.ts
+++ b/tests/connector-sdk-options.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import {
+  createConnectorServer,
+  defineConnector,
+  OPTIONS_TOOL,
+  runOptions
+} from '../packages/connector-sdk/src/index'
+import type { ActionDefinition, Connector } from '../packages/connector-sdk/src/types'
+
+const withOptions = (extra: Partial<ActionDefinition> = {}): Connector =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    options: {
+      channels: () => [
+        { value: 'C1', label: 'general' },
+        { value: 'C2', label: 'random' }
+      ],
+      // A bare string is the common case: the value is also what to show.
+      levels: () => ['high', 'low']
+    },
+    actions: [
+      {
+        type: 'post',
+        label: 'Post',
+        inputs: [
+          { key: 'channel', label: 'Channel', type: 'select', loadOptions: 'channels' },
+          {
+            key: 'level',
+            label: 'Level',
+            type: 'select',
+            required: true,
+            options: [{ value: 'high' }, { value: 'low', label: 'Low priority' }]
+          }
+        ],
+        run: () => ({ ok: true }),
+        ...extra
+      } as ActionDefinition
+    ]
+  })
+
+async function connect(connector: Connector): Promise<Client> {
+  const server = createConnectorServer(connector, { config: {} })
+  const client = new Client({ name: 'test', version: '1.0.0' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+  return client
+}
+
+describe('choices a connection has to be asked for', () => {
+  it('lists a set, taking a bare string as a choice that shows itself', async () => {
+    expect(await runOptions(withOptions(), 'channels')).toEqual([
+      { value: 'C1', label: 'general' },
+      { value: 'C2', label: 'random' }
+    ])
+    expect(await runOptions(withOptions(), 'levels')).toEqual([{ value: 'high' }, { value: 'low' }])
+  })
+
+  it('says so when nothing serves the set that was asked for', async () => {
+    await expect(runOptions(withOptions(), 'nope')).rejects.toThrow(/serves no options set "nope"/)
+  })
+
+  it('refuses an input pointing at a set the connector does not serve', () => {
+    expect(() =>
+      defineConnector({
+        id: 'acme',
+        name: 'Acme',
+        options: { channels: () => [] },
+        actions: [
+          {
+            type: 'post',
+            label: 'Post',
+            inputs: [{ key: 'c', label: 'C', type: 'select', loadOptions: 'chanels' }],
+            run: () => ({})
+          }
+        ]
+      })
+    ).toThrow(/loads options from "chanels", which the connector does not serve/)
+  })
+
+  it('serves the set over MCP, and only when the connector has one', async () => {
+    const client = await connect(withOptions())
+    const names = (await client.listTools()).tools.map((tool) => tool.name)
+    expect(names).toContain(OPTIONS_TOOL)
+
+    const result = await client.callTool({ name: OPTIONS_TOOL, arguments: { name: 'channels' } })
+    expect((result.structuredContent as { options: unknown[] }).options).toEqual([
+      { value: 'C1', label: 'general' },
+      { value: 'C2', label: 'random' }
+    ])
+
+    const plain = await connect(
+      defineConnector({
+        id: 'plain',
+        name: 'Plain',
+        actions: [{ type: 'go', label: 'Go', run: () => ({}) }]
+      })
+    )
+    expect((await plain.listTools()).tools.map((tool) => tool.name)).not.toContain(OPTIONS_TOOL)
+  })
+})
+
+describe('what the served schema says about an argument', () => {
+  it('states fixed choices, so a caller draws a picker rather than a text box', async () => {
+    const client = await connect(withOptions())
+    const post = (await client.listTools()).tools.find((tool) => tool.name === 'post')
+    const properties = (post?.inputSchema as { properties: Record<string, { enum?: string[] }> })
+      .properties
+
+    expect(properties.level.enum).toEqual(['high', 'low'])
+  })
+
+  it('names the set a dynamic field loads from, since its choices are not known yet', async () => {
+    const client = await connect(withOptions())
+    const post = (await client.listTools()).tools.find((tool) => tool.name === 'post')
+    const properties = (
+      post?.inputSchema as { properties: Record<string, { description?: string; enum?: string[] }> }
+    ).properties
+
+    expect(properties.channel.enum).toBeUndefined()
+    expect(properties.channel.description).toContain('"channels"')
+  })
+})

--- a/tests/connector-sdk-resilience.test.ts
+++ b/tests/connector-sdk-resilience.test.ts
@@ -127,6 +127,36 @@ describe('a call the SDK is allowed to repeat', () => {
     expect(calls()).toBe(2)
   })
 
+  it('will not try more than ten times, whatever it was asked for', async () => {
+    const { impl, calls } = scripted([{ status: 500 }])
+    const fetchImpl = resilientFetch({
+      fetchImpl: impl,
+      retryable: true,
+      retry: { attempts: 50, baseDelayMs: 1 },
+      sleep: fakeSleep().sleep
+    })
+
+    expect((await fetchImpl('https://api.test/t')).status).toBe(500)
+    expect(calls()).toBe(10)
+  })
+
+  it('stops once it would have waited two minutes on one call', async () => {
+    const { impl, calls } = scripted([{ status: 503 }])
+    const clock = fakeSleep()
+    const fetchImpl = resilientFetch({
+      fetchImpl: impl,
+      retryable: true,
+      retry: { attempts: 10, baseDelayMs: 30_000 },
+      sleep: clock.sleep
+    })
+
+    expect((await fetchImpl('https://api.test/t')).status).toBe(503)
+    // Four waits of the 30s ceiling spend the budget exactly; a fifth would
+    // pass it, so the call gives up with the status it had.
+    expect(clock.waits).toEqual([30_000, 30_000, 30_000, 30_000])
+    expect(calls()).toBe(5)
+  })
+
   it('leaves an answer that is not a hiccup alone', async () => {
     const { impl, calls } = scripted([{ status: 404, body: { error: 'gone' } }])
     const fetchImpl = resilientFetch({ fetchImpl: impl, retryable: true })

--- a/tests/connector-sdk-resilience.test.ts
+++ b/tests/connector-sdk-resilience.test.ts
@@ -224,6 +224,31 @@ describe('following a source to the end of its pages', () => {
     expect(nextLink('<https://api.test/t?page=1>; rel="prev"')).toBeUndefined()
   })
 
+  it('says the path is wrong when the first page has no list there', async () => {
+    const { impl } = scripted([{ body: { results: [1, 2] } }])
+    await expect(
+      runAction(
+        paginated({ kind: 'cursor', cursorPath: 'next', param: 'cursor', itemsPath: 'data' }),
+        'act',
+        {},
+        { fetchImpl: impl }
+      )
+    ).rejects.toThrow(
+      /Action act: Cannot page through this request: the response has no list at "data"/
+    )
+  })
+
+  it('treats a later page that is not a list as the end of the walk', async () => {
+    const { impl } = scripted([{ body: { data: [1], next: 'c2' } }, { body: { done: true } }])
+    const output = await runAction(
+      paginated({ kind: 'cursor', cursorPath: 'next', param: 'cursor', itemsPath: 'data' }),
+      'act',
+      {},
+      { fetchImpl: impl }
+    )
+    expect(output).toEqual({ items: [1] })
+  })
+
   it('refuses a cursor that does not move rather than looping forever', async () => {
     const { impl } = scripted([{ body: { data: [1], next: 'same' } }])
     await expect(

--- a/tests/connector-sdk-resilience.test.ts
+++ b/tests/connector-sdk-resilience.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  backoffMs,
+  defineConnector,
+  nextLink,
+  resilientFetch,
+  retryAfterMs,
+  runAction
+} from '../packages/connector-sdk/src/index'
+import type { ActionDefinition, PaginationStrategy } from '../packages/connector-sdk/src/types'
+
+/** Answers each call with the next scripted response, and counts the calls. */
+function scripted(
+  pages: Array<{ body?: unknown; status?: number; headers?: Record<string, string> }>
+) {
+  let index = 0
+  const urls: string[] = []
+  const impl = vi.fn(async (url: string | URL | Request) => {
+    urls.push(String(url))
+    const page = pages[Math.min(index, pages.length - 1)]
+    index += 1
+    return new Response(page.body === undefined ? '' : JSON.stringify(page.body), {
+      status: page.status ?? 200,
+      headers: { 'content-type': 'application/json', ...page.headers }
+    })
+  })
+  return { urls, impl: impl as unknown as typeof fetch, calls: () => impl.mock.calls.length }
+}
+
+/** A fake clock: records what it was asked to wait rather than waiting. */
+function fakeSleep() {
+  const waits: number[] = []
+  return {
+    waits,
+    sleep: async (ms: number) => {
+      waits.push(ms)
+    }
+  }
+}
+
+const withRequest = (action: Partial<ActionDefinition>) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    actions: [
+      {
+        type: 'act',
+        label: 'Act',
+        request: { url: 'https://api.test/t' },
+        ...action
+      } as ActionDefinition
+    ]
+  })
+
+describe('what the SDK waits before trying again', () => {
+  it('doubles each time, up to a ceiling', () => {
+    expect(backoffMs(0, { baseDelayMs: 100 })).toBe(100)
+    expect(backoffMs(1, { baseDelayMs: 100 })).toBe(200)
+    expect(backoffMs(2, { baseDelayMs: 100 })).toBe(400)
+    expect(backoffMs(10, { baseDelayMs: 100, maxDelayMs: 1000 })).toBe(1000)
+  })
+
+  it('reads a Retry-After given in seconds or as a date', () => {
+    const now = Date.parse('2026-09-02T00:00:00.000Z')
+    expect(retryAfterMs('2', now)).toBe(2000)
+    expect(retryAfterMs('Wed, 02 Sep 2026 00:00:05 GMT', now)).toBe(5000)
+    expect(retryAfterMs(null, now)).toBeUndefined()
+    expect(retryAfterMs('soon', now)).toBeUndefined()
+  })
+})
+
+describe('a call the SDK is allowed to repeat', () => {
+  it('tries a rate limit again, waiting exactly as long as it was asked to', async () => {
+    const { impl } = scripted([
+      { status: 429, headers: { 'retry-after': '3' } },
+      { body: { ok: true } }
+    ])
+    const clock = fakeSleep()
+    const fetchImpl = resilientFetch({ fetchImpl: impl, retryable: true, sleep: clock.sleep })
+
+    const response = await fetchImpl('https://api.test/t')
+
+    expect(response.status).toBe(200)
+    expect(clock.waits).toEqual([3000])
+  })
+
+  it('backs off when the server names no wait of its own', async () => {
+    const { impl } = scripted([{ status: 503 }, { status: 503 }, { body: { ok: true } }])
+    const clock = fakeSleep()
+    const fetchImpl = resilientFetch({
+      fetchImpl: impl,
+      retryable: true,
+      retry: { attempts: 3, baseDelayMs: 100 },
+      sleep: clock.sleep
+    })
+
+    expect((await fetchImpl('https://api.test/t')).status).toBe(200)
+    expect(clock.waits).toEqual([100, 200])
+  })
+
+  it('tries again when the network throws, and gives up with that error', async () => {
+    const impl = vi.fn(async () => {
+      throw new Error('socket hang up')
+    }) as unknown as typeof fetch
+    const clock = fakeSleep()
+    const fetchImpl = resilientFetch({
+      fetchImpl: impl,
+      retryable: true,
+      retry: { attempts: 2, baseDelayMs: 1 },
+      sleep: clock.sleep
+    })
+
+    await expect(fetchImpl('https://api.test/t')).rejects.toThrow('socket hang up')
+    expect(clock.waits).toHaveLength(1)
+  })
+
+  it('hands back the failing status once the tries run out', async () => {
+    const { impl, calls } = scripted([{ status: 500 }])
+    const fetchImpl = resilientFetch({
+      fetchImpl: impl,
+      retryable: true,
+      retry: { attempts: 2, baseDelayMs: 1 },
+      sleep: fakeSleep().sleep
+    })
+
+    expect((await fetchImpl('https://api.test/t')).status).toBe(500)
+    expect(calls()).toBe(2)
+  })
+
+  it('leaves an answer that is not a hiccup alone', async () => {
+    const { impl, calls } = scripted([{ status: 404, body: { error: 'gone' } }])
+    const fetchImpl = resilientFetch({ fetchImpl: impl, retryable: true })
+
+    expect((await fetchImpl('https://api.test/t')).status).toBe(404)
+    expect(calls()).toBe(1)
+  })
+})
+
+describe('a call the SDK must not repeat', () => {
+  it('leaves a write alone unless the action says repeating it is safe', async () => {
+    const { impl, calls } = scripted([{ status: 500 }])
+    await expect(
+      runAction(
+        withRequest({ request: { method: 'POST', url: 'https://api.test/t' } }),
+        'act',
+        {},
+        { fetchImpl: impl, sleep: fakeSleep().sleep }
+      )
+    ).rejects.toThrow(/500/)
+    expect(calls()).toBe(1)
+  })
+
+  it('repeats a write the action marked idempotent', async () => {
+    const { impl, calls } = scripted([{ status: 500 }, { body: { ok: true } }])
+    const output = await runAction(
+      withRequest({ idempotent: true, request: { method: 'PUT', url: 'https://api.test/t' } }),
+      'act',
+      {},
+      { fetchImpl: impl, retry: { attempts: 2, baseDelayMs: 1 }, sleep: fakeSleep().sleep }
+    )
+    expect(output).toEqual({ ok: true })
+    expect(calls()).toBe(2)
+  })
+
+  it('repeats a declared read without being asked, because a GET changes nothing', async () => {
+    const { impl, calls } = scripted([{ status: 503 }, { body: { ok: true } }])
+    await runAction(
+      withRequest({}),
+      'act',
+      {},
+      {
+        fetchImpl: impl,
+        retry: { attempts: 2, baseDelayMs: 1 },
+        sleep: fakeSleep().sleep
+      }
+    )
+    expect(calls()).toBe(2)
+  })
+})
+
+describe('following a source to the end of its pages', () => {
+  const paginated = (paginate: PaginationStrategy) =>
+    withRequest({ request: { url: 'https://api.test/t', paginate } })
+
+  it('follows a cursor until the source stops handing one back', async () => {
+    const { impl, urls } = scripted([
+      { body: { data: [1, 2], next: 'c2' } },
+      { body: { data: [3], next: null } }
+    ])
+    const output = await runAction(
+      paginated({ kind: 'cursor', cursorPath: 'next', param: 'cursor', itemsPath: 'data' }),
+      'act',
+      {},
+      { fetchImpl: impl }
+    )
+
+    expect(output).toEqual({ items: [1, 2, 3] })
+    expect(urls[1]).toContain('cursor=c2')
+  })
+
+  it('counts pages until one comes back empty', async () => {
+    const { impl, urls } = scripted([{ body: [1] }, { body: [2] }, { body: [] }])
+    const output = await runAction(
+      paginated({ kind: 'page', param: 'page' }),
+      'act',
+      {},
+      { fetchImpl: impl }
+    )
+
+    expect(output).toEqual({ items: [1, 2] })
+    expect(urls.map((url) => new URL(url).searchParams.get('page'))).toEqual(['1', '2', '3'])
+  })
+
+  it('follows the Link header a paged API sends', async () => {
+    const { impl, urls } = scripted([
+      { body: [1], headers: { link: '<https://api.test/t?page=2>; rel="next"' } },
+      { body: [2] }
+    ])
+    const output = await runAction(paginated({ kind: 'link' }), 'act', {}, { fetchImpl: impl })
+
+    expect(output).toEqual({ items: [1, 2] })
+    expect(urls[1]).toBe('https://api.test/t?page=2')
+    expect(nextLink('<https://api.test/t?page=2>; rel="next"')).toBe('https://api.test/t?page=2')
+    expect(nextLink('<https://api.test/t?page=1>; rel="prev"')).toBeUndefined()
+  })
+
+  it('refuses a cursor that does not move rather than looping forever', async () => {
+    const { impl } = scripted([{ body: { data: [1], next: 'same' } }])
+    await expect(
+      runAction(
+        paginated({ kind: 'cursor', cursorPath: 'next', param: 'cursor', itemsPath: 'data' }),
+        'act',
+        {},
+        { fetchImpl: impl }
+      )
+    ).rejects.toThrow(/same page twice/)
+  })
+})

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { scaffoldFiles, titleCase } from '../packages/connector-sdk/src/index'
+import { runCli } from '../packages/connector-sdk/src/cli'
+
+const fileMap = (id = 'acme-tickets') =>
+  new Map(scaffoldFiles({ id }).map((file) => [file.path, file.contents]))
+
+describe('the files a new connector starts as', () => {
+  it('writes everything build, check and pack expect to find', () => {
+    expect([...fileMap().keys()]).toEqual([
+      'package.json',
+      'src/connector.ts',
+      'src/entry.ts',
+      'src/index.ts',
+      'src/connector.test.ts',
+      'README.md'
+    ])
+  })
+
+  it('names the connector after its id when nobody said otherwise', () => {
+    expect(titleCase('acme-tickets')).toBe('Acme Tickets')
+    expect(fileMap().get('src/connector.ts')).toContain("name: 'Acme Tickets'")
+    expect(scaffoldFiles({ id: 'acme', name: 'Acme Corp' })[1].contents).toContain(
+      "name: 'Acme Corp'"
+    )
+  })
+
+  it('gives the package the scripts the factory runs, and the block the catalog reads', () => {
+    const pkg = JSON.parse(fileMap().get('package.json') as string) as {
+      name: string
+      scripts: Record<string, string>
+      dependencies: Record<string, string>
+      vorn: { category: string; keywords: string[] }
+    }
+
+    expect(pkg.name).toBe('vorn-connector-acme-tickets')
+    expect(pkg.scripts.check).toBe('vorn-connector check src/index.ts')
+    expect(pkg.scripts.pack).toBe('vorn-connector pack src/index.ts')
+    expect(pkg.dependencies['@vornrun/connector-sdk']).toMatch(/^\^/)
+    expect(pkg.vorn.keywords).toContain('acme-tickets')
+  })
+
+  it('starts from the SDK it is being written against: declared, with an auth rung', () => {
+    const source = fileMap().get('src/connector.ts') as string
+    expect(source).toContain('auth: { rung:')
+    expect(source).toContain('request: {')
+    expect(source).toContain('postReceive:')
+    expect(source).toContain('dedupe:')
+    expect(source).toContain('builderHint:')
+    // The generated connector uses the retrying fetch, not the global one.
+    expect(source).toContain('context.fetch(')
+  })
+
+  it('starts with a test that needs no network', () => {
+    const test = fileMap().get('src/connector.test.ts') as string
+    expect(test).toContain('createConnectorHarness')
+    expect(test).toContain('fetchImpl')
+    expect(test).toContain('pollTwice')
+  })
+
+  it('refuses an id that could not be a connector id', () => {
+    expect(() => scaffoldFiles({ id: '1nope' })).toThrow(/must start with a letter/)
+    expect(() => scaffoldFiles({ id: 'a/b' })).toThrow(/url-safe/)
+  })
+})
+
+describe('vorn-connector new', () => {
+  const capture = () => {
+    const lines: string[] = []
+    return { lines, write: (line: string) => lines.push(line) }
+  }
+  const load = async (): Promise<unknown> => {
+    throw new Error('new must not load a module')
+  }
+
+  it('writes the scaffold under the id, and says what it made', async () => {
+    const written = new Map<string, string>()
+    const out = capture()
+
+    const code = await runCli(['new', 'acme', '--out', '/tmp/work'], {
+      load,
+      write: out.write,
+      writeFile: async (path, contents) => {
+        written.set(path, contents)
+      }
+    })
+
+    expect(code).toBe(0)
+    expect([...written.keys()]).toContain('/tmp/work/acme/src/connector.ts')
+    expect([...written.keys()]).toContain('/tmp/work/acme/package.json')
+    expect(out.lines.join('\n')).toContain('Created acme in /tmp/work/acme')
+  })
+
+  it('takes a display name, and reports an id it cannot use', async () => {
+    const written = new Map<string, string>()
+    const writeFile = async (path: string, contents: string) => {
+      written.set(path, contents)
+    }
+    await runCli(['new', 'acme', '--name', 'Acme Corp', '--out', '/tmp/work'], {
+      load,
+      write: capture().write,
+      writeFile
+    })
+    expect(written.get('/tmp/work/acme/src/connector.ts')).toContain("name: 'Acme Corp'")
+
+    await expect(
+      runCli(['new', '1nope'], { load, write: capture().write, writeFile })
+    ).rejects.toThrow(/must start with a letter/)
+  })
+
+  it('is listed in the usage text', async () => {
+    const help = capture()
+    await runCli(['help'], { load, write: help.write })
+    expect(help.lines.join('\n')).toContain('new <id>')
+  })
+})

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -36,7 +36,9 @@ describe('the files a new connector starts as', () => {
     expect(pkg.name).toBe('vorn-connector-acme-tickets')
     expect(pkg.scripts.check).toBe('vorn-connector check src/index.ts')
     expect(pkg.scripts.pack).toBe('vorn-connector pack src/index.ts')
-    expect(pkg.dependencies['@vornrun/connector-sdk']).toMatch(/^\^/)
+    // Names a prerelease because that is all there is: a bare `^0.7.0` matches
+    // no prerelease, so a scaffold pinned to it would install nothing.
+    expect(pkg.dependencies['@vornrun/connector-sdk']).toBe('^0.7.0-beta.8')
     expect(pkg.vorn.keywords).toContain('acme-tickets')
   })
 

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -19,9 +19,9 @@ describe('the files a new connector starts as', () => {
 
   it('names the connector after its id when nobody said otherwise', () => {
     expect(titleCase('acme-tickets')).toBe('Acme Tickets')
-    expect(fileMap().get('src/connector.ts')).toContain("name: 'Acme Tickets'")
+    expect(fileMap().get('src/connector.ts')).toContain('name: "Acme Tickets"')
     expect(scaffoldFiles({ id: 'acme', name: 'Acme Corp' })[1].contents).toContain(
-      "name: 'Acme Corp'"
+      'name: "Acme Corp"'
     )
   })
 
@@ -45,6 +45,10 @@ describe('the files a new connector starts as', () => {
   it('starts from the SDK it is being written against: declared, with an auth rung', () => {
     const source = fileMap().get('src/connector.ts') as string
     expect(source).toContain("version: '0.1.0'")
+    const quoted = scaffoldFiles({ id: 'acme', name: "Bob's App", description: 'Two\nlines' })
+    const connector = quoted.find((f) => f.path === 'src/connector.ts')?.contents ?? ''
+    expect(connector).toContain('name: "Bob\'s App"')
+    expect(connector).toContain('description: "Two\\nlines"')
     expect(source).toContain('auth: { rung:')
     expect(source).toContain('request: {')
     expect(source).toContain('postReceive:')
@@ -104,7 +108,7 @@ describe('vorn-connector new', () => {
       write: capture().write,
       writeFile
     })
-    expect(written.get('/tmp/work/acme/src/connector.ts')).toContain("name: 'Acme Corp'")
+    expect(written.get('/tmp/work/acme/src/connector.ts')).toContain('name: "Acme Corp"')
 
     await expect(
       runCli(['new', '1nope'], { load, write: capture().write, writeFile })

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -44,6 +44,7 @@ describe('the files a new connector starts as', () => {
 
   it('starts from the SDK it is being written against: declared, with an auth rung', () => {
     const source = fileMap().get('src/connector.ts') as string
+    expect(source).toContain("version: '0.1.0'")
     expect(source).toContain('auth: { rung:')
     expect(source).toContain('request: {')
     expect(source).toContain('postReceive:')

--- a/tests/connector-sdk-server.test.ts
+++ b/tests/connector-sdk-server.test.ts
@@ -303,6 +303,10 @@ describe('vorn-connector CLI', () => {
     expect(await runCli(['manifest'], { load, write: noModule.write })).toBe(1)
     expect(noModule.lines.join('\n')).toContain('Missing <module>')
 
+    const noId = capture()
+    expect(await runCli(['new'], { load, write: noId.write })).toBe(1)
+    expect(noId.lines.join('\n')).toContain('Missing <id>')
+
     const noTrigger = capture()
     expect(await runCli(['poll', 'pkg'], { load, write: noTrigger.write })).toBe(1)
     expect(noTrigger.lines.join('\n')).toContain('Missing <trigger>')


### PR DESCRIPTION
Second half of the connector factory's SDK: a connector can now be declared rather than written, and the pipeline gets a scaffold to start from.

## What changed

- **Declarative actions.** An action may carry `request: { method, url, headers, query, body }` with `{{args.x}}` / `{{config.x}}` templates and a `postReceive` list of small pure ops (pick, rename, map, filter, flatten) instead of a `run()` function. Exactly one of the two is allowed. Values substituted into the URL are percent-encoded; header values with CR or LF are refused by name; the URL must be absolute or rooted in `{{config.…}}`.
- **Host-injected resilience.** Every action call and trigger fetch goes through retry with backoff (idempotent calls only), `Retry-After` handling for 429, and declared pagination (cursor, page, link). Attempts are capped at 10 and total wait per call at 120s. A first page whose `itemsPath` is not a list throws naming the action and the path.
- **Options for arguments.** Fixed `options` on an input reach the manifest and draw a picker in the step form, with a way back to a template value; the schema stays a string so a rendered template outside the list is not rejected at the tool boundary. `loadOptions` names a connector-served set (`vorn_connector_options` tool), served now and fetched by the app in a later lane.
- **`builderHint`** on config and input fields for the factory's agent.
- **`vorn-connector new <id>`** scaffolds a pack-ready package: package.json with the `vorn` block, `src/{index,entry,connector}.ts`, a colocated test and a README, pinned to `^0.7.0-beta.8`.
- **Harness** accepts `fetchImpl` and `sleep` so retry and pagination are observable under a fake clock.

## Verification

- typecheck 0 errors; full vitest 5511 passed, 2 known ambient failures (process-utils, pty-session-id)
- diff coverage 91%; prettier clean
- Manual: installed a scaffolded pack from file, added a connection, placed the action with its options picker, switched to a template value and back, ran with a hostile title and saw it encoded in the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
