### PR TITLE
Point Dependabot at the workspace, not at each package in it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,52 +1,22 @@
 version: 2
 updates:
+  # One entry for the whole workspace, not one per package.
+  #
+  # There is a single yarn.lock, at the root. Pointed at `/packages/server` and
+  # the rest, Dependabot treated each as a project of its own, found no lockfile
+  # beside the manifest, and opened pull requests that changed a package.json
+  # and nothing else -- which `yarn install --immutable` rejects on sight. Those
+  # could never go green, and three of them were open at once. From the root it
+  # resolves the workspace manifests together and updates the one lockfile they
+  # share.
+  #
   # TypeScript 7 is the native (Go port) rewrite: its main entry no longer
   # exposes the classic compiler API (breaks typescript-eslint) and Yarn's
   # bundled compat/typescript patch fails to install it. Hold the major bump
-  # in every npm package until the toolchain supports the native port.
-  # TS 6.x minor/patch updates still flow.
+  # until the toolchain supports the native port. TS 6.x minor and patch
+  # updates still flow.
   - package-ecosystem: 'npm'
     directory: '/'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/web'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/desktop'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/server'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/shared'
-    schedule:
-      interval: 'weekly'
-    ignore:
-      - dependency-name: 'typescript'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/packages/mcp'
     schedule:
       interval: 'weekly'
     ignore:


### PR DESCRIPTION
#523, #524 and #525 could never have gone green. Each changed a `packages/*/package.json` and nothing else, and `yarn install --immutable` rejects that on sight — the lockfile no longer matches the manifest.

The cause is configuration, not those pull requests. There is one `yarn.lock` and it sits at the root, but Dependabot was given a separate npm entry per package directory. Pointed at `/packages/server`, it treats that as a project of its own: no lockfile beside the manifest, so it updates the manifest alone. Three such pull requests were open at once, failing every week, and no amount of rebasing would have helped any of them.

From the root, Dependabot resolves the workspace manifests together and updates the single lockfile they share — which is the shape of the two dependency pull requests that did go green this week (#520, #539).

The typescript major-version hold moves to the remaining entry unchanged. With one entry it no longer has to be repeated six times to say the same thing.

I am closing #523, #524 and #525 rather than trying to fix them by hand. Dependabot will reopen what is still outstanding on its next run, with a lockfile this time.

## Testing

Config only — no source, no dependencies. `prettier --check` is clean, and the file still parses to exactly two entries: npm at `/` and github-actions at `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT