### PR TITLE
Let a session opened after launch count as one that exists

### DIFF
--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -587,8 +587,17 @@ function reconcileView(
  * that did something from one that did not.
  */
 function pruneAgainstKnown(state: AppStore): Partial<AppStore> | null {
-  const live = state.knownSessionIds
-  if (live === null) return null
+  if (state.knownSessionIds === null) return null
+  // What the server reported, plus whatever is on the board now.
+  //
+  // The sync answers once, at launch. Every session opened after it -- a shell
+  // taken out inside a card, a second agent -- is absent from that answer
+  // forever, and pruning against it alone treated all of them as sessions that
+  // never came back. Minimising one un-minimised it on the next reconcile, and a
+  // shell added to a terminals panel was dropped straight back out of it.
+  //
+  // A session on the board is real by definition: something just created it.
+  const live = new Set([...state.knownSessionIds, ...state.terminals.keys()])
   const panes = reconcilePanes(
     state.filesPanes,
     state.editorPanes,

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -570,33 +570,35 @@ function reconcileView(
 }
 
 /**
- * Drop everything belonging to a session the server does not have.
+ * Drop everything belonging to a session that no longer exists.
  *
  * Sessions restore by their persisted id, so pane entries stay valid across
  * restarts — but a session that never comes back would leave its entry behind
  * forever.
  *
- * Reconciled against what the server has rather than against what is on the
- * board. Those differ on the launch where reopen is off: the ended sessions are
- * deliberately left off the board and offered by the banner instead, and pruning
- * against the board would delete the panes of every one of them a moment before
- * the person is asked whether to bring them back. Null until a sync pass has
- * asked, which is not the same as none.
+ * "Exists" is the union of two answers, because neither is sufficient alone.
+ *
+ * What the server reported, because with reopen off the board deliberately
+ * leaves the ended sessions out for the banner to offer, and pruning against the
+ * board alone would delete their panes a moment before the person is asked
+ * whether to bring them back.
+ *
+ * And what is on the board, because the server is asked once at launch and
+ * nothing adds to that answer afterwards — so pruning against it alone treated
+ * every session opened later as one that never came back.
+ *
+ * A session missing from both is genuinely gone, which is the only case that
+ * should lose anything. Null before the first sync, which is not the same
+ * answer as none.
  *
  * Returns null when there is nothing to change, so a caller can tell a reconcile
  * that did something from one that did not.
  */
 function pruneAgainstKnown(state: AppStore): Partial<AppStore> | null {
   if (state.knownSessionIds === null) return null
-  // What the server reported, plus whatever is on the board now.
-  //
-  // The sync answers once, at launch. Every session opened after it -- a shell
-  // taken out inside a card, a second agent -- is absent from that answer
-  // forever, and pruning against it alone treated all of them as sessions that
-  // never came back. Minimising one un-minimised it on the next reconcile, and a
-  // shell added to a terminals panel was dropped straight back out of it.
-  //
-  // A session on the board is real by definition: something just created it.
+  // Minimising a shell used to undo itself on the next reconcile, and a shell
+  // added to a terminals panel was dropped straight back out of it. Both were
+  // sessions opened after the sync, absent from its answer and read as gone.
   const live = new Set([...state.knownSessionIds, ...state.terminals.keys()])
   const panes = reconcilePanes(
     state.filesPanes,

--- a/tests/terminals-panel.test.ts
+++ b/tests/terminals-panel.test.ts
@@ -183,6 +183,20 @@ describe('the terminals panel', () => {
     expect(s().terminalsPanes.get('owner')?.terminals).toEqual(['sh2'])
   })
 
+  it('keeps a shell taken out after the launch sync', () => {
+    // A shell opened now is a session the sync never heard of. Pruning against
+    // that answer alone dropped it straight back out of the panel it was just
+    // added to, which reads as the panel refusing to open a shell at all.
+    act(() =>
+      useAppStore.setState({
+        knownSessionIds: new Set(['owner']) as never
+      })
+    )
+    act(() => s().openTerminalsPane('owner', 'sh1'))
+    act(() => s().setVisibleTerminalIds(['owner']))
+    expect(s().terminalsPanes.get('owner')?.terminals).toEqual(['sh1'])
+  })
+
   it('drops a panel whose shells all failed to come back', () => {
     act(() => s().openTerminalsPane('owner', 'sh1'))
     act(() =>

--- a/tests/view-restore.test.ts
+++ b/tests/view-restore.test.ts
@@ -194,3 +194,37 @@ describe('a launch that finds nothing running', () => {
     expect([...useAppStore.getState().minimizedTerminals]).toEqual(['term-1'])
   })
 })
+
+describe('a session opened after the launch sync', () => {
+  it('can be minimised and stays minimised', () => {
+    // The sync answers once, at launch. Everything opened afterwards is absent
+    // from that answer forever, and pruning against it alone treated all of it
+    // as sessions that never came back -- so minimising un-minimised on the
+    // next reconcile, which is every time the visible list moves.
+    useAppStore.setState({ terminals: new Map([['term-1', { id: 'term-1' } as never]]) })
+    useAppStore.getState().setKnownSessions(['term-1'])
+
+    useAppStore.setState({
+      terminals: new Map([
+        ['term-1', { id: 'term-1' } as never],
+        ['shell-2', { id: 'shell-2' } as never]
+      ])
+    })
+    useAppStore.getState().toggleMinimized('shell-2')
+    useAppStore.getState().setVisibleTerminalIds(['term-1'])
+
+    expect([...useAppStore.getState().minimizedTerminals]).toContain('shell-2')
+  })
+
+  it('is still dropped once the server says it is gone', () => {
+    // The board is what makes a session real, so it has to stop being on it.
+    useAppStore.setState({
+      terminals: new Map([['term-1', { id: 'term-1' } as never]]),
+      minimizedTerminals: new Set(['shell-2'])
+    })
+    useAppStore.getState().setKnownSessions(['term-1'])
+    useAppStore.getState().setVisibleTerminalIds(['term-1'])
+
+    expect([...useAppStore.getState().minimizedTerminals]).toEqual([])
+  })
+})


### PR DESCRIPTION
Minimising a shell did nothing, and a shell taken out inside a session dropped straight back out of its panel. Both are the same mistake, made in #535, and both were found by using the app rather than by any test in it.

## What went wrong

#535 moved the prune from "sessions on the board" to "sessions the server reported". That was for a real reason: with reopen off the board deliberately leaves the ended sessions out for the banner to offer, and pruning against the board deleted their panes a moment before the person was asked whether to bring them back.

But that answer is given **once**, by the launch sync, and nothing adds to it afterwards. So every session opened later was absent from it forever, and the reconcile treated all of them as sessions that never came back.

Minimising is the clearest case because it is self-defeating:

1. the id goes into the minimised set
2. the card leaves the visible list
3. that runs the reconcile
4. the reconcile takes the id straight back out

The panel case is the same shape one layer down — a panel's shells are checked against the same set one by one, so a shell added to a panel is removed from it immediately.

It fell hardest on shells only because those are what you open mid-session. A session that was already there when the sync ran is in the set and behaves normally, which is exactly the split that was reported: sessions minimise, shells do not.

## The fix

Prune against what the server reported **plus what is on the board now**. A session on the board is real by definition — something just created it. One that truly never came back is on neither list, so it still goes, and the #535 behaviour this was all for is unaffected.

## Testing

Both regression tests were written against the broken code and failed on it. A third asserts the prune still drops what it should, so the fix cannot pass by doing nothing.

`yarn typecheck` passes; 5831 tests pass, with only the two that assert on environment variables a Vorn session injects and so fail when the suite runs inside one.

## Why the tests missed it

Every test in #535 seeded `knownSessionIds` and `terminals` together — `boardWith`, `seed`, and the view-restore fixtures all set both from one list. That made the two sets identical in every case, so the state where they diverge was unreachable. The reviewer found four real bugs in that PR and could not have found this one either; it needed the two sets to drift, which only happens once the app is running.

That is the gap worth remembering, not the line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT