### PR TITLE
chore(release): 0.7.0-beta.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.12",
+  "version": "0.7.0-beta.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Cut so the update handover can be tested, which is the one part of #552 no test could cover.

## What is in it

**#552 — the update takes the server with it.** Installing an update now ends the server rather than letting go of it, so the new build never adopts the old one. Both buttons that install say what it costs, counting only sessions that still have a process behind them.

## The test this release exists for

Update from beta.12 to beta.13 **with two sessions running**, at least one mid-turn.

Expected: the sessions end, the app relaunches on beta.13, and the sessions resume from their transcripts. Settings › Updates should then show beta.13 with nothing outstanding.

Before pressing Restart, the band should read *"Your 2 sessions restart on the new version. A turn in flight is lost."* — and the same line should appear above the sidebar's own **Restart to update** button.

If the relaunch does not happen, the app quits without coming back, with the server already stopped. Launch Vorn again: the sessions resume as they do after any stop. No work is lost beyond the turn that was in flight, but that would mean the handover needs to move back inside `before-quit`, and it is worth knowing before anyone relies on it.

Version only; `scripts/sync-versions.sh` carried the six workspace packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT