### PR TITLE
Take the patched versions of five vulnerable transitive deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   },
   "resolutions": {
     "serialize-javascript": "^7.0.5",
-    "@xmldom/xmldom": "^0.8.10",
+    "@xmldom/xmldom": "^0.8.15",
     "hono": "^4.13.1",
     "@hono/node-server": "^2.0.11",
     "lodash": "^4.18.1",
@@ -129,10 +129,11 @@
     "tar": "^7.5.21",
     "path-to-regexp": "^8.4.2",
     "picomatch": "^4.0.4",
-    "fastify": "^5.11.0",
+    "@humanfs/node": "^0.16.8",
+    "fastify": "^5.12.1",
     "js-yaml": "^4.3.1",
     "ip-address": "^10.3.1",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "node-gyp/undici": "^8.9.0",
     "tsup/esbuild": "^0.28.1",
     "postcss": "^8.5.23"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2224,20 +2224,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanfs/core@npm:^0.19.1":
-  version: 0.19.1
-  resolution: "@humanfs/core@npm:0.19.1"
-  checksum: 10c0/aa4e0152171c07879b458d0e8a704b8c3a89a8c0541726c6b65b81e84fd8b7564b5d6c633feadc6598307d34564bd53294b533491424e8e313d7ab6c7bc5dc67
+"@humanfs/core@npm:^0.19.2":
+  version: 0.19.2
+  resolution: "@humanfs/core@npm:0.19.2"
+  dependencies:
+    "@humanfs/types": "npm:^0.15.0"
+  checksum: 10c0/d0a1d52d7b30c27d49475a53072d1510b81c5803e44b342fb8faf3887f1aa27593a1e6dc76a45268e7892d3f4e198146659281f6b6d55eacf3fd5a38bac30c5c
   languageName: node
   linkType: hard
 
-"@humanfs/node@npm:^0.16.6":
-  version: 0.16.7
-  resolution: "@humanfs/node@npm:0.16.7"
+"@humanfs/node@npm:^0.16.8":
+  version: 0.16.8
+  resolution: "@humanfs/node@npm:0.16.8"
   dependencies:
-    "@humanfs/core": "npm:^0.19.1"
+    "@humanfs/core": "npm:^0.19.2"
+    "@humanfs/types": "npm:^0.15.0"
     "@humanwhocodes/retry": "npm:^0.4.0"
-  checksum: 10c0/9f83d3cf2cfa37383e01e3cdaead11cd426208e04c44adcdd291aa983aaf72d7d3598844d2fe9ce54896bb1bf8bd4b56883376611c8905a19c44684642823f30
+  checksum: 10c0/56140579db811af4e160b195d45d0f29acf644d192c93fe24c9e594ebf06f19dfc157494a07c84540b8a071c0e4b37209c2362765d31734f4d0be869c2422e25
+  languageName: node
+  linkType: hard
+
+"@humanfs/types@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@humanfs/types@npm:0.15.0"
+  checksum: 10c0/fc26b9a024b0e55f7eaf64036df94345bf5d36d6a41ef80ef38e78f1f7430ce26cf435af736adae58913baae18eac3f38c18739054a3d379102015978eae862e
   languageName: node
   linkType: hard
 
@@ -4764,10 +4774,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmldom/xmldom@npm:^0.8.10":
-  version: 0.8.13
-  resolution: "@xmldom/xmldom@npm:0.8.13"
-  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
+"@xmldom/xmldom@npm:^0.8.15":
+  version: 0.8.15
+  resolution: "@xmldom/xmldom@npm:0.8.15"
+  checksum: 10c0/59d09b85824b684fba5a0a224d5b43abea1a0d745e8d8b8136a7013e996eb6da122fdbb3deb32ed1621923a10e1937b1f7917cea43481d9d5b976e8c1ff836c1
   languageName: node
   linkType: hard
 
@@ -7038,10 +7048,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+"fast-uri@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "fast-uri@npm:3.1.6"
+  checksum: 10c0/77fa4f966f7d2cf83c34af2d3eb88882872fe90634f27a6bd309551db65377d3ca55616467c7cb4dcc57e33523d149e2fec1952d51cc2f00bfce68a66c3711ea
   languageName: node
   linkType: hard
 
@@ -7052,9 +7062,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fastify@npm:^5.11.0":
-  version: 5.11.0
-  resolution: "fastify@npm:5.11.0"
+"fastify@npm:^5.12.1":
+  version: 5.12.1
+  resolution: "fastify@npm:5.12.1"
   dependencies:
     "@fastify/ajv-compiler": "npm:^4.0.5"
     "@fastify/error": "npm:^4.0.0"
@@ -7066,12 +7076,12 @@ __metadata:
     find-my-way: "npm:^9.6.0"
     light-my-request: "npm:^6.0.0"
     pino: "npm:^9.14.0 || ^10.1.0"
-    process-warning: "npm:^5.0.0"
+    process-warning: "npm:^5.1.0"
     rfdc: "npm:^1.3.1"
     secure-json-parse: "npm:^4.0.0"
     semver: "npm:^7.6.0"
     toad-cache: "npm:^3.7.0"
-  checksum: 10c0/baca681a07272e7483ab453d4ef4df645c7512ac74162ef25190bb6e303ba115d009a349dd242a86d2cf8f931334bd31e89bb4e8f12a25d453076829cf149d27
+  checksum: 10c0/07e2219db3d7d522519fe16bfefa1768d3bbcb80a161762131db7315812af3f7a4cd131358985a9aeb84ab24c069a362ec3ef592a3a29eb4fa3446e77bbf6678
   languageName: node
   linkType: hard
 
@@ -9844,6 +9854,13 @@ __metadata:
   version: 5.0.0
   resolution: "process-warning@npm:5.0.0"
   checksum: 10c0/941f48863d368ec161e0b5890ba0c6af94170078f3d6b5e915c19b36fb59edb0dc2f8e834d25e0d375a8bf368a49d490f080508842168832b93489d17843ec29
+  languageName: node
+  linkType: hard
+
+"process-warning@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "process-warning@npm:5.1.0"
+  checksum: 10c0/2a48d48b575f4e7888fd4735a6604acd89914efa909f3db5dd20ae56e8a8cdd3c32a3c738bba539b46d1c5096630e15286bcb7c7fca18dfbf04cc7d00fe34a0f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes eight of the twelve open Dependabot alerts, including all four high ones that had no pull request of their own.

The awkward part is why they were open at all. Four of the five packages here were **already permitted** by the ranges in `resolutions` — `fast-uri` was pinned `^3.1.5` and the fix is 3.1.6 — and were held back only by the lockfile. So the repo looked patched and was not, and nothing would have refreshed it on its own: Dependabot opens PRs against direct dependencies, and these are all transitive.

So the floors move up to the version that carries the fix, rather than the version that happened to be current when the pin was written. A range that says `^3.1.5` invites the lockfile to sit on 3.1.5 indefinitely; one that says `^3.1.6` records why that number matters.

| | | | |
|---|---|---|---|
| `fast-uri` | 3.1.5 → 3.1.6 | **high** ×4 | host confusion via percent-encoded scheme normalisation and via skipped IDN canonicalisation; SSRF via malformed IPv6 normalisation and via repeated hostname percent-decoding |
| `fastify` | 5.11.0 → 5.12.1 | medium ×2 | schema validation bypass via root primitive coercion; `X-Forwarded-*` spoofing under a `trustProxy` hop count |
| `@xmldom/xmldom` | 0.8.13 → 0.8.15 | medium | XML fragment injection via an invalid `EntityReference.nodeName` during well-formed serialisation |
| `@humanfs/node` | 0.16.7 → 0.16.8 | medium | recursive copy following symlinks out of the source tree |

`@humanfs/node` had no pin at all and gets one. It reaches the tree through eslint, so it is development only.

## What this does not fix

`qs` stays at 6.15.2, carrying two medium advisories. The patched 6.16.0 is not resolvable from this machine's registry mirror yet, and committing a lockfile that names a version which cannot be fetched is worse than an honest gap. Worth a second pass once the mirror has ingested it.

The remaining alert is `@tiptap/core`, which needs the tiptap packages moved as a family — bumping one of them alone leaves the root core behind, yarn nests a second copy, and the typecheck fails on two unrelated `ExtendedOptions` types. That is #526's problem and belongs with it.

## Testing

`yarn typecheck` and `yarn test` pass — 5807, with only the two that assert on environment variables a Vorn session injects and so fail when the suite is run from inside one. `prettier --check` and `scripts/check-lockfile.mjs` are clean, and the lockfile carries no private-mirror archive URLs.

No source changed. `fastify` is the only one of these that runs in production, and it is a patch bump within 5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT
