### PR TITLE
Hold a connector to a receipt of the checks that ran

### DIFF
--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -302,6 +302,11 @@ expect(calls[0].url).toBe('https://acme.test/api/messages')
 A request no route matches is refused rather than served, so a test says which
 call escaped instead of quietly reaching a real service.
 
+The stub replaces `fetch`, and only `fetch`. A connector that shells out to a
+CLI or opens its own socket is not intercepted by it, so `--mock` reports any
+action the stub never heard from as `mock-not-observed` and leaves `mock` out
+of the receipt rather than vouching for a run it did not see.
+
 ```ts
 {
   type: 'newTicket',

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -366,6 +366,23 @@ hand:
 npx vorn-connector setup ./dist/index.js
 ```
 
+### Where a config field is read from
+
+A field is read from the environment variable it names in `env`, or from its
+key in CONSTANT_CASE when it names none — `apiToken` becomes `API_TOKEN`. The
+same rule decides what `--live` reads and what the host must set when it hands
+a connector its credentials, so it is exported rather than kept private:
+
+```ts
+import { envNameFor } from '@vornrun/connector-sdk'
+
+envNameFor('apiToken') // API_TOKEN
+envNameFor('apiToken', 'GH_TOKEN') // GH_TOKEN — an explicit env always wins
+```
+
+Anything computing these names on the host side should call this rather than
+re-implement it, or the two will disagree about a field named `oauth2Token`.
+
 ## Pack it as a file
 
 `vorn-connector pack` builds a single installable file: the manifest plus one

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -265,6 +265,43 @@ trigger and they are replayed through the real dedupe pipeline, so a connector
 can be checked before anyone has credentials for it; pass `--live` to poll the
 real source instead.
 
+`--mock` is the full gate, and the one to run in CI. It answers every HTTP
+request from routes instead of the network, runs each action on its own
+declared arguments, and asks the questions `pack` asks about the package —
+install-time scripts, and anything that would still need a registry at launch:
+
+```console
+$ npx vorn-connector check ./dist/index.js --mock --receipt verified.json
+Verified manifest, auth, secrets, actions, dedupe, no-lifecycle-scripts, keywords, no-runtime-deps, mock — wrote verified.json
+```
+
+`--receipt <file>` writes what was verified, for a catalog to carry:
+
+```json
+{ "schema": 1, "version": "1.2.0", "checkedAt": "…", "checks": ["manifest", "…"] }
+```
+
+A check that could not run is left out rather than listed as passed, and a
+connector with any error gets no receipt at all.
+
+`--live` additionally asks `preflight` whether the connector can sign in, then
+runs each action that declared `idempotent: true`. Actions that did not are
+never called: a smoke test must leave nothing behind.
+
+In a unit test the same stub is available directly, so an author can assert on
+what their connector sent:
+
+```ts
+const { result, calls } = await harness.withMockHttp(
+  [{ url: '/api/messages', method: 'POST', body: { id: 'm-1' } }],
+  () => harness.execute('post', { text: 'hi' })
+)
+expect(calls[0].url).toBe('https://acme.test/api/messages')
+```
+
+A request no route matches is refused rather than served, so a test says which
+call escaped instead of quietly reaching a real service.
+
 ```ts
 {
   type: 'newTicket',
@@ -384,5 +421,6 @@ vorn-connector serve <module>             Serve on stdio (what Vorn runs)
 declared config from your shell environment — the fastest way to confirm
 credentials and field mapping before wiring anything up.
 
-`check` runs against declared `sample` data by default and takes `--live` to
-poll the real source instead.
+`check` runs against declared `sample` data by default. `--mock` serves its
+HTTP and runs every action, `--live` polls the real source and runs the actions
+that are safe to repeat, and `--receipt <file>` writes down what was verified.

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -294,13 +294,36 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
   return found
 }
 
+/** A refusal to let the connector in at all, as opposed to any other failure. */
+const AUTH_FAILURE = /\b(401|403|unauthor|unauthenticat|forbidden|invalid[- ]?(token|credential))/i
+
+/**
+ * Whether a live run can call this action honestly.
+ *
+ * Only the ones that are safe to repeat, and only where the arguments are real:
+ * either the author named a `sample` set, or the action needs nothing required.
+ * Inventing an identifier just teaches the service to say "no such thing",
+ * which says nothing about the connector.
+ */
+function liveRunnable(action: ActionDefinition): boolean {
+  if (action.idempotent !== true) return false
+  if (action.sample !== undefined) return true
+  return !(action.inputs ?? []).some((input) => input.required === true)
+}
+
+/** Whether a live run has anything at all to ask, so a receipt can say it ran. */
+export function liveExamines(connector: Connector): boolean {
+  return connector.preflight !== undefined || connector.actions.some(liveRunnable)
+}
+
 /**
  * Ask the connector, against the real service, the questions only it can answer.
  *
  * Preflight first, because a connector that cannot sign in fails every later
- * check for one uninteresting reason. Then each action that declared itself
- * idempotent — and only those: a live run of `createIssue` would leave real
- * issues behind, so a smoke test never calls one.
+ * check for one uninteresting reason. Then each action that is both safe to
+ * repeat and callable with real arguments — a live run of `createIssue` would
+ * leave real issues behind, and one of `closeIssue('check')` would only prove
+ * that no such issue exists.
  */
 async function liveFindings(connector: Connector, options: CheckOptions): Promise<CheckFinding[]> {
   if (!options.live) return []
@@ -329,19 +352,24 @@ async function liveFindings(connector: Connector, options: CheckOptions): Promis
     }
   }
 
-  for (const action of connector.actions.filter((entry) => entry.idempotent === true)) {
-    const args = Object.fromEntries(
-      (action.inputs ?? []).map((input) => [input.key, sampleArg(input)])
-    )
+  for (const action of connector.actions.filter(liveRunnable)) {
     try {
-      await runAction(connector, action.type, args, {
+      await runAction(connector, action.type, action.sample ?? {}, {
         config: options.config ?? {},
         ...(options.now && { now: options.now })
       })
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
+      // A service can refuse for reasons that are not the connector's fault —
+      // an empty sandbox, a rate limit — so only a refusal to let it in at all
+      // is graded as broken.
       found.push(
-        finding('error', 'live-action-failed', `action ${action.type}`, `threw: ${reason}`)
+        finding(
+          AUTH_FAILURE.test(reason) ? 'error' : 'warn',
+          'live-action-failed',
+          `action ${action.type}`,
+          `threw: ${reason}`
+        )
       )
     }
   }

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -270,6 +270,61 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
 }
 
 /**
+ * Ask the connector, against the real service, the questions only it can answer.
+ *
+ * Preflight first, because a connector that cannot sign in fails every later
+ * check for one uninteresting reason. Then each action that declared itself
+ * idempotent — and only those: a live run of `createIssue` would leave real
+ * issues behind, so a smoke test never calls one.
+ */
+async function liveFindings(connector: Connector, options: CheckOptions): Promise<CheckFinding[]> {
+  if (!options.live) return []
+  const found: CheckFinding[] = []
+
+  if (connector.preflight) {
+    try {
+      const result = await connector.preflight()
+      if (!result.ok) {
+        found.push(
+          finding(
+            'error',
+            'preflight-failed',
+            connector.id,
+            result.message ?? 'reported that it is not ready, without saying why'
+          )
+        )
+        // Nothing below can succeed if it cannot sign in, and each failure
+        // would repeat this one in a less useful sentence.
+        return found
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      found.push(finding('error', 'preflight-failed', connector.id, `threw: ${reason}`))
+      return found
+    }
+  }
+
+  for (const action of connector.actions.filter((entry) => entry.idempotent === true)) {
+    const args = Object.fromEntries(
+      (action.inputs ?? []).map((input) => [input.key, sampleArg(input)])
+    )
+    try {
+      await runAction(connector, action.type, args, {
+        config: options.config ?? {},
+        ...(options.now && { now: options.now })
+      })
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      found.push(
+        finding('error', 'live-action-failed', `action ${action.type}`, `threw: ${reason}`)
+      )
+    }
+  }
+
+  return found
+}
+
+/**
  * Replay a trigger's declared `sample` through the real dedupe pipeline by
  * swapping in a fetch that serves the whole sample on every call. Serving it
  * again on the second poll is the point: a correct trigger recognizes its own
@@ -387,6 +442,7 @@ export async function checkConnector(
   found.push(...secretFindings(connector))
   found.push(...(await packageFindings(options)))
   found.push(...(await mockFindings(connector, options)))
+  found.push(...(await liveFindings(connector, options)))
 
   // Triggers share no state, so their checks run concurrently rather than
   // waiting on each other's polls.

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -274,8 +274,18 @@ function sampleArg(input: ActionInputField): string {
  * the service returns, so a throw is the connector's. Against the bare `{}`
  * default it is a warning, because an empty object is not a real reply.
  */
+// A mock run needs every config field to resolve a template: defaults where declared, placeholders elsewhere.
+export function mockConfig(connector: Connector): ConnectorConfig {
+  const config: ConnectorConfig = {}
+  for (const field of connector.config) {
+    config[field.key] = field.default ?? `mock-${field.key}`
+  }
+  return config
+}
+
 async function mockFindings(connector: Connector, options: CheckOptions): Promise<CheckFinding[]> {
   if (!options.mock) return []
+  const config = options.config ?? mockConfig(connector)
   const routes = options.mockRoutes ?? [{ url: /.*/ }]
   const level = options.mockRoutes?.length ? 'error' : 'warn'
   const found: CheckFinding[] = []
@@ -288,7 +298,7 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
     const { result: thrown, calls } = await withMockHttp(routes, async () => {
       try {
         await runAction(connector, action.type, args, {
-          config: options.config ?? {},
+          config,
           ...(options.now && { now: options.now })
         })
         return undefined

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -17,10 +17,43 @@ import type {
   TriggerDefinition
 } from './types'
 
+/**
+ * Every finding this SDK can report.
+ *
+ * A closed set, so `CHECK_OWNERS` cannot fall behind it: a new code that no
+ * named check owns is a compile error rather than a receipt quietly vouching
+ * for a check whose failure nothing was watching.
+ */
+export type CheckCode =
+  | 'missing-description'
+  | 'auth-undeclared'
+  | 'auth-probe-missing'
+  | 'secret-not-marked'
+  | 'action-no-outputs'
+  | 'input-type-unsupported'
+  | 'missing-idempotent'
+  | 'unverifiable'
+  | 'sample-unusable'
+  | 'poll-failed'
+  | 'no-items'
+  | 'no-cursor'
+  | 'cursor-rejected'
+  | 'redelivers-items'
+  | 'stuck-cursor'
+  | 'lifecycle-scripts'
+  | 'keywords-missing'
+  | 'runtime-dependencies'
+  | 'mock-action-failed'
+  | 'mock-network-escape'
+  | 'mock-not-observed'
+  | 'preflight-failed'
+  | 'live-action-failed'
+  | 'pack-too-large'
+
 export interface CheckFinding {
   /** `error` means the connector will misbehave in Vorn; `warn` is advisory. */
   level: 'error' | 'warn'
-  code: string
+  code: CheckCode
   /** Which part of the connector the finding is about. */
   target: string
   message: string
@@ -66,7 +99,7 @@ const INPUT_TYPES = new Set(['string', 'number', 'boolean', 'select', 'json'])
 
 function finding(
   level: CheckFinding['level'],
-  code: string,
+  code: CheckCode,
   target: string,
   message: string
 ): CheckFinding {
@@ -588,8 +621,14 @@ export interface ConnectorVerification {
   checks: string[]
 }
 
-/** Which named check each finding belongs to, so one failure clears one name. */
-const CHECK_OWNERS: Record<string, string> = {
+/**
+ * Which named check each finding belongs to, so one failure clears one name.
+ *
+ * `null` means the code belongs to no check a receipt can carry — `pack` has
+ * its own gates, and a receipt speaks only for the conformance run.
+ */
+export const CHECK_OWNERS: Record<CheckCode, string | null> = {
+  'pack-too-large': null,
   'missing-description': 'manifest',
   'auth-undeclared': 'auth',
   'auth-probe-missing': 'auth',

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -449,7 +449,7 @@ async function checkPollBehaviour(
 
   const attempt = async (
     cursor: string | undefined,
-    code: string,
+    code: CheckCode,
     what: string
   ): Promise<PollPage | CheckFinding> => {
     try {

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -615,13 +615,26 @@ const CHECK_OWNERS: Record<string, string> = {
   'live-action-failed': 'live'
 }
 
-/** The checks a run of these options actually performs. */
-function checksRun(options: CheckOptions): string[] {
-  const names = ['manifest', 'auth', 'secrets', 'actions', 'dedupe']
+/**
+ * The checks this run actually performed.
+ *
+ * Derived from what there was to examine, not from what was asked for: a
+ * connector with no triggers has nothing to say about dedupe, and listing it
+ * anyway would make the receipt vouch for a check that never looked at
+ * anything. Absent is the true answer, and a truthful short list is worth more
+ * than a long one.
+ */
+function checksRun(connector: Connector, options: CheckOptions): string[] {
+  const names = ['manifest', 'auth']
+  if (connector.config.length > 0) names.push('secrets')
+  if (connector.actions.length > 0) names.push('actions')
+  if (connector.triggers.length > 0) names.push('dedupe')
   if (options.packageDir !== undefined) names.push('no-lifecycle-scripts', 'keywords')
   if (options.bundle && options.entry !== undefined) names.push('no-runtime-deps')
-  if (options.mock) names.push('mock')
-  if (options.live) names.push('live')
+  // Whether the stub was actually reached is the `mock-not-observed` finding's
+  // job: it spoils this name for the action that stayed silent.
+  if (options.mock && connector.actions.length > 0) names.push('mock')
+  if (options.live && liveExamines(connector)) names.push('live')
   return names
 }
 
@@ -648,21 +661,24 @@ export async function runConformance(
 ): Promise<ConformanceRun> {
   const findings = await checkConnector(connector, options)
   const spoiled = new Set(findings.map((item) => CHECK_OWNERS[item.code]).filter(Boolean))
-  const passed = checksRun(options).filter((name) => !spoiled.has(name))
+  const passed = checksRun(connector, options).filter((name) => !spoiled.has(name))
   const failed = findings.some((item) => item.level === 'error')
   const now = options.now ?? (() => new Date().toISOString())
 
   return {
     findings,
     passed,
-    ...(!failed && {
-      receipt: {
-        schema: 1 as const,
-        version: connector.version,
-        checkedAt: now(),
-        checks: passed
-      }
-    })
+    // A receipt listing nothing would read as verified while vouching for
+    // nothing at all, which is worse than saying nothing.
+    ...(!failed &&
+      passed.length > 0 && {
+        receipt: {
+          schema: 1 as const,
+          version: connector.version,
+          checkedAt: now(),
+          checks: passed
+        }
+      })
   }
 }
 

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -519,6 +519,99 @@ export async function checkConnector(
   return found
 }
 
+/**
+ * What the factory checked, and when.
+ *
+ * Mirrors the receipt the catalog carries. "Verified" is not a word here but a
+ * list: the checks that ran and came back with nothing to say. A check that
+ * could not run — no sample to replay, no credentials to go live with — is
+ * absent rather than passed, because absent is the true answer.
+ */
+export interface ConnectorVerification {
+  /** Which receipt format this is, so a later one is not read as this one. */
+  schema: 1
+  version: string
+  checkedAt: string
+  checks: string[]
+}
+
+/** Which named check each finding belongs to, so one failure clears one name. */
+const CHECK_OWNERS: Record<string, string> = {
+  'missing-description': 'manifest',
+  'auth-undeclared': 'auth',
+  'auth-probe-missing': 'auth',
+  'secret-not-marked': 'secrets',
+  'action-no-outputs': 'actions',
+  'input-type-unsupported': 'actions',
+  'missing-idempotent': 'actions',
+  'poll-failed': 'dedupe',
+  'no-items': 'dedupe',
+  'no-cursor': 'dedupe',
+  'cursor-rejected': 'dedupe',
+  'redelivers-items': 'dedupe',
+  'stuck-cursor': 'dedupe',
+  unverifiable: 'dedupe',
+  'sample-unusable': 'dedupe',
+  'lifecycle-scripts': 'no-lifecycle-scripts',
+  'keywords-missing': 'keywords',
+  'runtime-dependencies': 'no-runtime-deps',
+  'mock-action-failed': 'mock',
+  'mock-network-escape': 'mock',
+  'preflight-failed': 'live',
+  'live-action-failed': 'live'
+}
+
+/** The checks a run of these options actually performs. */
+function checksRun(options: CheckOptions): string[] {
+  const names = ['manifest', 'auth', 'secrets', 'actions', 'dedupe']
+  if (options.packageDir !== undefined) names.push('no-lifecycle-scripts', 'keywords')
+  if (options.bundle && options.entry !== undefined) names.push('no-runtime-deps')
+  if (options.mock) names.push('mock')
+  if (options.live) names.push('live')
+  return names
+}
+
+export interface ConformanceRun {
+  findings: CheckFinding[]
+  /** Named checks that ran and had nothing to say. */
+  passed: string[]
+  /**
+   * The receipt to publish, or nothing when an error means there is no claim
+   * to make. Warnings do not void it — they are advice, not a failure.
+   */
+  receipt?: ConnectorVerification
+}
+
+/**
+ * Check a connector and say what can be vouched for.
+ *
+ * `checkConnector` answers "what is wrong"; this answers the catalog's
+ * question, "what did you check", which is what a verified badge shows.
+ */
+export async function runConformance(
+  connector: Connector,
+  options: CheckOptions = {}
+): Promise<ConformanceRun> {
+  const findings = await checkConnector(connector, options)
+  const spoiled = new Set(findings.map((item) => CHECK_OWNERS[item.code]).filter(Boolean))
+  const passed = checksRun(options).filter((name) => !spoiled.has(name))
+  const failed = findings.some((item) => item.level === 'error')
+  const now = options.now ?? (() => new Date().toISOString())
+
+  return {
+    findings,
+    passed,
+    ...(!failed && {
+      receipt: {
+        schema: 1 as const,
+        version: connector.version,
+        checkedAt: now(),
+        checks: passed
+      }
+    })
+  }
+}
+
 /** Render findings for a terminal. Returns an empty string when all clear. */
 export function formatFindings(findings: CheckFinding[]): string {
   return findings

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -229,6 +229,10 @@ function sampleArg(input: ActionInputField): string {
  * arguments — until now no check ever called one — and that it reaches nothing
  * the routes did not offer, which is what makes a conformance run hermetic.
  *
+ * Hermetic as far as `fetch` goes, which is the honest scope: a connector that
+ * shells out or opens its own socket is not intercepted, so an action the stub
+ * never heard from is reported as unobserved rather than counted as checked.
+ *
  * A failure is an error only when the caller supplied routes: they said what
  * the service returns, so a throw is the connector's. Against the bare `{}`
  * default it is a warning, because an empty object is not a real reply.
@@ -243,15 +247,21 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
     const args = Object.fromEntries(
       (action.inputs ?? []).map((input) => [input.key, sampleArg(input)])
     )
-    try {
-      await withMockHttp(routes, () =>
-        runAction(connector, action.type, args, {
+    // Caught inside, so the calls are readable even when the action threw.
+    const { result: thrown, calls } = await withMockHttp(routes, async () => {
+      try {
+        await runAction(connector, action.type, args, {
           config: options.config ?? {},
           ...(options.now && { now: options.now })
         })
-      )
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error)
+        return undefined
+      } catch (error) {
+        return error
+      }
+    })
+
+    if (thrown !== undefined) {
+      const reason = thrown instanceof Error ? thrown.message : String(thrown)
       // Reaching for the network is a failure in either mode: a conformance
       // run that touches a real service is not a conformance run.
       const escaped = reason.startsWith('No mock route')
@@ -261,6 +271,21 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
           escaped ? 'mock-network-escape' : 'mock-action-failed',
           `action ${action.type}`,
           `did not run against served HTTP: ${reason}`
+        )
+      )
+      continue
+    }
+
+    // Nothing was intercepted, so nothing was proved. The stub only sees
+    // `fetch`: an action that shells out or opens its own socket runs for
+    // real here, and saying `mock` of it would be a claim nobody checked.
+    if (calls.length === 0) {
+      found.push(
+        finding(
+          'warn',
+          'mock-not-observed',
+          `action ${action.type}`,
+          'made no request the stub could see, so this run vouches for nothing it did'
         )
       )
     }
@@ -557,6 +582,7 @@ const CHECK_OWNERS: Record<string, string> = {
   'runtime-dependencies': 'no-runtime-deps',
   'mock-action-failed': 'mock',
   'mock-network-escape': 'mock',
+  'mock-not-observed': 'mock',
   'preflight-failed': 'live',
   'live-action-failed': 'live'
 }

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -1,6 +1,7 @@
 import {
   bundleDependencyFindings,
   lifecycleScriptFindings,
+  packageDirFor,
   packEntryContents,
   readNearestPackageJson,
   type BundleOutput,
@@ -219,7 +220,10 @@ function actionShapeFindings(action: ActionDefinition): CheckFinding[] {
 /** What the package says about itself, when a check was pointed at one. */
 async function packageFindings(options: CheckOptions): Promise<CheckFinding[]> {
   if (options.packageDir === undefined) return []
-  const pkg = readNearestPackageJson(options.packageDir)
+  // The entry's own package, not the directory the command was run from: in a
+  // monorepo those are rarely the same, and the root's package.json says
+  // nothing about the connector being checked.
+  const pkg = readNearestPackageJson(packageDirFor(options.packageDir, options.entry))
   const found = [...lifecycleScriptFindings(pkg)]
 
   const vorn = (pkg as { vorn?: { keywords?: unknown } } | undefined)?.vorn

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -1,5 +1,19 @@
+import {
+  bundleDependencyFindings,
+  lifecycleScriptFindings,
+  packEntryContents,
+  readNearestPackageJson,
+  type BundleOutput,
+  type BundleRequest
+} from './packaging'
 import { runPoll, type PollPage } from './runtime'
-import type { Connector, ConnectorConfig, DedupeStrategy, TriggerDefinition } from './types'
+import type {
+  ActionDefinition,
+  Connector,
+  ConnectorConfig,
+  DedupeStrategy,
+  TriggerDefinition
+} from './types'
 
 export interface CheckFinding {
   /** `error` means the connector will misbehave in Vorn; `warn` is advisory. */
@@ -19,7 +33,27 @@ export interface CheckOptions {
   /** Credentials, required by `live`. */
   config?: ConnectorConfig
   now?: () => string
+  /**
+   * Directory whose nearest package.json says how the connector ships. Given,
+   * the checks that are about the package rather than the definition run too.
+   */
+  packageDir?: string
+  /**
+   * Bundles the connector so the check can see what would stay outside it.
+   * Given, a pack's no-install-step promise is verified before packing.
+   */
+  bundle?(request: BundleRequest): Promise<BundleOutput>
+  /** Module specifier the bundle starts from; required by `bundle`. */
+  entry?: string
 }
+
+/** What the host will run a probe by, so a check refuses what it would drop. */
+const EXECUTABLE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+
+/** Config keys that name a credential, whatever the connector calls them. */
+const CREDENTIAL_NAME = /(secret|token|password|passphrase|api[-_]?key|credential)/i
+
+const INPUT_TYPES = new Set(['string', 'number', 'boolean', 'select', 'json'])
 
 function finding(
   level: CheckFinding['level'],
@@ -28,6 +62,146 @@ function finding(
   message: string
 ): CheckFinding {
   return { level, code, target, message }
+}
+
+/**
+ * How the connector says it signs in, checked against what the host will keep.
+ *
+ * `defineConnector` already refuses a rung it cannot back up, so what is left
+ * here is the gap between the two: an author-side probe that passes validation
+ * and is then dropped at the host for not being a bare executable name, which
+ * would silently turn a Sign in into a token field.
+ */
+function authFindings(connector: Connector): CheckFinding[] {
+  const auth = connector.auth
+  if (!auth) {
+    return [
+      finding(
+        'warn',
+        'auth-undeclared',
+        connector.id,
+        'does not say how it signs in, so the app cannot tell anyone before they install it'
+      )
+    ]
+  }
+
+  const found: CheckFinding[] = []
+  const command = auth.probe?.command?.trim() ?? ''
+  const args = auth.probe?.args ?? []
+  if (auth.rung === 'cli') {
+    if (!EXECUTABLE_NAME.test(command)) {
+      found.push(
+        finding(
+          'error',
+          'auth-probe-missing',
+          `${connector.id} auth`,
+          `probe command "${command}" is not a bare executable name, so the host drops it and the rung promises a sign-in it cannot ask for`
+        )
+      )
+    }
+    if (args.some((arg) => typeof arg !== 'string')) {
+      found.push(
+        finding(
+          'error',
+          'auth-probe-missing',
+          `${connector.id} auth`,
+          'probe arguments must all be strings, or the host drops the probe'
+        )
+      )
+    }
+  }
+
+  return found
+}
+
+/** A credential Vorn would store in the clear because nothing marked it secret. */
+function secretFindings(connector: Connector): CheckFinding[] {
+  const named = new Set(connector.auth?.keys ?? [])
+  return connector.config
+    .filter((field) => !field.secret)
+    .filter((field) => named.has(field.key) || CREDENTIAL_NAME.test(field.key))
+    .map((field) =>
+      finding(
+        named.has(field.key) ? 'error' : 'warn',
+        'secret-not-marked',
+        `config ${field.key}`,
+        'holds a credential but is not marked `secret`, so Vorn would store it unencrypted'
+      )
+    )
+}
+
+/** What an action takes and returns, as far as a step can see it before running. */
+function actionShapeFindings(action: ActionDefinition): CheckFinding[] {
+  const target = `action ${action.type}`
+  const found: CheckFinding[] = []
+
+  if (!action.outputs?.length) {
+    found.push(
+      finding(
+        'warn',
+        'action-no-outputs',
+        target,
+        'declares no outputs, so a later step has nothing to autocomplete from'
+      )
+    )
+  }
+
+  for (const input of action.inputs ?? []) {
+    if (input.type !== undefined && !INPUT_TYPES.has(input.type)) {
+      found.push(
+        finding(
+          'error',
+          'input-type-unsupported',
+          `${target} input ${input.key}`,
+          `declares type "${input.type}", which Vorn cannot draw a field for`
+        )
+      )
+    }
+    // A select is a promise of choices; one with neither list is a text box
+    // wearing a dropdown's clothes.
+    if (input.type === 'select' && !input.options?.length && !input.loadOptions) {
+      found.push(
+        finding(
+          'error',
+          'input-type-unsupported',
+          `${target} input ${input.key}`,
+          'is a select with neither fixed options nor a loadOptions set to draw from'
+        )
+      )
+    }
+  }
+
+  return found
+}
+
+/** What the package says about itself, when a check was pointed at one. */
+async function packageFindings(options: CheckOptions): Promise<CheckFinding[]> {
+  if (options.packageDir === undefined) return []
+  const pkg = readNearestPackageJson(options.packageDir)
+  const found = [...lifecycleScriptFindings(pkg)]
+
+  const vorn = (pkg as { vorn?: { keywords?: unknown } } | undefined)?.vorn
+  const keywords = Array.isArray(vorn?.keywords) ? vorn.keywords : []
+  if (keywords.length === 0) {
+    found.push(
+      finding(
+        'warn',
+        'keywords-missing',
+        'package.json',
+        'names no keywords, so the connector is findable only by its own name'
+      )
+    )
+  }
+
+  if (options.bundle && options.entry !== undefined) {
+    const built = await options.bundle({
+      contents: packEntryContents(options.entry),
+      resolveDir: options.packageDir
+    })
+    found.push(...bundleDependencyFindings(built.external))
+  }
+
+  return found
 }
 
 /**
@@ -144,6 +318,10 @@ export async function checkConnector(
     )
   }
 
+  found.push(...authFindings(connector))
+  found.push(...secretFindings(connector))
+  found.push(...(await packageFindings(options)))
+
   // Triggers share no state, so their checks run concurrently rather than
   // waiting on each other's polls.
   const perTrigger = await Promise.all(
@@ -201,6 +379,7 @@ export async function checkConnector(
         )
       )
     }
+    found.push(...actionShapeFindings(action))
     for (const input of action.inputs ?? []) {
       if (!input.description?.trim()) {
         found.push(

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -6,9 +6,11 @@ import {
   type BundleOutput,
   type BundleRequest
 } from './packaging'
-import { runPoll, type PollPage } from './runtime'
+import { withMockHttp, type MockRoute } from './harness'
+import { runAction, runPoll, type PollPage } from './runtime'
 import type {
   ActionDefinition,
+  ActionInputField,
   Connector,
   ConnectorConfig,
   DedupeStrategy,
@@ -45,6 +47,13 @@ export interface CheckOptions {
   bundle?(request: BundleRequest): Promise<BundleOutput>
   /** Module specifier the bundle starts from; required by `bundle`. */
   entry?: string
+  /**
+   * Run every action against served HTTP rather than the network. Without
+   * routes each request is answered `{}`, which proves an action runs and
+   * escapes nowhere; with them, that it does the right thing.
+   */
+  mock?: boolean
+  mockRoutes?: MockRoute[]
 }
 
 /** What the host will run a probe by, so a check refuses what it would drop. */
@@ -204,6 +213,62 @@ async function packageFindings(options: CheckOptions): Promise<CheckFinding[]> {
   return found
 }
 
+/** A value of the declared type, so an action can be run without a person. */
+function sampleArg(input: ActionInputField): string {
+  if (input.type === 'number') return '1'
+  if (input.type === 'boolean') return 'false'
+  if (input.type === 'json') return '{}'
+  if (input.type === 'select') return input.options?.[0]?.value ?? 'check'
+  return 'check'
+}
+
+/**
+ * Run every action once with nothing but served HTTP behind it.
+ *
+ * Two things are being asked. That an action runs at all on its own declared
+ * arguments — until now no check ever called one — and that it reaches nothing
+ * the routes did not offer, which is what makes a conformance run hermetic.
+ *
+ * A failure is an error only when the caller supplied routes: they said what
+ * the service returns, so a throw is the connector's. Against the bare `{}`
+ * default it is a warning, because an empty object is not a real reply.
+ */
+async function mockFindings(connector: Connector, options: CheckOptions): Promise<CheckFinding[]> {
+  if (!options.mock) return []
+  const routes = options.mockRoutes ?? [{ url: /.*/ }]
+  const level = options.mockRoutes?.length ? 'error' : 'warn'
+  const found: CheckFinding[] = []
+
+  for (const action of connector.actions) {
+    const args = Object.fromEntries(
+      (action.inputs ?? []).map((input) => [input.key, sampleArg(input)])
+    )
+    try {
+      await withMockHttp(routes, () =>
+        runAction(connector, action.type, args, {
+          config: options.config ?? {},
+          ...(options.now && { now: options.now })
+        })
+      )
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      // Reaching for the network is a failure in either mode: a conformance
+      // run that touches a real service is not a conformance run.
+      const escaped = reason.startsWith('No mock route')
+      found.push(
+        finding(
+          escaped ? 'error' : level,
+          escaped ? 'mock-network-escape' : 'mock-action-failed',
+          `action ${action.type}`,
+          `did not run against served HTTP: ${reason}`
+        )
+      )
+    }
+  }
+
+  return found
+}
+
 /**
  * Replay a trigger's declared `sample` through the real dedupe pipeline by
  * swapping in a fetch that serves the whole sample on every call. Serving it
@@ -321,6 +386,7 @@ export async function checkConnector(
   found.push(...authFindings(connector))
   found.push(...secretFindings(connector))
   found.push(...(await packageFindings(options)))
+  found.push(...(await mockFindings(connector, options)))
 
   // Triggers share no state, so their checks run concurrently rather than
   // waiting on each other's polls.

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -7,7 +7,7 @@ import {
   type BundleOutput,
   type BundleRequest
 } from './packaging'
-import { withMockHttp, type MockRoute } from './harness'
+import { escapedMockHttp, withMockHttp, type MockRoute } from './harness'
 import { runAction, runPoll, type PollPage } from './runtime'
 import type {
   ActionDefinition,
@@ -300,8 +300,10 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
     if (thrown !== undefined) {
       const reason = thrown instanceof Error ? thrown.message : String(thrown)
       // Reaching for the network is a failure in either mode: a conformance
-      // run that touches a real service is not a conformance run.
-      const escaped = reason.startsWith('No mock route')
+      // run that touches a real service is not a conformance run. Asked of the
+      // error itself, not its wording, because a declarative action rethrows
+      // the refusal with its own name in front.
+      const escaped = escapedMockHttp(thrown)
       found.push(
         finding(
           escaped ? 'error' : level,

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -179,10 +179,15 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
       const { findings } = run
       const errors = findings.filter((item) => item.level === 'error')
       if (findings.length > 0) deps.write(formatFindings(findings))
-      if (flags.receipt !== undefined && run.receipt) {
-        const write = deps.writeFile ?? ((path, contents) => writeFile(path, contents))
-        await write(flags.receipt, `${JSON.stringify(run.receipt, null, 2)}\n`)
-        deps.write(`Verified ${run.receipt.checks.join(', ')} — wrote ${flags.receipt}`)
+      if (flags.receipt !== undefined) {
+        if (run.receipt) {
+          const write = deps.writeFile ?? ((path, contents) => writeFile(path, contents))
+          await write(flags.receipt, `${JSON.stringify(run.receipt, null, 2)}\n`)
+          deps.write(`Verified ${run.receipt.checks.join(', ')} — wrote ${flags.receipt}`)
+        } else {
+          deps.write(`No receipt written: nothing could be vouched for`)
+          if (errors.length === 0) return 1
+        }
       }
       deps.write(
         errors.length > 0

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -4,7 +4,8 @@ import { dirname, join, resolve } from 'node:path'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { checkConnector, formatFindings } from './check'
 import { resolveConfig } from './define'
-import { packConnector, type BundleOutput, type BundleRequest } from './pack'
+import { packConnector } from './pack'
+import { esbuildBundle, type BundleOutput, type BundleRequest } from './packaging'
 import { runPoll } from './runtime'
 import { scaffoldFiles } from './scaffold'
 import { connectionSetup, connectorManifest } from './setup'
@@ -26,6 +27,7 @@ Options:
   --since <iso>                 Lower bound passed to poll
   --limit <n>                   Maximum items to request
   --live                        Let check poll for real using the environment
+  --mock                        Run every action against served HTTP, not the network
   --out <dir>                   Directory new and pack write to
   --name <name>                 Display name for a new connector`
 
@@ -42,7 +44,7 @@ export interface CliDeps {
 }
 
 /** Flags that stand alone; everything else must be followed by a value. */
-const BOOLEAN_FLAGS = new Set(['live'])
+const BOOLEAN_FLAGS = new Set(['live', 'mock'])
 
 /**
  * Split arguments into flags and positionals in one pass, so a flag's value is
@@ -148,7 +150,19 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
     }
 
     case 'check': {
+      // A mock run is the whole conformance gate, so it also asks what the
+      // connector ships as — the questions pack would ask, before packing.
+      const packaged =
+        flags.mock === 'true'
+          ? {
+              mock: true,
+              packageDir: deps.cwd ?? process.cwd(),
+              entry: modulePath,
+              bundle: deps.bundle ?? esbuildBundle
+            }
+          : {}
       const findings = await checkConnector(connector, {
+        ...packaged,
         ...(flags.live === 'true' && {
           live: true,
           config: resolveConfig(connector, deps.env ?? process.env)

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { pathToFileURL } from 'node:url'
+import { existsSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { checkConnector, formatFindings } from './check'
+import { formatFindings, runConformance } from './check'
 import { resolveConfig } from './define'
 import { packConnector } from './pack'
 import { esbuildBundle, type BundleOutput, type BundleRequest } from './packaging'
@@ -28,6 +29,7 @@ Options:
   --limit <n>                   Maximum items to request
   --live                        Let check poll for real using the environment
   --mock                        Run every action against served HTTP, not the network
+  --receipt <file>              Where check writes what it verified, as JSON
   --out <dir>                   Directory new and pack write to
   --name <name>                 Display name for a new connector`
 
@@ -39,8 +41,10 @@ export interface CliDeps {
   cwd?: string
   /** Replaced in tests so pack does not shell out to a bundler. */
   bundle?(request: BundleRequest): Promise<BundleOutput>
-  /** Replaced in tests so scaffolding writes nowhere. */
+  /** Writes a scaffold file or a receipt; replaced in tests so nothing touches disk. */
   writeFile?(path: string, contents: string): Promise<void>
+  /** Replaced in tests beside writeFile. */
+  exists?(path: string): boolean
 }
 
 /** Flags that stand alone; everything else must be followed by a value. */
@@ -113,6 +117,10 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
       ...(flags.name !== undefined && { name: flags.name })
     })
     const root = join(flags.out ?? deps.cwd ?? '.', modulePath)
+    if ((deps.exists ?? existsSync)(root)) {
+      deps.write(`${root} already exists; a scaffold never overwrites`)
+      return 1
+    }
     for (const file of files) {
       await deps.writeFile(join(root, file.path), file.contents)
     }
@@ -161,15 +169,21 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
               bundle: deps.bundle ?? esbuildBundle
             }
           : {}
-      const findings = await checkConnector(connector, {
+      const run = await runConformance(connector, {
         ...packaged,
         ...(flags.live === 'true' && {
           live: true,
           config: resolveConfig(connector, deps.env ?? process.env)
         })
       })
+      const { findings } = run
       const errors = findings.filter((item) => item.level === 'error')
       if (findings.length > 0) deps.write(formatFindings(findings))
+      if (flags.receipt !== undefined && run.receipt) {
+        const write = deps.writeFile ?? ((path, contents) => writeFile(path, contents))
+        await write(flags.receipt, `${JSON.stringify(run.receipt, null, 2)}\n`)
+        deps.write(`Verified ${run.receipt.checks.join(', ')} — wrote ${flags.receipt}`)
+      }
       deps.write(
         errors.length > 0
           ? `\n${errors.length} error(s), ${findings.length - errors.length} warning(s)`
@@ -242,7 +256,7 @@ if (invokedDirectly) {
     write: (line) => process.stdout.write(`${line}\n`),
     writeFile: async (path, contents) => {
       await mkdir(dirname(path), { recursive: true })
-      await writeFile(path, contents, { flag: 'wx' })
+      await writeFile(path, contents)
     }
   })
     .then((code) => {

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -70,17 +70,31 @@ export interface ConnectorHarness {
   withMockHttp<T>(routes: MockRoute[], body: () => Promise<T> | T): Promise<MockRun<T>>
 }
 
+/** Whether a stub is already installed, so a second one cannot orphan the first. */
+let serving = false
+
 /**
  * Serve a connector's HTTP from a list of replies, in-process.
  *
  * Swapping `fetch` rather than opening a socket keeps a conformance run
  * hermetic: no port, no ordering between tests, and the same code path the
  * connector uses against the real service.
+ *
+ * One at a time, deliberately. Two overlapping installs share one global: the
+ * first to finish restores the real `fetch` under the second — whose calls
+ * then reach the network — and the second restores the first's dead stub
+ * permanently. Refusing is the only outcome that cannot corrupt the process.
  */
 export async function withMockHttp<T>(
   routes: MockRoute[],
   body: () => Promise<T> | T
 ): Promise<MockRun<T>> {
+  if (serving) {
+    throw new Error(
+      'withMockHttp is already serving; give one call every route it needs rather than installing a second stub'
+    )
+  }
+  serving = true
   const calls: MockCall[] = []
   const original = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -100,6 +114,7 @@ export async function withMockHttp<T>(
     return { result: await body(), calls }
   } finally {
     globalThis.fetch = original
+    serving = false
   }
 }
 

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -12,6 +12,44 @@ export interface HarnessOptions {
   sleep?: (ms: number) => Promise<void>
 }
 
+/** One reply the stub will serve, matched in the order the routes were given. */
+export interface MockRoute {
+  /** A string matches when the URL contains it; a pattern is tested against it. */
+  url: string | RegExp
+  /** Matched case-insensitively; absent matches any method. */
+  method?: string
+  /** Defaults to 200. */
+  status?: number
+  /** Serialized as JSON unless it is already a string. */
+  body?: unknown
+  headers?: Record<string, string>
+}
+
+/** What the connector asked for, in the order it asked. */
+export interface MockCall {
+  method: string
+  url: string
+  body?: string
+}
+
+export interface MockRun<T> {
+  result: T
+  calls: MockCall[]
+}
+
+function matches(route: MockRoute, method: string, url: string): boolean {
+  if (route.method && route.method.toUpperCase() !== method) return false
+  return typeof route.url === 'string' ? url.includes(route.url) : route.url.test(url)
+}
+
+function reply(route: MockRoute): Response {
+  const body = typeof route.body === 'string' ? route.body : JSON.stringify(route.body ?? {})
+  return new Response(body, {
+    status: route.status ?? 200,
+    headers: { 'content-type': 'application/json', ...route.headers }
+  })
+}
+
 export interface ConnectorHarness {
   poll(triggerType: string, options?: RunPollOptions): Promise<PollPage>
   drain(triggerType: string, options?: RunPollOptions): Promise<NormalizedItem[]>
@@ -24,6 +62,45 @@ export interface ConnectorHarness {
    * ignores its lower bound and re-delivers the same backlog forever.
    */
   pollTwice(triggerType: string, options?: RunPollOptions): Promise<NormalizedItem[]>
+  /**
+   * Run something with every HTTP request answered from `routes` instead of
+   * the network. A request no route matches is refused rather than served, so
+   * a test says which call escaped rather than reaching a real service.
+   */
+  withMockHttp<T>(routes: MockRoute[], body: () => Promise<T> | T): Promise<MockRun<T>>
+}
+
+/**
+ * Serve a connector's HTTP from a list of replies, in-process.
+ *
+ * Swapping `fetch` rather than opening a socket keeps a conformance run
+ * hermetic: no port, no ordering between tests, and the same code path the
+ * connector uses against the real service.
+ */
+export async function withMockHttp<T>(
+  routes: MockRoute[],
+  body: () => Promise<T> | T
+): Promise<MockRun<T>> {
+  const calls: MockCall[] = []
+  const original = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    const method = (init?.method ?? 'GET').toUpperCase()
+    calls.push({
+      method,
+      url,
+      ...(typeof init?.body === 'string' && { body: init.body })
+    })
+    const route = routes.find((candidate) => matches(candidate, method, url))
+    if (!route) throw new Error(`No mock route for ${method} ${url}`)
+    return reply(route)
+  }) as typeof fetch
+
+  try {
+    return { result: await body(), calls }
+  } finally {
+    globalThis.fetch = original
+  }
 }
 
 /**
@@ -68,6 +145,7 @@ export function createConnectorHarness(
       // Vorn drops anything at or before the watermark, so only strictly
       // newer items count as redelivered work.
       return watermark === undefined ? second : second.filter((item) => item.updatedAt > watermark)
-    }
+    },
+    withMockHttp
   }
 }

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -92,6 +92,30 @@ export interface ConnectorHarness {
   withMockHttp<T>(routes: MockRoute[], body: () => Promise<T> | T): Promise<MockRun<T>>
 }
 
+/**
+ * A call the routes did not offer.
+ *
+ * Its own class because callers wrap it: a declarative action rethrows with
+ * the action's name in front, so recognising an escape by reading the message
+ * would stop working the moment anything added a prefix.
+ */
+export class MockRouteMissError extends Error {
+  constructor(method: string, url: string) {
+    super(`No mock route for ${method} ${url}`)
+    this.name = 'MockRouteMissError'
+  }
+}
+
+/** Whether a call escaped the stub, however many times it was rethrown. */
+export function escapedMockHttp(error: unknown): boolean {
+  for (let current: unknown = error; current instanceof Error; current = current.cause) {
+    if (current instanceof MockRouteMissError) return true
+    // A connector that rethrew without a cause still leaves the sentence.
+    if (current.message.includes('No mock route for ')) return true
+  }
+  return false
+}
+
 /** Whether a stub is already installed, so a second one cannot orphan the first. */
 let serving = false
 
@@ -128,7 +152,7 @@ export async function withMockHttp<T>(
       ...(typeof init?.body === 'string' && { body: init.body })
     })
     const route = routes.find((candidate) => matches(candidate, method, url))
-    if (!route) throw new Error(`No mock route for ${method} ${url}`)
+    if (!route) throw new MockRouteMissError(method, url)
     return reply(route)
   }) as typeof fetch
 

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -14,7 +14,12 @@ export interface HarnessOptions {
 
 /** One reply the stub will serve, matched in the order the routes were given. */
 export interface MockRoute {
-  /** A string matches when the URL contains it; a pattern is tested against it. */
+  /**
+   * A string names a path: `/api/messages` matches that path and nothing else,
+   * and a trailing slash makes it a prefix — `/api/` matches everything under
+   * it. A pattern is tested against the whole URL, for the times host or query
+   * is what tells two calls apart.
+   */
   url: string | RegExp
   /** Matched case-insensitively; absent matches any method. */
   method?: string
@@ -37,9 +42,26 @@ export interface MockRun<T> {
   calls: MockCall[]
 }
 
+/**
+ * Whether a route answers this call.
+ *
+ * A string is compared against the path rather than searched for in the whole
+ * URL: `/api` should not be answered by a route because the query string
+ * happened to mention it, and a connector's own host is not something a stub
+ * should match by accident.
+ */
 function matches(route: MockRoute, method: string, url: string): boolean {
   if (route.method && route.method.toUpperCase() !== method) return false
-  return typeof route.url === 'string' ? url.includes(route.url) : route.url.test(url)
+  if (route.url instanceof RegExp) return route.url.test(url)
+
+  let pathname: string
+  try {
+    pathname = new URL(url).pathname
+  } catch {
+    // Not a URL the platform can parse; nothing about it can be trusted.
+    return false
+  }
+  return route.url.endsWith('/') ? pathname.startsWith(route.url) : pathname === route.url
 }
 
 function reply(route: MockRoute): Response {

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -145,7 +145,8 @@ export async function withMockHttp<T>(
   const original = globalThis.fetch
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-    const method = (init?.method ?? 'GET').toUpperCase()
+    const own = typeof input === 'object' && 'method' in input ? input.method : undefined
+    const method = (init?.method ?? own ?? 'GET').toUpperCase()
     calls.push({
       method,
       url,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -46,7 +46,12 @@ export { createConnectorServer, serveConnector } from './server'
 export type { ConnectorServerOptions } from './server'
 export { scaffoldFiles, titleCase } from './scaffold'
 export type { ScaffoldOptions, ScaffoldFile } from './scaffold'
-export { createConnectorHarness, withMockHttp } from './harness'
+export {
+  createConnectorHarness,
+  escapedMockHttp,
+  withMockHttp,
+  MockRouteMissError
+} from './harness'
 export type { ConnectorHarness, HarnessOptions, MockCall, MockRoute, MockRun } from './harness'
 export type {
   ActionContext,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,6 +1,12 @@
 export { defineConnector, resolveConfig, envNameFor } from './define'
-export { checkConnector, formatFindings, runConformance } from './check'
-export type { CheckFinding, CheckOptions, ConformanceRun, ConnectorVerification } from './check'
+export { checkConnector, formatFindings, runConformance, CHECK_OWNERS } from './check'
+export type {
+  CheckCode,
+  CheckFinding,
+  CheckOptions,
+  ConformanceRun,
+  ConnectorVerification
+} from './check'
 export { pollWithDedupe } from './dedupe'
 export { normalizeItem, normalizeItems } from './normalize'
 export { runPoll, drainPoll, runAction, runOptions, MAX_POLL_PAGES } from './runtime'

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { defineConnector, resolveConfig, envNameFor } from './define'
-export { checkConnector, formatFindings } from './check'
-export type { CheckFinding, CheckOptions } from './check'
+export { checkConnector, formatFindings, runConformance } from './check'
+export type { CheckFinding, CheckOptions, ConformanceRun, ConnectorVerification } from './check'
 export { pollWithDedupe } from './dedupe'
 export { normalizeItem, normalizeItems } from './normalize'
 export { runPoll, drainPoll, runAction, runOptions, MAX_POLL_PAGES } from './runtime'

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -26,15 +26,16 @@ export {
   PREFLIGHT_TOOL
 } from './setup'
 export type { ConnectionSetup, ConnectorManifest } from './setup'
+export { packConnector, packFileName } from './pack'
+export type { PackOptions, PackResult } from './pack'
 export {
-  packConnector,
-  packFileName,
   lifecycleScriptFindings,
   bundleDependencyFindings,
   readNearestPackageJson,
+  esbuildBundle,
   MAX_PACK_BYTES
-} from './pack'
-export type { PackOptions, PackResult, BundleRequest, BundleOutput } from './pack'
+} from './packaging'
+export type { BundleRequest, BundleOutput } from './packaging'
 export { createConnectorServer, serveConnector } from './server'
 export type { ConnectorServerOptions } from './server'
 export { scaffoldFiles, titleCase } from './scaffold'

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -40,8 +40,8 @@ export { createConnectorServer, serveConnector } from './server'
 export type { ConnectorServerOptions } from './server'
 export { scaffoldFiles, titleCase } from './scaffold'
 export type { ScaffoldOptions, ScaffoldFile } from './scaffold'
-export { createConnectorHarness } from './harness'
-export type { ConnectorHarness, HarnessOptions } from './harness'
+export { createConnectorHarness, withMockHttp } from './harness'
+export type { ConnectorHarness, HarnessOptions, MockCall, MockRoute, MockRun } from './harness'
 export type {
   ActionContext,
   ActionDefinition,

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -40,6 +40,11 @@ export interface PackResult {
   bytes?: number
 }
 
+/** A gate pack refuses on; the package-level ones say this for themselves. */
+function finding(code: string, target: string, message: string): CheckFinding {
+  return { level: 'error', code, target, message }
+}
+
 /** File name Vorn recognizes as a connector pack. */
 export function packFileName(connector: Connector): string {
   return `${connector.id}-${connector.version}.vorn.tgz`

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -1,11 +1,12 @@
 import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import { checkConnector, type CheckCode, type CheckFinding } from './check'
 import {
   bundleDependencyFindings,
   esbuildBundle,
   lifecycleScriptFindings,
+  packageDirFor,
   packEntryContents,
   readNearestPackageJson,
   MAX_PACK_BYTES,
@@ -56,10 +57,7 @@ export async function packConnector(
   options: PackOptions
 ): Promise<PackResult> {
   const resolveDir = resolve(options.resolveDir ?? process.cwd())
-  const entryDir =
-    options.entry.startsWith('.') || isAbsolute(options.entry)
-      ? dirname(resolve(resolveDir, options.entry))
-      : resolveDir
+  const entryDir = packageDirFor(resolveDir, options.entry)
 
   const findings = await checkConnector(connector)
   findings.push(...lifecycleScriptFindings(readNearestPackageJson(entryDir)))

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
-import { checkConnector, type CheckFinding } from './check'
+import { checkConnector, type CheckCode, type CheckFinding } from './check'
 import {
   bundleDependencyFindings,
   esbuildBundle,
@@ -41,7 +41,7 @@ export interface PackResult {
 }
 
 /** A gate pack refuses on; the package-level ones say this for themselves. */
-function finding(code: string, target: string, message: string): CheckFinding {
+function finding(code: CheckCode, target: string, message: string): CheckFinding {
   return { level: 'error', code, target, message }
 }
 

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -1,27 +1,22 @@
-import { builtinModules } from 'node:module'
 import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises'
-import { readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { checkConnector, type CheckFinding } from './check'
+import {
+  bundleDependencyFindings,
+  esbuildBundle,
+  lifecycleScriptFindings,
+  packEntryContents,
+  readNearestPackageJson,
+  MAX_PACK_BYTES,
+  type BundleOutput,
+  type BundleRequest
+} from './packaging'
 import { connectorManifest } from './setup'
 import type { Connector } from './types'
 
-/** Largest pack Vorn will install, matched by the server's own verification. */
-export const MAX_PACK_BYTES = 8 * 1024 * 1024
-
-/** Scripts npm would run at install time, which a pack must never carry. */
-const LIFECYCLE_SCRIPTS = [
-  'preinstall',
-  'install',
-  'postinstall',
-  'prepare',
-  'prepublish',
-  'prepublishOnly',
-  'postpublish'
-]
-
-const BUILTINS = new Set(builtinModules)
+export { bundleDependencyFindings, lifecycleScriptFindings, readNearestPackageJson, MAX_PACK_BYTES }
+export type { BundleOutput, BundleRequest }
 
 export interface PackOptions {
   /** Module specifier the connector was loaded from, bundled as the pack entry. */
@@ -38,100 +33,11 @@ export interface PackOptions {
   bundle?(request: BundleRequest): Promise<BundleOutput>
 }
 
-export interface BundleRequest {
-  contents: string
-  resolveDir: string
-}
-
-export interface BundleOutput {
-  code: string
-  /** Specifiers the bundler left for the runtime to resolve. */
-  external: string[]
-}
-
 export interface PackResult {
   findings: CheckFinding[]
   /** Absolute path of the written pack; absent when a gate failed. */
   file?: string
   bytes?: number
-}
-
-function finding(code: string, target: string, message: string): CheckFinding {
-  return { level: 'error', code, target, message }
-}
-
-/** Reject a source package whose install would run code on the user's machine. */
-export function lifecycleScriptFindings(pkg: unknown): CheckFinding[] {
-  const scripts = (pkg as { scripts?: Record<string, unknown> } | null)?.scripts
-  if (!scripts || typeof scripts !== 'object') return []
-  const named = LIFECYCLE_SCRIPTS.filter((name) => typeof scripts[name] === 'string')
-  if (named.length === 0) return []
-  return [
-    finding(
-      'lifecycle-scripts',
-      'package.json',
-      `Remove the ${named.join(', ')} script(s); a pack is installed by copying files, never by running them`
-    )
-  ]
-}
-
-/** Specifiers left outside a bundle, which would need a registry at launch. */
-export function bundleDependencyFindings(external: string[]): CheckFinding[] {
-  const specifiers = new Set<string>()
-  for (const specifier of external) {
-    if (specifier.startsWith('.') || specifier.startsWith('/')) continue
-    if (specifier.startsWith('node:') || BUILTINS.has(specifier)) continue
-    specifiers.add(specifier)
-  }
-  if (specifiers.size === 0) return []
-  return [
-    finding(
-      'runtime-dependencies',
-      'bundle',
-      `${[...specifiers].sort().join(', ')} stayed outside the bundle; a pack must launch with no install step`
-    )
-  ]
-}
-
-/** Nearest package.json at or above a directory, or undefined when there is none. */
-export function readNearestPackageJson(fromDir: string): Record<string, unknown> | undefined {
-  let current = resolve(fromDir)
-  for (;;) {
-    try {
-      return JSON.parse(readFileSync(join(current, 'package.json'), 'utf8')) as Record<
-        string,
-        unknown
-      >
-    } catch {
-      const parent = dirname(current)
-      if (parent === current) return undefined
-      current = parent
-    }
-  }
-}
-
-async function esbuildBundle(request: BundleRequest): Promise<BundleOutput> {
-  const { build } = await import('esbuild')
-  const result = await build({
-    stdin: {
-      contents: request.contents,
-      resolveDir: request.resolveDir,
-      sourcefile: 'vorn-connector-pack.js',
-      loader: 'js'
-    },
-    bundle: true,
-    platform: 'node',
-    target: 'node20',
-    format: 'esm',
-    write: false,
-    metafile: true,
-    legalComments: 'none'
-  })
-  const output = Object.values(result.metafile.outputs)[0]
-  return {
-    code: result.outputFiles[0].text,
-    external: (output?.imports ?? []).filter((item) => item.external).map((item) => item.path)
-  }
 }
 
 /** File name Vorn recognizes as a connector pack. */
@@ -154,15 +60,7 @@ export async function packConnector(
   findings.push(...lifecycleScriptFindings(readNearestPackageJson(entryDir)))
   if (findings.some((item) => item.level === 'error')) return { findings }
 
-  const sdkModule = options.sdkModule ?? '@vornrun/connector-sdk'
-  const contents = [
-    `import { serveConnector } from ${JSON.stringify(sdkModule)}`,
-    `import * as entry from ${JSON.stringify(options.entry)}`,
-    'const exported = Object.values(entry).find((value) => value && Array.isArray(value.triggers))',
-    `if (!exported) throw new Error(${JSON.stringify(`${options.entry} exports no connector`)})`,
-    'await serveConnector(exported)',
-    ''
-  ].join('\n')
+  const contents = packEntryContents(options.entry, options.sdkModule)
   const bundle = options.bundle ?? esbuildBundle
   const built = await bundle({ contents, resolveDir })
   findings.push(...bundleDependencyFindings(built.external))

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -1,6 +1,6 @@
 import { builtinModules } from 'node:module'
 import { readFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import type { CheckCode, CheckFinding } from './check'
 
 /**
@@ -73,6 +73,21 @@ export function bundleDependencyFindings(external: string[]): CheckFinding[] {
       `${[...specifiers].sort().join(', ')} stayed outside the bundle; a pack must launch with no install step`
     )
   ]
+}
+
+/**
+ * The directory whose package.json describes the connector being examined.
+ *
+ * A path-like entry names its own package — checking `packages/slack/dist` from
+ * a monorepo root has to judge Slack's package.json, not the root's — while a
+ * bare specifier was resolved from the working directory, so that is what
+ * describes it. `check` and `pack` share this, or a gate would judge one
+ * package and the artifact come from another.
+ */
+export function packageDirFor(resolveDir: string, entry: string | undefined): string {
+  const from = resolve(resolveDir)
+  if (entry === undefined) return from
+  return entry.startsWith('.') || isAbsolute(entry) ? dirname(resolve(from, entry)) : from
 }
 
 /** Nearest package.json at or above a directory, or undefined when there is none. */

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -1,7 +1,7 @@
 import { builtinModules } from 'node:module'
 import { readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
-import type { CheckFinding } from './check'
+import type { CheckCode, CheckFinding } from './check'
 
 /**
  * What a connector must be true of as a *package*, rather than as a definition.
@@ -38,7 +38,7 @@ export interface BundleOutput {
   external: string[]
 }
 
-function finding(code: string, target: string, message: string): CheckFinding {
+function finding(code: CheckCode, target: string, message: string): CheckFinding {
   return { level: 'error', code, target, message }
 }
 

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -1,0 +1,135 @@
+import { builtinModules } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import type { CheckFinding } from './check'
+
+/**
+ * What a connector must be true of as a *package*, rather than as a definition.
+ *
+ * Both `check` and `pack` ask these questions — check to fail a pull request
+ * early, pack to refuse an artifact — so they live here rather than in either,
+ * and neither imports the other.
+ */
+
+/** Largest pack Vorn will install, matched by the server's own verification. */
+export const MAX_PACK_BYTES = 8 * 1024 * 1024
+
+/** Scripts npm would run at install time, which a pack must never carry. */
+const LIFECYCLE_SCRIPTS = [
+  'preinstall',
+  'install',
+  'postinstall',
+  'prepare',
+  'prepublish',
+  'prepublishOnly',
+  'postpublish'
+]
+
+const BUILTINS = new Set(builtinModules)
+
+export interface BundleRequest {
+  contents: string
+  resolveDir: string
+}
+
+export interface BundleOutput {
+  code: string
+  /** Specifiers the bundler left for the runtime to resolve. */
+  external: string[]
+}
+
+function finding(code: string, target: string, message: string): CheckFinding {
+  return { level: 'error', code, target, message }
+}
+
+/** Reject a source package whose install would run code on the user's machine. */
+export function lifecycleScriptFindings(pkg: unknown): CheckFinding[] {
+  const scripts = (pkg as { scripts?: Record<string, unknown> } | null)?.scripts
+  if (!scripts || typeof scripts !== 'object') return []
+  const named = LIFECYCLE_SCRIPTS.filter((name) => typeof scripts[name] === 'string')
+  if (named.length === 0) return []
+  return [
+    finding(
+      'lifecycle-scripts',
+      'package.json',
+      `Remove the ${named.join(', ')} script(s); a pack is installed by copying files, never by running them`
+    )
+  ]
+}
+
+/** Specifiers left outside a bundle, which would need a registry at launch. */
+export function bundleDependencyFindings(external: string[]): CheckFinding[] {
+  const specifiers = new Set<string>()
+  for (const specifier of external) {
+    if (specifier.startsWith('.') || specifier.startsWith('/')) continue
+    if (specifier.startsWith('node:') || BUILTINS.has(specifier)) continue
+    specifiers.add(specifier)
+  }
+  if (specifiers.size === 0) return []
+  return [
+    finding(
+      'runtime-dependencies',
+      'bundle',
+      `${[...specifiers].sort().join(', ')} stayed outside the bundle; a pack must launch with no install step`
+    )
+  ]
+}
+
+/** Nearest package.json at or above a directory, or undefined when there is none. */
+export function readNearestPackageJson(fromDir: string): Record<string, unknown> | undefined {
+  let current = resolve(fromDir)
+  for (;;) {
+    try {
+      return JSON.parse(readFileSync(join(current, 'package.json'), 'utf8')) as Record<
+        string,
+        unknown
+      >
+    } catch {
+      const parent = dirname(current)
+      if (parent === current) return undefined
+      current = parent
+    }
+  }
+}
+
+/**
+ * The stdio entry a pack is built from.
+ *
+ * `check` bundles exactly this too: a gate that asked a different question than
+ * the one pack asks would pass a connector pack then refuses.
+ */
+export function packEntryContents(entry: string, sdkModule = '@vornrun/connector-sdk'): string {
+  return [
+    `import { serveConnector } from ${JSON.stringify(sdkModule)}`,
+    `import * as entry from ${JSON.stringify(entry)}`,
+    'const exported = Object.values(entry).find((value) => value && Array.isArray(value.triggers))',
+    `if (!exported) throw new Error(${JSON.stringify(`${entry} exports no connector`)})`,
+    'await serveConnector(exported)',
+    ''
+  ].join('\n')
+}
+
+/** The bundler `pack` uses, shared so `check` gates on the same answer. */
+export async function esbuildBundle(request: BundleRequest): Promise<BundleOutput> {
+  const { build } = await import('esbuild')
+  const result = await build({
+    stdin: {
+      contents: request.contents,
+      resolveDir: request.resolveDir,
+      sourcefile: 'vorn-connector-pack.js',
+      loader: 'js'
+    },
+    bundle: true,
+    platform: 'node',
+    target: 'node20',
+    format: 'esm',
+    write: false,
+    metafile: true,
+    legalComments: 'none'
+  })
+  const output = Object.values(result.metafile.outputs)[0]
+  return {
+    code: result.outputFiles[0].text,
+    external: (output?.imports ?? []).filter((item) => item.external).map((item) => item.path)
+  }
+}

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -129,6 +129,8 @@ export interface ConnectorManifest {
      * none, which is not the same as saying it returns nothing.
      */
     outputs?: Array<{ key: string; type?: string; description?: string }>
+    /** Arguments a live check may call it with, when the author named some. */
+    sample?: Record<string, string>
   }>
 }
 
@@ -165,7 +167,8 @@ export function connectorManifest(connector: Connector): ConnectorManifest {
         ...(input.loadOptions !== undefined && { loadOptions: input.loadOptions }),
         ...(input.builderHint !== undefined && { builderHint: input.builderHint })
       })),
-      ...(action.outputs !== undefined && { outputs: action.outputs })
+      ...(action.outputs !== undefined && { outputs: action.outputs }),
+      ...(action.sample !== undefined && { sample: action.sample })
     }))
   }
 }

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -312,6 +312,8 @@ interface ActionBase {
   idempotent?: boolean
   inputs?: ActionInputField[]
   outputs?: ActionOutputField[]
+  // Arguments a live check may call this action with: real identifiers in the sandbox, never placeholders.
+  sample?: Record<string, string>
 }
 
 /**

--- a/tests/connector-check-owners.test.ts
+++ b/tests/connector-check-owners.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CHECK_OWNERS,
+  checkConnector,
+  defineConnector,
+  packConnector,
+  runConformance
+} from '../packages/connector-sdk/src/index'
+import type { CheckCode } from '../packages/connector-sdk/src/check'
+
+/**
+ * Everything a run can say, gathered by actually provoking it.
+ *
+ * The union keeps `CHECK_OWNERS` complete at compile time; this keeps it
+ * honest at runtime, where a cast could still smuggle a code past the type.
+ */
+async function everyCodeAnyRunEmits(): Promise<Set<string>> {
+  const codes = new Set<string>()
+  const collect = (findings: Array<{ code: string }>) =>
+    findings.forEach((item) => codes.add(item.code))
+
+  // Nothing described, no auth, an action with no outputs and no idempotence.
+  collect(
+    await checkConnector(
+      defineConnector({
+        id: 'hollow',
+        name: 'Hollow',
+        triggers: [{ type: 'quiet', label: 'Quiet', poll: () => ({ items: [] }) }],
+        actions: [{ type: 'ping', label: 'Ping', run: () => ({}) }]
+      })
+    )
+  )
+
+  // A credential nobody marked, and a probe the host would drop.
+  collect(
+    await checkConnector(
+      defineConnector({
+        id: 'leaky',
+        name: 'Leaky',
+        description: 'Leaks',
+        auth: { rung: 'cli', probe: { command: '/usr/local/bin/glab' } },
+        config: [{ key: 'apiToken', label: 'Token' }],
+        actions: [
+          {
+            type: 'go',
+            label: 'Go',
+            description: 'Go',
+            idempotent: true,
+            outputs: [{ key: 'ok' }],
+            inputs: [{ key: 'level', label: 'Level', type: 'select', description: 'Which' }],
+            run: () => ({})
+          }
+        ]
+      })
+    )
+  )
+
+  // Samples that cannot be replayed, and a live poll that misbehaves.
+  const stuck = defineConnector({
+    id: 'stuck',
+    name: 'Stuck',
+    description: 'Stuck',
+    auth: { rung: 'none' },
+    triggers: [
+      {
+        type: 'a',
+        label: 'A',
+        description: 'Never advances',
+        poll: () => ({ items: [{ externalId: '1', title: 'One' }], nextCursor: 'same' })
+      },
+      {
+        type: 'b',
+        label: 'B',
+        description: 'Hand-written with samples',
+        poll: () => ({ items: [] }),
+        sample: [{ externalId: '1', title: 'One' }]
+      }
+    ]
+  })
+  collect(await checkConnector(stuck))
+  collect(await checkConnector(stuck, { live: true, config: {} }))
+
+  // A trigger that returns items without a cursor, and one that throws.
+  collect(
+    await checkConnector(
+      defineConnector({
+        id: 'cursorless',
+        name: 'Cursorless',
+        description: 'Cursorless',
+        auth: { rung: 'none' },
+        triggers: [
+          {
+            type: 'a',
+            label: 'A',
+            description: 'No cursor',
+            poll: () => ({ items: [{ externalId: '1', title: 'One' }] })
+          },
+          {
+            type: 'b',
+            label: 'B',
+            description: 'Throws',
+            poll: () => {
+              throw new Error('boom')
+            }
+          },
+          {
+            type: 'c',
+            label: 'C',
+            description: 'Refuses its own cursor',
+            poll: (context) => {
+              if (context.cursor) throw new Error('bad cursor')
+              return { items: [{ externalId: '1', title: 'One' }], nextCursor: 'next' }
+            }
+          }
+        ]
+      })
+    )
+  )
+
+  // Preflight that refuses, and a live action that fails.
+  collect(
+    await checkConnector(
+      defineConnector({
+        id: 'shut',
+        name: 'Shut',
+        description: 'Shut',
+        auth: { rung: 'none' },
+        actions: [
+          {
+            type: 'go',
+            label: 'Go',
+            description: 'Go',
+            idempotent: true,
+            outputs: [{ key: 'ok' }],
+            run: () => {
+              throw new Error('401 Unauthorized')
+            }
+          }
+        ]
+      }),
+      { live: true, config: {} }
+    )
+  )
+  collect(
+    await checkConnector(
+      defineConnector({
+        id: 'closed',
+        name: 'Closed',
+        description: 'Closed',
+        auth: { rung: 'none' },
+        preflight: () => ({ ok: false, message: 'sign in first' }),
+        actions: [
+          {
+            type: 'go',
+            label: 'Go',
+            description: 'Go',
+            idempotent: true,
+            outputs: [{ key: 'ok' }],
+            run: () => ({})
+          }
+        ]
+      }),
+      { live: true, config: {} }
+    )
+  )
+
+  // A mock run: one action escaping its routes, one the stub never heard.
+  const mocked = defineConnector({
+    id: 'mocked',
+    name: 'Mocked',
+    description: 'Mocked',
+    auth: { rung: 'none' },
+    actions: [
+      {
+        type: 'away',
+        label: 'Away',
+        description: 'Reaches out',
+        idempotent: true,
+        outputs: [{ key: 'ok' }],
+        run: async () => {
+          await fetch('https://acme.test/elsewhere')
+          return {}
+        }
+      },
+      {
+        type: 'quiet',
+        label: 'Quiet',
+        description: 'Asks nothing',
+        idempotent: true,
+        outputs: [{ key: 'ok' }],
+        run: () => ({})
+      },
+      {
+        type: 'angry',
+        label: 'Angry',
+        description: 'Refuses the reply',
+        idempotent: true,
+        outputs: [{ key: 'ok' }],
+        run: async () => {
+          await fetch('https://acme.test/api')
+          throw new Error('not what I wanted')
+        }
+      }
+    ]
+  })
+  collect(await checkConnector(mocked, { mock: true, mockRoutes: [{ url: '/api' }] }))
+
+  // The package gates, and the size gate that only `pack` gives.
+  const dir = mkdtempSync(join(tmpdir(), 'vorn-owners-'))
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ scripts: { postinstall: 'x' } }))
+  collect(
+    await checkConnector(
+      defineConnector({
+        id: 'shipped',
+        name: 'Shipped',
+        description: 'Shipped',
+        auth: { rung: 'none' },
+        actions: [
+          {
+            type: 'go',
+            label: 'Go',
+            description: 'Go',
+            idempotent: true,
+            outputs: [{ key: 'ok' }],
+            run: () => ({})
+          }
+        ]
+      }),
+      {
+        packageDir: dir,
+        entry: './index.js',
+        bundle: async () => ({ code: '', external: ['left-pad'] })
+      }
+    )
+  )
+
+  const big = await packConnector(
+    defineConnector({
+      id: 'big',
+      name: 'Big',
+      version: '1.0.0',
+      description: 'Big',
+      auth: { rung: 'none' },
+      triggers: [{ type: 'a', label: 'A', description: 'A', poll: () => ({ items: [] }) }]
+    }),
+    {
+      entry: './index.js',
+      resolveDir: dir,
+      outDir: dir,
+      maxBytes: 16,
+      bundle: async () => ({
+        code: `const x = ${JSON.stringify('y'.repeat(4096))}\n`,
+        external: []
+      })
+    }
+  )
+  collect(big.findings)
+
+  return codes
+}
+
+describe('every finding a run can make', () => {
+  it('belongs to a named check, or is marked as belonging to none', async () => {
+    const emitted = await everyCodeAnyRunEmits()
+
+    // Sanity: the battery really did provoke a broad spread of findings.
+    expect(emitted.size).toBeGreaterThan(15)
+    for (const code of emitted) {
+      expect(Object.keys(CHECK_OWNERS)).toContain(code)
+    }
+  })
+
+  it('names a check that a run can actually claim, when it names one', async () => {
+    const claimable = new Set<string | null>([
+      'manifest',
+      'auth',
+      'secrets',
+      'actions',
+      'dedupe',
+      'no-lifecycle-scripts',
+      'keywords',
+      'no-runtime-deps',
+      'mock',
+      'live',
+      null
+    ])
+    for (const owner of Object.values(CHECK_OWNERS)) {
+      expect(claimable).toContain(owner)
+    }
+  })
+
+  it('spoils exactly one check per failing code, so one fault clears one name', async () => {
+    const noAuth = defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      description: 'Talks to Acme',
+      actions: [
+        {
+          type: 'go',
+          label: 'Go',
+          description: 'Go',
+          idempotent: true,
+          outputs: [{ key: 'ok' }],
+          run: () => ({})
+        }
+      ]
+    })
+    const run = await runConformance(noAuth)
+
+    // `auth-undeclared` clears `auth` and leaves the rest standing.
+    expect(run.findings.map((item) => item.code as CheckCode)).toContain('auth-undeclared')
+    expect(run.passed).not.toContain('auth')
+    expect(run.passed).toContain('manifest')
+    expect(run.passed).toContain('actions')
+  })
+})

--- a/tests/connector-conformance-checks.test.ts
+++ b/tests/connector-conformance-checks.test.ts
@@ -122,7 +122,9 @@ describe('what a check says about an action', () => {
       inputs: [{ key: 'channel', label: 'Channel', type: 'select', loadOptions: 'channels' }]
     }
     expect(await codes({ actions: [fixed] })).not.toContain('input-type-unsupported')
-    expect(await codes({ actions: [loaded] })).not.toContain('input-type-unsupported')
+    expect(await codes({ actions: [loaded], options: { channels: () => [] } })).not.toContain(
+      'input-type-unsupported'
+    )
   })
 })
 

--- a/tests/connector-conformance-checks.test.ts
+++ b/tests/connector-conformance-checks.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { checkConnector, defineConnector } from '../packages/connector-sdk/src/index'
+import type {
+  ActionDefinition,
+  ConnectorAuth,
+  ConnectorConfigField,
+  ConnectorDefinition
+} from '../packages/connector-sdk/src/types'
+
+const ping: ActionDefinition = {
+  type: 'ping',
+  label: 'Ping',
+  description: 'Ask whether the service is up',
+  idempotent: true,
+  outputs: [{ key: 'ok', type: 'boolean' }],
+  run: () => ({ ok: true })
+}
+
+/** A connector that is clean apart from whatever the case under test changes. */
+const connector = (over: Partial<ConnectorDefinition> = {}) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    description: 'Talks to Acme',
+    actions: [ping],
+    ...over
+  })
+
+const codes = async (over: Partial<ConnectorDefinition> = {}) =>
+  (await checkConnector(connector(over))).map((item) => item.code)
+
+const cli = (probe: ConnectorAuth['probe']): ConnectorAuth => ({ rung: 'cli', probe })
+
+describe('what a check says about signing in', () => {
+  it('asks a connector that says nothing to say something', async () => {
+    expect(await codes()).toContain('auth-undeclared')
+  })
+
+  it('passes a rung the host will keep whole', async () => {
+    const auth = cli({ command: 'glab', args: ['auth', 'status'] })
+    expect(await codes({ auth })).not.toContain('auth-probe-missing')
+    expect(await codes({ auth })).not.toContain('auth-undeclared')
+  })
+
+  it('refuses a probe the host would drop, which is a rung promising a sign-in it cannot ask for', async () => {
+    // Passes defineConnector — a non-empty command — and is dropped at the host.
+    const found = await codes({ auth: cli({ command: '/usr/local/bin/glab' }) })
+    expect(found).toContain('auth-probe-missing')
+  })
+
+  it('refuses probe arguments the host cannot pass on', async () => {
+    const auth = cli({ command: 'glab', args: [7 as unknown as string] })
+    expect(await codes({ auth })).toContain('auth-probe-missing')
+  })
+
+  it('asks nothing of a key rung, which has no probe to run', async () => {
+    const config: ConnectorConfigField[] = [{ key: 'apiKey', label: 'API key', secret: true }]
+    const auth: ConnectorAuth = { rung: 'key', keys: ['apiKey'] }
+    expect(await codes({ auth, config })).not.toContain('auth-probe-missing')
+  })
+})
+
+describe('what a check says about credentials', () => {
+  it('refuses a named key that Vorn would store in the clear', async () => {
+    const config: ConnectorConfigField[] = [{ key: 'apiKey', label: 'API key' }]
+    const auth: ConnectorAuth = { rung: 'key', keys: ['apiKey'] }
+    const findings = await checkConnector(connector({ auth, config }))
+    const secret = findings.find((item) => item.code === 'secret-not-marked')
+    expect(secret?.level).toBe('error')
+  })
+
+  it('warns about a field that reads like a credential even when nothing names it', async () => {
+    const config: ConnectorConfigField[] = [{ key: 'webhookSecret', label: 'Webhook secret' }]
+    const findings = await checkConnector(connector({ config }))
+    const secret = findings.find((item) => item.code === 'secret-not-marked')
+    expect(secret?.level).toBe('warn')
+  })
+
+  it('says nothing about a credential that is already marked', async () => {
+    const config: ConnectorConfigField[] = [{ key: 'apiToken', label: 'Token', secret: true }]
+    expect(await codes({ config })).not.toContain('secret-not-marked')
+  })
+
+  it('says nothing about an ordinary setting', async () => {
+    const config: ConnectorConfigField[] = [{ key: 'project', label: 'Project' }]
+    expect(await codes({ config })).not.toContain('secret-not-marked')
+  })
+})
+
+describe('what a check says about an action', () => {
+  it('asks an action with no declared outputs to name them', async () => {
+    const bare: ActionDefinition = { ...ping, outputs: undefined }
+    expect(await codes({ actions: [bare] })).toContain('action-no-outputs')
+  })
+
+  it('refuses an input type Vorn cannot draw', async () => {
+    const odd: ActionDefinition = {
+      ...ping,
+      inputs: [{ key: 'when', label: 'When', type: 'date' as never }]
+    }
+    expect(await codes({ actions: [odd] })).toContain('input-type-unsupported')
+  })
+
+  it('refuses a select that offers no choices at all', async () => {
+    const empty: ActionDefinition = {
+      ...ping,
+      inputs: [{ key: 'level', label: 'Level', type: 'select' }]
+    }
+    expect(await codes({ actions: [empty] })).toContain('input-type-unsupported')
+  })
+
+  it('accepts a select that knows its choices, and one that fetches them', async () => {
+    const fixed: ActionDefinition = {
+      ...ping,
+      inputs: [{ key: 'level', label: 'Level', type: 'select', options: [{ value: 'high' }] }]
+    }
+    const loaded: ActionDefinition = {
+      ...ping,
+      inputs: [{ key: 'channel', label: 'Channel', type: 'select', loadOptions: 'channels' }]
+    }
+    expect(await codes({ actions: [fixed] })).not.toContain('input-type-unsupported')
+    expect(await codes({ actions: [loaded] })).not.toContain('input-type-unsupported')
+  })
+})
+
+describe('what a check says about the package a connector ships as', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vorn-check-pkg-'))
+  const writePackage = (pkg: Record<string, unknown>) =>
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(pkg))
+
+  it('says nothing about a package it was never pointed at', async () => {
+    expect(await codes()).not.toContain('keywords-missing')
+  })
+
+  it('refuses a package whose install would run code', async () => {
+    writePackage({
+      name: 'acme',
+      scripts: { postinstall: 'node evil.js' },
+      vorn: { keywords: ['acme'] }
+    })
+    const findings = await checkConnector(connector(), { packageDir: dir })
+    const lifecycle = findings.find((item) => item.code === 'lifecycle-scripts')
+    expect(lifecycle?.level).toBe('error')
+  })
+
+  it('asks for keywords, because a catalog of fifty is searched rather than read', async () => {
+    writePackage({ name: 'acme' })
+    const findings = await checkConnector(connector(), { packageDir: dir })
+    expect(findings.map((item) => item.code)).toContain('keywords-missing')
+  })
+
+  it('refuses what would still need a registry at launch', async () => {
+    writePackage({ name: 'acme', vorn: { keywords: ['acme'] } })
+    const findings = await checkConnector(connector(), {
+      packageDir: dir,
+      entry: './index.js',
+      bundle: async () => ({ code: '', external: ['left-pad', 'node:fs', './local.js'] })
+    })
+    const deps = findings.find((item) => item.code === 'runtime-dependencies')
+    expect(deps?.level).toBe('error')
+    // Builtins and relative files are not dependencies a pack has to carry.
+    expect(deps?.message).toContain('left-pad')
+    expect(deps?.message).not.toContain('node:fs')
+  })
+
+  it('passes a package that bundles everything it needs', async () => {
+    writePackage({ name: 'acme', vorn: { keywords: ['acme'] } })
+    const findings = await checkConnector(connector(), {
+      packageDir: dir,
+      entry: './index.js',
+      bundle: async () => ({ code: '', external: [] })
+    })
+    expect(findings.map((item) => item.code)).not.toContain('runtime-dependencies')
+  })
+})

--- a/tests/connector-conformance-checks.test.ts
+++ b/tests/connector-conformance-checks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { checkConnector, defineConnector } from '../packages/connector-sdk/src/index'
@@ -164,6 +164,39 @@ describe('what a check says about the package a connector ships as', () => {
     // Builtins and relative files are not dependencies a pack has to carry.
     expect(deps?.message).toContain('left-pad')
     expect(deps?.message).not.toContain('node:fs')
+  })
+
+  it('judges the entry package, not the directory the command was run from', async () => {
+    // A monorepo: the root is clean, the connector's own package is not.
+    const root = mkdtempSync(join(tmpdir(), 'vorn-check-root-'))
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ vorn: { keywords: ['root'] } }))
+    const own = join(root, 'packages', 'slack')
+    mkdirSync(join(own, 'dist'), { recursive: true })
+    writeFileSync(
+      join(own, 'package.json'),
+      JSON.stringify({ name: 'slack', scripts: { postinstall: 'node setup.js' } })
+    )
+
+    const findings = await checkConnector(connector(), {
+      packageDir: root,
+      entry: './packages/slack/dist/index.js'
+    })
+
+    const codes = findings.map((item) => item.code)
+    expect(codes).toContain('lifecycle-scripts')
+    // Slack's package names no keywords; the root's do not stand in for them.
+    expect(codes).toContain('keywords-missing')
+  })
+
+  it('judges the working directory when the entry is a bare specifier', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'vorn-check-bare-'))
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ vorn: { keywords: ['root'] } }))
+
+    const findings = await checkConnector(connector(), {
+      packageDir: root,
+      entry: '@acme/connector-slack'
+    })
+    expect(findings.map((item) => item.code)).not.toContain('keywords-missing')
   })
 
   it('passes a package that bundles everything it needs', async () => {

--- a/tests/connector-live-smoke.test.ts
+++ b/tests/connector-live-smoke.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+import { checkConnector, defineConnector } from '../packages/connector-sdk/src/index'
+import type {
+  ActionDefinition,
+  ConnectorDefinition,
+  PreflightResult
+} from '../packages/connector-sdk/src/types'
+
+const read: ActionDefinition = {
+  type: 'read',
+  label: 'Read',
+  description: 'Read something back',
+  idempotent: true,
+  outputs: [{ key: 'ok', type: 'boolean' }],
+  run: () => ({ ok: true })
+}
+
+const connector = (over: Partial<ConnectorDefinition> = {}) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    description: 'Talks to Acme',
+    auth: { rung: 'none' },
+    actions: [read],
+    ...over
+  })
+
+const live = (over: Partial<ConnectorDefinition> = {}) =>
+  checkConnector(connector(over), { live: true, config: {} })
+
+describe('a live check, before it trusts anything else', () => {
+  it('asks the connector whether it can sign in at all', async () => {
+    const preflight = vi.fn(
+      (): PreflightResult => ({ ok: false, message: 'Run `acme login` first' })
+    )
+    const findings = await live({ preflight })
+
+    expect(preflight).toHaveBeenCalled()
+    const failure = findings.find((item) => item.code === 'preflight-failed')
+    expect(failure?.level).toBe('error')
+    expect(failure?.message).toBe('Run `acme login` first')
+  })
+
+  it('reports a preflight that threw in the same shape as one that refused', async () => {
+    const findings = await live({
+      preflight: () => {
+        throw new Error('acme is not installed')
+      }
+    })
+    expect(findings.find((item) => item.code === 'preflight-failed')?.message).toContain(
+      'acme is not installed'
+    )
+  })
+
+  it('stops after a failed preflight, rather than blaming every action for it', async () => {
+    const run = vi.fn(() => ({ ok: true }))
+    const findings = await live({
+      preflight: () => ({ ok: false }),
+      actions: [{ ...read, run }]
+    })
+
+    expect(run).not.toHaveBeenCalled()
+    expect(findings.filter((item) => item.code === 'live-action-failed')).toHaveLength(0)
+  })
+
+  it('says nothing when there is nothing to ask, which is not the same as passing', async () => {
+    const findings = await live()
+    expect(findings.map((item) => item.code)).not.toContain('preflight-failed')
+  })
+})
+
+describe('what a live check does to a real service', () => {
+  it('runs an action that says repeating it is safe', async () => {
+    const run = vi.fn(() => ({ ok: true }))
+    await live({ actions: [{ ...read, run }] })
+    expect(run).toHaveBeenCalled()
+  })
+
+  it('never runs one that does not, because a smoke test must leave nothing behind', async () => {
+    const run = vi.fn(() => ({ id: 'issue-1' }))
+    const create: ActionDefinition = {
+      type: 'createIssue',
+      label: 'Create issue',
+      description: 'Opens an issue',
+      idempotent: false,
+      outputs: [{ key: 'id', type: 'string' }],
+      run
+    }
+    await live({ actions: [create] })
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('leaves an undeclared action alone too, because unknown is not safe', async () => {
+    const run = vi.fn(() => ({}))
+    const unknown: ActionDefinition = {
+      type: 'maybe',
+      label: 'Maybe',
+      description: 'Nobody said',
+      outputs: [{ key: 'ok' }],
+      run
+    }
+    await live({ actions: [unknown] })
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('reports an action that threw against the real service', async () => {
+    const findings = await live({
+      actions: [
+        {
+          ...read,
+          run: () => {
+            throw new Error('403 from Acme')
+          }
+        }
+      ]
+    })
+    const failure = findings.find((item) => item.code === 'live-action-failed')
+    expect(failure?.level).toBe('error')
+    expect(failure?.message).toContain('403 from Acme')
+  })
+
+  it('runs no action at all when the check was not asked to go live', async () => {
+    const run = vi.fn(() => ({ ok: true }))
+    await checkConnector(connector({ actions: [{ ...read, run }] }))
+    expect(run).not.toHaveBeenCalled()
+  })
+})

--- a/tests/connector-live-smoke.test.ts
+++ b/tests/connector-live-smoke.test.ts
@@ -119,6 +119,81 @@ describe('what a live check does to a real service', () => {
     expect(failure?.message).toContain('403 from Acme')
   })
 
+  it('skips an action whose arguments it would have to invent', async () => {
+    const run = vi.fn(() => ({ ok: true }))
+    const byId: ActionDefinition = {
+      ...read,
+      inputs: [{ key: 'id', label: 'Id', description: 'Which one', required: true }],
+      run
+    }
+    const findings = await live({ actions: [byId] })
+
+    // Calling it with a made-up id would only prove the id does not exist.
+    expect(run).not.toHaveBeenCalled()
+    expect(findings.map((item) => item.code)).not.toContain('live-action-failed')
+  })
+
+  it('runs it with the arguments the author named, exactly', async () => {
+    const run = vi.fn(() => ({ ok: true }))
+    const byId: ActionDefinition = {
+      ...read,
+      inputs: [{ key: 'id', label: 'Id', description: 'Which one', required: true }],
+      sample: { id: 'ticket-42' },
+      run
+    }
+    await live({ actions: [byId] })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run.mock.calls[0][0]).toEqual({ id: 'ticket-42' })
+  })
+
+  it('runs one whose arguments are all optional, with none of them', async () => {
+    const run = vi.fn(() => ({ ok: true }))
+    const listing: ActionDefinition = {
+      ...read,
+      inputs: [{ key: 'limit', label: 'Limit', description: 'How many', type: 'number' }],
+      run
+    }
+    await live({ actions: [listing] })
+
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run.mock.calls[0][0]).toEqual({})
+  })
+})
+
+describe('how a live failure is graded', () => {
+  const failing = (message: string) =>
+    live({
+      actions: [
+        {
+          ...read,
+          run: () => {
+            throw new Error(message)
+          }
+        }
+      ]
+    })
+
+  it('calls a refusal to let the connector in broken', async () => {
+    for (const message of [
+      '401 Unauthorized',
+      'HTTP 403',
+      'unauthenticated request',
+      'Forbidden',
+      'invalid token'
+    ]) {
+      const findings = await failing(message)
+      expect(findings.find((item) => item.code === 'live-action-failed')?.level).toBe('error')
+    }
+  })
+
+  it('calls anything else advice, because the sandbox is not the connector', async () => {
+    for (const message of ['429 Too Many Requests', 'no records found', '500 from Acme']) {
+      const findings = await failing(message)
+      expect(findings.find((item) => item.code === 'live-action-failed')?.level).toBe('warn')
+    }
+  })
+
   it('runs no action at all when the check was not asked to go live', async () => {
     const run = vi.fn(() => ({ ok: true }))
     await checkConnector(connector({ actions: [{ ...read, run }] }))

--- a/tests/connector-live-smoke.test.ts
+++ b/tests/connector-live-smoke.test.ts
@@ -53,7 +53,7 @@ describe('a live check, before it trusts anything else', () => {
   })
 
   it('stops after a failed preflight, rather than blaming every action for it', async () => {
-    const run = vi.fn(() => ({ ok: true }))
+    const run = vi.fn((_args: Record<string, unknown>) => ({ ok: true }))
     const findings = await live({
       preflight: () => ({ ok: false }),
       actions: [{ ...read, run }]
@@ -71,7 +71,7 @@ describe('a live check, before it trusts anything else', () => {
 
 describe('what a live check does to a real service', () => {
   it('runs an action that says repeating it is safe', async () => {
-    const run = vi.fn(() => ({ ok: true }))
+    const run = vi.fn((_args: Record<string, unknown>) => ({ ok: true }))
     await live({ actions: [{ ...read, run }] })
     expect(run).toHaveBeenCalled()
   })
@@ -120,7 +120,7 @@ describe('what a live check does to a real service', () => {
   })
 
   it('skips an action whose arguments it would have to invent', async () => {
-    const run = vi.fn(() => ({ ok: true }))
+    const run = vi.fn((_args: Record<string, unknown>) => ({ ok: true }))
     const byId: ActionDefinition = {
       ...read,
       inputs: [{ key: 'id', label: 'Id', description: 'Which one', required: true }],
@@ -134,7 +134,7 @@ describe('what a live check does to a real service', () => {
   })
 
   it('runs it with the arguments the author named, exactly', async () => {
-    const run = vi.fn(() => ({ ok: true }))
+    const run = vi.fn((_args: Record<string, unknown>) => ({ ok: true }))
     const byId: ActionDefinition = {
       ...read,
       inputs: [{ key: 'id', label: 'Id', description: 'Which one', required: true }],
@@ -148,7 +148,7 @@ describe('what a live check does to a real service', () => {
   })
 
   it('runs one whose arguments are all optional, with none of them', async () => {
-    const run = vi.fn(() => ({ ok: true }))
+    const run = vi.fn((_args: Record<string, unknown>) => ({ ok: true }))
     const listing: ActionDefinition = {
       ...read,
       inputs: [{ key: 'limit', label: 'Limit', description: 'How many', type: 'number' }],
@@ -195,7 +195,7 @@ describe('how a live failure is graded', () => {
   })
 
   it('runs no action at all when the check was not asked to go live', async () => {
-    const run = vi.fn(() => ({ ok: true }))
+    const run = vi.fn((_args: Record<string, unknown>) => ({ ok: true }))
     await checkConnector(connector({ actions: [{ ...read, run }] }))
     expect(run).not.toHaveBeenCalled()
   })

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -195,6 +195,27 @@ describe('a check that runs every action against served HTTP', () => {
     expect(codes(findings)).not.toContain('mock-not-observed')
   })
 
+  it('still calls it an escape when the action rethrew with its own name in front', async () => {
+    // What a declarative action does: catch, prefix, rethrow with a cause.
+    const wrapping: ActionDefinition = {
+      ...post,
+      async run() {
+        try {
+          await fetch('https://acme.test/elsewhere')
+          return {}
+        } catch (error) {
+          throw new Error(`Action post: ${(error as Error).message}`, { cause: error })
+        }
+      }
+    }
+    const findings = await checkConnector(connector([wrapping]), {
+      mock: true,
+      mockRoutes: [{ url: '/api/messages' }]
+    })
+    const escape = findings.find((item) => item.code === 'mock-network-escape')
+    expect(escape?.level).toBe('error')
+  })
+
   it('reports the escape, not the silence, when an action reached past its routes', async () => {
     const findings = await checkConnector(connector(), {
       mock: true,

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -174,6 +174,36 @@ describe('a check that runs every action against served HTTP', () => {
     expect(codes(findings)).not.toContain('mock-action-failed')
   })
 
+  it('says so when the stub heard nothing, because it only replaces fetch', async () => {
+    const elsewhere: ActionDefinition = {
+      ...post,
+      // Stands in for a connector that shells out or opens its own socket:
+      // whatever it did, the stub did not see it.
+      run: () => ({ id: 'from-a-subprocess' })
+    }
+    const findings = await checkConnector(connector([elsewhere]), { mock: true })
+    const unobserved = findings.find((item) => item.code === 'mock-not-observed')
+    expect(unobserved?.level).toBe('warn')
+    expect(unobserved?.target).toBe('action post')
+  })
+
+  it('says nothing of the sort when a call was intercepted', async () => {
+    const findings = await checkConnector(connector(), {
+      mock: true,
+      mockRoutes: [{ url: '/api/messages', body: { id: 'm-1' } }]
+    })
+    expect(codes(findings)).not.toContain('mock-not-observed')
+  })
+
+  it('reports the escape, not the silence, when an action reached past its routes', async () => {
+    const findings = await checkConnector(connector(), {
+      mock: true,
+      mockRoutes: [{ url: '/somewhere-else' }]
+    })
+    expect(codes(findings)).toContain('mock-network-escape')
+    expect(codes(findings)).not.toContain('mock-not-observed')
+  })
+
   it('only warns when an empty reply was all the action had to go on', async () => {
     const strict: ActionDefinition = {
       ...post,

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -56,6 +56,13 @@ describe('serving a connector its HTTP in-process', () => {
     ).rejects.toThrow(/No mock route for POST https:\/\/acme.test\/api\/messages/)
   })
 
+  it('reads the method off a Request, not only off init', async () => {
+    const { calls } = await withMockHttp([{ url: '/api/messages', method: 'POST' }], () =>
+      fetch(new Request('https://acme.test/api/messages', { method: 'POST' }))
+    )
+    expect(calls[0].method).toBe('POST')
+  })
+
   it('serves the status a route names, so error handling can be exercised', async () => {
     const failing: ActionDefinition = {
       ...post,

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -5,6 +5,7 @@ import {
   defineConnector,
   withMockHttp
 } from '../packages/connector-sdk/src/index'
+import { mockConfig } from '../packages/connector-sdk/src/check'
 import type { ActionDefinition } from '../packages/connector-sdk/src/types'
 
 /** An action that talks to a service, the way a real connector's would. */
@@ -163,6 +164,36 @@ describe('a check that runs every action against served HTTP', () => {
     })
     const escape = findings.find((item) => item.code === 'mock-network-escape')
     expect(escape?.level).toBe('error')
+  })
+
+  it('fills config from defaults and placeholders, so a templated URL resolves', async () => {
+    const declared: ActionDefinition = {
+      type: 'create',
+      label: 'Create',
+      request: {
+        method: 'POST',
+        url: '{{config.baseUrl}}/v1/items',
+        headers: { authorization: 'Bearer {{config.apiToken}}' }
+      }
+    }
+    const sdk = defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      config: [
+        { key: 'apiToken', label: 'Token', required: true, secret: true },
+        { key: 'baseUrl', label: 'Base URL', default: 'https://api.example.com' }
+      ],
+      actions: [declared]
+    })
+    expect(mockConfig(sdk)).toEqual({
+      apiToken: 'mock-apiToken',
+      baseUrl: 'https://api.example.com'
+    })
+    const findings = await checkConnector(sdk, {
+      mock: true,
+      mockRoutes: [{ url: '/v1/items', body: { id: 'i-1' } }]
+    })
+    expect(codes(findings)).not.toContain('mock-action-failed')
   })
 
   it('answers everything when no routes were named, so a bare run still proves it runs', async () => {

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -66,7 +66,7 @@ describe('serving a connector its HTTP in-process', () => {
     }
     const harness = createConnectorHarness(connector([failing]))
     await expect(
-      harness.withMockHttp([{ url: '/api', status: 503 }], () =>
+      harness.withMockHttp([{ url: '/api/', status: 503 }], () =>
         harness.execute('post', { text: 'hi' })
       )
     ).rejects.toThrow('Acme said 503')
@@ -107,9 +107,32 @@ describe('serving a connector its HTTP in-process', () => {
     expect(calls).toHaveLength(1)
   })
 
-  it('matches a route by pattern as well as by substring', async () => {
-    const { calls } = await withMockHttp([{ url: /messages$/ }], () =>
-      fetch('https://acme.test/api/messages')
+  it('matches a path exactly, so a query string cannot claim a route', async () => {
+    const exact = await withMockHttp([{ url: '/api/messages' }], () =>
+      fetch('https://acme.test/api/messages?limit=1')
+    )
+    expect(exact.calls).toHaveLength(1)
+
+    await expect(
+      withMockHttp([{ url: '/admin' }], () => fetch('https://acme.test/api?next=/admin'))
+    ).rejects.toThrow(/No mock route/)
+  })
+
+  it('takes a trailing slash as everything underneath', async () => {
+    const { calls } = await withMockHttp([{ url: '/api/' }], () =>
+      fetch('https://acme.test/api/messages/42')
+    )
+    expect(calls).toHaveLength(1)
+
+    // The prefix is a path prefix, not a string one: /apiary is elsewhere.
+    await expect(
+      withMockHttp([{ url: '/api/' }], () => fetch('https://acme.test/apiary'))
+    ).rejects.toThrow(/No mock route/)
+  })
+
+  it('lets a pattern see the whole URL, for when the host is the difference', async () => {
+    const { calls } = await withMockHttp([{ url: /^https:\/\/auth\.acme\.test\// }], () =>
+      fetch('https://auth.acme.test/token')
     )
     expect(calls[0].method).toBe('GET')
   })
@@ -170,7 +193,7 @@ describe('a check that runs every action against served HTTP', () => {
     // connector's to answer for.
     const routed = await checkConnector(connector([strict]), {
       mock: true,
-      mockRoutes: [{ url: '/api', body: {} }]
+      mockRoutes: [{ url: '/api/', body: {} }]
     })
     expect(routed.find((item) => item.code === 'mock-action-failed')?.level).toBe('error')
   })

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -82,6 +82,31 @@ describe('serving a connector its HTTP in-process', () => {
     expect(globalThis.fetch).toBe(original)
   })
 
+  it('refuses a second stub rather than letting one orphan the other', async () => {
+    const original = globalThis.fetch
+    const settled = await Promise.allSettled([
+      withMockHttp([{ url: '/api', body: { n: 1 } }], async () => {
+        await fetch('https://acme.test/api')
+        // Long enough that the second install would overlap this one.
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        return 'first'
+      }),
+      withMockHttp([{ url: '/api', body: { n: 2 } }], () => 'second')
+    ])
+
+    expect(settled.map((entry) => entry.status)).toEqual(['fulfilled', 'rejected'])
+    const refused = settled[1] as PromiseRejectedResult
+    expect(String(refused.reason)).toContain('already serving')
+    // The real fetch is back: a dead stub would have been left installed.
+    expect(globalThis.fetch).toBe(original)
+  })
+
+  it('serves again once the first call is done', async () => {
+    await withMockHttp([{ url: '/api' }], () => fetch('https://acme.test/api'))
+    const { calls } = await withMockHttp([{ url: '/api' }], () => fetch('https://acme.test/api'))
+    expect(calls).toHaveLength(1)
+  })
+
   it('matches a route by pattern as well as by substring', async () => {
     const { calls } = await withMockHttp([{ url: /messages$/ }], () =>
       fetch('https://acme.test/api/messages')

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import {
+  checkConnector,
+  createConnectorHarness,
+  defineConnector,
+  withMockHttp
+} from '../packages/connector-sdk/src/index'
+import type { ActionDefinition } from '../packages/connector-sdk/src/types'
+
+/** An action that talks to a service, the way a real connector's would. */
+const post: ActionDefinition = {
+  type: 'post',
+  label: 'Post message',
+  description: 'Send a message',
+  idempotent: false,
+  inputs: [{ key: 'text', label: 'Text', description: 'What to send', required: true }],
+  outputs: [{ key: 'id', type: 'string' }],
+  async run(args) {
+    const response = await fetch('https://acme.test/api/messages', {
+      method: 'POST',
+      body: JSON.stringify({ text: args.text })
+    })
+    const body = (await response.json()) as { id?: string }
+    return { id: body.id ?? '' }
+  }
+}
+
+const connector = (actions: ActionDefinition[] = [post]) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    description: 'Talks to Acme',
+    auth: { rung: 'none' },
+    actions
+  })
+
+describe('serving a connector its HTTP in-process', () => {
+  it('answers from the routes and hands back what was asked', async () => {
+    const harness = createConnectorHarness(connector())
+    const { result, calls } = await harness.withMockHttp(
+      [{ url: '/api/messages', method: 'POST', body: { id: 'm-1' } }],
+      () => harness.execute('post', { text: 'hi' })
+    )
+
+    expect(result).toEqual({ id: 'm-1' })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toMatchObject({ method: 'POST', url: 'https://acme.test/api/messages' })
+    expect(calls[0].body).toContain('hi')
+  })
+
+  it('refuses a call no route offered, rather than letting it reach a service', async () => {
+    const harness = createConnectorHarness(connector())
+    await expect(
+      harness.withMockHttp([{ url: '/api/other' }], () => harness.execute('post', { text: 'hi' }))
+    ).rejects.toThrow(/No mock route for POST https:\/\/acme.test\/api\/messages/)
+  })
+
+  it('serves the status a route names, so error handling can be exercised', async () => {
+    const failing: ActionDefinition = {
+      ...post,
+      async run() {
+        const response = await fetch('https://acme.test/api/messages', { method: 'POST' })
+        if (!response.ok) throw new Error(`Acme said ${response.status}`)
+        return {}
+      }
+    }
+    const harness = createConnectorHarness(connector([failing]))
+    await expect(
+      harness.withMockHttp([{ url: '/api', status: 503 }], () => harness.execute('post', {}))
+    ).rejects.toThrow('Acme said 503')
+  })
+
+  it('gives the real fetch back, even when the body threw', async () => {
+    const original = globalThis.fetch
+    await expect(
+      withMockHttp([], () => {
+        throw new Error('boom')
+      })
+    ).rejects.toThrow('boom')
+    expect(globalThis.fetch).toBe(original)
+  })
+
+  it('matches a route by pattern as well as by substring', async () => {
+    const { calls } = await withMockHttp([{ url: /messages$/ }], () =>
+      fetch('https://acme.test/api/messages')
+    )
+    expect(calls[0].method).toBe('GET')
+  })
+})
+
+describe('a check that runs every action against served HTTP', () => {
+  const codes = (findings: Awaited<ReturnType<typeof checkConnector>>) =>
+    findings.map((item) => item.code)
+
+  it('says nothing about actions until it is asked to run them', async () => {
+    const findings = await checkConnector(connector())
+    expect(codes(findings)).not.toContain('mock-network-escape')
+  })
+
+  it('runs an action on its own declared arguments', async () => {
+    const findings = await checkConnector(connector(), {
+      mock: true,
+      mockRoutes: [{ url: '/api/messages', body: { id: 'm-1' } }]
+    })
+    expect(codes(findings)).not.toContain('mock-action-failed')
+    expect(codes(findings)).not.toContain('mock-network-escape')
+  })
+
+  it('refuses an action that reaches past the routes it was given', async () => {
+    const findings = await checkConnector(connector(), {
+      mock: true,
+      mockRoutes: [{ url: '/somewhere-else' }]
+    })
+    const escape = findings.find((item) => item.code === 'mock-network-escape')
+    expect(escape?.level).toBe('error')
+  })
+
+  it('answers everything when no routes were named, so a bare run still proves it runs', async () => {
+    const local: ActionDefinition = {
+      ...post,
+      run: () => ({ id: 'local' })
+    }
+    const findings = await checkConnector(connector([local]), { mock: true })
+    expect(codes(findings)).not.toContain('mock-action-failed')
+  })
+
+  it('only warns when an empty reply was all the action had to go on', async () => {
+    const strict: ActionDefinition = {
+      ...post,
+      async run() {
+        const response = await fetch('https://acme.test/api/messages')
+        const body = (await response.json()) as { id?: string }
+        if (!body.id) throw new Error('Acme returned no id')
+        return body
+      }
+    }
+    // The default route answers `{}`, which is not a real reply — the
+    // connector is not wrong for refusing it.
+    const bare = await checkConnector(connector([strict]), { mock: true })
+    expect(bare.find((item) => item.code === 'mock-action-failed')?.level).toBe('warn')
+
+    // With routes the caller said what the service returns, so a throw is the
+    // connector's to answer for.
+    const routed = await checkConnector(connector([strict]), {
+      mock: true,
+      mockRoutes: [{ url: '/api', body: {} }]
+    })
+    expect(routed.find((item) => item.code === 'mock-action-failed')?.level).toBe('error')
+  })
+})

--- a/tests/connector-mock-http.test.ts
+++ b/tests/connector-mock-http.test.ts
@@ -66,7 +66,9 @@ describe('serving a connector its HTTP in-process', () => {
     }
     const harness = createConnectorHarness(connector([failing]))
     await expect(
-      harness.withMockHttp([{ url: '/api', status: 503 }], () => harness.execute('post', {}))
+      harness.withMockHttp([{ url: '/api', status: 503 }], () =>
+        harness.execute('post', { text: 'hi' })
+      )
     ).rejects.toThrow('Acme said 503')
   })
 

--- a/tests/connector-sdk-action-fields.test.ts
+++ b/tests/connector-sdk-action-fields.test.ts
@@ -52,3 +52,14 @@ describe('the fields an action returns', () => {
     expect(manifestFor({}).outputs).toBeUndefined()
   })
 })
+
+describe('the arguments a live check may use', () => {
+  it('reach the manifest, so a factory can see what a live run would send', () => {
+    const sample = { id: 'ticket-42' }
+    expect(manifestFor({ sample }).sample).toEqual(sample)
+  })
+
+  it('stay absent when the author named none, which is what makes a live run skip it', () => {
+    expect(manifestFor({}).sample).toBeUndefined()
+  })
+})

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -494,8 +494,10 @@ describe('checkConnector', () => {
 
   it('renders findings for a terminal', () => {
     expect(
-      formatFindings([{ level: 'error', code: 'x', target: 'trigger a', message: 'broke' }])
-    ).toBe('error  trigger a: broke [x]')
+      formatFindings([
+        { level: 'error', code: 'poll-failed', target: 'trigger a', message: 'broke' }
+      ])
+    ).toBe('error  trigger a: broke [poll-failed]')
     expect(formatFindings([])).toBe('')
   })
 })

--- a/tests/connector-sdk-dedupe.test.ts
+++ b/tests/connector-sdk-dedupe.test.ts
@@ -347,6 +347,7 @@ describe('checkConnector', () => {
     id: 'acme',
     name: 'Acme',
     description: 'Acme tickets',
+    auth: { rung: 'none' },
     triggers: [
       {
         type: 'newTicket',
@@ -364,6 +365,7 @@ describe('checkConnector', () => {
         description: 'Close a ticket',
         idempotent: true,
         inputs: [{ key: 'id', label: 'Id', description: 'Ticket id' }],
+        outputs: [{ key: 'closed', type: 'boolean' }],
         run: () => ({})
       }
     ]
@@ -399,6 +401,7 @@ describe('checkConnector', () => {
       id: 'broken',
       name: 'Broken',
       description: 'Broken',
+      auth: { rung: 'none' },
       triggers: [
         {
           type: 'newTicket',
@@ -417,6 +420,7 @@ describe('checkConnector', () => {
       id: 'broken',
       name: 'Broken',
       description: 'Broken',
+      auth: { rung: 'none' },
       triggers: [
         {
           type: 'newTicket',
@@ -453,6 +457,7 @@ describe('checkConnector', () => {
       id: 'manual',
       name: 'Manual',
       description: 'Manual',
+      auth: { rung: 'none' },
       triggers: [
         {
           type: 'newTicket',
@@ -471,6 +476,7 @@ describe('checkConnector', () => {
       id: 'empty',
       name: 'Empty',
       description: 'Empty',
+      auth: { rung: 'none' },
       triggers: [
         {
           type: 'newTicket',

--- a/tests/connector-sdk.test.ts
+++ b/tests/connector-sdk.test.ts
@@ -116,6 +116,37 @@ describe('resolveConfig', () => {
   })
 })
 
+/**
+ * The host has to compute the same names when it hands a connector its
+ * secrets, so this is a shared contract rather than an internal detail: it is
+ * exported for that reason, and pinned here so both sides can rely on it.
+ */
+describe('the environment name a config field is read from', () => {
+  it('turns a camelCase key into CONSTANT_CASE', () => {
+    expect(envNameFor('apiToken')).toBe('API_TOKEN')
+    expect(envNameFor('organizationUrl')).toBe('ORGANIZATION_URL')
+    expect(envNameFor('token')).toBe('TOKEN')
+  })
+
+  it('treats hyphens and spaces as the same separator', () => {
+    expect(envNameFor('api-token')).toBe('API_TOKEN')
+    expect(envNameFor('api token')).toBe('API_TOKEN')
+  })
+
+  it('keeps a digit with the word it belongs to', () => {
+    expect(envNameFor('oauth2Token')).toBe('OAUTH2_TOKEN')
+  })
+
+  it('leaves a name that is already shouting alone', () => {
+    expect(envNameFor('API_TOKEN')).toBe('API_TOKEN')
+  })
+
+  it('lets the field name its own variable, which then wins outright', () => {
+    expect(envNameFor('organizationUrl', 'ACME_ORG_URL')).toBe('ACME_ORG_URL')
+    expect(envNameFor('apiToken', 'GH_TOKEN')).toBe('GH_TOKEN')
+  })
+})
+
 describe('normalizeItem', () => {
   it('fills every field Vorn reads by name', () => {
     expect(normalizeItem({ externalId: 7, title: 'Seven' }, NOW)).toEqual({

--- a/tests/connector-verified-receipt.test.ts
+++ b/tests/connector-verified-receipt.test.ts
@@ -29,12 +29,59 @@ const clean = (over: Partial<ConnectorDefinition> = {}) =>
 describe('what a conformance run vouches for', () => {
   it('names the checks that ran and had nothing to say', async () => {
     const run = await runConformance(clean(), { now: at })
+    // No config fields and no triggers: `secrets` and `dedupe` examined
+    // nothing, so they are absent rather than vouched for.
     expect(run.receipt).toEqual({
       schema: 1,
       version: '1.2.0',
       checkedAt: at(),
-      checks: ['manifest', 'auth', 'secrets', 'actions', 'dedupe']
+      checks: ['manifest', 'auth', 'actions']
     })
+  })
+
+  it('claims dedupe only once there is a trigger to have checked', async () => {
+    const withTrigger = clean({
+      triggers: [
+        {
+          type: 'newTicket',
+          label: 'New ticket',
+          description: 'Tickets since the last poll',
+          dedupe: 'timestamp',
+          fetch: () => [],
+          sample: [{ externalId: '1', title: 'One', updatedAt: '2026-09-01T00:00:00.000Z' }]
+        }
+      ]
+    })
+    expect((await runConformance(withTrigger, { now: at })).receipt?.checks).toContain('dedupe')
+    expect((await runConformance(clean(), { now: at })).receipt?.checks).not.toContain('dedupe')
+  })
+
+  it('claims secrets only once there is a config field to have checked', async () => {
+    const withConfig = clean({ config: [{ key: 'project', label: 'Project' }] })
+    expect((await runConformance(withConfig, { now: at })).receipt?.checks).toContain('secrets')
+    expect((await runConformance(clean(), { now: at })).receipt?.checks).not.toContain('secrets')
+  })
+
+  it('claims actions only once there is an action to have checked', async () => {
+    const bare = clean({
+      actions: undefined,
+      triggers: [{ type: 't', label: 'T', poll: () => ({ items: [] }) }]
+    })
+    expect((await runConformance(bare, { now: at })).receipt?.checks).not.toContain('actions')
+  })
+
+  it('writes no receipt at all when every check came back empty-handed', async () => {
+    // Nothing to examine but a description it does not have: the run looked at
+    // nothing, so it says nothing rather than issuing a blank badge.
+    const nothing = defineConnector({
+      id: 'hollow',
+      name: 'Hollow',
+      actions: [{ type: 'ping', label: 'Ping', run: () => ({}) }]
+    })
+    const run = await runConformance(nothing, { now: at })
+
+    expect(run.passed).toEqual([])
+    expect(run.receipt).toBeUndefined()
   })
 
   it('leaves out a check that had something to say, rather than vouching for it', async () => {

--- a/tests/connector-verified-receipt.test.ts
+++ b/tests/connector-verified-receipt.test.ts
@@ -112,8 +112,33 @@ describe('what a conformance run vouches for', () => {
   })
 
   it('grows the list with the checks the caller asked for', async () => {
-    const run = await runConformance(clean(), { now: at, mock: true })
+    const fetching = clean({
+      actions: [
+        {
+          type: 'read',
+          label: 'Read',
+          description: 'Read something back',
+          idempotent: true,
+          outputs: [{ key: 'ok', type: 'boolean' }],
+          run: async () => {
+            await fetch('https://acme.test/api/things')
+            return { ok: true }
+          }
+        }
+      ]
+    })
+    const run = await runConformance(fetching, {
+      now: at,
+      mock: true,
+      mockRoutes: [{ url: '/api/things', body: {} }]
+    })
     expect(run.receipt?.checks).toContain('mock')
+  })
+
+  it('will not claim mock for an action the stub never heard from', async () => {
+    // `clean`'s action makes no request, so the run saw nothing to vouch for.
+    const run = await runConformance(clean(), { now: at, mock: true })
+    expect(run.receipt?.checks).not.toContain('mock')
   })
 
   it('does not claim a check nobody ran', async () => {

--- a/tests/connector-verified-receipt.test.ts
+++ b/tests/connector-verified-receipt.test.ts
@@ -156,7 +156,9 @@ describe('writing the receipt from the command line', () => {
     const base: CliDeps = {
       load: async () => ({ default: clean() }),
       write: (line) => lines.push(line),
-      writeFile: (path, contents) => written.push({ path, contents }),
+      writeFile: async (path, contents) => {
+        written.push({ path, contents })
+      },
       ...over
     }
     return { deps: base, lines, written }

--- a/tests/connector-verified-receipt.test.ts
+++ b/tests/connector-verified-receipt.test.ts
@@ -207,6 +207,20 @@ describe('writing the receipt from the command line', () => {
     expect(written).toHaveLength(0)
   })
 
+  it('says so, and fails, when a receipt was asked for but nothing could be vouched for', async () => {
+    const hollow = defineConnector({
+      id: 'hollow',
+      name: 'Hollow',
+      actions: [{ type: 'ping', label: 'Ping', run: () => ({}) }]
+    })
+    const { deps: cli, lines, written } = deps({ load: async () => ({ default: hollow }) })
+
+    const code = await runCli(['check', './acme.js', '--receipt', 'verified.json'], cli)
+    expect(written).toHaveLength(0)
+    expect(lines.join('\n')).toContain('No receipt written')
+    expect(code).toBe(1)
+  })
+
   it('runs the package gates too when asked to mock, so one command is the whole gate', async () => {
     const bundle = vi.fn(async () => ({ code: '', external: [] }))
     const { deps: cli } = deps({ bundle, cwd: process.cwd() })

--- a/tests/connector-verified-receipt.test.ts
+++ b/tests/connector-verified-receipt.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { defineConnector, runCli, runConformance } from '../packages/connector-sdk/src/index'
-import type { CliDeps } from '../packages/connector-sdk/src/cli'
+import { defineConnector, runConformance } from '../packages/connector-sdk/src/index'
+import { runCli, type CliDeps } from '../packages/connector-sdk/src/cli'
 import type { ConnectorDefinition } from '../packages/connector-sdk/src/types'
 
 const at = () => '2026-09-02T12:00:00.000Z'

--- a/tests/connector-verified-receipt.test.ts
+++ b/tests/connector-verified-receipt.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineConnector, runCli, runConformance } from '../packages/connector-sdk/src/index'
+import type { CliDeps } from '../packages/connector-sdk/src/cli'
+import type { ConnectorDefinition } from '../packages/connector-sdk/src/types'
+
+const at = () => '2026-09-02T12:00:00.000Z'
+
+/** A connector with nothing for any check to say about it. */
+const clean = (over: Partial<ConnectorDefinition> = {}) =>
+  defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    version: '1.2.0',
+    description: 'Talks to Acme',
+    auth: { rung: 'none' },
+    actions: [
+      {
+        type: 'read',
+        label: 'Read',
+        description: 'Read something back',
+        idempotent: true,
+        outputs: [{ key: 'ok', type: 'boolean' }],
+        run: () => ({ ok: true })
+      }
+    ],
+    ...over
+  })
+
+describe('what a conformance run vouches for', () => {
+  it('names the checks that ran and had nothing to say', async () => {
+    const run = await runConformance(clean(), { now: at })
+    expect(run.receipt).toEqual({
+      schema: 1,
+      version: '1.2.0',
+      checkedAt: at(),
+      checks: ['manifest', 'auth', 'secrets', 'actions', 'dedupe']
+    })
+  })
+
+  it('leaves out a check that had something to say, rather than vouching for it', async () => {
+    // No auth block is a warning, so the run still passes — but `auth` is not
+    // among the things it checked and found clean.
+    const run = await runConformance(clean({ auth: undefined }), { now: at })
+    expect(run.passed).not.toContain('auth')
+    expect(run.receipt?.checks).not.toContain('auth')
+    expect(run.receipt).toBeDefined()
+  })
+
+  it('makes no claim at all when something failed', async () => {
+    const broken = clean({
+      actions: [
+        {
+          type: 'read',
+          label: 'Read',
+          description: 'Read',
+          idempotent: true,
+          outputs: [{ key: 'ok' }],
+          inputs: [{ key: 'level', label: 'Level', type: 'select', description: 'How much' }],
+          run: () => ({})
+        }
+      ]
+    })
+    const run = await runConformance(broken, { now: at })
+    expect(run.receipt).toBeUndefined()
+  })
+
+  it('grows the list with the checks the caller asked for', async () => {
+    const run = await runConformance(clean(), { now: at, mock: true })
+    expect(run.receipt?.checks).toContain('mock')
+  })
+
+  it('does not claim a check nobody ran', async () => {
+    const run = await runConformance(clean(), { now: at })
+    expect(run.receipt?.checks).not.toContain('mock')
+    expect(run.receipt?.checks).not.toContain('live')
+    expect(run.receipt?.checks).not.toContain('no-runtime-deps')
+  })
+})
+
+describe('writing the receipt from the command line', () => {
+  const deps = (over: Partial<CliDeps> = {}) => {
+    const lines: string[] = []
+    const written: Array<{ path: string; contents: string }> = []
+    const base: CliDeps = {
+      load: async () => ({ default: clean() }),
+      write: (line) => lines.push(line),
+      writeFile: (path, contents) => written.push({ path, contents }),
+      ...over
+    }
+    return { deps: base, lines, written }
+  }
+
+  it('writes what it verified where it was told to', async () => {
+    const { deps: cli, written } = deps()
+    const code = await runCli(['check', './acme.js', '--receipt', 'verified.json'], cli)
+
+    expect(code).toBe(0)
+    expect(written).toHaveLength(1)
+    expect(written[0].path).toBe('verified.json')
+    const receipt = JSON.parse(written[0].contents) as { schema: number; checks: string[] }
+    expect(receipt.schema).toBe(1)
+    expect(receipt.checks).toContain('manifest')
+  })
+
+  it('writes nothing when it was not asked for a receipt', async () => {
+    const { deps: cli, written } = deps()
+    await runCli(['check', './acme.js'], cli)
+    expect(written).toHaveLength(0)
+  })
+
+  it('writes no receipt for a connector that failed, and says so by exit code', async () => {
+    const broken = defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      description: 'Talks to Acme',
+      auth: { rung: 'none' },
+      actions: [
+        {
+          type: 'read',
+          label: 'Read',
+          description: 'Read',
+          idempotent: true,
+          outputs: [{ key: 'ok' }],
+          inputs: [{ key: 'level', label: 'Level', type: 'select', description: 'How much' }],
+          run: () => ({})
+        }
+      ]
+    })
+    const { deps: cli, written } = deps({ load: async () => ({ default: broken }) })
+
+    const code = await runCli(['check', './acme.js', '--receipt', 'verified.json'], cli)
+    expect(code).toBe(1)
+    expect(written).toHaveLength(0)
+  })
+
+  it('runs the package gates too when asked to mock, so one command is the whole gate', async () => {
+    const bundle = vi.fn(async () => ({ code: '', external: [] }))
+    const { deps: cli } = deps({ bundle, cwd: process.cwd() })
+
+    await runCli(['check', './acme.js', '--mock'], cli)
+    expect(bundle).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
The factory's review step: "verified" becomes a receipt of the checks that actually ran.

## What changed

- **`vorn-connector check --mock`** runs every action against an in-process HTTP stub (`withMockHttp(routes)` on the harness, no sockets). Routes match on pathname, exact or prefix with a trailing slash; a pattern sees the whole URL. An action that reaches past the routes is a `mock-network-escape` error; one the stub never heard from is `mock-not-observed`, so a connector that shells out cannot earn `mock`. A mock run fills config from field defaults and placeholders so templated URLs resolve. Concurrent installs of the stub are refused rather than orphaned.
- **`--live`** runs preflight, one poll cycle, and each idempotent action whose arguments are real: a declared `sample` set on the action, or nothing required. Auth refusals are errors; anything else is a warning.
- **`--receipt <file>`** writes `{ schema, version, checkedAt, checks[] }`. Checks are derived from what was examinable, and a check with a finding against it is left out; an empty receipt is refused.
- **New findings**: `auth-undeclared`, `auth-probe-missing`, `input-type-unsupported`, `action-no-outputs`, `secret-not-marked`, `keywords-missing`, and `no-lifecycle-scripts` / `no-runtime-deps` promoted from pack. Every finding code is typed (`CheckCode`) with an owner.
- **Package gates** judge the entry's own package directory (shared `packageDirFor` with pack), not the working directory.
- `CliDeps.writeFile` serves both the scaffold and the receipt; a scaffold refuses an existing directory instead of relying on an open flag.

The connectors-repo half (CI running the mock check per package, rung gate, catalog folding the receipt) is on a branch there and lands once the SDK publishes as 0.7.0-beta.9.

## Verification

- typecheck 0; full vitest 5587 passed with the two known ambient failures; diff coverage 96%; prettier clean
- Manual, in a terminal on a scaffolded connector: receipt written with `mock`; an action using `execFileSync` dropped `mock` with `mock-not-observed`; `--live` without a token stopped naming `API_TOKEN`; a connector with no actions produced a receipt without `mock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
