### PR TITLE
chore(release): 0.7.0-beta.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -20,7 +20,7 @@ const ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
  * `^0.7.0` matches no prerelease at all — a scaffold pinned to it installs
  * nothing. Bumped with the SDK's own version until a stable one exists.
  */
-const SDK_DEPENDENCY_RANGE = '^0.7.0-beta.8'
+const SDK_DEPENDENCY_RANGE = '^0.7.0-beta.9'
 
 /** What a scaffold starts at, in the package and in the changelog section that must match it. */
 const SCAFFOLD_VERSION = '0.1.0'

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.8",
+  "version": "0.7.0-beta.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -39,7 +39,7 @@ describe('the files a new connector starts as', () => {
     expect(pkg.scripts.pack).toBe('vorn-connector pack src/index.ts')
     // Names a prerelease because that is all there is: a bare `^0.7.0` matches
     // no prerelease, so a scaffold pinned to it would install nothing.
-    expect(pkg.dependencies['@vornrun/connector-sdk']).toBe('^0.7.0-beta.8')
+    expect(pkg.dependencies['@vornrun/connector-sdk']).toBe('^0.7.0-beta.9')
     expect(pkg.vorn.keywords).toContain('acme-tickets')
   })
 


### PR DESCRIPTION
Version bump to 0.7.0-beta.9 so the connector SDK publishes with declared actions, auth rungs, conformance receipts and the repo-conventions scaffold; the scaffold now pins ^0.7.0-beta.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc