### PR TITLE
Resolve electron-to-chromium to a version every registry has

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6260,9 +6260,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.402":
-  version: 1.5.420
-  resolution: "electron-to-chromium@npm:1.5.420"
-  checksum: 10c0/0c4a4932991cefc9aa655cbb00b3b693680709df9e4eb2fc1a51cab851b735a2be9510c345b5ed6cad571e58e6d27867731607741df82de9535a7eb041fceda2
+  version: 1.5.415
+  resolution: "electron-to-chromium@npm:1.5.415"
+  checksum: 10c0/5eb45148e9b3e44183dc970ba2311cf82724a1eb21dafb8b352fb60010ab569e8faf50a3729358b6723a1bdafb99efdeff3d1d613ca07c44ef6568ed4d61c6e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`yarn install` currently fails on a machine behind a registry mirror. The lockfile asks for `electron-to-chromium` 1.5.420; the mirror's index stops at 1.5.415, so the fetch 404s and no install completes — no new dependency, no clean checkout, and nothing that needs one.

It arrived that way through #520, which Dependabot resolved against public npm. Nothing about the version is deliberate: the range is `^1.5.402`, and 1.5.415 satisfies it just as well. The package publishes roughly daily and the mirror trails it, so the lockfile had simply landed on a version only one of the two registries could serve.

This re-resolves it down to a version both can. Public npm has 1.5.415 too, so CI is unaffected — and this is browserslist's browser-version data, not anything that runs.

## Worth knowing

A plain `yarn install` cannot get out of this state. It honours the lockfile and never re-resolves, so it asks for the missing version again every time — retrying looks like the obvious move and cannot work. `yarn install --mode=update-lockfile` is what picks a different one.

This is also not a general fix. Every browserslist bump can land here again, because Dependabot resolves against public npm and the mirror trails a daily-publishing package. The durable answer is the mirror keeping pace, not anything in this repo.

## Testing

Lockfile only, three lines, no `package.json` change. `yarn install` completes; `yarn typecheck` passes; 5807 tests pass, with only the two that assert on environment variables a Vorn session injects and so fail when the suite runs inside one. `scripts/check-lockfile.mjs` is clean and the lockfile references no host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT