### PR TITLE
Let a pack claim the ado and kusto ids, which nothing in the app answers to

### DIFF
--- a/packages/server/src/connectors/packs.ts
+++ b/packages/server/src/connectors/packs.ts
@@ -108,7 +108,7 @@ function requireSafeId(id: string): void {
   if (!isSafeId(id)) throw new Error(`"${id}" is not a usable connector id`)
 }
 
-/** The two connector kinds the app answers to itself; a pack claiming one would shadow it in every list. */
+/** The two connector ids the app answers to itself; a pack claiming one would shadow it in every list. */
 const RESERVED_IDS = new Set(['mcp', 'http'])
 
 function requireUnreservedId(id: string): void {

--- a/packages/server/src/connectors/packs.ts
+++ b/packages/server/src/connectors/packs.ts
@@ -108,8 +108,8 @@ function requireSafeId(id: string): void {
   if (!isSafeId(id)) throw new Error(`"${id}" is not a usable connector id`)
 }
 
-/** Ids the app already answers to; a pack claiming one would shadow it in every list. */
-const RESERVED_IDS = new Set(['mcp', 'http', 'ado', 'kusto'])
+/** The two connector kinds the app answers to itself; a pack claiming one would shadow it in every list. */
+const RESERVED_IDS = new Set(['mcp', 'http'])
 
 function requireUnreservedId(id: string): void {
   if (RESERVED_IDS.has(id.toLowerCase())) {

--- a/tests/connector-packs.test.ts
+++ b/tests/connector-packs.test.ts
@@ -273,6 +273,14 @@ describe('inspectPack', () => {
     expect(result.ok).toBe(true)
   })
 
+  it('lets a pack take an id the seed catalog lists as a package', async () => {
+    const file = await buildArchive(goodFiles('1.0.0', 'kusto'))
+
+    const result = await inspectPack({ kind: 'file', path: file }, { root: tempDir() })
+
+    expect(result.ok).toBe(true)
+  })
+
   it('reports a source that cannot be read rather than throwing', async () => {
     const root = tempDir()
 

--- a/tests/connector-packs.test.ts
+++ b/tests/connector-packs.test.ts
@@ -1,3 +1,4 @@
+import { CONNECTOR_CATALOG } from '../packages/server/src/connectors/catalog'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   chmodSync,
@@ -274,6 +275,7 @@ describe('inspectPack', () => {
   })
 
   it('lets a pack take an id the seed catalog lists as a package', async () => {
+    expect(CONNECTOR_CATALOG.map((entry) => entry.id)).toContain('kusto')
     const file = await buildArchive(goodFiles('1.0.0', 'kusto'))
 
     const result = await inspectPack({ kind: 'file', path: file }, { root: tempDir() })


### PR DESCRIPTION
Installing the kusto pack from the directory fails with `"kusto" is the id of a connector Vorn already ships`. It is not: the reservation dates from #515, when the app still answered to `ado` and `kusto` itself. Today nothing in the app does, and the seed catalog lists both as packages to install, so the reservation only blocks the two connectors it was meant to protect.

The reserved set is now the two kinds the app really answers to, `mcp` and `http`. A test pins that a pack may take `kusto`, beside the one that already pins `github`.

## How to verify

Open the connector directory and install Azure Data Explorer or Azure DevOps; both now install from their packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
