### PR TITLE
Type a fetch input the way Node declares it, so the SDK's declarations build

### DIFF
--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -143,7 +143,7 @@ export async function withMockHttp<T>(
   serving = true
   const calls: MockCall[] = []
   const original = globalThis.fetch
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
     const own = typeof input === 'object' && 'method' in input ? input.method : undefined
     const method = (init?.method ?? own ?? 'GET').toUpperCase()

--- a/packages/connector-sdk/src/resilience.ts
+++ b/packages/connector-sdk/src/resilience.ts
@@ -93,7 +93,7 @@ export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
 
   const ceiling = options.retry?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
 
-  const send = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const send = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     let waited = 0
     /** Wait, unless doing so would spend more than one call is allowed. */
     const pause = async (ms: number): Promise<boolean> => {


### PR DESCRIPTION
The v0.7.0-beta.9 release published the MCP package but not the SDK: tsup --dts failed on RequestInfo, a DOM name the SDK tsconfig does not carry. Uses string | URL | Request instead. Followed by a beta.10 tag for the SDK publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc