### PR TITLE
chore(release): 0.7.0-beta.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.11",
+  "version": "0.7.0-beta.12",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cut to get the shell fix out. beta.11 was tagged a few minutes before the tiptap merge landed, so this carries both.

## What is in it

**#550 — a session opened after launch counts as one that exists.** The user-visible bug: minimising a shell did nothing, and a shell taken out inside a session dropped straight back out of its panel. Both were the same regression from #535 — the prune reconciled only against the sessions the launch sync reported, and nothing adds to that answer afterwards, so everything opened later read as a session that never came back. Renderer-side, so the fix takes effect on update regardless of which server the app adopts.

**#546 — the tiptap family at 3.30.5.** Closes the last fixable Dependabot alert: `@tiptap/core` before 3.30.4 turns an own `__proto__` key passed to `mergeAttributes()` into an inherited executable DOM attribute.

## Also on main since beta.11

- **#535** — P6: the arrangement comes back with the sessions. Minimised cards, active tab, maximised pane, project and worktree scope, terminal scroll anchored to a command, device panes re-claimed with named refusals, unsaved editor buffers with a conflict check.
- **#539, #520** — nine security advisories including all five high ones.
- **#542** — Dependabot pointed at the workspace root.
- **#543** — lockfile resolvable behind a registry mirror.

Version only; `scripts/sync-versions.sh` carried the six workspace packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT