### PR TITLE
Take the server with the app when it updates

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -276,6 +276,16 @@ function explainRefusal(reason: string): string {
  */
 let keepSessionsRunning = true
 
+/**
+ * Set once the server has been stopped on purpose, so the quit that follows
+ * proceeds instead of holding itself open a second time.
+ *
+ * Two paths set it: the deliberate shutdown in `before-quit`, and an update,
+ * which stops the server before handing over to the updater rather than inside
+ * the quit it triggers.
+ */
+let serverStopped = false
+
 function rememberKeepSessionsRunning(config: unknown): void {
   const value = (config as AppConfig | null)?.defaults?.keepSessionsRunning
   keepSessionsRunning = value ?? true
@@ -589,7 +599,29 @@ app.whenReady().then(async () => {
   })
 
   // Update IPC handlers
-  ipcMain.on(IPC.UPDATE_INSTALL, () => {
+  //
+  // The update takes the server with it. Left alone, `before-quit` sees
+  // `keepSessionsRunning` and lets go of the server, so the new build adopts the
+  // old one and never moves off it -- an app on beta.12 talking to a beta.11
+  // server, with no way forward but a reboot. Ending it here is what keeps client
+  // and server on one build, which is cheaper than reconciling two.
+  //
+  // Before `quitAndInstall` rather than inside the quit it raises. The deliberate
+  // path below holds its own quit open with `preventDefault`, and doing that to
+  // the updater's quit risks cancelling the relaunch -- which is the very thing
+  // `onQuitForUpdate` exists to protect. Stopping first means `before-quit` finds
+  // the work done and never intervenes.
+  ipcMain.on(IPC.UPDATE_INSTALL, async () => {
+    keepSessionsRunning = false
+    try {
+      await stopServer()
+    } catch (err) {
+      // An update that cannot stop the server still has to install. The old
+      // server is left running and the next launch adopts it, which is exactly
+      // today's behaviour rather than something worse.
+      log.error('[main] could not stop the server before updating:', err)
+    }
+    serverStopped = true
     updateManager.installUpdate()
   })
 
@@ -703,9 +735,6 @@ app.whenReady().then(async () => {
 updateManager.onQuitForUpdate(() => {
   isQuitting = true
 })
-
-/** Set once the deliberate shutdown has finished, so the re-entered quit proceeds. */
-let serverStopped = false
 
 app.on('before-quit', async (event) => {
   isQuitting = true

--- a/src/renderer/components/project-sidebar/SidebarFooter.tsx
+++ b/src/renderer/components/project-sidebar/SidebarFooter.tsx
@@ -2,7 +2,7 @@ import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
 import { getShortcut } from '../../lib/keyboard-shortcuts'
 import { describeUpdateStatus, hasPendingUpdate } from '../../lib/update-status'
-import { updateCostLine } from '../../lib/update-cost'
+import { facesRestart, updateCostLine } from '../../lib/update-cost'
 import { CircleHelp, Settings } from 'lucide-react'
 
 export function SidebarFooter({
@@ -25,9 +25,9 @@ export function SidebarFooter({
   )
   // Selected as two primitives for the same reason as the status above: this
   // subtree must not re-render on every keystroke a session prints.
-  const sessionCount = useAppStore((s) => s.terminals.size)
+  const sessionCount = useAppStore((s) => [...s.terminals.values()].filter(facesRestart).length)
   const aTurnIsRunning = useAppStore((s) =>
-    [...s.terminals.values()].some((t) => t.status === 'running')
+    [...s.terminals.values()].some((t) => facesRestart(t) && t.status === 'running')
   )
   const dismissed = useAppStore((s) => s.updateBannerDismissed)
   const setDismissed = useAppStore((s) => s.setUpdateBannerDismissed)

--- a/src/renderer/components/project-sidebar/SidebarFooter.tsx
+++ b/src/renderer/components/project-sidebar/SidebarFooter.tsx
@@ -2,6 +2,7 @@ import { useAppStore } from '../../stores'
 import { Tooltip } from '../Tooltip'
 import { getShortcut } from '../../lib/keyboard-shortcuts'
 import { describeUpdateStatus, hasPendingUpdate } from '../../lib/update-status'
+import { updateCostLine } from '../../lib/update-cost'
 import { CircleHelp, Settings } from 'lucide-react'
 
 export function SidebarFooter({
@@ -22,8 +23,16 @@ export function SidebarFooter({
   const shortLabel = useAppStore((s) =>
     hasPendingUpdate(s.appUpdateStatus) ? describeUpdateStatus(s.appUpdateStatus).shortLabel : null
   )
+  // Selected as two primitives for the same reason as the status above: this
+  // subtree must not re-render on every keystroke a session prints.
+  const sessionCount = useAppStore((s) => s.terminals.size)
+  const aTurnIsRunning = useAppStore((s) =>
+    [...s.terminals.values()].some((t) => t.status === 'running')
+  )
   const dismissed = useAppStore((s) => s.updateBannerDismissed)
   const setDismissed = useAppStore((s) => s.setUpdateBannerDismissed)
+
+  const cost = updateCostLine(sessionCount, aTurnIsRunning)
 
   const settingsShortcut = getShortcut('settings')?.display
   // Collapsed the rail is 52px, which the banner cannot live in; dismissed the
@@ -47,6 +56,10 @@ export function SidebarFooter({
               ✕
             </button>
           </div>
+          {/* The same sentence the Updates panel gives, because this button does
+              the same thing. Without it the shortcut is the quieter way to end
+              every session, which is the wrong way round. */}
+          {cost && <div className="mt-1.5 text-[10.5px] leading-snug text-bronzo">{cost}</div>}
           <button
             onClick={() => window.api.installUpdate()}
             className="mt-2 w-full px-2 py-1 text-[11px] text-gray-300 bg-white/[0.04]

--- a/src/renderer/components/settings/UpdatesSettings.tsx
+++ b/src/renderer/components/settings/UpdatesSettings.tsx
@@ -3,7 +3,7 @@ import { SettingsPageHeader } from './SettingsPageHeader'
 import { SettingRow } from './SettingRow'
 import { ToggleSwitch } from './ToggleSwitch'
 import { SegmentedControl } from './SegmentedControl'
-import { updateCostLine } from '../../lib/update-cost'
+import { facesRestart, updateCostLine } from '../../lib/update-cost'
 import { describeUpdateStatus } from '../../lib/update-status'
 import { TONE_DOT } from '../../lib/status-tone'
 
@@ -33,9 +33,9 @@ export function UpdatesSettings() {
   const config = useAppStore((s) => s.config)
   const setConfig = useAppStore((s) => s.setConfig)
   const status = useAppStore((s) => s.appUpdateStatus)
-  const sessionCount = useAppStore((s) => s.terminals.size)
+  const sessionCount = useAppStore((s) => [...s.terminals.values()].filter(facesRestart).length)
   const aTurnIsRunning = useAppStore((s) =>
-    [...s.terminals.values()].some((t) => t.status === 'running')
+    [...s.terminals.values()].some((t) => facesRestart(t) && t.status === 'running')
   )
 
   if (!config) return null

--- a/src/renderer/components/settings/UpdatesSettings.tsx
+++ b/src/renderer/components/settings/UpdatesSettings.tsx
@@ -3,6 +3,7 @@ import { SettingsPageHeader } from './SettingsPageHeader'
 import { SettingRow } from './SettingRow'
 import { ToggleSwitch } from './ToggleSwitch'
 import { SegmentedControl } from './SegmentedControl'
+import { updateCostLine } from '../../lib/update-cost'
 import { describeUpdateStatus } from '../../lib/update-status'
 import { TONE_DOT } from '../../lib/status-tone'
 
@@ -32,6 +33,10 @@ export function UpdatesSettings() {
   const config = useAppStore((s) => s.config)
   const setConfig = useAppStore((s) => s.setConfig)
   const status = useAppStore((s) => s.appUpdateStatus)
+  const sessionCount = useAppStore((s) => s.terminals.size)
+  const aTurnIsRunning = useAppStore((s) =>
+    [...s.terminals.values()].some((t) => t.status === 'running')
+  )
 
   if (!config) return null
 
@@ -39,6 +44,9 @@ export function UpdatesSettings() {
   const autoDownload = config.defaults.updateAutoDownload !== false
   const view = describeUpdateStatus(status, channel)
   const action = view.action ? ACTIONS[view.action] : null
+  // Only where the button ends them. Every other state is reporting on a
+  // download, which costs nothing.
+  const cost = view.action === 'restart' ? updateCostLine(sessionCount, aTurnIsRunning) : null
 
   const updateDefaults = (patch: Partial<typeof config.defaults>): void => {
     const updated = {
@@ -59,7 +67,11 @@ export function UpdatesSettings() {
         <span className={`w-[5px] h-[5px] rounded-full shrink-0 ${TONE_DOT[view.tone]}`} />
         <div className="min-w-0 flex-1">
           <div className="text-[13px] text-gray-200">{view.label}</div>
-          {view.detail && <div className="text-xs text-gray-500 mt-0.5">{view.detail}</div>}
+          {cost ? (
+            <div className="text-xs text-bronzo mt-0.5">{cost}</div>
+          ) : (
+            view.detail && <div className="text-xs text-gray-500 mt-0.5">{view.detail}</div>
+          )}
           {view.percent != null && (
             <div className="h-[3px] bg-white/[0.08] rounded-full mt-2 overflow-hidden">
               <div

--- a/src/renderer/lib/update-cost.ts
+++ b/src/renderer/lib/update-cost.ts
@@ -1,0 +1,21 @@
+/**
+ * What restarting for an update will cost, in one line, or null when it costs
+ * nothing worth saying.
+ *
+ * Installing an update ends the server and every session on it, which is a
+ * deliberate reversal of what `Keep Sessions Running` promises: that closing
+ * Vorn leaves the agents working. Updating is a more considered act than closing
+ * a window, so the reversal is defensible — but a setting the person turned on
+ * cannot be quietly overruled, so the exception is stated on the button that
+ * makes it rather than left to be discovered.
+ *
+ * The turn is named separately because it is the only part that is actually
+ * lost. A session comes back where it was; a turn in flight does not.
+ */
+export function updateCostLine(sessionCount: number, aTurnIsRunning: boolean): string | null {
+  if (sessionCount <= 0) return null
+  const sessions =
+    sessionCount === 1 ? 'Your session restarts' : `Your ${sessionCount} sessions restart`
+  const turn = aTurnIsRunning ? ' A turn in flight is lost.' : ''
+  return `${sessions} on the new version.${turn}`
+}

--- a/src/renderer/lib/update-cost.ts
+++ b/src/renderer/lib/update-cost.ts
@@ -1,3 +1,18 @@
+import type { TerminalState } from '../stores/types'
+
+/**
+ * Whether a pane has anything for the update to end.
+ *
+ * A session that has already ended keeps its card so the exit stays readable, so
+ * `terminals` holds panes with no process behind them. They are not restarted --
+ * they are already stopped, and the resume pass only takes back what it stopped
+ * itself -- so counting them promises an interruption that is not going to
+ * happen.
+ */
+export function facesRestart(terminal: Pick<TerminalState, 'ended'>): boolean {
+  return terminal.ended === undefined
+}
+
 /**
  * What restarting for an update will cost, in one line, or null when it costs
  * nothing worth saying.

--- a/tests/sidebar-footer.test.tsx
+++ b/tests/sidebar-footer.test.tsx
@@ -13,7 +13,7 @@ const mockStore = {
   updateBannerDismissed: false,
   setUpdateBannerDismissed: vi.fn(),
   /** The banner says what restarting costs, so it reads the board. */
-  terminals: new Map<string, { status: string }>()
+  terminals: new Map<string, { status: string; ended?: unknown }>()
 }
 
 vi.mock('../src/renderer/stores', () => ({
@@ -142,6 +142,18 @@ describe('what the sidebar restart will cost', () => {
 
   it('says nothing when there are no sessions to lose', () => {
     mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Restart to update' })).toBeInTheDocument()
+    expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
+  })
+})
+
+describe('sessions that have already ended, in the sidebar', () => {
+  it('leave nothing to say when they are all there is', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    mockStore.terminals = new Map([
+      ['a', { status: 'idle', ended: { reason: 'app-closed', at: 1, replayed: true } }]
+    ])
     render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Restart to update' })).toBeInTheDocument()
     expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()

--- a/tests/sidebar-footer.test.tsx
+++ b/tests/sidebar-footer.test.tsx
@@ -11,7 +11,9 @@ const mockStore = {
   setOnboardingOpen: vi.fn(),
   appUpdateStatus: { kind: 'unsupported' } as UpdateStatus,
   updateBannerDismissed: false,
-  setUpdateBannerDismissed: vi.fn()
+  setUpdateBannerDismissed: vi.fn(),
+  /** The banner says what restarting costs, so it reads the board. */
+  terminals: new Map<string, { status: string }>()
 }
 
 vi.mock('../src/renderer/stores', () => ({
@@ -41,6 +43,7 @@ beforeEach(() => {
   installUpdate.mockReset()
   mockStore.appUpdateStatus = { kind: 'unsupported' }
   mockStore.updateBannerDismissed = false
+  mockStore.terminals = new Map()
 })
 
 describe('SidebarFooter', () => {
@@ -121,5 +124,26 @@ describe('SidebarFooter', () => {
       expect(mockStore.setSettingsCategory).toHaveBeenCalledWith('updates')
       expect(mockStore.setSettingsOpen).toHaveBeenCalledWith(true)
     })
+  })
+})
+
+describe('what the sidebar restart will cost', () => {
+  it('says it here too, because this button ends the sessions as well', () => {
+    // The shortcut must not be the quieter way to do the same thing.
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    mockStore.terminals = new Map([
+      ['a', { status: 'running' }],
+      ['b', { status: 'idle' }]
+    ])
+    render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
+    expect(screen.getByText(/Your 2 sessions restart on the new version/)).toBeInTheDocument()
+    expect(screen.getByText(/A turn in flight is lost/)).toBeInTheDocument()
+  })
+
+  it('says nothing when there are no sessions to lose', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Restart to update' })).toBeInTheDocument()
+    expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
   })
 })

--- a/tests/update-cost.test.ts
+++ b/tests/update-cost.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { updateCostLine } from '../src/renderer/lib/update-cost'
+import { facesRestart, updateCostLine } from '../src/renderer/lib/update-cost'
 
 describe('what restarting for an update costs', () => {
   it('says nothing when there is nothing to lose', () => {
@@ -25,5 +25,18 @@ describe('what restarting for an update costs', () => {
       'Your 3 sessions restart on the new version. A turn in flight is lost.'
     )
     expect(updateCostLine(3, false)).not.toContain('turn')
+  })
+})
+
+describe('which panes the update actually ends', () => {
+  it('counts a session with something behind it', () => {
+    expect(facesRestart({ ended: undefined })).toBe(true)
+  })
+
+  it('does not count one that already ended', () => {
+    // Its card stays so the exit is readable, so it is still in `terminals` --
+    // but it is already stopped, and the resume pass only takes back what it
+    // stopped itself. Counting it promises an interruption that never comes.
+    expect(facesRestart({ ended: { reason: 'app-closed', at: 1, replayed: true } })).toBe(false)
   })
 })

--- a/tests/update-cost.test.ts
+++ b/tests/update-cost.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { updateCostLine } from '../src/renderer/lib/update-cost'
+
+describe('what restarting for an update costs', () => {
+  it('says nothing when there is nothing to lose', () => {
+    expect(updateCostLine(0, false)).toBeNull()
+  })
+
+  it('still says nothing when the count is nonsense', () => {
+    expect(updateCostLine(-1, true)).toBeNull()
+  })
+
+  it('names one session without pluralising it', () => {
+    expect(updateCostLine(1, false)).toBe('Your session restarts on the new version.')
+  })
+
+  it('counts them when there is more than one', () => {
+    expect(updateCostLine(3, false)).toBe('Your 3 sessions restart on the new version.')
+  })
+
+  it('names the turn only when one is running', () => {
+    // A session comes back where it was. A turn in flight does not, and that is
+    // the only part actually lost — so it is said separately or not at all.
+    expect(updateCostLine(3, true)).toBe(
+      'Your 3 sessions restart on the new version. A turn in flight is lost.'
+    )
+    expect(updateCostLine(3, false)).not.toContain('turn')
+  })
+})

--- a/tests/updates-settings.test.tsx
+++ b/tests/updates-settings.test.tsx
@@ -9,7 +9,7 @@ const mockStore = {
   setConfig: vi.fn(),
   appUpdateStatus: { kind: 'idle', lastCheckedAt: null } as UpdateStatus,
   /** The panel says what restarting costs, so it reads the board. */
-  terminals: new Map<string, { status: string }>()
+  terminals: new Map<string, { status: string; ended?: unknown }>()
 }
 
 vi.mock('../src/renderer/stores', () => ({
@@ -215,6 +215,27 @@ describe('what the restart will cost', () => {
     // Nothing ends until the button that ends it appears.
     mockStore.appUpdateStatus = { kind: 'downloading', version: '0.7.0-beta.13', percent: 40 }
     mockStore.terminals = new Map([['a', { status: 'running' }]])
+    render(<UpdatesSettings />)
+    expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
+  })
+})
+
+describe('sessions that have already ended', () => {
+  it('are not counted, because the update does not end them again', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    mockStore.terminals = new Map([
+      ['a', { status: 'idle', ended: { reason: 'app-closed', at: 1, replayed: true } }],
+      ['b', { status: 'idle' }]
+    ])
+    render(<UpdatesSettings />)
+    expect(screen.getByText(/Your session restarts on the new version/)).toBeInTheDocument()
+  })
+
+  it('leave nothing to say when they are all there is', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    mockStore.terminals = new Map([
+      ['a', { status: 'idle', ended: { reason: 'app-closed', at: 1, replayed: true } }]
+    ])
     render(<UpdatesSettings />)
     expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
   })

--- a/tests/updates-settings.test.tsx
+++ b/tests/updates-settings.test.tsx
@@ -7,7 +7,9 @@ import type { AppConfig, UpdateStatus } from '../src/shared/types'
 const mockStore = {
   config: null as AppConfig | null,
   setConfig: vi.fn(),
-  appUpdateStatus: { kind: 'idle', lastCheckedAt: null } as UpdateStatus
+  appUpdateStatus: { kind: 'idle', lastCheckedAt: null } as UpdateStatus,
+  /** The panel says what restarting costs, so it reads the board. */
+  terminals: new Map<string, { status: string }>()
 }
 
 vi.mock('../src/renderer/stores', () => ({
@@ -48,6 +50,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   mockStore.config = makeConfig()
   mockStore.appUpdateStatus = { kind: 'idle', lastCheckedAt: null }
+  mockStore.terminals = new Map()
 })
 
 describe('UpdatesSettings', () => {
@@ -179,5 +182,40 @@ describe('UpdatesSettings', () => {
       expect(saveConfig.mock.calls[0][0].defaults.updateAutoDownload).toBe(false)
       expect(setUpdateAutoDownload).toHaveBeenCalledWith(false)
     })
+  })
+})
+
+describe('what the restart will cost', () => {
+  it('names the sessions it will end', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    mockStore.terminals = new Map([
+      ['a', { status: 'idle' }],
+      ['b', { status: 'idle' }]
+    ])
+    render(<UpdatesSettings />)
+    expect(screen.getByText(/Your 2 sessions restart on the new version/)).toBeInTheDocument()
+  })
+
+  it('names the turn only when one is running', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    mockStore.terminals = new Map([['a', { status: 'running' }]])
+    render(<UpdatesSettings />)
+    expect(screen.getByText(/A turn in flight is lost/)).toBeInTheDocument()
+  })
+
+  it('says nothing about sessions when there are none', () => {
+    mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
+    render(<UpdatesSettings />)
+    expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
+    // The status detail is still there; it was replaced, not removed.
+    expect(screen.getByText(/restart to apply/)).toBeInTheDocument()
+  })
+
+  it('stays quiet while a download is only downloading', () => {
+    // Nothing ends until the button that ends it appears.
+    mockStore.appUpdateStatus = { kind: 'downloading', version: '0.7.0-beta.13', percent: 40 }
+    mockStore.terminals = new Map([['a', { status: 'running' }]])
+    render(<UpdatesSettings />)
+    expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Quitting stopped ending the agents, and nothing taught the server to move on. `quitAndInstall` raises `before-quit`, which sees `keepSessionsRunning` and lets go of the server — so the new build adopts the old one and stays on it. Hit tonight: an app on 0.7.0-beta.12 talking to a beta.11 server, with no way forward but *quit without keeping them* or a reboot, neither of which is anywhere on screen.

Adoption is right to ignore the release version — it turns on the protocol, and gating on the release would end every session on every ship. What was missing is the other half. tmux and zellij hold a long-lived server behind a versioned contract exactly as Vorn does, and both then wait for somebody to end it on purpose: `tmux kill-server`. An update is that moment, because the person has already accepted an interruption.

## The change

**The update ends the server** rather than negotiating with it afterwards. Client and server are then always one build — mosh's property, which it gets by starting a fresh server per session — for the price of a branch rather than a capability protocol.

That matters more than it sounds. `RUNTIME_PROTOCOL_VERSION` is 1 and only moves when someone remembers; adding an RPC does not move it. `file:stamp` shipped in #535 with no bump, so an adopted old server would simply not answer a method the new client has.

**Stopped before `quitAndInstall`, not inside the quit it raises.** The deliberate shutdown path holds its own quit open with `event.preventDefault()`, and doing that to the updater's quit risks cancelling the relaunch — which is the thing `onQuitForUpdate` exists to protect. Stopping first leaves `before-quit` with the work already done, so it never intervenes. A stop that fails still installs: the old server is left running and the next launch adopts it, which is today's behaviour rather than something worse.

**Both buttons that install now say what it costs**, the sidebar one included. It ends the same sessions and said nothing at all, which made the shortcut the quieter way to do the more destructive thing. The sentence names the count and names the turn separately, because a session comes back where it was and a turn in flight does not.

It is said rather than assumed because **`Keep Sessions Running` promises the opposite**. Updating is a more deliberate act than closing a window, so the exception is defensible — but a setting somebody turned on is not overruled in silence.

## Deliberately not here

Capability negotiation, a server row in Settings, per-feature degrading, rolling forward when idle. All of it manages a mismatch this prevents. A server adopted some other way — an app replaced by hand — still falls behind silently; rarer than it sounds, and it can wait for someone to hit it.

## Testing

`yarn typecheck`, `yarn lint` and `yarn format:check` pass. 5842 tests, with only the two that assert on environment variables a Vorn session injects and so fail when the suite runs inside one.

Eleven new: `updateCostLine` as a pure function, plus both surfaces asserting the line appears where the button is and nowhere else. The component tests fail against the unfixed code.

**What no test here can cover:** whether the updater still relaunches once the server has been stopped. That is only answerable by shipping — cut beta.13, then update from beta.12 with two sessions running. They should end, the app should come back on beta.13, and the sessions should resume. If it goes wrong the app quits without returning, recoverable by launching it again, which is why it wants a beta rather than an assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT