### PR TITLE
Show every connector the catalog knows, and offer its steps before it is installed

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -907,11 +907,7 @@ export interface CallConnectorActionConfig {
   action: string
   /** The action's authored label, kept so a card can name it without asking the connector. */
   actionLabel?: string
-  /**
-   * Which connector the action belongs to, for a step placed before any
-   * connection existed. Two connectors can serve an action of the same name, so
-   * the connector cannot be inferred from `action` once the step is unbound.
-   */
+  // Which connector the action belongs to, for a step placed before any connection existed.
   connectorId?: string
   /** Raw args map; values support template placeholders. */
   args: Record<string, string>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -907,6 +907,12 @@ export interface CallConnectorActionConfig {
   action: string
   /** The action's authored label, kept so a card can name it without asking the connector. */
   actionLabel?: string
+  /**
+   * Which connector the action belongs to, for a step placed before any
+   * connection existed. Two connectors can serve an action of the same name, so
+   * the connector cannot be inferred from `action` once the step is unbound.
+   */
+  connectorId?: string
   /** Raw args map; values support template placeholders. */
   args: Record<string, string>
 }

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -198,16 +198,27 @@ export function toPortable(
 
     const key = boundConnectionKey(node, config)
     const bound = key === null ? '' : config[key]
-    if (key !== null && typeof bound === 'string' && bound !== '') {
+    // A step bound to a connection here, and one that was never bound at all,
+    // both arrive elsewhere needing the same answer — so both say so. Only a
+    // request with no profile field stays silent: that is a public URL, not a
+    // question. An unbound step can still name its connector, which is what
+    // lets the importing machine offer to install it.
+    const unbound = key !== null && key !== 'profileConnectionId' && bound === ''
+    if (key !== null && ((typeof bound === 'string' && bound !== '') || unbound)) {
       const source = connections.find((connection) => connection.id === bound)
       const event = config.event
+      const declared = config.connectorId
       requires.push(
         key === 'profileConnectionId'
           ? { kind: 'httpProfile', nodeId: node.id, name: source?.name ?? '' }
           : {
               kind: 'connection',
               nodeId: node.id,
-              connectorId: source ? connectorOf(source) : '',
+              connectorId: source
+                ? connectorOf(source)
+                : typeof declared === 'string'
+                  ? declared
+                  : '',
               name: source?.name ?? '',
               ...(typeof event === 'string' && event !== '' && { event })
             }

--- a/packages/shared/src/workflow-portability.ts
+++ b/packages/shared/src/workflow-portability.ts
@@ -198,11 +198,7 @@ export function toPortable(
 
     const key = boundConnectionKey(node, config)
     const bound = key === null ? '' : config[key]
-    // A step bound to a connection here, and one that was never bound at all,
-    // both arrive elsewhere needing the same answer — so both say so. Only a
-    // request with no profile field stays silent: that is a public URL, not a
-    // question. An unbound step can still name its connector, which is what
-    // lets the importing machine offer to install it.
+    // A step bound to a connection here, and one that was never bound at all, both arrive elsewhere needing the same.
     const unbound = key !== null && key !== 'profileConnectionId' && bound === ''
     if (key !== null && ((typeof bound === 'string' && bound !== '') || unbound)) {
       const source = connections.find((connection) => connection.id === bound)

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -13,7 +13,7 @@ import { ConnectorIcon } from '../ConnectorIcon'
 import type { ConnectorCatalogVerification, ConnectorInstallProgress } from '../../../shared/types'
 import {
   listingDetails,
-  AUTH_RUNG_LABEL,
+  AUTH_RUNG,
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
@@ -147,18 +147,11 @@ export function ConnectorDetail({
         </>
       )}
 
-      {/* The rung answers "what will this ask of me" in one word the list can
-          also filter by; the connector's own sentence says it in its own terms. */}
+      {/* The rung answers "what will this ask of me"; the connector's own sentence says it in its terms. */}
       {(listing.authRung || entry?.auth) && (
         <Section label="Signs in with">
-          {listing.authRung === 'none' ? (
-            <p className="text-[12.5px] text-gray-300">
-              Nothing — ready as soon as it is installed.
-            </p>
-          ) : (
-            listing.authRung && (
-              <p className="text-[12.5px] text-gray-300">{AUTH_RUNG_LABEL[listing.authRung]}</p>
-            )
+          {listing.authRung && (
+            <p className="text-[12.5px] text-gray-300">{AUTH_RUNG[listing.authRung].detail}</p>
           )}
           {entry?.auth && <p className="text-[12.5px] text-gray-500">{entry.auth}</p>}
         </Section>
@@ -183,8 +176,7 @@ export function ConnectorDetail({
       )}
 
       <div className="flex items-center gap-2 mt-6">
-        {/* Nothing to connect: installing it was the whole setup, so the next
-            useful move is the one the connector exists for. */}
+        {/* Nothing to connect: installing it was the whole setup, so the next move is the one it exists for. */}
         {listing.implicitlyConnected ? (
           onUse ? (
             <button

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -1,8 +1,19 @@
-import { Plus, ArrowLeft, ExternalLink, Download, RefreshCw, Undo2, Trash2 } from 'lucide-react'
+import {
+  Plus,
+  ArrowLeft,
+  Check,
+  ExternalLink,
+  Download,
+  RefreshCw,
+  Undo2,
+  Trash2,
+  Workflow
+} from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
-import type { ConnectorInstallProgress } from '../../../shared/types'
+import type { ConnectorCatalogVerification, ConnectorInstallProgress } from '../../../shared/types'
 import {
   listingDetails,
+  AUTH_RUNG_LABEL,
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
@@ -30,6 +41,7 @@ export function ConnectorDetail({
   onInstall,
   onRollback,
   onRemove,
+  onUse,
   onClose
 }: {
   listing: ConnectorListing
@@ -40,6 +52,8 @@ export function ConnectorDetail({
   onInstall?: () => void
   onRollback?: () => void
   onRemove?: () => void
+  /** Where a connector that needs no connection is actually used. */
+  onUse?: () => void
   onClose: () => void
 }) {
   const details = listingDetails(listing, builtIns)
@@ -76,6 +90,8 @@ export function ConnectorDetail({
             {entry?.version && ` · v${entry.version}`}
             {listing.connectedCount > 0 && ` · ${count(listing.connectedCount, 'connection')}`}
           </div>
+          {/* A badge is a claim; this is the claim's receipt, said in full. */}
+          {listing.verified && <VerifiedStrip verification={listing.verified} />}
         </div>
       </div>
 
@@ -131,7 +147,22 @@ export function ConnectorDetail({
         </>
       )}
 
-      {entry?.auth && <p className="text-[12.5px] text-gray-400 mt-4">{entry.auth}</p>}
+      {/* The rung answers "what will this ask of me" in one word the list can
+          also filter by; the connector's own sentence says it in its own terms. */}
+      {(listing.authRung || entry?.auth) && (
+        <Section label="Signs in with">
+          {listing.authRung === 'none' ? (
+            <p className="text-[12.5px] text-gray-300">
+              Nothing — ready as soon as it is installed.
+            </p>
+          ) : (
+            listing.authRung && (
+              <p className="text-[12.5px] text-gray-300">{AUTH_RUNG_LABEL[listing.authRung]}</p>
+            )
+          )}
+          {entry?.auth && <p className="text-[12.5px] text-gray-500">{entry.auth}</p>}
+        </Section>
+      )}
 
       {/* The question this page could not answer while a connector was a package name. */}
       {listing.pack && (
@@ -152,16 +183,31 @@ export function ConnectorDetail({
       )}
 
       <div className="flex items-center gap-2 mt-6">
-        {canAddConnection(state, {
-          source: listing.source,
-          hasLegacyLaunch: Boolean(entry?.packageName)
-        }) && (
-          <button
-            onClick={onAdd}
-            className="text-xs text-gray-100 bg-white/[0.1] hover:bg-white/[0.16] px-3 py-1.5 rounded-sm transition-colors flex items-center gap-1"
-          >
-            <Plus size={12} /> Add a connection
-          </button>
+        {/* Nothing to connect: installing it was the whole setup, so the next
+            useful move is the one the connector exists for. */}
+        {listing.implicitlyConnected ? (
+          onUse ? (
+            <button
+              onClick={onUse}
+              className="text-xs text-gray-100 bg-white/[0.1] hover:bg-white/[0.16] px-3 py-1.5 rounded-sm transition-colors flex items-center gap-1"
+            >
+              <Workflow size={12} /> Use in a workflow
+            </button>
+          ) : (
+            <span className="text-[12px] text-gray-500">Ready to use in a workflow.</span>
+          )
+        ) : (
+          canAddConnection(state, {
+            source: listing.source,
+            hasLegacyLaunch: Boolean(entry?.packageName)
+          }) && (
+            <button
+              onClick={onAdd}
+              className="text-xs text-gray-100 bg-white/[0.1] hover:bg-white/[0.16] px-3 py-1.5 rounded-sm transition-colors flex items-center gap-1"
+            >
+              <Plus size={12} /> Add a connection
+            </button>
+          )
         )}
 
         {onInstall && status.action && (
@@ -219,6 +265,35 @@ export function ConnectorDetail({
       </div>
     </div>
   )
+}
+
+/**
+ * The receipt behind the badge: what ran, against which version, and when.
+ *
+ * Named checks rather than a score, because "verified" is only worth anything
+ * if it says what was verified — and a date, because a check that ran against
+ * a version three releases back vouches for less than it appears to.
+ */
+function VerifiedStrip({ verification }: { verification: ConnectorCatalogVerification }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5 text-[11px] text-gray-500">
+      {verification.checks.map((check) => (
+        <span key={check} className="inline-flex items-center gap-1">
+          <Check size={10} /> {check}
+        </span>
+      ))}
+      <span className="text-gray-600">
+        checked {formatDay(verification.checkedAt)} against v{verification.version}
+      </span>
+    </div>
+  )
+}
+
+/** A date said the way a person would, falling back to the raw stamp. */
+function formatDay(iso: string): string {
+  const at = new Date(iso)
+  if (Number.isNaN(at.getTime())) return iso
+  return at.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
 function Fact({ term, value, mono }: { term: string; value: string; mono?: boolean }) {

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -1,13 +1,18 @@
 import { useMemo, useState } from 'react'
-import { Search, Plus, RefreshCw, ChevronRight, Download, FolderOpen } from 'lucide-react'
+import { Search, Plus, RefreshCw, ChevronRight, Check, Download, FolderOpen } from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
-import type { ConnectorInstallProgress } from '../../../shared/types'
+import type { ConnectorAuthRung, ConnectorInstallProgress } from '../../../shared/types'
 import {
   describeCatalogAge,
   filterConnectorListings,
+  filterByAuthRung,
   filterByCategory,
+  connectorAuthRungs,
   connectorCategories,
+  groupListingsByCategory,
   listingDetails,
+  AUTH_RUNG_BADGE,
+  AUTH_RUNG_LABEL,
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
@@ -60,14 +65,23 @@ export function ConnectorDirectory({
 }) {
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('')
+  const [rung, setRung] = useState<'' | ConnectorAuthRung>('')
   const [refreshing, setRefreshing] = useState(false)
   const [dragOver, setDragOver] = useState(false)
 
   const categories = useMemo(() => connectorCategories(listings), [listings])
+  const rungs = useMemo(() => connectorAuthRungs(listings), [listings])
   const visible = useMemo(
-    () => filterByCategory(filterConnectorListings(listings, search), category || undefined),
-    [listings, search, category]
+    () =>
+      filterByAuthRung(
+        filterByCategory(filterConnectorListings(listings, search), category || undefined),
+        rung || undefined
+      ),
+    [listings, search, category, rung]
   )
+  // Sections earn their keep once there is more than one; below that they are
+  // a heading over the whole list, which says nothing.
+  const sections = useMemo(() => groupListingsByCategory(visible), [visible])
 
   const handleDrop = (event: React.DragEvent): void => {
     event.preventDefault()
@@ -140,6 +154,23 @@ export function ConnectorDirectory({
             ))}
           </select>
         )}
+        {/* What setting one up will ask of you is the question people bring
+            here second, right after what it talks to. */}
+        {rungs.length > 1 && (
+          <select
+            value={rung}
+            onChange={(e) => setRung(e.target.value as '' | ConnectorAuthRung)}
+            aria-label="Filter by sign-in"
+            className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
+          >
+            <option value="">Any sign-in</option>
+            {rungs.map((name) => (
+              <option key={name} value={name}>
+                {AUTH_RUNG_LABEL[name]}
+              </option>
+            ))}
+          </select>
+        )}
       </div>
 
       {installError && (
@@ -152,23 +183,30 @@ export function ConnectorDirectory({
       {/* A verified pack waiting on the decision to keep it. */}
       {pending && <div className="mt-2">{pending}</div>}
 
-      <div>
-        {visible.map((listing) => (
-          <ConnectorRow
-            key={listing.key}
-            listing={listing}
-            builtIns={builtIns}
-            {...(progress?.[listing.id] && { progress: progress[listing.id] })}
-            onSelect={() => onSelect(listing)}
-            onAdd={() => onAdd(listing)}
-            {...(onInstall && { onInstall: () => onInstall(listing) })}
-          />
-        ))}
-      </div>
+      {sections.map((section) => (
+        <div key={section.category}>
+          {sections.length > 1 && (
+            <h3 className="text-[10px] uppercase tracking-[0.08em] text-gray-600 pt-4 pb-1">
+              {section.category}
+            </h3>
+          )}
+          {section.listings.map((listing) => (
+            <ConnectorRow
+              key={listing.key}
+              listing={listing}
+              builtIns={builtIns}
+              {...(progress?.[listing.id] && { progress: progress[listing.id] })}
+              onSelect={() => onSelect(listing)}
+              onAdd={() => onAdd(listing)}
+              {...(onInstall && { onInstall: () => onInstall(listing) })}
+            />
+          ))}
+        </div>
+      ))}
 
       {visible.length === 0 && (
         <p className="text-sm text-gray-500 py-4">
-          {search || category
+          {search || category || rung
             ? 'No connectors match that.'
             : 'No connectors available. Check your connection and try again.'}
         </p>
@@ -242,8 +280,24 @@ export function ConnectorRow({
           />
         </span>
         <span className="min-w-0">
-          <span className="block text-[13.5px] text-gray-200 font-medium group-hover:underline underline-offset-2 decoration-white/25">
-            {listing.name}
+          <span className="flex items-center gap-1.5 min-w-0">
+            <span className="text-[13.5px] text-gray-200 font-medium group-hover:underline underline-offset-2 decoration-white/25 truncate">
+              {listing.name}
+            </span>
+            {/* Both are facts rather than states, so they are lettered, not coloured. */}
+            {listing.authRung && (
+              <span className="shrink-0 text-[10px] text-gray-500 border border-white/[0.1] rounded-sm px-1.5 py-px">
+                {AUTH_RUNG_BADGE[listing.authRung]}
+              </span>
+            )}
+            {listing.verified && (
+              <span
+                title={`Checked ${listing.verified.checks.join(', ')} against v${listing.verified.version}`}
+                className="shrink-0 inline-flex items-center gap-0.5 text-[10px] text-gray-500 border border-white/[0.1] rounded-sm px-1.5 py-px"
+              >
+                <Check size={9} /> verified
+              </span>
+            )}
           </span>
           {listing.description && (
             <span className="block text-[12.5px] text-gray-500 leading-snug mt-0.5">
@@ -292,23 +346,25 @@ export function ConnectorRow({
             {status.label}
           </button>
         )}
-        {/* A pack must be on disk before there is anything to connect to. */}
-        {canAddConnection(state, {
-          source: listing.source,
-          hasLegacyLaunch: Boolean(listing.catalogItem?.packageName)
-        }) && (
-          <button
-            onClick={onAdd}
-            className="text-[11.5px] text-gray-300 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
-          >
-            <Plus size={11} />{' '}
-            {listing.connectedCount > 0
-              ? 'Add another'
-              : listing.source === 'mcp'
-                ? 'Add server'
-                : 'Add'}
-          </button>
-        )}
+        {/* A pack must be on disk before there is anything to connect to, and a
+            connector that signs in with nothing was connected by installing it. */}
+        {!listing.implicitlyConnected &&
+          canAddConnection(state, {
+            source: listing.source,
+            hasLegacyLaunch: Boolean(listing.catalogItem?.packageName)
+          }) && (
+            <button
+              onClick={onAdd}
+              className="text-[11.5px] text-gray-300 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+            >
+              <Plus size={11} />{' '}
+              {listing.connectedCount > 0
+                ? 'Add another'
+                : listing.source === 'mcp'
+                  ? 'Add server'
+                  : 'Add'}
+            </button>
+          )}
       </div>
     </div>
   )
@@ -334,6 +390,8 @@ function facts(listing: ConnectorListing, details: ReturnType<typeof listingDeta
   const version = listing.catalogItem?.version
   if (version) parts.push(`v${version}`)
   if (listing.connectedCount > 0) parts.push('in use')
+  // Nothing was connected, and nothing needs to be: it is usable as it stands.
+  else if (listing.implicitlyConnected) parts.push('ready')
 
   return parts.join(' · ')
 }

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -11,8 +11,7 @@ import {
   connectorCategories,
   groupListingsByCategory,
   listingDetails,
-  AUTH_RUNG_BADGE,
-  AUTH_RUNG_LABEL,
+  AUTH_RUNG,
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
@@ -166,7 +165,7 @@ export function ConnectorDirectory({
             <option value="">Any sign-in</option>
             {rungs.map((name) => (
               <option key={name} value={name}>
-                {AUTH_RUNG_LABEL[name]}
+                {AUTH_RUNG[name].label}
               </option>
             ))}
           </select>
@@ -287,7 +286,7 @@ export function ConnectorRow({
             {/* Both are facts rather than states, so they are lettered, not coloured. */}
             {listing.authRung && (
               <span className="shrink-0 text-[10px] text-gray-500 border border-white/[0.1] rounded-sm px-1.5 py-px">
-                {AUTH_RUNG_BADGE[listing.authRung]}
+                {AUTH_RUNG[listing.authRung].badge}
               </span>
             )}
             {listing.verified && (

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -16,11 +16,9 @@ import { AddConnectionForm, MCP_CONNECTOR_ID, type ConnectorInfo } from './AddCo
 
 export function ConnectorSettings() {
   const workflows = useAppStore((s) => s.config?.workflows ?? [])
-  const openWorkflowEditor = (id: string) => {
+  // Settings is a modal overlay, so it closes first or the editor renders behind it; null opens a new workflow.
+  const openWorkflowEditor = (id: string | null) => {
     const store = useAppStore.getState()
-    // Close settings, switch to workflows view, select the workflow, and
-    // open the editor. Settings is a modal overlay — if we only set the
-    // editor state, the editor renders behind settings and looks dead.
     store.setSettingsOpen(false)
     store.setMainViewMode('workflows')
     store.setEditingWorkflowId(id)
@@ -35,8 +33,7 @@ export function ConnectorSettings() {
   // connectors before they are installed, and two copies would disagree the
   // moment either was refreshed.
   const { items: catalog, mcpServers, fetchedAt: catalogFetchedAt } = useConnectorCatalog()
-  // What the detail view is describing. Separate from `adding` so opening a
-  // connector to read about it is not the same as committing to install it.
+  // What the detail view is describing.
   const [selected, setSelected] = useState<ConnectorListing | null>(null)
   // Connections lead once there are any; with none there is nothing to lead
   // with, so the catalog opens instead of a second empty-state layout.
@@ -73,13 +70,10 @@ export function ConnectorSettings() {
     void load()
   }, [load])
 
-  // Inspect, ask, keep — the same three steps the editor's template rows use.
-  // Installing changes what is on disk, which the library reads too, so the
-  // shared cache is refreshed rather than only this page's copy.
+  // Installing changes what is on disk, which the library reads too, so the shared cache is told as well.
   const install = usePackInstall(
     useCallback(async () => {
-      await load()
-      await refreshConnections()
+      await Promise.all([load(), refreshConnections()])
     }, [load])
   )
   const {
@@ -261,6 +255,7 @@ export function ConnectorSettings() {
             progress: installProgress[selectedListing.id]
           })}
           onAdd={() => setAdding(selectedListing)}
+          onUse={() => openWorkflowEditor(null)}
           onInstall={() => handleInstall(selectedListing)}
           onRollback={() => handleRollback(selectedListing.id)}
           onRemove={() => handleRemovePack(selectedListing.id)}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -231,7 +231,9 @@ export function ConnectorSettings() {
           builtIns={connectors}
           progress={installProgress}
           fetchedAt={catalogFetchedAt}
-          onRefresh={refreshConnectorCatalog}
+          onRefresh={async () => {
+            await refreshConnectorCatalog()
+          }}
           onSelect={setSelected}
           onAdd={setAdding}
           onInstall={handleInstall}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -3,17 +3,13 @@ import { useAppStore } from '../../stores'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { buildConnectorListings, type ConnectorListing } from '../../lib/connector-browse'
 import { usePackInstall } from '../../lib/use-pack-install'
+import { useConnectorCatalog, refreshConnectorCatalog } from '../../lib/use-connector-catalog'
+import { refreshConnections } from '../../lib/use-connections'
 import { SDK_FILTER_KEYS } from '../../../shared/types'
 import { ConnectorDirectory } from './ConnectorDirectory'
 import { ConnectorDetail } from './ConnectorDetail'
 import { ConnectionGroups, type ConnectorStatus } from './ConnectionGroups'
-import type {
-  ConnectorCatalogItem,
-  ConnectorCatalogSnapshot,
-  InstalledConnectorPack,
-  McpServerCatalogEntry,
-  SourceConnection
-} from '../../../shared/types'
+import type { InstalledConnectorPack, SourceConnection } from '../../../shared/types'
 import { SdkConnectorForm } from './SdkConnectorForm'
 import { PackInstallConfirm } from './PackInstallConfirm'
 import { AddConnectionForm, MCP_CONNECTOR_ID, type ConnectorInfo } from './AddConnectionForm'
@@ -35,9 +31,10 @@ export function ConnectorSettings() {
   const [statuses, setStatuses] = useState<ConnectorStatus[]>([])
   // One selection, so "both open at once" is not a representable state.
   const [adding, setAdding] = useState<ConnectorListing | null>(null)
-  const [catalog, setCatalog] = useState<ConnectorCatalogItem[]>([])
-  const [mcpServers, setMcpServers] = useState<McpServerCatalogEntry[]>([])
-  const [catalogFetchedAt, setCatalogFetchedAt] = useState<number>()
+  // One catalog for the whole app: the step library offers these same
+  // connectors before they are installed, and two copies would disagree the
+  // moment either was refreshed.
+  const { items: catalog, mcpServers, fetchedAt: catalogFetchedAt } = useConnectorCatalog()
   // What the detail view is describing. Separate from `adding` so opening a
   // connector to read about it is not the same as committing to install it.
   const [selected, setSelected] = useState<ConnectorListing | null>(null)
@@ -76,21 +73,15 @@ export function ConnectorSettings() {
     void load()
   }, [load])
 
-  // Fetched once rather than with every refresh: the catalog is fixed for the
-  // life of the process, so re-reading it after each run, delete or install
-  // would be a round trip that always returns the same answer.
-  const applyCatalog = useCallback((snapshot: ConnectorCatalogSnapshot) => {
-    setCatalog(snapshot.items)
-    setMcpServers(snapshot.mcpServers ?? [])
-    setCatalogFetchedAt(snapshot.fetchedAt)
-  }, [])
-
-  useEffect(() => {
-    void window.api.listConnectorCatalog().then(applyCatalog)
-  }, [applyCatalog])
-
   // Inspect, ask, keep — the same three steps the editor's template rows use.
-  const install = usePackInstall(load)
+  // Installing changes what is on disk, which the library reads too, so the
+  // shared cache is refreshed rather than only this page's copy.
+  const install = usePackInstall(
+    useCallback(async () => {
+      await load()
+      await refreshConnections()
+    }, [load])
+  )
   const {
     progress: installProgress,
     pending: pendingPack,
@@ -240,7 +231,7 @@ export function ConnectorSettings() {
           builtIns={connectors}
           progress={installProgress}
           fetchedAt={catalogFetchedAt}
-          onRefresh={async () => applyCatalog(await window.api.refreshConnectorCatalog())}
+          onRefresh={refreshConnectorCatalog}
           onSelect={setSelected}
           onAdd={setAdding}
           onInstall={handleInstall}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -655,7 +655,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     )
   }, [imported, editingId, connections, nodes])
   // Dismiss means "stop asking about the import"; a row the canvas derives is a live fact until the step is bound.
-  const importContributed = imported !== null && imported.workflowId === editingId
+  const importContributed = imported?.workflowId === editingId
 
   // Asked for only while someone is looking; a fetch that lost the startup race caches nothing, so opening again asks again.
   const { items: catalog, templates, mcpServers } = useConnectorCatalog(isActive)

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -719,8 +719,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
    * requirement and the unbound step it describes are the same gap named twice.
    */
   const stillNeeded = useMemo(() => {
-    const fromImport =
-      imported && imported.workflowId === editingId ? imported.requirements : ([] as const)
+    const fromImport = imported && imported.workflowId === editingId ? imported.requirements : []
     const derived = requirementsOfDefinition(nodes)
     const seen = new Set(derived.map((requirement) => requirement.nodeId))
     const all = [...derived, ...fromImport.filter((entry) => !seen.has(entry.nodeId))]

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -30,9 +30,7 @@ import {
   WorkflowNodeErrorPolicy,
   WorkflowEdge,
   WorkflowTemplate,
-  ConnectorCatalogItem,
   InstalledConnectorPack,
-  McpServerCatalogEntry,
   NodeExecutionStatus,
   WorkflowExecution,
   TriggerConfig,
@@ -87,6 +85,7 @@ import {
 } from '../../lib/workflow-execution'
 import { toast } from '../Toast'
 import { refreshConnections, useConnections } from '../../lib/use-connections'
+import { useConnectorCatalog } from '../../lib/use-connector-catalog'
 import { describeRequirement, fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
 import {
   connectorSuggestions,
@@ -155,14 +154,11 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const [pendingInsert, setPendingInsert] = useState<InsertAnchor | null>(null)
   const [showRunHistory, setShowRunHistory] = useState(false)
   const [showStartFrom, setShowStartFrom] = useState(true)
-  const [templates, setTemplates] = useState<WorkflowTemplate[]>([])
   const [connectors, setConnectors] = useState<ConnectorInfo[]>([])
   /** The connector a requirement asked to connect, and the profile it asked for. */
   const [connectFor, setConnectFor] = useState<ConnectorListing | null>(null)
   const [profileFor, setProfileFor] = useState<string | null>(null)
-  const [catalog, setCatalog] = useState<ConnectorCatalogItem[]>([])
   const [packs, setPacks] = useState<InstalledConnectorPack[]>([])
-  const [mcpServers, setMcpServers] = useState<McpServerCatalogEntry[]>([])
   const [launchingSince, setLaunchingSince] = useState<number | null>(null)
   const [followRunId, setFollowRunId] = useState<string | null>(null)
   const followArmRef = useRef(false)
@@ -654,21 +650,14 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   // left needs — without it a row could name a connector but never offer it.
   const needsConnectorData = !editingId || imported?.workflowId === editingId
 
-  // Optional calls: a build without a catalog costs the offer, never the editor.
-  // Keyed on the editor opening: a fetch that lost the startup race against the
-  // server socket must try again the next time someone is actually looking.
-  useEffect(() => {
-    if (!isActive || !needsConnectorData || templates.length > 0) return
-    void Promise.resolve(window.api?.listConnectorCatalog?.())
-      .then((snapshot) => {
-        setTemplates(snapshot?.templates ?? [])
-        // Kept as well as the templates: what a requirement can offer to do
-        // about itself is a question about the catalog.
-        setCatalog(snapshot?.items ?? [])
-        setMcpServers(snapshot?.mcpServers ?? [])
-      })
-      .catch(() => {})
-  }, [isActive, needsConnectorData, templates.length])
+  // The one catalog the settings list also reads, asked for only while someone
+  // is looking: a fetch that lost the startup race against the server socket
+  // caches nothing, so opening the editor again asks again.
+  const {
+    items: catalog,
+    templates,
+    mcpServers
+  } = useConnectorCatalog(isActive && needsConnectorData)
 
   useEffect(() => {
     if (!isActive || !needsConnectorData) return
@@ -699,6 +688,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const refreshPacks = useCallback(async () => {
     const list = await window.api.listConnectorPacks?.().catch(() => [])
     setPacks(list ?? [])
+    // What is on disk is also what the library reads to decide whether a step
+    // would install or only connect, so the shared cache is told too.
+    await refreshConnections()
   }, [])
   const install = usePackInstall(refreshPacks)
 

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -646,9 +646,25 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   // against this machine each render, so answering one clears its row.
   const imported = useAppStore((s) => s.importedRequirements)
   const setImportedRequirements = useAppStore((s) => s.setImportedRequirements)
-  // The start-from list needs the catalog, and so does a workflow whose import
-  // left needs — without it a row could name a connector but never offer it.
-  const needsConnectorData = !editingId || imported?.workflowId === editingId
+  /**
+   * Everything the canvas is still missing, however it got here.
+   *
+   * An import announces its needs; a step picked from a connector nobody has
+   * installed simply sits there unbound. Both are the same question, so they
+   * are answered by one list of rows, merged per step so the import keeps what
+   * only it knows — which connector, and which account it was pointed at.
+   */
+  const stillNeeded = useMemo(() => {
+    const fromImport = imported && imported.workflowId === editingId ? imported.requirements : []
+    const all = mergeRequirements(requirementsOfDefinition(nodes), fromImport)
+    return requirementsWithBindings(all, connections).filter(
+      (entry) => entry.connectionId === undefined
+    )
+  }, [imported, editingId, connections, nodes])
+  // Dismiss means "stop asking about the import"; a row the canvas derives is a live fact until the step is bound.
+  const importContributed = imported !== null && imported.workflowId === editingId
+  // The start-from list needs the catalog, and so does any row that must offer an install or a connection.
+  const needsConnectorData = !editingId || importContributed || stillNeeded.length > 0
 
   // The one catalog the settings list also reads, asked for only while someone
   // is looking: a fetch that lost the startup race against the server socket
@@ -702,22 +718,6 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     },
     [install]
   )
-
-  /**
-   * Everything the canvas is still missing, however it got here.
-   *
-   * An import announces its needs; a step picked from a connector nobody has
-   * installed simply sits there unbound. Both are the same question, so they
-   * are answered by one list of rows, merged per step so the import keeps what
-   * only it knows — which connector, and which account it was pointed at.
-   */
-  const stillNeeded = useMemo(() => {
-    const fromImport = imported && imported.workflowId === editingId ? imported.requirements : []
-    const all = mergeRequirements(requirementsOfDefinition(nodes), fromImport)
-    return requirementsWithBindings(all, connections).filter(
-      (entry) => entry.connectionId === undefined
-    )
-  }, [imported, editingId, connections, nodes])
 
   /** Nothing half-opened survives leaving the panel that opened it. */
   const closeStartFrom = useCallback(() => {
@@ -1594,13 +1594,15 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
             <div className="w-[280px] border-l border-white/[0.08] bg-surface-node flex flex-col h-full overflow-y-auto titlebar-no-drag">
               <div className="px-4 py-3 border-b border-white/[0.08] flex items-center justify-between">
                 <span className="text-[13px] font-medium text-white">Still needs</span>
-                <button
-                  aria-label="Dismiss"
-                  onClick={() => setImportedRequirements(null)}
-                  className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
-                >
-                  <X size={14} />
-                </button>
+                {importContributed && (
+                  <button
+                    aria-label="Dismiss"
+                    onClick={() => setImportedRequirements(null)}
+                    className="p-1 rounded-md text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
               </div>
               {install.error && (
                 <div className="px-4 py-2 border-b border-white/[0.08] text-[11px] text-danger">

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -90,6 +90,7 @@ import { refreshConnections, useConnections } from '../../lib/use-connections'
 import { describeRequirement, fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
 import {
   connectorSuggestions,
+  mergeRequirements,
   requirementsOfDefinition,
   requirementsWithBindings,
   templateSeed,
@@ -715,14 +716,12 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
    *
    * An import announces its needs; a step picked from a connector nobody has
    * installed simply sits there unbound. Both are the same question, so they
-   * are answered by one list of rows — deduped by step, since an imported
-   * requirement and the unbound step it describes are the same gap named twice.
+   * are answered by one list of rows, merged per step so the import keeps what
+   * only it knows — which connector, and which account it was pointed at.
    */
   const stillNeeded = useMemo(() => {
     const fromImport = imported && imported.workflowId === editingId ? imported.requirements : []
-    const derived = requirementsOfDefinition(nodes)
-    const seen = new Set(derived.map((requirement) => requirement.nodeId))
-    const all = [...derived, ...fromImport.filter((entry) => !seen.has(entry.nodeId))]
+    const all = mergeRequirements(requirementsOfDefinition(nodes), fromImport)
     return requirementsWithBindings(all, connections).filter(
       (entry) => entry.connectionId === undefined
     )

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -705,9 +705,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   const handleConnected = useCallback(() => {
     setConnectFor(null)
     setProfileFor(null)
-    // The shared cache is what every glyph and picker reads; refreshing it here
-    // means a new connection shows up without waiting for a config round trip.
-    void refreshConnections()
+    // The shared cache is what every glyph and picker reads, so a new connection shows up at once.
     void refreshConnections()
   }, [])
 

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -38,6 +38,7 @@ import {
   TriggerConfig,
   AiAgentType,
   CallConnectorActionConfig,
+  HttpRequestConfig,
   ConnectorActionDef,
   supportsExactSessionResume,
   getProjectRemoteHostId
@@ -89,6 +90,8 @@ import { refreshConnections, useConnections } from '../../lib/use-connections'
 import { describeRequirement, fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
 import {
   connectorSuggestions,
+  requirementsOfDefinition,
+  requirementsWithBindings,
   templateSeed,
   type ConnectorSuggestion,
   type RequirementAction
@@ -110,7 +113,6 @@ function connectorFor(
 }
 import { StartFromPanel } from './panels/StartFromPanel'
 import { RequirementRow } from './panels/RequirementRow'
-import { resolveRequirement } from '../../../shared/workflow-portability'
 import {
   slugify,
   ensureUniqueSlug,
@@ -708,15 +710,24 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     [install]
   )
 
-  const importedPending = useMemo(() => {
-    if (!imported || imported.workflowId !== editingId) return []
-    return imported.requirements
-      .map((requirement) => {
-        const connectionId = resolveRequirement(requirement, connections)
-        return connectionId === undefined ? { requirement } : { requirement, connectionId }
-      })
-      .filter((entry) => entry.connectionId === undefined)
-  }, [imported, editingId, connections])
+  /**
+   * Everything the canvas is still missing, however it got here.
+   *
+   * An import announces its needs; a step picked from a connector nobody has
+   * installed simply sits there unbound. Both are the same question, so they
+   * are answered by one list of rows — deduped by step, since an imported
+   * requirement and the unbound step it describes are the same gap named twice.
+   */
+  const stillNeeded = useMemo(() => {
+    const fromImport =
+      imported && imported.workflowId === editingId ? imported.requirements : ([] as const)
+    const derived = requirementsOfDefinition(nodes)
+    const seen = new Set(derived.map((requirement) => requirement.nodeId))
+    const all = [...derived, ...fromImport.filter((entry) => !seen.has(entry.nodeId))]
+    return requirementsWithBindings(all, connections).filter(
+      (entry) => entry.connectionId === undefined
+    )
+  }, [imported, editingId, connections, nodes])
 
   /** Nothing half-opened survives leaving the panel that opened it. */
   const closeStartFrom = useCallback(() => {
@@ -830,7 +841,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
       afterNodeId: string,
       beforeNodeId: string | null,
       type: AddableNodeType,
-      preset?: Partial<CallConnectorActionConfig>
+      // A step can arrive already knowing part of its own configuration: which
+      // action it is, or which profile it calls.
+      preset?: Partial<CallConnectorActionConfig> | Partial<HttpRequestConfig>
     ) => {
       // Condition nodes use a special insertion that creates true/false branches
       if (type === 'condition') {
@@ -847,7 +860,10 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
 
       const created = createNodeWithUniqueSlug(type)
       const newNode = preset
-        ? { ...created, config: { ...(created.config as CallConnectorActionConfig), ...preset } }
+        ? ({
+            ...created,
+            config: { ...(created.config as Record<string, unknown>), ...preset }
+          } as WorkflowNode)
         : created
 
       let result: { nodes: WorkflowNode[]; edges: WorkflowEdge[] }
@@ -966,21 +982,32 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         return
       }
 
+      /** A step that arrives knowing something about itself, dropped where asked. */
+      const preset = (type: AddableNodeType, config: Record<string, unknown>): WorkflowNode => {
+        const n = createNodeWithUniqueSlug(type)
+        return {
+          ...n,
+          config: { ...(n.config as Record<string, unknown>), ...config }
+        } as WorkflowNode
+      }
+
       const newNode =
         pick.kind === 'connectorAction'
-          ? (() => {
-              const n = createNodeWithUniqueSlug('connectorAction')
-              return {
-                ...n,
-                config: {
-                  ...(n.config as CallConnectorActionConfig),
-                  connectionId: pick.connectionId,
-                  action: pick.action,
-                  actionLabel: pick.actionLabel
-                }
-              }
-            })()
-          : createNodeWithUniqueSlug(pick.type)
+          ? preset('connectorAction', {
+              connectionId: pick.connectionId,
+              action: pick.action,
+              actionLabel: pick.actionLabel
+            })
+          : pick.kind === 'catalogAction'
+            ? preset('connectorAction', {
+                connectionId: '',
+                connectorId: pick.connectorId,
+                action: pick.action,
+                actionLabel: pick.actionLabel
+              })
+            : pick.kind === 'httpProfile'
+              ? preset('httpRequest', { profileConnectionId: pick.profileConnectionId })
+              : createNodeWithUniqueSlug(pick.type)
 
       const result = appendNodeAfter(nodes, edges, afterNodeId, newNode)
       setNodes(placeAll(result.nodes, result.edges, newNode.id))
@@ -1100,6 +1127,19 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, 'connectorAction', {
           connectionId: pick.connectionId,
           action: pick.action
+        })
+      } else if (pick.kind === 'catalogAction') {
+        // Nothing to bind it to yet: it lands naming what it is, and the panel
+        // that lists what is still needed offers the install.
+        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, 'connectorAction', {
+          connectionId: '',
+          connectorId: pick.connectorId,
+          action: pick.action,
+          actionLabel: pick.actionLabel
+        })
+      } else if (pick.kind === 'httpProfile') {
+        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, 'httpRequest', {
+          profileConnectionId: pick.profileConnectionId
         })
       } else {
         handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, pick.type)
@@ -1551,7 +1591,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           </StartFromPanel>
         )}
 
-        {/* An imported workflow says what it could not bind, with the same
+        {/* Whatever the canvas cannot run yet — an import's leftovers, or a step
+            picked from a connector that is not installed — with the same
             actions the template rows offer. */}
         {/* One occupant of the slot, on the same terms as the rest: the panels
             that answer a selection or a run outrank an import's leftovers. */}
@@ -1559,7 +1600,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
           !pendingInsert &&
           !showRunHistory &&
           !selectedNode &&
-          importedPending.length > 0 && (
+          stillNeeded.length > 0 && (
             <div className="w-[280px] border-l border-white/[0.08] bg-surface-node flex flex-col h-full overflow-y-auto titlebar-no-drag">
               <div className="px-4 py-3 border-b border-white/[0.08] flex items-center justify-between">
                 <span className="text-[13px] font-medium text-white">Still needs</span>
@@ -1615,7 +1656,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
                 </div>
               )}
               <div className="py-2">
-                {importedPending.map((entry) => (
+                {stillNeeded.map((entry) => (
                   <RequirementRow
                     key={entry.requirement.nodeId + entry.requirement.kind}
                     requirement={entry}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -30,7 +30,6 @@ import {
   WorkflowNodeErrorPolicy,
   WorkflowEdge,
   WorkflowTemplate,
-  InstalledConnectorPack,
   NodeExecutionStatus,
   WorkflowExecution,
   TriggerConfig,
@@ -43,6 +42,7 @@ import {
 } from '../../../shared/types'
 import { WorkflowCanvas, AddableNodeType, InsertAnchor } from './WorkflowCanvas'
 import { StepLibrary, type LibraryPick } from './panels/StepLibrary'
+import { stepForPick } from '../../lib/library-pick'
 import {
   alignedNodes,
   layoutPositions,
@@ -84,7 +84,7 @@ import {
   stopWorkflowRun
 } from '../../lib/workflow-execution'
 import { toast } from '../Toast'
-import { refreshConnections, useConnections } from '../../lib/use-connections'
+import { refreshConnections, useConnections, useInstalledPacks } from '../../lib/use-connections'
 import { useConnectorCatalog } from '../../lib/use-connector-catalog'
 import { describeRequirement, fileFromWorkflow, projectForWorkflow } from '../../lib/workflow-files'
 import {
@@ -158,7 +158,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   /** The connector a requirement asked to connect, and the profile it asked for. */
   const [connectFor, setConnectFor] = useState<ConnectorListing | null>(null)
   const [profileFor, setProfileFor] = useState<string | null>(null)
-  const [packs, setPacks] = useState<InstalledConnectorPack[]>([])
+  const packs = useInstalledPacks()
   const [launchingSince, setLaunchingSince] = useState<number | null>(null)
   const [followRunId, setFollowRunId] = useState<string | null>(null)
   const followArmRef = useRef(false)
@@ -646,14 +646,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   // against this machine each render, so answering one clears its row.
   const imported = useAppStore((s) => s.importedRequirements)
   const setImportedRequirements = useAppStore((s) => s.setImportedRequirements)
-  /**
-   * Everything the canvas is still missing, however it got here.
-   *
-   * An import announces its needs; a step picked from a connector nobody has
-   * installed simply sits there unbound. Both are the same question, so they
-   * are answered by one list of rows, merged per step so the import keeps what
-   * only it knows — which connector, and which account it was pointed at.
-   */
+  // Everything the canvas is still missing, however it got here.
   const stillNeeded = useMemo(() => {
     const fromImport = imported && imported.workflowId === editingId ? imported.requirements : []
     const all = mergeRequirements(requirementsOfDefinition(nodes), fromImport)
@@ -663,31 +656,16 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   }, [imported, editingId, connections, nodes])
   // Dismiss means "stop asking about the import"; a row the canvas derives is a live fact until the step is bound.
   const importContributed = imported !== null && imported.workflowId === editingId
-  // The start-from list needs the catalog, and so does any row that must offer an install or a connection.
-  const needsConnectorData = !editingId || importContributed || stillNeeded.length > 0
 
-  // The one catalog the settings list also reads, asked for only while someone
-  // is looking: a fetch that lost the startup race against the server socket
-  // caches nothing, so opening the editor again asks again.
-  const {
-    items: catalog,
-    templates,
-    mcpServers
-  } = useConnectorCatalog(isActive && needsConnectorData)
+  // Asked for only while someone is looking; a fetch that lost the startup race caches nothing, so opening again asks again.
+  const { items: catalog, templates, mcpServers } = useConnectorCatalog(isActive)
 
   useEffect(() => {
-    if (!isActive || !needsConnectorData) return
-    void Promise.resolve(window.api?.listConnectorPacks?.())
-      .then((list) => setPacks(list ?? []))
-      .catch(() => {})
-  }, [isActive, needsConnectorData])
-
-  useEffect(() => {
-    if (!isActive || !needsConnectorData) return
+    if (!isActive) return
     void Promise.resolve(window.api?.listConnectors?.())
       .then((list) => setConnectors(list ?? []))
       .catch(() => {})
-  }, [isActive, needsConnectorData])
+  }, [isActive])
 
   const suggestions = useMemo(
     () => connectorSuggestions(connections, connectors),
@@ -701,14 +679,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
   )
 
   // The same inspect-then-confirm the directory uses, run from the panel.
-  const refreshPacks = useCallback(async () => {
-    const list = await window.api.listConnectorPacks?.().catch(() => [])
-    setPacks(list ?? [])
-    // What is on disk is also what the library reads to decide whether a step
-    // would install or only connect, so the shared cache is told too.
-    await refreshConnections()
-  }, [])
-  const install = usePackInstall(refreshPacks)
+  const install = usePackInstall(refreshConnections)
 
   const handleFixRequirement = useCallback(
     (action: RequirementAction) => {
@@ -737,8 +708,8 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
     // The shared cache is what every glyph and picker reads; refreshing it here
     // means a new connection shows up without waiting for a config round trip.
     void refreshConnections()
-    void refreshPacks()
-  }, [refreshPacks])
+    void refreshConnections()
+  }, [])
 
   /** The server builds these from the connector's own manifest, and repeats are the same workflow. */
   const handlePickSuggestion = useCallback(
@@ -972,32 +943,14 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         return
       }
 
-      /** A step that arrives knowing something about itself, dropped where asked. */
-      const preset = (type: AddableNodeType, config: Record<string, unknown>): WorkflowNode => {
-        const n = createNodeWithUniqueSlug(type)
-        return {
-          ...n,
-          config: { ...(n.config as Record<string, unknown>), ...config }
-        } as WorkflowNode
-      }
-
-      const newNode =
-        pick.kind === 'connectorAction'
-          ? preset('connectorAction', {
-              connectionId: pick.connectionId,
-              action: pick.action,
-              actionLabel: pick.actionLabel
-            })
-          : pick.kind === 'catalogAction'
-            ? preset('connectorAction', {
-                connectionId: '',
-                connectorId: pick.connectorId,
-                action: pick.action,
-                actionLabel: pick.actionLabel
-              })
-            : pick.kind === 'httpProfile'
-              ? preset('httpRequest', { profileConnectionId: pick.profileConnectionId })
-              : createNodeWithUniqueSlug(pick.type)
+      const { type, config } = stepForPick(pick)
+      const created = createNodeWithUniqueSlug(type)
+      const newNode = config
+        ? ({
+            ...created,
+            config: { ...(created.config as Record<string, unknown>), ...config }
+          } as WorkflowNode)
+        : created
 
       const result = appendNodeAfter(nodes, edges, afterNodeId, newNode)
       setNodes(placeAll(result.nodes, result.edges, newNode.id))
@@ -1027,8 +980,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
                 event: pick.event,
                 cron: '*/5 * * * *'
               }
-        // A pick replaces the existing trigger in place; edges stay put,
-        // while the label resets to the new type's default like any swap.
+        // A pick replaces the existing trigger in place; edges stay put, while the label resets to the new type's default.
         const existing = nodes.find((n) => n.type === 'trigger')
         if (existing) {
           const cur = existing.config as TriggerConfig
@@ -1113,26 +1065,9 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
         handleAddParallelBranch(anchor.afterNodeId, 'agent')
       } else if (anchor.position && anchor.beforeNodeId === null) {
         handlePaletteInsert(pick, anchor.afterNodeId, anchor.position)
-      } else if (pick.kind === 'connectorAction') {
-        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, 'connectorAction', {
-          connectionId: pick.connectionId,
-          action: pick.action
-        })
-      } else if (pick.kind === 'catalogAction') {
-        // Nothing to bind it to yet: it lands naming what it is, and the panel
-        // that lists what is still needed offers the install.
-        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, 'connectorAction', {
-          connectionId: '',
-          connectorId: pick.connectorId,
-          action: pick.action,
-          actionLabel: pick.actionLabel
-        })
-      } else if (pick.kind === 'httpProfile') {
-        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, 'httpRequest', {
-          profileConnectionId: pick.profileConnectionId
-        })
       } else {
-        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, pick.type)
+        const { type, config } = stepForPick(pick)
+        handleInsertNode(anchor.afterNodeId, anchor.beforeNodeId, type, config)
       }
     },
     [

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -2,14 +2,41 @@ import { useEffect, useState } from 'react'
 import type {
   CallConnectorActionConfig,
   ConnectorActionDef,
+  ConnectorCatalogActionInput,
   ConnectorConfigField,
   TriggerConfig
 } from '../../../../shared/types'
 import { SelectPicker } from '../../SelectPicker'
 import { ConnectorIcon } from '../../ConnectorIcon'
 import { useConnections, iconForConnection } from '../../../lib/use-connections'
+import { useConnectorCatalog } from '../../../lib/use-connector-catalog'
 import { TEMPLATE_VARIABLES, StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 import { VariableAutocomplete } from './VariableAutocomplete'
+
+/**
+ * A published argument, in the shape this form already draws.
+ *
+ * The connector describes an argument once; it reaches the app as a tool schema
+ * when a connection exists and as a catalog entry when one does not. Mapping
+ * the second onto the first is what keeps a step from looking like a different
+ * step before and after it is installed.
+ */
+function asConfigField(input: ConnectorCatalogActionInput): ConnectorConfigField {
+  const type: ConnectorConfigField['type'] =
+    input.type === 'select' ? 'select' : input.type === 'json' ? 'textarea' : 'text'
+  return {
+    key: input.key,
+    label: input.label,
+    type,
+    required: input.required,
+    ...(input.options && {
+      options: input.options.map((option) => ({
+        value: option.value,
+        label: option.label ?? option.value
+      }))
+    })
+  }
+}
 
 interface Props {
   config: CallConnectorActionConfig
@@ -146,7 +173,18 @@ export function CallConnectorActionNodeForm({
     (a) => a.type === config.action
   )
 
-  const argFields = selectedAction?.configFields ?? []
+  // A step picked from the catalog has no connection to ask, so its arguments
+  // come from what the catalog published — the same description the connector
+  // will serve once it is installed, so the form does not change under you.
+  const catalog = useConnectorCatalog()
+  const awaited =
+    !config.connectionId && config.connectorId
+      ? catalog.items
+          .find((entry) => entry.id === config.connectorId)
+          ?.actions?.find((action) => action.type === config.action)
+      : undefined
+
+  const argFields = selectedAction?.configFields ?? (awaited?.inputs ?? []).map(asConfigField)
 
   return (
     <div className="space-y-5">
@@ -170,10 +208,17 @@ export function CallConnectorActionNodeForm({
           variant="form"
           placeholder="Select a connection..."
         />
-        {connections.length === 0 && (
+        {awaited ? (
           <p className="text-[11px] text-gray-500 mt-1.5">
-            No connections yet. Add one from Settings › Connectors first.
+            {config.actionLabel || config.action} comes from a connector that is not installed yet —
+            the workflow panel offers to install and connect it.
           </p>
+        ) : (
+          connections.length === 0 && (
+            <p className="text-[11px] text-gray-500 mt-1.5">
+              No connections yet. Add one from Settings › Connectors first.
+            </p>
+          )
         )}
       </div>
 

--- a/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type {
   CallConnectorActionConfig,
   ConnectorActionDef,
@@ -13,14 +13,7 @@ import { useConnectorCatalog } from '../../../lib/use-connector-catalog'
 import { TEMPLATE_VARIABLES, StepVariableGroup, TemplateVariable } from '../../../lib/template-vars'
 import { VariableAutocomplete } from './VariableAutocomplete'
 
-/**
- * A published argument, in the shape this form already draws.
- *
- * The connector describes an argument once; it reaches the app as a tool schema
- * when a connection exists and as a catalog entry when one does not. Mapping
- * the second onto the first is what keeps a step from looking like a different
- * step before and after it is installed.
- */
+// A published argument, in the shape this form already draws.
 function asConfigField(input: ConnectorCatalogActionInput): ConnectorConfigField {
   const type: ConnectorConfigField['type'] =
     input.type === 'select' ? 'select' : input.type === 'json' ? 'textarea' : 'text'
@@ -173,18 +166,17 @@ export function CallConnectorActionNodeForm({
     (a) => a.type === config.action
   )
 
-  // A step picked from the catalog has no connection to ask, so its arguments
-  // come from what the catalog published — the same description the connector
-  // will serve once it is installed, so the form does not change under you.
-  const catalog = useConnectorCatalog()
-  const awaited =
-    !config.connectionId && config.connectorId
-      ? catalog.items
-          .find((entry) => entry.id === config.connectorId)
-          ?.actions?.find((action) => action.type === config.action)
-      : undefined
-
-  const argFields = selectedAction?.configFields ?? (awaited?.inputs ?? []).map(asConfigField)
+  // A step picked from the catalog has no connection to ask, so its arguments come from what the catalog published.
+  const unbound = !config.connectionId && Boolean(config.connectorId)
+  const catalog = useConnectorCatalog(unbound)
+  const argFields = useMemo(() => {
+    if (selectedAction?.configFields) return selectedAction.configFields
+    if (!unbound) return []
+    const awaited = catalog.items
+      .find((entry) => entry.id === config.connectorId)
+      ?.actions?.find((action) => action.type === config.action)
+    return (awaited?.inputs ?? []).map(asConfigField)
+  }, [selectedAction, unbound, catalog.items, config.connectorId, config.action])
 
   return (
     <div className="space-y-5">
@@ -208,7 +200,7 @@ export function CallConnectorActionNodeForm({
           variant="form"
           placeholder="Select a connection..."
         />
-        {awaited ? (
+        {unbound ? (
           <p className="text-[11px] text-gray-500 mt-1.5">
             {config.actionLabel || config.action} comes from a connector that is not installed yet —
             the workflow panel offers to install and connect it.

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -19,6 +19,7 @@ import type { LucideIcon } from 'lucide-react'
 import type {
   ConnectorActionDef,
   ConnectorManifest,
+  SdkConnectorIcon,
   SourceConnection,
   TriggerConfig
 } from '../../../../shared/types'
@@ -27,6 +28,9 @@ import {
   useConnectorIdFor,
   useConnectionIconFor
 } from '../../../lib/use-connections'
+import { useConnectorCatalog } from '../../../lib/use-connector-catalog'
+import { connectionConnectorId } from '../../../lib/connection-icon'
+import { HTTP_PROFILE_CONNECTOR } from '../../../../shared/workflow-portability'
 import { ConnectorIcon } from '../../ConnectorIcon'
 import { NODE_GLYPH } from '../node-visuals'
 import type { AddableNodeType } from '../WorkflowCanvas'
@@ -38,6 +42,10 @@ export type LibraryPick =
   | { kind: 'connectorAction'; connectionId: string; action: string; actionLabel: string }
   | { kind: 'triggerType'; triggerType: TriggerConfig['triggerType'] }
   | { kind: 'connectorTrigger'; connectionId: string; event: string }
+  /** An action from a connector nobody has installed yet; it lands unbound. */
+  | { kind: 'catalogAction'; connectorId: string; action: string; actionLabel: string }
+  /** An HTTP request with one of the saved profiles already chosen. */
+  | { kind: 'httpProfile'; profileConnectionId: string; profileName: string }
 
 /** What the anchor that opened the library allows. */
 export interface LibraryScope {
@@ -79,14 +87,26 @@ interface Row {
   pick: LibraryPick
   icon?: LucideIcon
   connection?: SourceConnection
+  /** A connector's own mark, for a step that belongs to one nobody has installed. */
+  mark?: { connectorId: string; icon?: SdkConnectorIcon }
+  /** What picking it will also do, said where the eye ends up anyway. */
+  detail?: string
   header?: false
 }
 
+/**
+ * A heading over the rows beneath it.
+ *
+ * A connection's heading names the connection; the catalog's names itself,
+ * because the rows under it belong to no connection yet — which is the whole
+ * difference between what you have and what you could have.
+ */
 interface GroupHeader {
   key: string
   header: true
-  connection: SourceConnection
+  label: string
   count: number
+  connection?: SourceConnection
 }
 
 function ConnectionMark({ connection }: { connection: SourceConnection }) {
@@ -112,6 +132,7 @@ export function StepLibrary({
   const [highlight, setHighlight] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const connections = useConnections()
+  const catalog = useConnectorCatalog()
   const [actionsByConnection, setActionsByConnection] = useState<Map<string, ConnectorActionDef[]>>(
     () => new Map()
   )
@@ -172,6 +193,7 @@ export function StepLibrary({
         rows.push({
           key: `group:${conn.id}`,
           header: true,
+          label: conn.name,
           connection: conn,
           count: triggers.length
         })
@@ -212,6 +234,26 @@ export function StepLibrary({
         pick: { kind: 'parallel' }
       })
     }
+
+    // A saved profile is an HTTP request with the hard part already answered,
+    // so it sits directly beneath the request rather than inside a form field.
+    if (!scope.bodyOnly) {
+      const profiles: Row[] = connections
+        .filter((c) => c.connectorId === HTTP_PROFILE_CONNECTOR)
+        .map((profile) => ({
+          key: `profile:${profile.id}`,
+          label: `Call ${profile.name}`,
+          icon: Globe,
+          pick: {
+            kind: 'httpProfile' as const,
+            profileConnectionId: profile.id,
+            profileName: profile.name
+          }
+        }))
+        .filter((row) => !q || row.label.toLowerCase().includes(q))
+      const afterHttp = steps.findIndex((s) => s.key === 'type:httpRequest')
+      steps.splice(afterHttp >= 0 ? afterHttp + 1 : steps.length, 0, ...profiles)
+    }
     if (steps.length > 0) rows.push(...steps)
 
     if (!scope.bodyOnly) {
@@ -226,6 +268,7 @@ export function StepLibrary({
         rows.push({
           key: `group:${conn.id}`,
           header: true,
+          label: conn.name,
           connection: conn,
           count: actions.length
         })
@@ -245,8 +288,58 @@ export function StepLibrary({
       }
     }
 
+    // Steps from connectors nobody has installed. The catalog describes an
+    // action well enough to offer it, so search answers with the step you asked
+    // for rather than with silence and a trip to Settings.
+    if (!scope.bodyOnly) {
+      const connected = new Set(connections.map((conn) => connectionConnectorId(conn)))
+      const offers = catalog.items
+        .filter((entry) => !connected.has(entry.id) && (entry.actions?.length ?? 0) > 0)
+        .map((entry) => ({
+          entry,
+          actions: (entry.actions ?? []).filter(
+            (action) =>
+              !q ||
+              (action.label || action.type).toLowerCase().includes(q) ||
+              entry.name.toLowerCase().includes(q) ||
+              (entry.keywords ?? []).some((word) => word.toLowerCase().includes(q))
+          )
+        }))
+        .filter((offer) => offer.actions.length > 0)
+
+      const rowFor = (
+        entry: (typeof offers)[number]['entry'],
+        action: { type: string; label: string }
+      ) => ({
+        key: `catalog:${entry.id}:${action.type}`,
+        label: action.label || action.type,
+        mark: { connectorId: entry.id, ...(entry.icon && { icon: entry.icon }) },
+        detail: 'install on add',
+        pick: {
+          kind: 'catalogAction' as const,
+          connectorId: entry.id,
+          action: action.type,
+          actionLabel: action.label || action.type
+        }
+      })
+
+      // A connector the factory checked is offered as plainly as an installed
+      // one; the rest are worth finding, but not worth putting first.
+      for (const offer of offers.filter((o) => o.entry.verified)) {
+        rows.push(...offer.actions.map((action) => rowFor(offer.entry, action)))
+      }
+      const unvouched = offers.filter((o) => !o.entry.verified)
+      const count = unvouched.reduce((total, offer) => total + offer.actions.length, 0)
+      if (count > 0) {
+        rows.push({ key: 'group:catalog', header: true, label: 'More from the catalog', count })
+        for (const offer of unvouched) {
+          rows.push(...offer.actions.map((action) => rowFor(offer.entry, action)))
+        }
+      }
+    }
+
     return { rows, pickable: rows.filter((r): r is Row => !('header' in r && r.header)) }
-  }, [query, scope, connections, actionsByConnection, manifestsByConnector])
+  }, [query, scope, connections, actionsByConnection, manifestsByConnector, catalog])
 
   const clamped = Math.min(highlight, Math.max(0, pickable.length - 1))
 
@@ -313,9 +406,9 @@ export function StepLibrary({
             if ('header' in row && row.header) {
               return (
                 <div key={row.key} className="flex items-center gap-2 px-2 pt-3 pb-1">
-                  <ConnectionMark connection={row.connection} />
+                  {row.connection && <ConnectionMark connection={row.connection} />}
                   <span className="text-[12px] font-semibold text-ink-secondary truncate">
-                    {row.connection.name}
+                    {row.label}
                   </span>
                   <span className="ml-auto text-[10px] font-mono text-gray-600">{row.count}</span>
                 </div>
@@ -333,7 +426,18 @@ export function StepLibrary({
                           ${index === clamped ? 'bg-white/[0.06] text-white' : 'text-gray-300'}`}
               >
                 {Icon && <Icon size={14} className={`${NODE_GLYPH} shrink-0`} />}
+                {row.mark && (
+                  <ConnectorIcon
+                    connectorId={row.mark.connectorId}
+                    icon={row.mark.icon}
+                    size={14}
+                    className="text-ink shrink-0"
+                  />
+                )}
                 <span className="truncate">{row.label}</span>
+                {row.detail && (
+                  <span className="ml-auto shrink-0 text-[10px] text-gray-600">{row.detail}</span>
+                )}
               </button>
             )
           })

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -26,7 +26,8 @@ import type {
 import {
   useConnections,
   useConnectorIdFor,
-  useConnectionIconFor
+  useConnectionIconFor,
+  useInstalledPacks
 } from '../../../lib/use-connections'
 import { useConnectorCatalog } from '../../../lib/use-connector-catalog'
 import { connectionConnectorId } from '../../../lib/connection-icon'
@@ -132,6 +133,7 @@ export function StepLibrary({
   const [highlight, setHighlight] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const connections = useConnections()
+  const packs = useInstalledPacks()
   const catalog = useConnectorCatalog()
   const [actionsByConnection, setActionsByConnection] = useState<Map<string, ConnectorActionDef[]>>(
     () => new Map()
@@ -237,7 +239,7 @@ export function StepLibrary({
 
     // A saved profile is an HTTP request with the hard part already answered,
     // so it sits directly beneath the request rather than inside a form field.
-    if (!scope.bodyOnly) {
+    if (!scope.bodyOnly && !scope.replacing) {
       const profiles: Row[] = connections
         .filter((c) => c.connectorId === HTTP_PROFILE_CONNECTOR)
         .map((profile) => ({
@@ -288,11 +290,15 @@ export function StepLibrary({
       }
     }
 
-    // Steps from connectors nobody has installed. The catalog describes an
+    // Steps from connectors nobody has connected. The catalog describes an
     // action well enough to offer it, so search answers with the step you asked
     // for rather than with silence and a trip to Settings.
-    if (!scope.bodyOnly) {
+    //
+    // Not while replacing: swapping a step in place takes the pick apart and
+    // rebuilds the node, and neither of these picks survives that.
+    if (!scope.bodyOnly && !scope.replacing) {
       const connected = new Set(connections.map((conn) => connectionConnectorId(conn)))
+      const installed = new Set(packs.map((pack) => pack.id))
       const offers = catalog.items
         .filter((entry) => !connected.has(entry.id) && (entry.actions?.length ?? 0) > 0)
         .map((entry) => ({
@@ -314,7 +320,13 @@ export function StepLibrary({
         key: `catalog:${entry.id}:${action.type}`,
         label: action.label || action.type,
         mark: { connectorId: entry.id, ...(entry.icon && { icon: entry.icon }) },
-        detail: 'install on add',
+        // Say the step someone is actually about to take: a connector already
+        // on disk only wants connecting, and promising an install would be a
+        // small lie repeated on every row.
+        detail:
+          !installed.has(entry.id) && (entry.packUrl || entry.packageName)
+            ? 'install on add'
+            : 'add connection',
         pick: {
           kind: 'catalogAction' as const,
           connectorId: entry.id,
@@ -339,7 +351,7 @@ export function StepLibrary({
     }
 
     return { rows, pickable: rows.filter((r): r is Row => !('header' in r && r.header)) }
-  }, [query, scope, connections, actionsByConnection, manifestsByConnector, catalog])
+  }, [query, scope, connections, packs, actionsByConnection, manifestsByConnector, catalog])
 
   const clamped = Math.min(highlight, Math.max(0, pickable.length - 1))
 

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -34,19 +34,11 @@ import { connectionConnectorId } from '../../../lib/connection-icon'
 import { HTTP_PROFILE_CONNECTOR } from '../../../../shared/workflow-portability'
 import { ConnectorIcon } from '../../ConnectorIcon'
 import { NODE_GLYPH } from '../node-visuals'
+import { canAddConnection, packStateFor } from '../../../lib/pack-status'
 import type { AddableNodeType } from '../WorkflowCanvas'
+import type { LibraryPick } from '../../../lib/library-pick'
 
-/** A step type, a parallel branch, a connector action, or a trigger. */
-export type LibraryPick =
-  | { kind: 'type'; type: AddableNodeType }
-  | { kind: 'parallel' }
-  | { kind: 'connectorAction'; connectionId: string; action: string; actionLabel: string }
-  | { kind: 'triggerType'; triggerType: TriggerConfig['triggerType'] }
-  | { kind: 'connectorTrigger'; connectionId: string; event: string }
-  /** An action from a connector nobody has installed yet; it lands unbound. */
-  | { kind: 'catalogAction'; connectorId: string; action: string; actionLabel: string }
-  /** An HTTP request with one of the saved profiles already chosen. */
-  | { kind: 'httpProfile'; profileConnectionId: string; profileName: string }
+export type { LibraryPick } from '../../../lib/library-pick'
 
 /** What the anchor that opened the library allows. */
 export interface LibraryScope {
@@ -241,7 +233,7 @@ export function StepLibrary({
     // so it sits directly beneath the request rather than inside a form field.
     if (!scope.bodyOnly && !scope.replacing) {
       const profiles: Row[] = connections
-        .filter((c) => c.connectorId === HTTP_PROFILE_CONNECTOR)
+        .filter((c) => connectionConnectorId(c) === HTTP_PROFILE_CONNECTOR)
         .map((profile) => ({
           key: `profile:${profile.id}`,
           label: `Call ${profile.name}`,
@@ -290,63 +282,61 @@ export function StepLibrary({
       }
     }
 
-    // Steps from connectors nobody has connected. The catalog describes an
-    // action well enough to offer it, so search answers with the step you asked
-    // for rather than with silence and a trip to Settings.
-    //
-    // Not while replacing: swapping a step in place takes the pick apart and
-    // rebuilds the node, and neither of these picks survives that.
+    // Steps from connectors nobody has connected; not while replacing, which rebuilds the node from the pick.
     if (!scope.bodyOnly && !scope.replacing) {
       const connected = new Set(connections.map((conn) => connectionConnectorId(conn)))
-      const installed = new Set(packs.map((pack) => pack.id))
-      const offers = catalog.items
-        .filter((entry) => !connected.has(entry.id) && (entry.actions?.length ?? 0) > 0)
-        .map((entry) => ({
-          entry,
-          actions: (entry.actions ?? []).filter(
-            (action) =>
-              !q ||
-              (action.label || action.type).toLowerCase().includes(q) ||
-              entry.name.toLowerCase().includes(q) ||
-              (entry.keywords ?? []).some((word) => word.toLowerCase().includes(q))
-          )
-        }))
-        .filter((offer) => offer.actions.length > 0)
-
-      const rowFor = (
-        entry: (typeof offers)[number]['entry'],
-        action: { type: string; label: string }
-      ) => ({
-        key: `catalog:${entry.id}:${action.type}`,
-        label: action.label || action.type,
-        mark: { connectorId: entry.id, ...(entry.icon && { icon: entry.icon }) },
-        // Say the step someone is actually about to take: a connector already
-        // on disk only wants connecting, and promising an install would be a
-        // small lie repeated on every row.
-        detail:
-          !installed.has(entry.id) && (entry.packUrl || entry.packageName)
+      const vouched: Row[] = []
+      const unvouched: Row[] = []
+      for (const entry of catalog.items) {
+        if (connected.has(entry.id) || !entry.actions?.length) continue
+        const entryMatches =
+          !q ||
+          entry.name.toLowerCase().includes(q) ||
+          (entry.keywords ?? []).some((word) => word.toLowerCase().includes(q))
+        const actions = entryMatches
+          ? entry.actions
+          : entry.actions.filter((action) =>
+              (action.label || action.type).toLowerCase().includes(q)
+            )
+        if (actions.length === 0) continue
+        // Say the step someone is about to take: a connector already on disk only wants connecting.
+        const state = packStateFor({ installed: packs.find((pack) => pack.id === entry.id) })
+        const connectable = canAddConnection(state, {
+          source: 'catalog',
+          hasLegacyLaunch: Boolean(entry.packageName)
+        })
+        const detail =
+          state.kind !== 'installed' && entry.packUrl
             ? 'install on add'
-            : 'add connection',
-        pick: {
-          kind: 'catalogAction' as const,
-          connectorId: entry.id,
-          action: action.type,
-          actionLabel: action.label || action.type
+            : connectable
+              ? 'add connection'
+              : 'install on add'
+        const into = entry.verified ? vouched : unvouched
+        for (const action of actions) {
+          into.push({
+            key: `catalog:${entry.id}:${action.type}`,
+            label: action.label || action.type,
+            mark: { connectorId: entry.id, ...(entry.icon && { icon: entry.icon }) },
+            detail,
+            pick: {
+              kind: 'catalogAction' as const,
+              connectorId: entry.id,
+              action: action.type,
+              actionLabel: action.label || action.type
+            }
+          })
         }
-      })
-
-      // A connector the factory checked is offered as plainly as an installed
-      // one; the rest are worth finding, but not worth putting first.
-      for (const offer of offers.filter((o) => o.entry.verified)) {
-        rows.push(...offer.actions.map((action) => rowFor(offer.entry, action)))
       }
-      const unvouched = offers.filter((o) => !o.entry.verified)
-      const count = unvouched.reduce((total, offer) => total + offer.actions.length, 0)
-      if (count > 0) {
-        rows.push({ key: 'group:catalog', header: true, label: 'More from the catalog', count })
-        for (const offer of unvouched) {
-          rows.push(...offer.actions.map((action) => rowFor(offer.entry, action)))
-        }
+      // A connector the factory checked is offered as plainly as an installed one; the rest come after.
+      rows.push(...vouched)
+      if (unvouched.length > 0) {
+        rows.push({
+          key: 'group:catalog',
+          header: true,
+          label: 'More from the catalog',
+          count: unvouched.length
+        })
+        rows.push(...unvouched)
       }
     }
 

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -327,6 +327,10 @@ export interface ConnectionGroup {
  * named after its connector id, with the icon the connection itself stored.
  * Groups keep the order the connections arrive in, which is the order the
  * server returns them.
+ *
+ * A connection the app made for a connector that signs in with nothing is left
+ * out: nobody chose it, there is nothing in it to edit, and deleting it would
+ * only break the connector it was made for.
  */
 export function groupConnections(
   connections: SourceConnection[],
@@ -334,7 +338,7 @@ export function groupConnections(
 ): ConnectionGroup[] {
   const byConnector = new Map<string, ConnectionGroup>()
 
-  for (const conn of connections) {
+  for (const conn of connections.filter((connection) => !isImplicit(connection))) {
     const id = connectionConnectorId(conn)
     const existing = byConnector.get(id)
     if (existing) {

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -8,6 +8,7 @@ import type {
   SdkConnectorIcon,
   SourceConnection
 } from '../../shared/types'
+import { isImplicitConnection } from '../../shared/types'
 import { connectionConnectorId, connectionIcon } from './connection-icon'
 
 /**
@@ -39,19 +40,11 @@ export interface ConnectorListing {
   icon?: SdkConnectorIcon
   /** The pack on disk, when this connector has been installed as one. */
   pack?: InstalledConnectorPack
-  /**
-   * What setting this one up will ask of you. Read from the pack that is on
-   * disk before the catalog's claim about it, since the pack is what runs.
-   * Absent means unknown, which is not the same as `none`.
-   */
+  // What setting this one up will ask of you.
   authRung?: ConnectorAuthRung
   /** What the factory checked, when this connector has been through it. */
   verified?: ConnectorCatalogVerification
-  /**
-   * Connected without anyone being asked to connect it — a connector that
-   * signs in with nothing is ready the moment it is installed. Absent reads as
-   * false, so a listing built by hand says only what it means to say.
-   */
+  // Connected without anyone being asked to connect it — a connector that signs in with nothing is ready the moment it.
   implicitlyConnected?: boolean
 }
 
@@ -157,16 +150,6 @@ export function listingDetails(
 
 const UNCATEGORIZED = 'Other'
 
-/**
- * A connection the app made for a connector that signs in with nothing.
- *
- * It exists so a step still binds to a connection id, and is deliberately not
- * shown: nobody chose it, and nobody can usefully edit it.
- */
-export function isImplicit(connection: SourceConnection): boolean {
-  return connection.filters?.implicit === true
-}
-
 /** What a pack offers, in the vocabulary the catalog uses for the same thing. */
 function packCapabilities(pack: InstalledConnectorPack): string[] {
   return [
@@ -193,11 +176,17 @@ export function buildConnectorListings(
   packs: InstalledConnectorPack[] = [],
   mcpServers: McpServerCatalogEntry[] = []
 ): ConnectorListing[] {
-  const mine = (id: string) => connections.filter((conn) => connectionConnectorId(conn) === id)
-  // Only the connections someone made: an implicit one was never asked for, so
-  // counting it would offer "Add another" for a connector nobody added once.
-  const countFor = (id: string) => mine(id).filter((conn) => !isImplicit(conn)).length
-  const implicitFor = (id: string) => mine(id).some(isImplicit)
+  // One pass over the connections; an implicit one was never asked for, so it is not counted as "another".
+  const owned = new Map<string, { count: number; implicit: boolean }>()
+  for (const conn of connections) {
+    const id = connectionConnectorId(conn)
+    const entry = owned.get(id) ?? { count: 0, implicit: false }
+    if (isImplicitConnection(conn)) entry.implicit = true
+    else entry.count += 1
+    owned.set(id, entry)
+  }
+  const countFor = (id: string) => owned.get(id)?.count ?? 0
+  const implicitFor = (id: string) => owned.get(id)?.implicit ?? false
   const packFor = (id: string) => packs.find((pack) => pack.id === id)
 
   const listings: ConnectorListing[] = [
@@ -287,13 +276,7 @@ export interface ListingSection {
   listings: ConnectorListing[]
 }
 
-/**
- * Cut the list into the sections it already sorts itself into.
- *
- * Categories appear in the order their first connector does, so the ordering
- * the list was sorted by — what you can use right now, then by name — survives
- * being grouped rather than being overruled by an alphabet.
- */
+// Cut the list into the sections it already sorts itself into.
 export function groupListingsByCategory(listings: ConnectorListing[]): ListingSection[] {
   const sections = new Map<string, ConnectorListing[]>()
   for (const listing of listings) {
@@ -338,7 +321,7 @@ export function groupConnections(
 ): ConnectionGroup[] {
   const byConnector = new Map<string, ConnectionGroup>()
 
-  for (const conn of connections.filter((connection) => !isImplicit(connection))) {
+  for (const conn of connections.filter((connection) => !isImplicitConnection(connection))) {
     const id = connectionConnectorId(conn)
     const existing = byConnector.get(id)
     if (existing) {
@@ -413,26 +396,27 @@ export function connectorCategories(listings: ConnectorListing[]): string[] {
   return [...categories, ...facets]
 }
 
-/**
- * What a rung will ask of you, said as the question people actually have.
- *
- * Phrased from the reader's side rather than the manifest's: "signs in with a
- * tool you already use" is the fact that decides whether to click, where
- * "cli" is a word only the person who wrote the connector knows.
- */
-export const AUTH_RUNG_LABEL: Record<ConnectorAuthRung, string> = {
-  none: 'Needs no sign-in',
-  cli: 'Signs in with a CLI',
-  key: 'Needs a key',
-  oauth: 'Signs in through a browser'
-}
-
-/** The short form for a row, where the long one would crowd the facts line. */
-export const AUTH_RUNG_BADGE: Record<ConnectorAuthRung, string> = {
-  none: 'no sign-in',
-  cli: 'CLI login',
-  key: 'key',
-  oauth: 'OAuth'
+// What a rung asks of you, from the reader's side: a filter label, a row badge, and the detail page's sentence.
+export const AUTH_RUNG: Record<
+  ConnectorAuthRung,
+  { label: string; badge: string; detail: string }
+> = {
+  none: {
+    label: 'Needs no sign-in',
+    badge: 'no sign-in',
+    detail: 'Nothing — ready as soon as it is installed.'
+  },
+  cli: {
+    label: 'Signs in with a CLI',
+    badge: 'CLI login',
+    detail: 'Signs in with a CLI'
+  },
+  key: { label: 'Needs a key', badge: 'key', detail: 'Needs a key' },
+  oauth: {
+    label: 'Signs in through a browser',
+    badge: 'OAuth',
+    detail: 'Signs in through a browser'
+  }
 }
 
 /** The rungs actually present, so the filter never offers an empty answer. */

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -1,5 +1,8 @@
 import type {
+  ConnectorAuthRung,
+  ConnectorCatalogActionInput,
   ConnectorCatalogItem,
+  ConnectorCatalogVerification,
   InstalledConnectorPack,
   McpServerCatalogEntry,
   SdkConnectorIcon,
@@ -36,6 +39,19 @@ export interface ConnectorListing {
   icon?: SdkConnectorIcon
   /** The pack on disk, when this connector has been installed as one. */
   pack?: InstalledConnectorPack
+  /**
+   * What setting this one up will ask of you. Read from the pack that is on
+   * disk before the catalog's claim about it, since the pack is what runs.
+   * Absent means unknown, which is not the same as `none`.
+   */
+  authRung?: ConnectorAuthRung
+  /** What the factory checked, when this connector has been through it. */
+  verified?: ConnectorCatalogVerification
+  /**
+   * Connected without anyone being asked to connect it — a connector that
+   * signs in with nothing is ready the moment it is installed.
+   */
+  implicitlyConnected: boolean
 }
 
 export interface BuiltInConnector {
@@ -59,7 +75,13 @@ export interface BuiltInConnector {
  */
 export interface ConnectorDetails {
   triggers: Array<{ type: string; label: string; description?: string }>
-  actions: Array<{ type: string; label: string; description?: string }>
+  /** Arguments ride along, so a step can be offered before anything is installed. */
+  actions: Array<{
+    type: string
+    label: string
+    description?: string
+    inputs?: ConnectorCatalogActionInput[]
+  }>
   settings: Array<{ name: string; required: boolean; description?: string }>
   /** Absent on a row nothing describes — an installed package with no manifest. */
   known: boolean
@@ -134,6 +156,16 @@ export function listingDetails(
 
 const UNCATEGORIZED = 'Other'
 
+/**
+ * A connection the app made for a connector that signs in with nothing.
+ *
+ * It exists so a step still binds to a connection id, and is deliberately not
+ * shown: nobody chose it, and nobody can usefully edit it.
+ */
+export function isImplicit(connection: SourceConnection): boolean {
+  return connection.filters?.implicit === true
+}
+
 /** What a pack offers, in the vocabulary the catalog uses for the same thing. */
 function packCapabilities(pack: InstalledConnectorPack): string[] {
   return [
@@ -160,8 +192,11 @@ export function buildConnectorListings(
   packs: InstalledConnectorPack[] = [],
   mcpServers: McpServerCatalogEntry[] = []
 ): ConnectorListing[] {
-  const countFor = (id: string) =>
-    connections.filter((conn) => connectionConnectorId(conn) === id).length
+  const mine = (id: string) => connections.filter((conn) => connectionConnectorId(conn) === id)
+  // Only the connections someone made: an implicit one was never asked for, so
+  // counting it would offer "Add another" for a connector nobody added once.
+  const countFor = (id: string) => mine(id).filter((conn) => !isImplicit(conn)).length
+  const implicitFor = (id: string) => mine(id).some(isImplicit)
   const packFor = (id: string) => packs.find((pack) => pack.id === id)
 
   const listings: ConnectorListing[] = [
@@ -173,10 +208,14 @@ export function buildConnectorListings(
       category: 'Built in',
       source: 'builtin' as const,
       keywords: [],
-      connectedCount: countFor(c.id)
+      connectedCount: countFor(c.id),
+      implicitlyConnected: implicitFor(c.id)
     })),
     ...catalog.map((entry) => {
       const pack = packFor(entry.id)
+      // The installed files answer for themselves; the catalog only says what
+      // installing would ask for, which a newer pack on disk may have changed.
+      const rung = pack?.auth?.rung ?? entry.authRung
       return {
         ...entry,
         key: `catalog:${entry.id}`,
@@ -184,7 +223,10 @@ export function buildConnectorListings(
         source: 'catalog' as const,
         keywords: entry.keywords ?? [],
         connectedCount: countFor(entry.id),
+        implicitlyConnected: implicitFor(entry.id),
         catalogItem: entry,
+        ...(rung !== undefined && { authRung: rung }),
+        ...(entry.verified !== undefined && { verified: entry.verified }),
         ...(pack && { pack })
       }
     }),
@@ -207,6 +249,8 @@ export function buildConnectorListings(
         source: 'installed' as const,
         keywords: [],
         connectedCount: countFor(pack.id),
+        implicitlyConnected: implicitFor(pack.id),
+        ...(pack.auth?.rung !== undefined && { authRung: pack.auth.rung }),
         ...(pack.icon !== undefined && { icon: pack.icon }),
         pack
       })),
@@ -222,12 +266,16 @@ export function buildConnectorListings(
       source: 'mcp' as const,
       keywords: server.keywords ?? [],
       connectedCount: countFor(server.id),
+      implicitlyConnected: implicitFor(server.id),
       mcpServer: server
     }))
   ]
 
+  // Usable-now sorts first, whether that took a connection or nothing at all.
+  const ready = (listing: ConnectorListing) =>
+    listing.connectedCount > 0 || listing.implicitlyConnected
   return listings.sort((a, b) => {
-    if (a.connectedCount > 0 !== b.connectedCount > 0) return a.connectedCount > 0 ? -1 : 1
+    if (ready(a) !== ready(b)) return ready(a) ? -1 : 1
     return a.name.localeCompare(b.name)
   })
 }
@@ -335,6 +383,43 @@ export function connectorCategories(listings: ConnectorListing[]): string[] {
   }
   if (listings.some((listing) => listing.connectedCount > 0)) facets.push(CONNECTED_FILTER)
   return [...categories, ...facets]
+}
+
+/**
+ * What a rung will ask of you, said as the question people actually have.
+ *
+ * Phrased from the reader's side rather than the manifest's: "signs in with a
+ * tool you already use" is the fact that decides whether to click, where
+ * "cli" is a word only the person who wrote the connector knows.
+ */
+export const AUTH_RUNG_LABEL: Record<ConnectorAuthRung, string> = {
+  none: 'Needs no sign-in',
+  cli: 'Signs in with a CLI',
+  key: 'Needs a key',
+  oauth: 'Signs in through a browser'
+}
+
+/** The short form for a row, where the long one would crowd the facts line. */
+export const AUTH_RUNG_BADGE: Record<ConnectorAuthRung, string> = {
+  none: 'no sign-in',
+  cli: 'CLI login',
+  key: 'key',
+  oauth: 'OAuth'
+}
+
+/** The rungs actually present, so the filter never offers an empty answer. */
+export function connectorAuthRungs(listings: ConnectorListing[]): ConnectorAuthRung[] {
+  const order: ConnectorAuthRung[] = ['none', 'cli', 'key', 'oauth']
+  return order.filter((rung) => listings.some((listing) => listing.authRung === rung))
+}
+
+/** Narrow to the connectors that sign in a particular way. */
+export function filterByAuthRung(
+  listings: ConnectorListing[],
+  rung: ConnectorAuthRung | undefined
+): ConnectorListing[] {
+  if (!rung) return listings
+  return listings.filter((listing) => listing.authRung === rung)
 }
 
 /** Narrow to one category, or to one of the two derived facets. */

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -49,9 +49,10 @@ export interface ConnectorListing {
   verified?: ConnectorCatalogVerification
   /**
    * Connected without anyone being asked to connect it — a connector that
-   * signs in with nothing is ready the moment it is installed.
+   * signs in with nothing is ready the moment it is installed. Absent reads as
+   * false, so a listing built by hand says only what it means to say.
    */
-  implicitlyConnected: boolean
+  implicitlyConnected?: boolean
 }
 
 export interface BuiltInConnector {
@@ -272,8 +273,8 @@ export function buildConnectorListings(
   ]
 
   // Usable-now sorts first, whether that took a connection or nothing at all.
-  const ready = (listing: ConnectorListing) =>
-    listing.connectedCount > 0 || listing.implicitlyConnected
+  const ready = (listing: ConnectorListing): boolean =>
+    listing.connectedCount > 0 || listing.implicitlyConnected === true
   return listings.sort((a, b) => {
     if (ready(a) !== ready(b)) return ready(a) ? -1 : 1
     return a.name.localeCompare(b.name)

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -280,6 +280,29 @@ export function buildConnectorListings(
   })
 }
 
+/** A heading and the connectors under it, for a list too long to scan flat. */
+export interface ListingSection {
+  category: string
+  listings: ConnectorListing[]
+}
+
+/**
+ * Cut the list into the sections it already sorts itself into.
+ *
+ * Categories appear in the order their first connector does, so the ordering
+ * the list was sorted by — what you can use right now, then by name — survives
+ * being grouped rather than being overruled by an alphabet.
+ */
+export function groupListingsByCategory(listings: ConnectorListing[]): ListingSection[] {
+  const sections = new Map<string, ConnectorListing[]>()
+  for (const listing of listings) {
+    const existing = sections.get(listing.category)
+    if (existing) existing.push(listing)
+    else sections.set(listing.category, [listing])
+  }
+  return [...sections].map(([category, entries]) => ({ category, listings: entries }))
+}
+
 /** A connector someone actually uses, with the connections they made to it. */
 export interface ConnectionGroup {
   connectorId: string

--- a/src/renderer/lib/library-pick.ts
+++ b/src/renderer/lib/library-pick.ts
@@ -1,0 +1,48 @@
+import type { TriggerConfig } from '../../shared/types'
+import type { AddableNodeType } from '../components/workflow-editor/WorkflowCanvas'
+
+/** A step type, a parallel branch, a connector action, or a trigger. */
+export type LibraryPick =
+  | { kind: 'type'; type: AddableNodeType }
+  | { kind: 'parallel' }
+  | { kind: 'connectorAction'; connectionId: string; action: string; actionLabel: string }
+  | { kind: 'triggerType'; triggerType: TriggerConfig['triggerType'] }
+  | { kind: 'connectorTrigger'; connectionId: string; event: string }
+  /** An action from a connector nobody has installed yet; it lands unbound. */
+  | { kind: 'catalogAction'; connectorId: string; action: string; actionLabel: string }
+  /** An HTTP request with one of the saved profiles already chosen. */
+  | { kind: 'httpProfile'; profileConnectionId: string; profileName: string }
+
+/** The step a pick becomes: its node type and whatever it already knows about itself. */
+export function stepForPick(pick: LibraryPick): {
+  type: AddableNodeType
+  config?: Record<string, unknown>
+} {
+  switch (pick.kind) {
+    case 'connectorAction':
+      return {
+        type: 'connectorAction',
+        config: {
+          connectionId: pick.connectionId,
+          action: pick.action,
+          actionLabel: pick.actionLabel
+        }
+      }
+    case 'catalogAction':
+      return {
+        type: 'connectorAction',
+        config: {
+          connectionId: '',
+          connectorId: pick.connectorId,
+          action: pick.action,
+          actionLabel: pick.actionLabel
+        }
+      }
+    case 'httpProfile':
+      return { type: 'httpRequest', config: { profileConnectionId: pick.profileConnectionId } }
+    case 'type':
+      return { type: pick.type }
+    default:
+      throw new Error(`${pick.kind} is not a step`)
+  }
+}

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../shared/types'
 import { connectionConnectorId } from '../../shared/types'
 import {
+  boundConnectionKey,
   fromPortable,
   resolveRequirement,
   unresolvedRequirements,
@@ -109,6 +110,49 @@ export function requirementAction(
   return canAddConnection(state, route)
     ? { kind: 'addConnection', listing }
     : { kind: 'install', listing }
+}
+
+/**
+ * What the workflow on the canvas is still missing.
+ *
+ * An imported file says what it needs in its own `requires` block, but a step
+ * picked from the library says it only by sitting there unbound — and both
+ * deserve the same row offering the same fix. Derived from the definition on
+ * every render rather than stored: answering a requirement is what makes it
+ * stop being one, and nothing should have to remember to clear it.
+ *
+ * Only a step that cannot run without a connection counts. An HTTP request with
+ * no profile is a request to a public URL, which is a legitimate step and not a
+ * question anyone needs to answer.
+ */
+export function requirementsOfDefinition(nodes: WorkflowNode[]): PortableRequirement[] {
+  const requirements: PortableRequirement[] = []
+  for (const node of nodes) {
+    const config = node.config as Record<string, unknown>
+    const key = boundConnectionKey(node, config)
+    if (key === null || key === 'profileConnectionId') continue
+    if (typeof config[key] === 'string' && config[key] !== '') continue
+    requirements.push({
+      kind: 'connection',
+      nodeId: node.id,
+      // Empty when nothing recorded which connector the step was picked from,
+      // which reads as "cannot be offered" rather than as some other connector.
+      connectorId: typeof config.connectorId === 'string' ? config.connectorId : '',
+      name: ''
+    })
+  }
+  return requirements
+}
+
+/** Pair each requirement with the connection this machine would bind to it. */
+export function requirementsWithBindings(
+  requirements: PortableRequirement[],
+  connections: SourceConnection[]
+): TemplateRequirement[] {
+  return requirements.map((requirement) => {
+    const connectionId = resolveRequirement(requirement, connections)
+    return connectionId === undefined ? { requirement } : { requirement, connectionId }
+  })
 }
 
 export function templateRequirements(

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -144,6 +144,35 @@ export function requirementsOfDefinition(nodes: WorkflowNode[]): PortableRequire
   return requirements
 }
 
+/**
+ * One list of gaps from the two that describe them.
+ *
+ * A step can be named twice: once by the file that imported it, which knows the
+ * connector, the account it was pointed at and the event it fired on, and once
+ * by the canvas, which knows only that the field is empty. They are the same
+ * gap, so they become one row — and the import wins every field it filled,
+ * because a row that forgets the connector is a row with nothing to offer.
+ */
+export function mergeRequirements(
+  derived: PortableRequirement[],
+  imported: PortableRequirement[]
+): PortableRequirement[] {
+  const byNode = new Map(imported.map((requirement) => [requirement.nodeId, requirement]))
+  const merged = derived.map((fromCanvas) => {
+    const fromFile = byNode.get(fromCanvas.nodeId)
+    byNode.delete(fromCanvas.nodeId)
+    if (!fromFile) return fromCanvas
+    if (fromFile.kind !== 'connection' || fromCanvas.kind !== 'connection') return fromFile
+    return {
+      ...fromFile,
+      connectorId: fromFile.connectorId || fromCanvas.connectorId,
+      name: fromFile.name || fromCanvas.name
+    }
+  })
+  // An import can also name a step the canvas has nothing to say about.
+  return [...merged, ...byNode.values()]
+}
+
 /** Pair each requirement with the connection this machine would bind to it. */
 export function requirementsWithBindings(
   requirements: PortableRequirement[],

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -112,19 +112,7 @@ export function requirementAction(
     : { kind: 'install', listing }
 }
 
-/**
- * What the workflow on the canvas is still missing.
- *
- * An imported file says what it needs in its own `requires` block, but a step
- * picked from the library says it only by sitting there unbound — and both
- * deserve the same row offering the same fix. Derived from the definition on
- * every render rather than stored: answering a requirement is what makes it
- * stop being one, and nothing should have to remember to clear it.
- *
- * Only a step that cannot run without a connection counts, and only one this
- * panel can do something about: a row that names no connector has no button to
- * offer, and the step's own config panel is where it gets pointed at one.
- */
+// What the workflow on the canvas is still missing.
 export function requirementsOfDefinition(nodes: WorkflowNode[]): PortableRequirement[] {
   const requirements: PortableRequirement[] = []
   for (const node of nodes) {
@@ -135,16 +123,13 @@ export function requirementsOfDefinition(nodes: WorkflowNode[]): PortableRequire
     if (typeof bound === 'string' && bound !== '') continue
 
     if (key === 'profileConnectionId') {
-      // A request with no profile field at all is a request to a public URL —
-      // a finished step, not a question. One whose profile was chosen and then
-      // cleared is the opposite, and the field left behind is what says so.
+      // A request with no profile field at all is a request to a public URL — a finished step, not a question.
       if (!(key in config)) continue
       requirements.push({ kind: 'httpProfile', nodeId: node.id, name: '' })
       continue
     }
 
-    // Nothing recorded which connector this came from, so no row could offer to
-    // install or connect one; the config panel is where it gets chosen.
+    // Nothing recorded which connector this came from, so no row could offer to install or connect one; the config panel.
     const connectorId = typeof config.connectorId === 'string' ? config.connectorId : ''
     if (connectorId === '') continue
     requirements.push({ kind: 'connection', nodeId: node.id, connectorId, name: '' })
@@ -152,15 +137,7 @@ export function requirementsOfDefinition(nodes: WorkflowNode[]): PortableRequire
   return requirements
 }
 
-/**
- * One list of gaps from the two that describe them.
- *
- * A step can be named twice: once by the file that imported it, which knows the
- * connector, the account it was pointed at and the event it fired on, and once
- * by the canvas, which knows only that the field is empty. They are the same
- * gap, so they become one row — and the import wins every field it filled,
- * because a row that forgets the connector is a row with nothing to offer.
- */
+// One list of gaps from the two that describe them.
 export function mergeRequirements(
   derived: PortableRequirement[],
   imported: PortableRequirement[]
@@ -196,10 +173,7 @@ export function templateRequirements(
   template: WorkflowTemplate,
   connections: SourceConnection[]
 ): TemplateRequirement[] {
-  return (template.portable.requires ?? []).map((requirement) => {
-    const connectionId = resolveRequirement(requirement, connections)
-    return connectionId === undefined ? { requirement } : { requirement, connectionId }
-  })
+  return requirementsWithBindings(template.portable.requires ?? [], connections)
 }
 
 /** Whether every connection this template names is already answered here. */

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -121,25 +121,33 @@ export function requirementAction(
  * every render rather than stored: answering a requirement is what makes it
  * stop being one, and nothing should have to remember to clear it.
  *
- * Only a step that cannot run without a connection counts. An HTTP request with
- * no profile is a request to a public URL, which is a legitimate step and not a
- * question anyone needs to answer.
+ * Only a step that cannot run without a connection counts, and only one this
+ * panel can do something about: a row that names no connector has no button to
+ * offer, and the step's own config panel is where it gets pointed at one.
  */
 export function requirementsOfDefinition(nodes: WorkflowNode[]): PortableRequirement[] {
   const requirements: PortableRequirement[] = []
   for (const node of nodes) {
     const config = node.config as Record<string, unknown>
     const key = boundConnectionKey(node, config)
-    if (key === null || key === 'profileConnectionId') continue
-    if (typeof config[key] === 'string' && config[key] !== '') continue
-    requirements.push({
-      kind: 'connection',
-      nodeId: node.id,
-      // Empty when nothing recorded which connector the step was picked from,
-      // which reads as "cannot be offered" rather than as some other connector.
-      connectorId: typeof config.connectorId === 'string' ? config.connectorId : '',
-      name: ''
-    })
+    if (key === null) continue
+    const bound = config[key]
+    if (typeof bound === 'string' && bound !== '') continue
+
+    if (key === 'profileConnectionId') {
+      // A request with no profile field at all is a request to a public URL —
+      // a finished step, not a question. One whose profile was chosen and then
+      // cleared is the opposite, and the field left behind is what says so.
+      if (!(key in config)) continue
+      requirements.push({ kind: 'httpProfile', nodeId: node.id, name: '' })
+      continue
+    }
+
+    // Nothing recorded which connector this came from, so no row could offer to
+    // install or connect one; the config panel is where it gets chosen.
+    const connectorId = typeof config.connectorId === 'string' ? config.connectorId : ''
+    if (connectorId === '') continue
+    requirements.push({ kind: 'connection', nodeId: node.id, connectorId, name: '' })
   }
   return requirements
 }

--- a/src/renderer/lib/use-connections.ts
+++ b/src/renderer/lib/use-connections.ts
@@ -60,6 +60,29 @@ export function useConnections(): SourceConnection[] {
   return value
 }
 
+/**
+ * The packs on disk, from the same read that refreshed the connections.
+ *
+ * Riding the one cache rather than fetching again keeps "what is installed"
+ * from disagreeing with "what is connected" between two surfaces drawing at
+ * the same moment.
+ */
+export function useInstalledPacks(): InstalledConnectorPack[] {
+  const [value, setValue] = useState<InstalledConnectorPack[]>(packCache)
+  useEffect(() => {
+    void ensureInit()
+    const onChanged = (): void => setValue(packCache)
+    listeners.add(onChanged)
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: seeds from a cache populated before this component mounted
+    if (packCache !== value) setValue(packCache)
+    return () => {
+      listeners.delete(onChanged)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  return value
+}
+
 /** Resolve a connectionId → connectorId via the cache. Returns null when
  *  the cache hasn't warmed up yet or the connection was deleted. */
 export function useConnectorIdFor(connectionId: string | null | undefined): string | null {

--- a/src/renderer/lib/use-connections.ts
+++ b/src/renderer/lib/use-connections.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import type { InstalledConnectorPack, SdkConnectorIcon, SourceConnection } from '../../shared/types'
 import { connectionConnectorId } from '../../shared/types'
 import { connectionIcon } from './connection-icon'
@@ -62,8 +62,16 @@ export function useConnections(): SourceConnection[] {
 
 // The packs on disk, from the same read that refreshed the connections, so two surfaces never disagree.
 export function useInstalledPacks(): InstalledConnectorPack[] {
-  useConnections()
-  return packCache
+  return useSyncExternalStore(subscribePacks, () => packCache)
+}
+
+function subscribePacks(onChange: () => void): () => void {
+  void ensureInit()
+  const listener = (): void => onChange()
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
 }
 
 /** Resolve a connectionId → connectorId via the cache. Returns null when

--- a/src/renderer/lib/use-connections.ts
+++ b/src/renderer/lib/use-connections.ts
@@ -60,27 +60,10 @@ export function useConnections(): SourceConnection[] {
   return value
 }
 
-/**
- * The packs on disk, from the same read that refreshed the connections.
- *
- * Riding the one cache rather than fetching again keeps "what is installed"
- * from disagreeing with "what is connected" between two surfaces drawing at
- * the same moment.
- */
+// The packs on disk, from the same read that refreshed the connections, so two surfaces never disagree.
 export function useInstalledPacks(): InstalledConnectorPack[] {
-  const [value, setValue] = useState<InstalledConnectorPack[]>(packCache)
-  useEffect(() => {
-    void ensureInit()
-    const onChanged = (): void => setValue(packCache)
-    listeners.add(onChanged)
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: seeds from a cache populated before this component mounted
-    if (packCache !== value) setValue(packCache)
-    return () => {
-      listeners.delete(onChanged)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-  return value
+  useConnections()
+  return packCache
 }
 
 /** Resolve a connectionId → connectorId via the cache. Returns null when

--- a/src/renderer/lib/use-connector-catalog.ts
+++ b/src/renderer/lib/use-connector-catalog.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react'
+import type {
+  ConnectorCatalogItem,
+  McpServerCatalogEntry,
+  WorkflowTemplate
+} from '../../shared/types'
+
+/**
+ * The published catalog, read once and shared.
+ *
+ * Two surfaces want it — the connector list and the step library, which offers
+ * a connector's actions before anything is installed — and both mount and
+ * unmount as panels. A module-level cache is what keeps that from being a fetch
+ * per open, and keeps the second surface from waiting on a request the first
+ * one already made.
+ */
+export interface CatalogSnapshot {
+  items: ConnectorCatalogItem[]
+  templates: WorkflowTemplate[]
+  mcpServers: McpServerCatalogEntry[]
+  fetchedAt?: number
+}
+
+const EMPTY: CatalogSnapshot = { items: [], templates: [], mcpServers: [] }
+
+let cache: CatalogSnapshot | undefined
+let inFlight: Promise<CatalogSnapshot> | undefined
+const listeners = new Set<(snapshot: CatalogSnapshot) => void>()
+
+/**
+ * Ask once, and only where the answer is wanted.
+ *
+ * A failure is not cached: the server may simply not have been listening yet,
+ * and the next panel that opens should ask again rather than inherit a silence.
+ */
+async function load(): Promise<CatalogSnapshot> {
+  if (cache) return cache
+  if (inFlight) return inFlight
+  inFlight = Promise.resolve(window.api?.listConnectorCatalog?.())
+    .then((snapshot) => {
+      const next: CatalogSnapshot = {
+        items: snapshot?.items ?? [],
+        templates: snapshot?.templates ?? [],
+        mcpServers: snapshot?.mcpServers ?? [],
+        ...(snapshot?.fetchedAt !== undefined && { fetchedAt: snapshot.fetchedAt })
+      }
+      cache = next
+      for (const listener of listeners) listener(next)
+      return next
+    })
+    .catch(() => EMPTY)
+    .finally(() => {
+      inFlight = undefined
+    })
+  return inFlight
+}
+
+/** What the catalog says right now, fetching it the first time anyone asks. */
+export function useConnectorCatalog(): CatalogSnapshot {
+  const [snapshot, setSnapshot] = useState<CatalogSnapshot>(() => cache ?? EMPTY)
+
+  useEffect(() => {
+    let live = true
+    listeners.add(setSnapshot)
+    void load().then((next) => {
+      if (live) setSnapshot(next)
+    })
+    return () => {
+      live = false
+      listeners.delete(setSnapshot)
+    }
+  }, [])
+
+  return snapshot
+}
+
+/** Read it again after something that changes what is published or installed. */
+export async function refreshConnectorCatalog(): Promise<void> {
+  cache = undefined
+  await load()
+}
+
+/** Test seam: forget what this process has read. */
+export function __resetCatalogCacheForTests(): void {
+  cache = undefined
+  inFlight = undefined
+  listeners.clear()
+}

--- a/src/renderer/lib/use-connector-catalog.ts
+++ b/src/renderer/lib/use-connector-catalog.ts
@@ -55,11 +55,18 @@ async function load(): Promise<CatalogSnapshot> {
   return inFlight
 }
 
-/** What the catalog says right now, fetching it the first time anyone asks. */
-export function useConnectorCatalog(): CatalogSnapshot {
+/**
+ * What the catalog says right now, fetching it the first time anyone asks.
+ *
+ * `enabled` is how a surface says nobody is looking yet — a panel that is
+ * closed should not send the request, and one that opens after a failed
+ * attempt should send it again rather than inherit the silence.
+ */
+export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
   const [snapshot, setSnapshot] = useState<CatalogSnapshot>(() => cache ?? EMPTY)
 
   useEffect(() => {
+    if (!enabled) return
     let live = true
     listeners.add(setSnapshot)
     void load().then((next) => {
@@ -69,15 +76,32 @@ export function useConnectorCatalog(): CatalogSnapshot {
       live = false
       listeners.delete(setSnapshot)
     }
-  }, [])
+  }, [enabled])
 
   return snapshot
 }
 
-/** Read it again after something that changes what is published or installed. */
-export async function refreshConnectorCatalog(): Promise<void> {
+/**
+ * Go and ask the publisher again, and tell everyone what came back.
+ *
+ * This is what "Check now" means: not re-reading the copy this process already
+ * has, which is what makes the button feel like it did nothing.
+ */
+export async function refreshConnectorCatalog(): Promise<CatalogSnapshot> {
   cache = undefined
-  await load()
+  const fetched = await Promise.resolve(window.api?.refreshConnectorCatalog?.()).catch(
+    () => undefined
+  )
+  if (!fetched) return load()
+  const next: CatalogSnapshot = {
+    items: fetched.items ?? [],
+    templates: fetched.templates ?? [],
+    mcpServers: fetched.mcpServers ?? [],
+    ...(fetched.fetchedAt !== undefined && { fetchedAt: fetched.fetchedAt })
+  }
+  cache = next
+  for (const listener of listeners) listener(next)
+  return next
 }
 
 /** Test seam: forget what this process has read. */

--- a/src/renderer/lib/use-connector-catalog.ts
+++ b/src/renderer/lib/use-connector-catalog.ts
@@ -5,15 +5,7 @@ import type {
   WorkflowTemplate
 } from '../../shared/types'
 
-/**
- * The published catalog, read once and shared.
- *
- * Two surfaces want it — the connector list and the step library, which offers
- * a connector's actions before anything is installed — and both mount and
- * unmount as panels. A module-level cache is what keeps that from being a fetch
- * per open, and keeps the second surface from waiting on a request the first
- * one already made.
- */
+// The published catalog, read once and shared by every panel that wants it.
 export interface CatalogSnapshot {
   items: ConnectorCatalogItem[]
   templates: WorkflowTemplate[]
@@ -27,27 +19,25 @@ let cache: CatalogSnapshot | undefined
 let inFlight: Promise<CatalogSnapshot> | undefined
 const listeners = new Set<(snapshot: CatalogSnapshot) => void>()
 
-/**
- * Ask once, and only where the answer is wanted.
- *
- * A failure is not cached: the server may simply not have been listening yet,
- * and the next panel that opens should ask again rather than inherit a silence.
- */
+// Keep what came back and tell everyone; the one place a snapshot is shaped.
+function publish(raw: Partial<CatalogSnapshot> | undefined): CatalogSnapshot {
+  const next: CatalogSnapshot = {
+    items: raw?.items ?? [],
+    templates: raw?.templates ?? [],
+    mcpServers: raw?.mcpServers ?? [],
+    ...(raw?.fetchedAt !== undefined && { fetchedAt: raw.fetchedAt })
+  }
+  cache = next
+  for (const listener of listeners) listener(next)
+  return next
+}
+
+// Ask once, only where wanted; a failure is not cached, so the next panel to open asks again.
 async function load(): Promise<CatalogSnapshot> {
   if (cache) return cache
   if (inFlight) return inFlight
   inFlight = Promise.resolve(window.api?.listConnectorCatalog?.())
-    .then((snapshot) => {
-      const next: CatalogSnapshot = {
-        items: snapshot?.items ?? [],
-        templates: snapshot?.templates ?? [],
-        mcpServers: snapshot?.mcpServers ?? [],
-        ...(snapshot?.fetchedAt !== undefined && { fetchedAt: snapshot.fetchedAt })
-      }
-      cache = next
-      for (const listener of listeners) listener(next)
-      return next
-    })
+    .then(publish)
     .catch(() => EMPTY)
     .finally(() => {
       inFlight = undefined
@@ -55,13 +45,7 @@ async function load(): Promise<CatalogSnapshot> {
   return inFlight
 }
 
-/**
- * What the catalog says right now, fetching it the first time anyone asks.
- *
- * `enabled` is how a surface says nobody is looking yet — a panel that is
- * closed should not send the request, and one that opens after a failed
- * attempt should send it again rather than inherit the silence.
- */
+// `enabled` is how a closed panel says nobody is looking yet.
 export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
   const [snapshot, setSnapshot] = useState<CatalogSnapshot>(() => cache ?? EMPTY)
 
@@ -81,27 +65,13 @@ export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
   return snapshot
 }
 
-/**
- * Go and ask the publisher again, and tell everyone what came back.
- *
- * This is what "Check now" means: not re-reading the copy this process already
- * has, which is what makes the button feel like it did nothing.
- */
+// "Check now": ask the publisher again rather than re-read the copy this process holds.
 export async function refreshConnectorCatalog(): Promise<CatalogSnapshot> {
   cache = undefined
   const fetched = await Promise.resolve(window.api?.refreshConnectorCatalog?.()).catch(
     () => undefined
   )
-  if (!fetched) return load()
-  const next: CatalogSnapshot = {
-    items: fetched.items ?? [],
-    templates: fetched.templates ?? [],
-    mcpServers: fetched.mcpServers ?? [],
-    ...(fetched.fetchedAt !== undefined && { fetchedAt: fetched.fetchedAt })
-  }
-  cache = next
-  for (const listener of listeners) listener(next)
-  return next
+  return fetched ? publish(fetched) : load()
 }
 
 /** Test seam: forget what this process has read. */

--- a/src/renderer/lib/use-connector-catalog.ts
+++ b/src/renderer/lib/use-connector-catalog.ts
@@ -17,6 +17,8 @@ const EMPTY: CatalogSnapshot = { items: [], templates: [], mcpServers: [] }
 
 let cache: CatalogSnapshot | undefined
 let inFlight: Promise<CatalogSnapshot> | undefined
+// Bumped by a refresh, so a read that started before it cannot overwrite what the refresh brought back.
+let generation = 0
 const listeners = new Set<(snapshot: CatalogSnapshot) => void>()
 
 // Keep what came back and tell everyone; the one place a snapshot is shaped.
@@ -36,8 +38,10 @@ function publish(raw: Partial<CatalogSnapshot> | undefined): CatalogSnapshot {
 async function load(): Promise<CatalogSnapshot> {
   if (cache) return cache
   if (inFlight) return inFlight
+  const started = generation
   inFlight = Promise.resolve(window.api?.listConnectorCatalog?.())
-    .then(publish)
+    // No answer is a build that cannot ask yet, not an empty catalog: nothing is kept.
+    .then((raw) => (raw && started === generation ? publish(raw) : (cache ?? EMPTY)))
     .catch(() => EMPTY)
     .finally(() => {
       inFlight = undefined
@@ -68,6 +72,7 @@ export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
 // "Check now": ask the publisher again rather than re-read the copy this process holds.
 export async function refreshConnectorCatalog(): Promise<CatalogSnapshot> {
   cache = undefined
+  generation += 1
   const fetched = await Promise.resolve(window.api?.refreshConnectorCatalog?.()).catch(
     () => undefined
   )

--- a/tests/connector-action-form-catalog.test.tsx
+++ b/tests/connector-action-form-catalog.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { CallConnectorActionConfig, ConnectorCatalogItem } from '../src/shared/types'
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => [],
+  iconForConnection: () => undefined
+}))
+
+const SLACK: ConnectorCatalogItem = {
+  id: 'slack',
+  name: 'Slack',
+  description: 'Messages and channels',
+  packageName: '@vornrun/connector-slack',
+  capabilities: ['actions'],
+  actions: [
+    {
+      type: 'post',
+      label: 'Post message',
+      inputs: [
+        { key: 'text', label: 'Text', type: 'string', required: true },
+        {
+          key: 'channel',
+          label: 'Channel',
+          type: 'select',
+          required: true,
+          options: [{ value: 'general', label: 'General' }, { value: 'random' }]
+        },
+        { key: 'blocks', label: 'Blocks', type: 'json', required: false }
+      ]
+    }
+  ],
+  launch: { command: 'npx', args: [] }
+}
+
+const listConnectorCatalog = vi.fn(async () => ({
+  items: [SLACK],
+  templates: [],
+  mcpServers: []
+}))
+;(window as unknown as { api: Record<string, unknown> }).api = {
+  ...(window as unknown as { api?: Record<string, unknown> }).api,
+  listConnectionActions: vi.fn(async () => []),
+  listConnectorCatalog
+}
+
+const { CallConnectorActionNodeForm } =
+  await import('../src/renderer/components/workflow-editor/panels/CallConnectorActionNodeForm')
+const { __resetCatalogCacheForTests } = await import('../src/renderer/lib/use-connector-catalog')
+
+beforeEach(() => {
+  __resetCatalogCacheForTests()
+  listConnectorCatalog.mockResolvedValue({ items: [SLACK], templates: [], mcpServers: [] })
+})
+afterEach(cleanup)
+
+const config = (over: Partial<CallConnectorActionConfig> = {}): CallConnectorActionConfig => ({
+  nodeType: 'callConnectorAction',
+  connectionId: '',
+  connectorId: 'slack',
+  action: 'post',
+  actionLabel: 'Post message',
+  args: {},
+  ...over
+})
+
+describe('a step configured before its connector arrives', () => {
+  it('asks for the arguments the catalog published', async () => {
+    render(<CallConnectorActionNodeForm config={config()} onChange={vi.fn()} />)
+
+    expect(await screen.findByText('Text')).toBeInTheDocument()
+    expect(screen.getByText('Channel')).toBeInTheDocument()
+    expect(screen.getByText('Blocks')).toBeInTheDocument()
+  })
+
+  it('says why there is no connection to choose yet', async () => {
+    render(<CallConnectorActionNodeForm config={config()} onChange={vi.fn()} />)
+
+    expect(await screen.findByText(/is not installed yet/)).toBeInTheDocument()
+  })
+
+  it('asks nothing extra of a step that names no connector', async () => {
+    const { container } = render(
+      <CallConnectorActionNodeForm config={config({ connectorId: undefined })} onChange={vi.fn()} />
+    )
+    await Promise.resolve()
+
+    expect(screen.queryByText('Text')).toBeNull()
+    expect(container.textContent).toContain('No connections yet')
+  })
+})

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -485,6 +485,14 @@ describe('a connection nobody asked for', () => {
     expect(listing.connectedCount).toBe(1)
     expect(listing.implicitlyConnected).toBe(true)
   })
+
+  it('keeps it out of the connections someone can manage', () => {
+    expect(groupConnections([implicit], [])).toEqual([])
+
+    const groups = groupConnections([implicit, chosen], [])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].connections.map((c) => c.id)).toEqual(['mine'])
+  })
 })
 
 describe('an action carried before it is installed', () => {

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -7,11 +7,19 @@ import {
   describeCatalogAge,
   filterByCategory,
   listingDetails,
+  connectorAuthRungs,
+  filterByAuthRung,
+  isImplicit,
   CALLABLE_FILTER,
   CONNECTED_FILTER,
   type BuiltInConnector
 } from '../src/renderer/lib/connector-browse'
-import type { ConnectorCatalogItem, SourceConnection } from '../src/shared/types'
+import type {
+  ConnectorAuthRung,
+  ConnectorCatalogItem,
+  InstalledConnectorPack,
+  SourceConnection
+} from '../src/shared/types'
 
 const builtIn = (id: string, name: string): BuiltInConnector => ({
   id,
@@ -372,5 +380,133 @@ describe('describeCatalogAge', () => {
   it('does not say "1 minutes"', () => {
     expect(describeCatalogAge(now - 3_600_000, now)).toBe('Updated 1 hour ago')
     expect(describeCatalogAge(now - 86_400_000, now)).toBe('Updated 1 day ago')
+  })
+})
+
+const packOf = (id: string, rung?: ConnectorAuthRung): InstalledConnectorPack => ({
+  id,
+  name: id,
+  version: '1.0.0',
+  path: `/packs/${id}`,
+  installedAt: 0,
+  bytes: 1,
+  triggers: [],
+  actions: [],
+  env: [],
+  ...(rung && { auth: { rung } })
+})
+
+const RECEIPT = {
+  schema: 1 as const,
+  version: '1.2.0',
+  checkedAt: '2026-09-02T00:00:00Z',
+  checks: ['manifest', 'no-runtime-deps']
+}
+
+describe('what a listing says about signing in', () => {
+  it('carries the rung and the receipt the catalog published', () => {
+    const [listing] = buildConnectorListings(
+      [],
+      [catalogItem('slack', 'Slack', { authRung: 'key', verified: RECEIPT })],
+      []
+    )
+
+    expect(listing.authRung).toBe('key')
+    expect(listing.verified).toEqual(RECEIPT)
+  })
+
+  it('believes the pack on disk over the catalog, since the pack is what runs', () => {
+    const [listing] = buildConnectorListings(
+      [],
+      [catalogItem('slack', 'Slack', { authRung: 'key' })],
+      [],
+      [packOf('slack', 'cli')]
+    )
+
+    expect(listing.authRung).toBe('cli')
+  })
+
+  it('says nothing rather than none when neither declares a rung', () => {
+    const [listing] = buildConnectorListings([], [catalogItem('slack', 'Slack')], [])
+
+    expect(listing.authRung).toBeUndefined()
+    expect(listing.verified).toBeUndefined()
+  })
+
+  it('reads a side-loaded pack its rung from its own manifest', () => {
+    const [listing] = buildConnectorListings([], [], [], [packOf('echo', 'none')])
+
+    expect(listing.authRung).toBe('none')
+  })
+
+  it('offers only the rungs on the page, in the order they ask for less', () => {
+    const listings = buildConnectorListings(
+      [],
+      [
+        catalogItem('a', 'A', { authRung: 'key' }),
+        catalogItem('b', 'B', { authRung: 'none' }),
+        catalogItem('c', 'C')
+      ],
+      []
+    )
+
+    expect(connectorAuthRungs(listings)).toEqual(['none', 'key'])
+    expect(filterByAuthRung(listings, 'key').map((l) => l.id)).toEqual(['a'])
+    expect(filterByAuthRung(listings, undefined)).toHaveLength(3)
+  })
+})
+
+describe('a connection nobody asked for', () => {
+  const implicit = connection({ id: 'imp', filters: { sdkConnectorId: 'echo', implicit: true } })
+  const chosen = connection({ id: 'mine', filters: { sdkConnectorId: 'echo' } })
+
+  it('leaves the count at nothing, so no row offers another of it', () => {
+    const [listing] = buildConnectorListings([], [catalogItem('echo', 'Echo')], [implicit])
+
+    expect(listing.connectedCount).toBe(0)
+    expect(listing.implicitlyConnected).toBe(true)
+    expect(isImplicit(implicit)).toBe(true)
+    expect(isImplicit(chosen)).toBe(false)
+  })
+
+  it('still sorts a ready connector above one that needs setting up', () => {
+    const listings = buildConnectorListings(
+      [],
+      [catalogItem('alpha', 'Alpha'), catalogItem('echo', 'Echo')],
+      [implicit]
+    )
+
+    expect(listings.map((l) => l.id)).toEqual(['echo', 'alpha'])
+  })
+
+  it('counts the connections someone made beside it', () => {
+    const [listing] = buildConnectorListings([], [catalogItem('echo', 'Echo')], [implicit, chosen])
+
+    expect(listing.connectedCount).toBe(1)
+    expect(listing.implicitlyConnected).toBe(true)
+  })
+})
+
+describe('an action carried before it is installed', () => {
+  it('keeps the arguments a step will ask for', () => {
+    const [listing] = buildConnectorListings(
+      [],
+      [
+        catalogItem('slack', 'Slack', {
+          actions: [
+            {
+              type: 'post',
+              label: 'Post message',
+              inputs: [{ key: 'text', label: 'Text', type: 'string', required: true }]
+            }
+          ]
+        })
+      ],
+      []
+    )
+
+    expect(listingDetails(listing).actions[0].inputs).toEqual([
+      { key: 'text', label: 'Text', type: 'string', required: true }
+    ])
   })
 })

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { isImplicitConnection } from '../packages/shared/src/types'
 import {
   buildConnectorListings,
   filterConnectorListings,
@@ -9,7 +10,6 @@ import {
   listingDetails,
   connectorAuthRungs,
   filterByAuthRung,
-  isImplicit,
   CALLABLE_FILTER,
   CONNECTED_FILTER,
   type BuiltInConnector
@@ -465,8 +465,8 @@ describe('a connection nobody asked for', () => {
 
     expect(listing.connectedCount).toBe(0)
     expect(listing.implicitlyConnected).toBe(true)
-    expect(isImplicit(implicit)).toBe(true)
-    expect(isImplicit(chosen)).toBe(false)
+    expect(isImplicitConnection(implicit)).toBe(true)
+    expect(isImplicitConnection(chosen)).toBe(false)
   })
 
   it('still sorts a ready connector above one that needs setting up', () => {

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -327,6 +327,18 @@ describe('a list too long to scan flat', () => {
     expect(queryByText('Azure DevOps')).not.toBeInTheDocument()
   })
 
+  it('shows the receipt behind the badge, not just the word', () => {
+    const listing = buildConnectorListings([], [SLACK], []).find((l) => l.id === 'slack')!
+    const { getByText } = render(
+      <ConnectorDetail listing={listing} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+
+    expect(getByText('manifest')).toBeInTheDocument()
+    expect(getByText('no-runtime-deps')).toBeInTheDocument()
+    expect(getByText(/checked .* against v0\.6\.0/)).toBeInTheDocument()
+    expect(getByText('Needs a key')).toBeInTheDocument()
+  })
+
   it('offers no sign-in filter when every connector answers it the same way', () => {
     const { queryByLabelText } = render(
       <ConnectorDirectory
@@ -362,6 +374,35 @@ describe('a connector that signs in with nothing', () => {
     statusMapping: {},
     createdAt: '2026-09-02T00:00:00Z'
   }
+
+  it('offers the workflow rather than a connection nobody needs', () => {
+    const [listing] = buildConnectorListings([], [], [implicitConnection as never], [ECHO])
+    const onUse = vi.fn()
+    const { getByText, queryByText } = render(
+      <ConnectorDetail
+        listing={listing}
+        builtIns={[]}
+        onAdd={vi.fn()}
+        onUse={onUse}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(queryByText('Add a connection')).not.toBeInTheDocument()
+    expect(getByText(/Nothing — ready as soon as it is installed/)).toBeInTheDocument()
+    fireEvent.click(getByText('Use in a workflow'))
+    expect(onUse).toHaveBeenCalled()
+  })
+
+  it('says so plainly rather than offering a button that goes nowhere', () => {
+    const [listing] = buildConnectorListings([], [], [implicitConnection as never], [ECHO])
+    const { getByText, queryByText } = render(
+      <ConnectorDetail listing={listing} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+
+    expect(queryByText('Use in a workflow')).not.toBeInTheDocument()
+    expect(getByText('Ready to use in a workflow.')).toBeInTheDocument()
+  })
 
   it('asks nobody to add a connection it already made', () => {
     const { queryByText, getByText } = render(

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -267,3 +267,116 @@ describe('the connector detail panel', () => {
     expect(getByText(/Nothing is on disk until you install it/)).toBeInTheDocument()
   })
 })
+
+describe('a list too long to scan flat', () => {
+  const SLACK: ConnectorCatalogItem = {
+    ...KUSTO,
+    id: 'slack',
+    name: 'Slack',
+    description: 'Messages and channels.',
+    packageName: '@vornrun/connector-slack',
+    category: 'Chat',
+    authRung: 'key',
+    verified: {
+      schema: 1,
+      version: '0.6.0',
+      checkedAt: '2026-09-02T00:00:00Z',
+      checks: ['manifest', 'no-runtime-deps']
+    },
+    launch: { command: 'npx', args: ['-y', '@vornrun/connector-slack'] }
+  }
+  const GITLAB: ConnectorCatalogItem = {
+    ...ADO,
+    id: 'gitlab',
+    name: 'GitLab',
+    packageName: '@vornrun/connector-gitlab',
+    category: 'Development',
+    authRung: 'cli',
+    launch: { command: 'npx', args: ['-y', '@vornrun/connector-gitlab'] }
+  }
+
+  const draw = () =>
+    render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [ADO, SLACK, GITLAB], [])}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+      />
+    )
+
+  it('heads each category once, in the order the list already sorted them', () => {
+    const { container } = draw()
+    const headings = [...container.querySelectorAll('h3')].map((h) => h.textContent)
+    expect(headings).toEqual(['Development', 'Chat'])
+  })
+
+  it('says on the row how a connector signs in, and that it was checked', () => {
+    const { getByText, getAllByText } = draw()
+    expect(getByText('CLI login')).toBeInTheDocument()
+    expect(getByText('key')).toBeInTheDocument()
+    expect(getAllByText('verified')).toHaveLength(1)
+  })
+
+  it('narrows to the connectors that ask the same thing of you', () => {
+    const { getByLabelText, queryByText, getByText } = draw()
+    fireEvent.change(getByLabelText('Filter by sign-in'), { target: { value: 'cli' } })
+
+    expect(getByText('GitLab')).toBeInTheDocument()
+    expect(queryByText('Slack')).not.toBeInTheDocument()
+    expect(queryByText('Azure DevOps')).not.toBeInTheDocument()
+  })
+
+  it('offers no sign-in filter when every connector answers it the same way', () => {
+    const { queryByLabelText } = render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [ADO, KUSTO], [])}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+      />
+    )
+    expect(queryByLabelText('Filter by sign-in')).not.toBeInTheDocument()
+  })
+})
+
+describe('a connector that signs in with nothing', () => {
+  const ECHO = {
+    id: 'echo',
+    name: 'Echo Bench',
+    version: '1.0.0',
+    path: '/packs/echo',
+    installedAt: 0,
+    bytes: 1,
+    auth: { rung: 'none' as const },
+    triggers: [],
+    actions: [{ type: 'echo', label: 'Echo' }],
+    env: []
+  }
+  const implicitConnection = {
+    id: 'implicit-1',
+    connectorId: 'mcp',
+    name: 'Echo Bench',
+    filters: { sdkConnectorId: 'echo', implicit: true },
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-09-02T00:00:00Z'
+  }
+
+  it('asks nobody to add a connection it already made', () => {
+    const { queryByText, getByText } = render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [], [implicitConnection as never], [ECHO])}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+        onInstall={vi.fn()}
+      />
+    )
+
+    expect(queryByText('Add')).not.toBeInTheDocument()
+    expect(queryByText('Add another')).not.toBeInTheDocument()
+    expect(getByText('no sign-in')).toBeInTheDocument()
+    expect(getByText(/ready/)).toBeInTheDocument()
+  })
+})

--- a/tests/step-library-catalog.test.tsx
+++ b/tests/step-library-catalog.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ConnectorCatalogItem } from '../src/shared/types'
+
+const connections = [
+  { id: 'http-1', name: 'reporting API', connectorId: 'http', filters: {} },
+  { id: 'c1', name: 'Pack Demo', connectorId: 'mcp', filters: { sdkConnectorId: 'packdemo' } }
+]
+
+vi.mock('../src/renderer/lib/use-connections', () => ({
+  useConnections: () => connections,
+  useConnectorIdFor: () => null,
+  useConnectionIconFor: () => undefined
+}))
+
+const SLACK: ConnectorCatalogItem = {
+  id: 'slack',
+  name: 'Slack',
+  description: 'Messages and channels',
+  packageName: '@vornrun/connector-slack',
+  capabilities: ['actions'],
+  keywords: ['chat'],
+  verified: {
+    schema: 1,
+    version: '1.2.0',
+    checkedAt: '2026-09-02T00:00:00Z',
+    checks: ['manifest']
+  },
+  actions: [{ type: 'post', label: 'Post message' }],
+  launch: { command: 'npx', args: [] }
+}
+
+const DISCORD: ConnectorCatalogItem = {
+  ...SLACK,
+  id: 'discord',
+  name: 'Discord',
+  packageName: '@vornrun/connector-discord',
+  keywords: ['chat'],
+  actions: [{ type: 'post', label: 'Post message' }],
+  launch: { command: 'npx', args: [] }
+}
+// Nothing vouched for this one; it is findable but not offered first.
+delete (DISCORD as { verified?: unknown }).verified
+
+// The connector this machine already has a connection to must not be offered
+// twice — once as a live action, once as something to install.
+const PACKDEMO: ConnectorCatalogItem = {
+  ...SLACK,
+  id: 'packdemo',
+  name: 'Pack Demo',
+  packageName: '@vornrun/connector-packdemo',
+  actions: [{ type: 'echo', label: 'Echo' }],
+  launch: { command: 'npx', args: [] }
+}
+
+const listConnectionActions = vi.fn(async () => [])
+const listConnectorCatalog = vi.fn(async () => ({
+  items: [SLACK, DISCORD, PACKDEMO],
+  templates: [],
+  mcpServers: []
+}))
+;(window as unknown as { api: Record<string, unknown> }).api = {
+  ...(window as unknown as { api?: Record<string, unknown> }).api,
+  listConnectionActions,
+  listConnectorCatalog
+}
+
+const { StepLibrary } =
+  await import('../src/renderer/components/workflow-editor/panels/StepLibrary')
+const { __resetCatalogCacheForTests } = await import('../src/renderer/lib/use-connector-catalog')
+
+beforeEach(() => {
+  __resetCatalogCacheForTests()
+  vi.clearAllMocks()
+  listConnectorCatalog.mockResolvedValue({
+    items: [SLACK, DISCORD, PACKDEMO],
+    templates: [],
+    mcpServers: []
+  })
+})
+afterEach(cleanup)
+
+const draw = (scope = { bodyOnly: false, insideBranch: false }) => {
+  const onPick = vi.fn()
+  const utils = render(<StepLibrary scope={scope} onPick={onPick} onClose={vi.fn()} />)
+  return { ...utils, onPick }
+}
+
+describe('steps from connectors nobody has installed', () => {
+  it('offers a checked connector as plainly as an installed one', async () => {
+    draw()
+    expect(await screen.findAllByText('Post message')).toHaveLength(2)
+    expect(screen.getAllByText('install on add').length).toBeGreaterThan(0)
+  })
+
+  it('keeps the unvouched ones under their own heading', async () => {
+    draw()
+    expect(await screen.findByText('More from the catalog')).toBeInTheDocument()
+  })
+
+  it('says nothing about a connector this machine is already connected to', async () => {
+    draw()
+    await screen.findByText('More from the catalog')
+    expect(screen.queryByText('Echo')).toBeNull()
+  })
+
+  it('finds a step by what its connector talks about', async () => {
+    draw()
+    await screen.findByText('More from the catalog')
+    fireEvent.change(screen.getByPlaceholderText('Search steps and actions'), {
+      target: { value: 'chat' }
+    })
+
+    expect(screen.getAllByText('Post message')).toHaveLength(2)
+    expect(screen.queryByText('Agent')).toBeNull()
+  })
+
+  it('hands back the connector, so the step knows what to ask for', async () => {
+    const { onPick } = draw()
+    const [first] = await screen.findAllByText('Post message')
+    fireEvent.click(first)
+
+    expect(onPick).toHaveBeenCalledWith({
+      kind: 'catalogAction',
+      connectorId: 'slack',
+      action: 'post',
+      actionLabel: 'Post message'
+    })
+  })
+
+  it('leaves a loop body to the steps it can repeat', async () => {
+    draw({ bodyOnly: true, insideBranch: false })
+    await Promise.resolve()
+    expect(screen.queryByText('Post message')).toBeNull()
+    expect(screen.queryByText('More from the catalog')).toBeNull()
+  })
+})
+
+describe('a saved profile as a step', () => {
+  it('offers the call beside the request it is a shortcut for', async () => {
+    draw()
+    expect(await screen.findByText('Call reporting API')).toBeInTheDocument()
+  })
+
+  it('picks the profile rather than asking for it again', async () => {
+    const { onPick } = draw()
+    fireEvent.click(await screen.findByText('Call reporting API'))
+
+    expect(onPick).toHaveBeenCalledWith({
+      kind: 'httpProfile',
+      profileConnectionId: 'http-1',
+      profileName: 'reporting API'
+    })
+  })
+})

--- a/tests/step-library-catalog.test.tsx
+++ b/tests/step-library-catalog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import { act, render, cleanup, fireEvent, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type { ConnectorCatalogItem } from '../src/shared/types'
 
@@ -64,16 +64,19 @@ const listConnectorCatalog = vi.fn(async () => ({
   templates: [],
   mcpServers: []
 }))
+const refreshCatalog = vi.fn()
 ;(window as unknown as { api: Record<string, unknown> }).api = {
   ...(window as unknown as { api?: Record<string, unknown> }).api,
   listConnectionActions,
-  listConnectorCatalog
+  listConnectorCatalog,
+  refreshConnectorCatalog: refreshCatalog
 }
 
 const { StepLibrary } =
   await import('../src/renderer/components/workflow-editor/panels/StepLibrary')
 type LibraryScope = Parameters<typeof StepLibrary>[0]['scope']
-const { __resetCatalogCacheForTests } = await import('../src/renderer/lib/use-connector-catalog')
+const { __resetCatalogCacheForTests, refreshConnectorCatalog } =
+  await import('../src/renderer/lib/use-connector-catalog')
 
 beforeEach(() => {
   __resetCatalogCacheForTests()
@@ -150,6 +153,23 @@ describe('steps from connectors nobody has installed', () => {
     expect(screen.getAllByText('add connection').length).toBeGreaterThan(0)
     // Discord is still only in the catalog, so its row still promises the install.
     expect(screen.getAllByText('install on add')).toHaveLength(1)
+  })
+
+  it('shows what Check now found, without the panel being reopened', async () => {
+    draw()
+    await screen.findAllByText('Post message')
+
+    refreshCatalog.mockResolvedValue({
+      items: [{ ...SLACK, actions: [{ type: 'status', label: 'Set status' }] }],
+      templates: [],
+      mcpServers: []
+    })
+    await act(async () => {
+      await refreshConnectorCatalog()
+    })
+
+    expect(await screen.findByText('Set status')).toBeInTheDocument()
+    expect(screen.queryByText('Post message')).toBeNull()
   })
 
   it('offers none of this when a step is being swapped in place', async () => {

--- a/tests/step-library-catalog.test.tsx
+++ b/tests/step-library-catalog.test.tsx
@@ -23,6 +23,8 @@ const SLACK: ConnectorCatalogItem = {
   name: 'Slack',
   description: 'Messages and channels',
   packageName: '@vornrun/connector-slack',
+  packUrl: 'https://packs.example/slack-1.2.0.vorn.tgz',
+  sha256: 'a'.repeat(64),
   capabilities: ['actions'],
   keywords: ['chat'],
   verified: {
@@ -39,7 +41,7 @@ const DISCORD: ConnectorCatalogItem = {
   ...SLACK,
   id: 'discord',
   name: 'Discord',
-  packageName: '@vornrun/connector-discord',
+  packUrl: 'https://packs.example/discord-1.0.0.vorn.tgz',
   keywords: ['chat'],
   actions: [{ type: 'post', label: 'Post message' }],
   launch: { command: 'npx', args: [] }
@@ -47,8 +49,7 @@ const DISCORD: ConnectorCatalogItem = {
 // Nothing vouched for this one; it is findable but not offered first.
 delete (DISCORD as { verified?: unknown }).verified
 
-// The connector this machine already has a connection to must not be offered
-// twice — once as a live action, once as something to install.
+// The connector this machine already has a connection to must not be offered twice — once as a live action, once as.
 const PACKDEMO: ConnectorCatalogItem = {
   ...SLACK,
   id: 'packdemo',

--- a/tests/step-library-catalog.test.tsx
+++ b/tests/step-library-catalog.test.tsx
@@ -9,8 +9,11 @@ const connections = [
   { id: 'c1', name: 'Pack Demo', connectorId: 'mcp', filters: { sdkConnectorId: 'packdemo' } }
 ]
 
+const packs: Array<{ id: string }> = []
+
 vi.mock('../src/renderer/lib/use-connections', () => ({
   useConnections: () => connections,
+  useInstalledPacks: () => packs,
   useConnectorIdFor: () => null,
   useConnectionIconFor: () => undefined
 }))
@@ -69,11 +72,13 @@ const listConnectorCatalog = vi.fn(async () => ({
 
 const { StepLibrary } =
   await import('../src/renderer/components/workflow-editor/panels/StepLibrary')
+type LibraryScope = Parameters<typeof StepLibrary>[0]['scope']
 const { __resetCatalogCacheForTests } = await import('../src/renderer/lib/use-connector-catalog')
 
 beforeEach(() => {
   __resetCatalogCacheForTests()
   vi.clearAllMocks()
+  packs.length = 0
   listConnectorCatalog.mockResolvedValue({
     items: [SLACK, DISCORD, PACKDEMO],
     templates: [],
@@ -82,7 +87,7 @@ beforeEach(() => {
 })
 afterEach(cleanup)
 
-const draw = (scope = { bodyOnly: false, insideBranch: false }) => {
+const draw = (scope: LibraryScope = { bodyOnly: false, insideBranch: false }) => {
   const onPick = vi.fn()
   const utils = render(<StepLibrary scope={scope} onPick={onPick} onClose={vi.fn()} />)
   return { ...utils, onPick }
@@ -135,6 +140,25 @@ describe('steps from connectors nobody has installed', () => {
     await Promise.resolve()
     expect(screen.queryByText('Post message')).toBeNull()
     expect(screen.queryByText('More from the catalog')).toBeNull()
+  })
+
+  it('promises a connection rather than an install once the files are on disk', async () => {
+    packs.push({ id: 'slack' })
+    draw()
+    await screen.findAllByText('Post message')
+
+    expect(screen.getAllByText('add connection').length).toBeGreaterThan(0)
+    // Discord is still only in the catalog, so its row still promises the install.
+    expect(screen.getAllByText('install on add')).toHaveLength(1)
+  })
+
+  it('offers none of this when a step is being swapped in place', async () => {
+    draw({ bodyOnly: false, insideBranch: false, replacing: true })
+    await Promise.resolve()
+
+    expect(screen.queryByText('Post message')).toBeNull()
+    expect(screen.queryByText('More from the catalog')).toBeNull()
+    expect(screen.queryByText('Call reporting API')).toBeNull()
   })
 })
 

--- a/tests/step-library-catalog.test.tsx
+++ b/tests/step-library-catalog.test.tsx
@@ -49,7 +49,7 @@ const DISCORD: ConnectorCatalogItem = {
 // Nothing vouched for this one; it is findable but not offered first.
 delete (DISCORD as { verified?: unknown }).verified
 
-// The connector this machine already has a connection to must not be offered twice — once as a live action, once as.
+// A connector this machine is connected to is offered once, as a live action, never also as an install.
 const PACKDEMO: ConnectorCatalogItem = {
   ...SLACK,
   id: 'packdemo',

--- a/tests/step-library-triggers.test.tsx
+++ b/tests/step-library-triggers.test.tsx
@@ -9,7 +9,8 @@ vi.mock('../src/renderer/lib/use-connections', () => ({
     { id: 'c2', name: 'Notes MCP', connectorId: 'mcp' }
   ],
   useConnectorIdFor: () => null,
-  useConnectionIconFor: () => undefined
+  useConnectionIconFor: () => undefined,
+  useInstalledPacks: () => []
 }))
 
 const listConnectors = vi.fn(async () => [

--- a/tests/step-library.test.tsx
+++ b/tests/step-library.test.tsx
@@ -9,7 +9,8 @@ vi.mock('../src/renderer/lib/use-connections', () => ({
     { id: 'c2', name: 'Azure DevOps' }
   ],
   useConnectorIdFor: () => null,
-  useConnectionIconFor: () => undefined
+  useConnectionIconFor: () => undefined,
+  useInstalledPacks: () => []
 }))
 
 const listConnectionActions = vi.fn(async (id: string) =>

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   connectorSuggestions,
+  mergeRequirements,
   requirementAction,
   requirementsOfDefinition,
   requirementsWithBindings,
@@ -296,6 +297,31 @@ describe('what the canvas itself is still missing', () => {
     const [requirement] = requirementsOfDefinition([anonymous])
     if (requirement.kind !== 'connection') throw new Error('expected a connection requirement')
     expect(requirement.connectorId).toBe('')
+  })
+
+  it('keeps what only the file knew about a step the canvas also names', () => {
+    const fromFile = {
+      kind: 'connection' as const,
+      nodeId: 'n1',
+      connectorId: 'slack',
+      name: 'workspace-eng',
+      event: 'message'
+    }
+    const merged = mergeRequirements(requirementsOfDefinition([unbound]), [fromFile])
+
+    expect(merged).toEqual([fromFile])
+  })
+
+  it('falls back to the canvas for a field the file left empty', () => {
+    const vague = { kind: 'connection' as const, nodeId: 'n1', connectorId: '', name: '' }
+    const [merged] = mergeRequirements(requirementsOfDefinition([unbound]), [vague])
+
+    expect(merged.kind === 'connection' && merged.connectorId).toBe('slack')
+  })
+
+  it('keeps a requirement for a step the canvas says nothing about', () => {
+    const orphan = { kind: 'httpProfile' as const, nodeId: 'gone', name: 'reporting API' }
+    expect(mergeRequirements([], [orphan])).toEqual([orphan])
   })
 
   it('binds a requirement the moment this machine has one answer for it', () => {

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -293,7 +293,9 @@ describe('what the canvas itself is still missing', () => {
       action: 'post',
       args: {}
     })
-    expect(requirementsOfDefinition([anonymous])[0].connectorId).toBe('')
+    const [requirement] = requirementsOfDefinition([anonymous])
+    if (requirement.kind !== 'connection') throw new Error('expected a connection requirement')
+    expect(requirement.connectorId).toBe('')
   })
 
   it('binds a requirement the moment this machine has one answer for it', () => {

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   connectorSuggestions,
   requirementAction,
+  requirementsOfDefinition,
+  requirementsWithBindings,
   templateRequirements,
   templateIsReady,
   templateSeed,
@@ -12,6 +14,7 @@ import { TEMPLATE_SEED } from '../packages/server/src/connectors/template-seed'
 import type {
   ConnectorManifest,
   SourceConnection,
+  WorkflowNode,
   WorkflowTemplate
 } from '../packages/shared/src/types'
 
@@ -241,5 +244,71 @@ describe('what a template puts on the canvas', () => {
     expect(seed.nodes).toHaveLength(3)
     expect(seed.edges.find((e) => e.conditionBranch === 'true')).toBeTruthy()
     expect(seed.name).toBe('Webhook to report')
+  })
+})
+
+describe('what the canvas itself is still missing', () => {
+  const node = (id: string, type: string, config: Record<string, unknown>): WorkflowNode =>
+    ({ id, type, label: id, config, position: { x: 0, y: 0 } }) as WorkflowNode
+
+  const unbound = node('n1', 'callConnectorAction', {
+    nodeType: 'callConnectorAction',
+    connectionId: '',
+    connectorId: 'slack',
+    action: 'post',
+    args: {}
+  })
+
+  it('asks for the connector a step was picked from', () => {
+    expect(requirementsOfDefinition([unbound])).toEqual([
+      { kind: 'connection', nodeId: 'n1', connectorId: 'slack', name: '' }
+    ])
+  })
+
+  it('says nothing about a step that is already bound', () => {
+    const bound = node('n2', 'callConnectorAction', {
+      nodeType: 'callConnectorAction',
+      connectionId: 'conn-1',
+      action: 'post',
+      args: {}
+    })
+    expect(requirementsOfDefinition([bound])).toEqual([])
+  })
+
+  it('leaves a request to a public URL alone, profile or no profile', () => {
+    const request = node('n3', 'httpRequest', {
+      nodeType: 'httpRequest',
+      method: 'GET',
+      url: 'https://example.test',
+      headers: {},
+      body: ''
+    })
+    expect(requirementsOfDefinition([request])).toEqual([])
+  })
+
+  it('names no connector when nothing recorded which one it was', () => {
+    const anonymous = node('n4', 'callConnectorAction', {
+      nodeType: 'callConnectorAction',
+      connectionId: '',
+      action: 'post',
+      args: {}
+    })
+    expect(requirementsOfDefinition([anonymous])[0].connectorId).toBe('')
+  })
+
+  it('binds a requirement the moment this machine has one answer for it', () => {
+    const slack = connection({
+      id: 'slack-1',
+      name: 'workspace',
+      connectorId: 'mcp',
+      filters: { sdkConnectorId: 'slack' }
+    })
+
+    expect(requirementsWithBindings(requirementsOfDefinition([unbound]), [])).toEqual([
+      { requirement: { kind: 'connection', nodeId: 'n1', connectorId: 'slack', name: '' } }
+    ])
+    expect(
+      requirementsWithBindings(requirementsOfDefinition([unbound]), [slack])[0].connectionId
+    ).toBe('slack-1')
   })
 })

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -313,8 +313,7 @@ describe('what the canvas itself is still missing', () => {
       connectionId: '',
       event: 'issueCreated'
     })
-    // Both are fixed in the step's own panel, where the connector is chosen;
-    // a row here would be amber forever with no button on it.
+    // Both are fixed in the step's own panel, where the connector is chosen; a row here would be amber forever with no.
     expect(requirementsOfDefinition([anonymous, strippedTrigger])).toEqual([])
   })
 

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -313,7 +313,7 @@ describe('what the canvas itself is still missing', () => {
       connectionId: '',
       event: 'issueCreated'
     })
-    // Both are fixed in the step's own panel, where the connector is chosen; a row here would be amber forever with no.
+    // Both are fixed in the step's own panel, where the connector is chosen; a row here could offer nothing.
     expect(requirementsOfDefinition([anonymous, strippedTrigger])).toEqual([])
   })
 

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -276,7 +276,7 @@ describe('what the canvas itself is still missing', () => {
     expect(requirementsOfDefinition([bound])).toEqual([])
   })
 
-  it('leaves a request to a public URL alone, profile or no profile', () => {
+  it('leaves a request to a public URL alone', () => {
     const request = node('n3', 'httpRequest', {
       nodeType: 'httpRequest',
       method: 'GET',
@@ -287,16 +287,35 @@ describe('what the canvas itself is still missing', () => {
     expect(requirementsOfDefinition([request])).toEqual([])
   })
 
-  it('names no connector when nothing recorded which one it was', () => {
+  it('asks about a profile that was chosen and then cleared', () => {
+    const emptied = node('n5', 'httpRequest', {
+      nodeType: 'httpRequest',
+      method: 'GET',
+      url: '/report',
+      headers: {},
+      body: '',
+      profileConnectionId: ''
+    })
+    expect(requirementsOfDefinition([emptied])).toEqual([
+      { kind: 'httpProfile', nodeId: 'n5', name: '' }
+    ])
+  })
+
+  it('says nothing it could not offer a fix for', () => {
     const anonymous = node('n4', 'callConnectorAction', {
       nodeType: 'callConnectorAction',
       connectionId: '',
       action: 'post',
       args: {}
     })
-    const [requirement] = requirementsOfDefinition([anonymous])
-    if (requirement.kind !== 'connection') throw new Error('expected a connection requirement')
-    expect(requirement.connectorId).toBe('')
+    const strippedTrigger = node('n6', 'trigger', {
+      triggerType: 'connectorPoll',
+      connectionId: '',
+      event: 'issueCreated'
+    })
+    // Both are fixed in the step's own panel, where the connector is chosen;
+    // a row here would be amber forever with no button on it.
+    expect(requirementsOfDefinition([anonymous, strippedTrigger])).toEqual([])
   })
 
   it('keeps what only the file knew about a step the canvas also names', () => {

--- a/tests/use-connection-icon.test.tsx
+++ b/tests/use-connection-icon.test.tsx
@@ -8,6 +8,7 @@ import {
   useConnectorGlyph,
   useConnectorIdFor,
   useConnectorLook,
+  useInstalledPacks,
   __resetConnectionsCacheForTests
 } from '../src/renderer/lib/use-connections'
 
@@ -182,5 +183,35 @@ describe('useConnectorGlyph', () => {
 
     await waitFor(() => expect(listConnections).toHaveBeenCalled())
     expect(getByTestId('out')).toHaveTextContent('none')
+  })
+})
+
+function PacksProbe() {
+  const packs = useInstalledPacks()
+  return <span data-testid="out">{packs.map((pack) => pack.id).join(',') || 'none'}</span>
+}
+
+describe('useInstalledPacks', () => {
+  it('reads the packs the connections refresh already fetched', async () => {
+    const { getByTestId } = render(<PacksProbe />)
+
+    await waitFor(() => expect(getByTestId('out')).toHaveTextContent('packdemo'))
+    // One read served both, rather than a second round trip for the same answer.
+    expect(listConnectorPacks).toHaveBeenCalledTimes(1)
+  })
+
+  it('sees a newly installed pack without being remounted', async () => {
+    const { getByTestId } = render(<PacksProbe />)
+    await waitFor(() => expect(getByTestId('out')).toHaveTextContent('packdemo'))
+
+    listConnectorPacks.mockResolvedValue([
+      { id: 'packdemo', name: 'Pack Demo', version: '1.0.0' },
+      { id: 'slack', name: 'Slack', version: '1.2.0' }
+    ])
+    await act(async () => {
+      await refreshConnections()
+    })
+
+    expect(getByTestId('out')).toHaveTextContent('packdemo,slack')
   })
 })

--- a/tests/use-connector-catalog.test.ts
+++ b/tests/use-connector-catalog.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 
 const listConnectorCatalog = vi.fn()
 const refreshRpc = vi.fn()
-;(globalThis as unknown as { window: unknown }).window = {
-  api: { listConnectorCatalog, refreshConnectorCatalog: refreshRpc }
-}
+vi.stubGlobal('window', { api: { listConnectorCatalog, refreshConnectorCatalog: refreshRpc } })
+afterAll(() => vi.unstubAllGlobals())
 
 const { refreshConnectorCatalog, __resetCatalogCacheForTests } =
   await import('../src/renderer/lib/use-connector-catalog')
@@ -21,6 +20,31 @@ beforeEach(() => {
   vi.clearAllMocks()
   listConnectorCatalog.mockResolvedValue(snapshot('slack'))
   refreshRpc.mockResolvedValue(snapshot('gitlab'))
+})
+
+describe('reading the catalog', () => {
+  it('keeps nothing when the build cannot ask yet, so the next panel asks again', async () => {
+    refreshRpc.mockResolvedValue(undefined)
+    listConnectorCatalog.mockResolvedValueOnce(undefined)
+    expect((await refreshConnectorCatalog()).items).toEqual([])
+
+    const next = await refreshConnectorCatalog()
+    expect(listConnectorCatalog).toHaveBeenCalledTimes(2)
+    expect(next.items[0].id).toBe('slack')
+  })
+
+  it('lets a refresh win over a read that started before it', async () => {
+    let answerRead: (value: unknown) => void = () => {}
+    listConnectorCatalog.mockReturnValueOnce(new Promise((resolve) => (answerRead = resolve)))
+    refreshRpc.mockResolvedValue(undefined)
+    const slow = refreshConnectorCatalog()
+    refreshRpc.mockResolvedValue(snapshot('gitlab'))
+    const fresh = await refreshConnectorCatalog()
+    answerRead(snapshot('stale'))
+    await slow
+    expect(fresh.items[0].id).toBe('gitlab')
+    expect((await refreshConnectorCatalog()).items[0].id).toBe('gitlab')
+  })
 })
 
 describe('checking the catalog again', () => {

--- a/tests/use-connector-catalog.test.ts
+++ b/tests/use-connector-catalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const listConnectorCatalog = vi.fn()
+const refreshRpc = vi.fn()
+;(globalThis as unknown as { window: unknown }).window = {
+  api: { listConnectorCatalog, refreshConnectorCatalog: refreshRpc }
+}
+
+const { refreshConnectorCatalog, __resetCatalogCacheForTests } =
+  await import('../src/renderer/lib/use-connector-catalog')
+
+const snapshot = (id: string) => ({
+  items: [{ id, name: id, description: '', packageName: `p-${id}`, capabilities: [] }],
+  templates: [],
+  mcpServers: [],
+  fetchedAt: 1
+})
+
+beforeEach(() => {
+  __resetCatalogCacheForTests()
+  vi.clearAllMocks()
+  listConnectorCatalog.mockResolvedValue(snapshot('slack'))
+  refreshRpc.mockResolvedValue(snapshot('gitlab'))
+})
+
+describe('checking the catalog again', () => {
+  it('asks the publisher rather than re-reading the copy it already has', async () => {
+    const next = await refreshConnectorCatalog()
+
+    expect(refreshRpc).toHaveBeenCalled()
+    expect(next.items[0].id).toBe('gitlab')
+  })
+
+  it('falls back to reading the catalog when this build cannot re-fetch', async () => {
+    refreshRpc.mockResolvedValue(undefined)
+
+    const next = await refreshConnectorCatalog()
+    expect(listConnectorCatalog).toHaveBeenCalled()
+    expect(next.items[0].id).toBe('slack')
+  })
+
+  it('caches an answer but never a silence', async () => {
+    listConnectorCatalog.mockRejectedValueOnce(new Error('not connected'))
+    refreshRpc.mockResolvedValue(undefined)
+
+    expect((await refreshConnectorCatalog()).items).toEqual([])
+
+    listConnectorCatalog.mockResolvedValue(snapshot('slack'))
+    expect((await refreshConnectorCatalog()).items[0].id).toBe('slack')
+  })
+})

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -84,6 +84,34 @@ const EXPORTABLE: WorkflowDefinition = {
   edges: []
 }
 
+/**
+ * A workflow as an import leaves it: the step is on the canvas with its
+ * connection blanked, and nothing in the node itself says which connector it
+ * came from — only the `requires` block the file carried does.
+ */
+const IMPORTED: WorkflowDefinition = {
+  ...EXPORTABLE,
+  id: 'wf-imported',
+  name: 'Announce a release',
+  nodes: [
+    ...EXPORTABLE.nodes,
+    {
+      id: 'n1',
+      type: 'callConnectorAction',
+      label: 'Post message',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: '',
+        action: 'post',
+        actionLabel: 'Post message',
+        args: {}
+      },
+      position: { x: 0, y: 120 }
+    }
+  ] as WorkflowDefinition['nodes'],
+  edges: []
+}
+
 const mockState = {
   isWorkflowEditorOpen: true,
   editingWorkflowId: null as string | null,
@@ -93,7 +121,7 @@ const mockState = {
   updateWorkflow: vi.fn(),
   removeWorkflow: vi.fn(),
   config: {
-    workflows: [EXPORTABLE],
+    workflows: [EXPORTABLE, IMPORTED],
     tasks: [],
     projects: [{ name: 'Novum', path: '/Users/someone/dev/novum', preferredAgents: [] }],
     defaults: {}
@@ -292,6 +320,27 @@ describe('a requirement answered from the panel', () => {
     // Verified and described, but nothing kept until it is confirmed.
     expect((await screen.findAllByText(/Slack/)).length).toBeGreaterThan(0)
     expect(api.installConnectorPack).not.toHaveBeenCalled()
+  })
+
+  // What the file knew must survive meeting the step it describes: the canvas
+  // can only see that the field is empty, and a row that forgets the connector
+  // is a row with nothing to offer.
+  it('keeps the connector an import named, on the step the canvas also sees', async () => {
+    api.listConnectorCatalog.mockResolvedValue({
+      items: [SLACK_CATALOG],
+      templates: TEMPLATE_SEED,
+      mcpServers: []
+    })
+    mockState.editingWorkflowId = 'wf-imported'
+    mockState.importedRequirements = {
+      workflowId: 'wf-imported',
+      requirements: [
+        { kind: 'connection', nodeId: 'n1', connectorId: 'slack', name: 'workspace-eng' }
+      ]
+    }
+    render(<WorkflowEditor />)
+
+    expect(await screen.findByRole('button', { name: 'Install Slack' })).toBeInTheDocument()
   })
 
   // The whole point of the phase, in one pass: a requirement that named a

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -112,6 +112,16 @@ const IMPORTED: WorkflowDefinition = {
   edges: []
 }
 
+/** A saved workflow with a step placed from the catalog and never bound. */
+const UNBOUND: WorkflowDefinition = {
+  ...IMPORTED,
+  id: 'wf-unbound',
+  name: 'Post from the catalog',
+  nodes: IMPORTED.nodes.map((node) =>
+    node.id === 'n1' ? { ...node, config: { ...node.config, connectorId: 'slack' } } : node
+  ) as WorkflowDefinition['nodes']
+}
+
 const mockState = {
   isWorkflowEditorOpen: true,
   editingWorkflowId: null as string | null,
@@ -121,7 +131,7 @@ const mockState = {
   updateWorkflow: vi.fn(),
   removeWorkflow: vi.fn(),
   config: {
-    workflows: [EXPORTABLE, IMPORTED],
+    workflows: [EXPORTABLE, IMPORTED, UNBOUND],
     tasks: [],
     projects: [{ name: 'Novum', path: '/Users/someone/dev/novum', preferredAgents: [] }],
     defaults: {}
@@ -407,6 +417,20 @@ describe('a requirement answered from the panel', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Add connection' }))
 
     expect(await screen.findByText('Connect GitHub')).toBeInTheDocument()
+  })
+
+  it('offers the install for a step the canvas placed, with no import in sight', async () => {
+    api.listConnectorCatalog.mockResolvedValue({
+      items: [SLACK_CATALOG],
+      templates: TEMPLATE_SEED,
+      mcpServers: []
+    })
+    mockState.editingWorkflowId = 'wf-unbound'
+    render(<WorkflowEditor />)
+
+    expect(await screen.findByRole('button', { name: 'Install Slack' })).toBeInTheDocument()
+    // A row the canvas derives cannot be dismissed: binding or deleting the step is what clears it.
+    expect(screen.queryByLabelText('Dismiss')).toBeNull()
   })
 
   it('says what an import could not bind, on the workflow it imported', async () => {

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -194,12 +194,14 @@ const CONNECTION = {
 const { TEMPLATE_SEED } = await import('../packages/server/src/connectors/template-seed')
 const { __resetConnectionsCacheForTests, refreshConnections } =
   await import('../src/renderer/lib/use-connections')
+const { __resetCatalogCacheForTests } = await import('../src/renderer/lib/use-connector-catalog')
 const { WorkflowEditor } = await import('../src/renderer/components/workflow-editor/WorkflowEditor')
 
 const api = (window as unknown as { api: Record<string, ReturnType<typeof vi.fn>> }).api
 
 beforeEach(() => {
   __resetConnectionsCacheForTests()
+  __resetCatalogCacheForTests()
   vi.clearAllMocks()
   api.listWorkflowRuns.mockResolvedValue([])
   api.listConnections.mockResolvedValue([CONNECTION])

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -330,7 +330,7 @@ describe('a requirement answered from the panel', () => {
     expect(api.installConnectorPack).not.toHaveBeenCalled()
   })
 
-  // What the file knew must survive meeting the step it describes: the canvas can only see that the field is empty,.
+  // What the file knew must survive meeting the step it describes; the canvas only sees an empty field.
   it('keeps the connector an import named, on the step the canvas also sees', async () => {
     api.listConnectorCatalog.mockResolvedValue({
       items: [SLACK_CATALOG],

--- a/tests/workflow-editor-templates.test.tsx
+++ b/tests/workflow-editor-templates.test.tsx
@@ -84,11 +84,7 @@ const EXPORTABLE: WorkflowDefinition = {
   edges: []
 }
 
-/**
- * A workflow as an import leaves it: the step is on the canvas with its
- * connection blanked, and nothing in the node itself says which connector it
- * came from — only the `requires` block the file carried does.
- */
+// A workflow as an import leaves it: the step is on the canvas with its connection blanked, and nothing in the node.
 const IMPORTED: WorkflowDefinition = {
   ...EXPORTABLE,
   id: 'wf-imported',
@@ -334,9 +330,7 @@ describe('a requirement answered from the panel', () => {
     expect(api.installConnectorPack).not.toHaveBeenCalled()
   })
 
-  // What the file knew must survive meeting the step it describes: the canvas
-  // can only see that the field is empty, and a row that forgets the connector
-  // is a row with nothing to offer.
+  // What the file knew must survive meeting the step it describes: the canvas can only see that the field is empty,.
   it('keeps the connector an import named, on the step the canvas also sees', async () => {
     api.listConnectorCatalog.mockResolvedValue({
       items: [SLACK_CATALOG],

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -211,6 +211,54 @@ describe('connections travel as requirements', () => {
     expect(p.requires).toEqual([{ kind: 'httpProfile', nodeId: 'http-1', name: '' }])
   })
 
+  it('reports a step that was never bound, and names what it was picked from', () => {
+    const wf = workflow()
+    wf.nodes.push({
+      id: 'act-2',
+      type: 'callConnectorAction',
+      label: 'Post message',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: '',
+        connectorId: 'slack',
+        action: 'post',
+        args: {}
+      } as WorkflowDefinition['nodes'][number]['config'],
+      position: { x: 0, y: 550 }
+    })
+
+    const p = toPortable(wf, PROJECT)
+    expect(p.requires).toEqual([
+      { kind: 'connection', nodeId: 'act-2', connectorId: 'slack', name: '' }
+    ])
+
+    // And the machine that opens it is told, rather than finding out at run time.
+    const imported = fromPortable(p, 'novum', { name: 'N', path: '/n' }, [])
+    expect(unresolvedRequirements(p, [])).toHaveLength(1)
+    expect(
+      (imported.nodes.find((n) => n.id === 'act-2')!.config as Record<string, unknown>).connectionId
+    ).toBe('')
+  })
+
+  it('says nothing about a step that never had a connection to lose', () => {
+    const wf = workflow()
+    wf.nodes.push({
+      id: 'anon-1',
+      type: 'callConnectorAction',
+      label: 'Connector Action',
+      config: {
+        nodeType: 'callConnectorAction',
+        connectionId: '',
+        action: '',
+        args: {}
+      } as WorkflowDefinition['nodes'][number]['config'],
+      position: { x: 0, y: 660 }
+    })
+
+    const p = toPortable(wf, PROJECT)
+    expect((p.requires ?? [])[0]).toMatchObject({ nodeId: 'anon-1', connectorId: '' })
+  })
+
   it('never lets a local id reach the file', () => {
     const p = toPortable(connectorWorkflow(), PROJECT, [connection()])
     expect(JSON.stringify(p)).not.toContain('conn-1')


### PR DESCRIPTION
The directory at the scale the factory will feed it, and the library offering a connector before it is installed.

## What changed

- **Listings carry the new facts.** `authRung` and `verified` come from the catalog item or the installed pack's manifest. Connections the app made for rung-none packs are hidden from "Your connections" and never count toward "Add another".
- **Directory.** Category sections instead of a flat list; a "Signs in with" facet beside the category select; each row shows a rung badge and a verified badge, with the pack status dot still the only colour. One rung table (label, badge, detail sentence) drives the facet, the row and the detail page.
- **Detail.** A verified strip with the checks and the date; a "Signs in with" line; a rung-none connector reads "Nothing — ready as soon as it is installed" and offers "Use in a workflow" instead of "Add a connection".
- **One catalog.** `useConnectorCatalog` is a module cache with an `enabled` gate; Settings and the editor read it; "Check now" asks the publisher again. Installed packs come from the connections cache through `useInstalledPacks`, so the editor and the library never disagree on what is on disk.
- **Library promotion.** Actions of connectors nobody has connected are offered from the catalog: verified ones inline, tagged by the same install-versus-connect rule the directory uses; the rest under "More from the catalog". Search matches action labels and keywords. HTTP profiles appear as "Call <profile>". One `stepForPick` mapping serves both insert paths; neither pick is offered in replace scope.
- **Unbound placement and derived requirements.** A catalog pick lands as an unbound step naming its connector; `requirementsOfDefinition` derives a "Still needs" row for every unbound step, merged with an import's rows so the import keeps the connector, account and event it named. Every row offers an install or a connection; Dismiss appears only when an import contributed rows. `toPortable` names the connector of a never-bound step.
- **Argument form.** An unbound step draws its arguments from the catalog's published inputs, subscribing to the catalog only in that case.

## Verification

- `/review`: two findings fixed (an undismissable panel for canvas-derived rows; no fix button in a saved workflow). `/simplify`: shared pack cache, one pick mapping, one rung table, shared implicit predicate, one-pass listing build, comments to one line. `/security-review`: no findings.
- typecheck 0; full vitest 5713 passed with the two known ambient failures; diff coverage 94%; prettier clean
- Manual: sections, facet and badges in the directory; verified strip and rung-none action on the detail page; Check now refreshes in place; "post" finds Slack before install with "install on add"; the picked step's row installs, connects and binds; the app's own connection is not listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
