### PR TITLE
Check the worktree before resuming into it, and open Vorn at sign-in

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1255,6 +1255,8 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
     // terminal drew and waits. There is nothing to ask, and leaving it off made
     // the whole thing invisible unless somebody went looking for a toggle.
     reopenSessions: (map.reopenSessions as boolean) ?? true,
+    // Off by default: nothing starts itself because someone installed an app.
+    startAtLogin: (map.startAtLogin as boolean) ?? false,
     // Saving iterates over every key in defaults, but loading is this explicit
     // list — so a key missing here round-trips to nothing and its feature is
     // silently inert.

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1004,8 +1004,10 @@ export function registerAllMethods(): void {
           reason: 'workspace-gone' as const,
           message: `${previous.projectPath} is gone`
         }
-      // buildRestorePayload reads worktreePath for the cwd, so the fallback goes through it.
-      const grounded = landing.fellBackFrom
+      // buildRestorePayload reads worktreePath for the cwd, so a gone worktree is cleared from the record.
+      const worktreeGone =
+        previous.worktreePath !== undefined && landing.cwd === previous.projectPath
+      const grounded = worktreeGone
         ? { ...previous, worktreePath: undefined, isWorktree: false }
         : previous
 

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -23,6 +23,7 @@ import {
 import { clearScreen } from './terminal-screen'
 import { discardHistory } from './history/writer'
 import { buildRestorePayload } from '@vornrun/shared/session-restore'
+import { resumeCwdFor } from './resume-cwd'
 import { clearScrollback, readScrollback } from './terminal-scrollback'
 import {
   claimTranscriptFor,
@@ -959,13 +960,14 @@ export function registerAllMethods(): void {
         // that pane could have written it -- and a resume is the one moment it
         // turns into where a process starts. A stale or fabricated path falls
         // back to the project rather than being spawned into.
-        const remembered = previous.shellCwd
-        // One question, asked once, and never allowed to throw. Asking whether it
-        // exists and then whether it is a directory is two questions with a gap
-        // between them: a directory removed in that gap turns a fallback into a
-        // rejected resume, and the fallback is the whole point of asking.
-        const usable = remembered !== undefined && isDirectory(remembered)
-        const cwd = usable ? remembered : (previous.worktreePath ?? previous.projectPath)
+        const landing = resumeCwdFor(previous, isDirectory)
+        if (!landing)
+          return {
+            ok: false as const,
+            reason: 'workspace-gone' as const,
+            message: `${previous.projectPath} is gone`
+          }
+        const cwd = landing.cwd
         // The same id, which is what makes this the same pane rather than a new
         // one beside it: the client keys its terminal by this, so a fresh id
         // would hand back a blank shell and drop the screen being resumed. The
@@ -993,10 +995,24 @@ export function registerAllMethods(): void {
         return { ok: true as const, session }
       }
 
-      transcriptId = claimTranscriptFor(previous, live, id, headlessManager.getActiveSessions())
+      // Checked before anything is claimed: a worktree removed while the machine
+      // was off used to be spawned into as though it were there.
+      const landing = resumeCwdFor(previous, isDirectory)
+      if (!landing)
+        return {
+          ok: false as const,
+          reason: 'workspace-gone' as const,
+          message: `${previous.projectPath} is gone`
+        }
+      // buildRestorePayload reads worktreePath for the cwd, so the fallback goes through it.
+      const grounded = landing.fellBackFrom
+        ? { ...previous, worktreePath: undefined, isWorktree: false }
+        : previous
+
+      transcriptId = claimTranscriptFor(grounded, live, id, headlessManager.getActiveSessions())
 
       // Same id, same reasons as the shell branch above.
-      const session = ptyManager.createPty(buildRestorePayload(previous, transcriptId), id)
+      const session = ptyManager.createPty(buildRestorePayload(grounded, transcriptId), id)
       // The record names the conversation now, so the claim standing in for it is
       // spent; leaving it would hold an id the session already reports.
       if (session.agentSessionId) releaseSpawningTranscriptsFor(id)

--- a/packages/server/src/resume-cwd.ts
+++ b/packages/server/src/resume-cwd.ts
@@ -1,0 +1,39 @@
+import type { TerminalSession } from '@vornrun/shared/types'
+
+/**
+ * Where a session resumes into, or null when there is nowhere left.
+ *
+ * A resume is the one moment a remembered path turns into where a process
+ * starts, so every candidate is checked before it is spawned into. The shell
+ * branch of `sessions:resume` already asked this question; the agent branch
+ * handed its worktree straight to the spawn, so a worktree removed while the
+ * machine was off -- or simply cleaned up after its branch merged -- was spawned
+ * into as though it were there. One function for both, so they cannot drift
+ * apart again.
+ *
+ * Order is the most specific place first: the shell's own reported directory,
+ * then the worktree, then the project. Falling back is deliberate -- a session
+ * whose worktree is gone can still do useful work in the project -- but it is
+ * reported, because the person deserves to know they are not where they were.
+ *
+ * `isDirectory` is a parameter so this can be decided without a filesystem.
+ */
+export interface ResumeCwd {
+  cwd: string
+  /** Set when the resume did not land where the session was. */
+  fellBackFrom?: string
+}
+
+export function resumeCwdFor(
+  previous: Pick<TerminalSession, 'projectPath' | 'worktreePath' | 'shellCwd'>,
+  isDirectory: (at: string) => boolean
+): ResumeCwd | null {
+  const preferred = previous.shellCwd ?? previous.worktreePath
+  if (preferred !== undefined && isDirectory(preferred)) return { cwd: preferred }
+  if (isDirectory(previous.projectPath)) {
+    return preferred === undefined
+      ? { cwd: previous.projectPath }
+      : { cwd: previous.projectPath, fellBackFrom: preferred }
+  }
+  return null
+}

--- a/packages/server/src/resume-cwd.ts
+++ b/packages/server/src/resume-cwd.ts
@@ -1,39 +1,20 @@
 import type { TerminalSession } from '@vornrun/shared/types'
 
-/**
- * Where a session resumes into, or null when there is nowhere left.
- *
- * A resume is the one moment a remembered path turns into where a process
- * starts, so every candidate is checked before it is spawned into. The shell
- * branch of `sessions:resume` already asked this question; the agent branch
- * handed its worktree straight to the spawn, so a worktree removed while the
- * machine was off -- or simply cleaned up after its branch merged -- was spawned
- * into as though it were there. One function for both, so they cannot drift
- * apart again.
- *
- * Order is the most specific place first: the shell's own reported directory,
- * then the worktree, then the project. Falling back is deliberate -- a session
- * whose worktree is gone can still do useful work in the project -- but it is
- * reported, because the person deserves to know they are not where they were.
- *
- * `isDirectory` is a parameter so this can be decided without a filesystem.
- */
 export interface ResumeCwd {
   cwd: string
-  /** Set when the resume did not land where the session was. */
+  /** The more specific place the session wanted, when it is no longer there. */
   fellBackFrom?: string
 }
 
+// Most specific place first: the shell's own directory, the worktree, the project.
 export function resumeCwdFor(
   previous: Pick<TerminalSession, 'projectPath' | 'worktreePath' | 'shellCwd'>,
   isDirectory: (at: string) => boolean
 ): ResumeCwd | null {
-  const preferred = previous.shellCwd ?? previous.worktreePath
-  if (preferred !== undefined && isDirectory(preferred)) return { cwd: preferred }
-  if (isDirectory(previous.projectPath)) {
-    return preferred === undefined
-      ? { cwd: previous.projectPath }
-      : { cwd: previous.projectPath, fellBackFrom: preferred }
-  }
-  return null
+  const wanted = [previous.shellCwd, previous.worktreePath, previous.projectPath].filter(
+    (at): at is string => at !== undefined
+  )
+  const cwd = wanted.find(isDirectory)
+  if (cwd === undefined) return null
+  return cwd === wanted[0] ? { cwd } : { cwd, fellBackFrom: wanted[0] }
 }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -562,7 +562,7 @@ export interface RequestMethods {
     params: { id: string }
     result: /** `boundTo` names the session already writing this conversation, when one was. */
       | { ok: true; session: TerminalSession; boundTo?: string }
-      | { ok: false; reason: 'gone' | 'failed'; message?: string }
+      | { ok: false; reason: 'gone' | 'failed' | 'workspace-gone'; message?: string }
   }
   'sessions:clear': { params: void; result: void }
   'sessions:getRecent': { params: string | undefined; result: RecentSession[] }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1219,6 +1219,8 @@ export interface AppConfig {
     notifications?: NotificationConfig
     hasSeenOnboarding?: boolean | number
     reopenSessions?: boolean
+    // Open Vorn at sign-in. Off until asked; a no-op on Linux.
+    startAtLogin?: boolean
     widgetEnabled?: boolean
     taskViewMode?: TaskViewMode
     layoutMode?: 'grid' | 'tabs'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,7 @@ import { registerConnectHandlers, showConnectWindow } from './server/connect-win
 import { readPortFile } from './server/server-adoption'
 import type { ServerBridge } from './server/server-bridge'
 import log from './logger'
+import { loginItemFor } from './login-item'
 
 let isQuitting = false
 
@@ -291,6 +292,14 @@ function rememberKeepSessionsRunning(config: unknown): void {
   keepSessionsRunning = value ?? true
 }
 
+// Null means leave the OS record alone; see loginItemFor for why a dev build must.
+function applyLoginItem(config: unknown): void {
+  const openAtLogin = loginItemFor(config as AppConfig | null, app.isPackaged)
+  if (openAtLogin === null) return
+  if (app.getLoginItemSettings().openAtLogin === openAtLogin) return
+  app.setLoginItemSettings({ openAtLogin })
+}
+
 /**
  * Wire up server notification forwarding.
  * When the server pushes events via WebSocket, forward them to the
@@ -301,7 +310,10 @@ function wireServerNotifications(bridge: ServerBridge): void {
     // Before the switch rather than inside it: `CONFIG_CHANGED` is one label in a
     // fall-through group that forwards seventeen events identically, so giving it
     // a body of its own would mean splitting it out and repeating the forward.
-    if (method === IPC.CONFIG_CHANGED) rememberKeepSessionsRunning(params)
+    if (method === IPC.CONFIG_CHANGED) {
+      rememberKeepSessionsRunning(params)
+      applyLoginItem(params)
+    }
     switch (method) {
       // Terminal data/exit → forward to renderer
       case IPC.TERMINAL_DATA:
@@ -581,6 +593,7 @@ app.whenReady().then(async () => {
     // who turned this off in an earlier session and never touched it again would
     // otherwise have their sessions kept running against their wish.
     rememberKeepSessionsRunning(config)
+    applyLoginItem(config)
   } catch {
     // Config not available yet, use defaults
   }

--- a/src/main/login-item.ts
+++ b/src/main/login-item.ts
@@ -1,0 +1,11 @@
+import type { AppConfig } from '../shared/types'
+
+// Null leaves the OS record alone: a dev build would register node_modules' Electron.
+export function loginItemFor(
+  config: AppConfig | null | undefined,
+  isPackaged: boolean
+): boolean | null {
+  if (!isPackaged) return null
+  if (!config) return null
+  return config.defaults?.startAtLogin === true
+}

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -102,7 +102,7 @@ export function GeneralSettings() {
         {isElectron && (
           <SettingRow
             label="Start Vorn When I Sign In"
-            description="Vorn opens with the machine, so a restart puts you back where you were. Not available on Linux."
+            description="Vorn opens with the machine, so a restart puts you back where you were."
             note={
               config.defaults.reopenSessions !== false
                 ? 'With Reopen Sessions on, your agents start again at sign-in rather than when you next open Vorn.'

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -98,6 +98,24 @@ export function GeneralSettings() {
           />
         </SettingRow>
 
+        {/* Start at login: above Reopen Sessions because it changes what that one does */}
+        {isElectron && (
+          <SettingRow
+            label="Start Vorn When I Sign In"
+            description="Vorn opens with the machine, so a restart puts you back where you were. Not available on Linux."
+            note={
+              config.defaults.reopenSessions !== false
+                ? 'With Reopen Sessions on, your agents start again at sign-in rather than when you next open Vorn.'
+                : undefined
+            }
+          >
+            <ToggleSwitch
+              checked={config.defaults.startAtLogin === true}
+              onChange={(startAtLogin) => updateDefaults({ startAtLogin })}
+            />
+          </SettingRow>
+        )}
+
         {/* Reopen Sessions */}
         <SettingRow
           label="Reopen Sessions on Startup"

--- a/tests/login-item.test.ts
+++ b/tests/login-item.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { loginItemFor } from '../src/main/login-item'
+import type { AppConfig } from '../src/shared/types'
+
+const withDefaults = (defaults: Partial<AppConfig['defaults']>): AppConfig =>
+  ({
+    version: 1,
+    defaults: { shell: '/bin/zsh', fontSize: 13, theme: 'dark', ...defaults }
+  }) as AppConfig
+
+describe('registering to open at sign-in', () => {
+  it('is off until asked', () => {
+    expect(loginItemFor(withDefaults({}), true)).toBe(false)
+  })
+
+  it('is on when asked', () => {
+    expect(loginItemFor(withDefaults({ startAtLogin: true }), true)).toBe(true)
+  })
+
+  it('leaves the record alone before config has loaded', () => {
+    // Nothing yet means nothing to say, not "off": unsetting a record the last
+    // packaged run wrote would be acting on an answer nobody has given.
+    expect(loginItemFor(null, true)).toBeNull()
+  })
+
+  it('never touches the record from a development build', () => {
+    // A dev build would register the Electron binary under node_modules, and the
+    // machine would keep trying to launch it after the checkout was gone. So it
+    // must not write "on" -- and must not write "off" either, which would unset
+    // what the packaged app had set.
+    expect(loginItemFor(withDefaults({ startAtLogin: true }), false)).toBeNull()
+    expect(loginItemFor(withDefaults({ startAtLogin: false }), false)).toBeNull()
+  })
+})

--- a/tests/resume-cwd.test.ts
+++ b/tests/resume-cwd.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { resumeCwdFor } from '../packages/server/src/resume-cwd'
+
+/** A filesystem with exactly these directories in it. */
+const has =
+  (...dirs: string[]) =>
+  (at: string) =>
+    dirs.includes(at)
+
+const agent = { projectPath: '/repo', worktreePath: '/repo/.wt/feature' }
+const shell = { ...agent, shellCwd: '/repo/.wt/feature/src' }
+
+describe('where a session resumes into', () => {
+  it('lands where it was when that is still there', () => {
+    expect(resumeCwdFor(agent, has('/repo', '/repo/.wt/feature'))).toEqual({
+      cwd: '/repo/.wt/feature'
+    })
+  })
+
+  it('prefers the directory a shell reported over its worktree', () => {
+    expect(resumeCwdFor(shell, has('/repo', '/repo/.wt/feature', '/repo/.wt/feature/src'))).toEqual(
+      { cwd: '/repo/.wt/feature/src' }
+    )
+  })
+
+  it('falls back to the project when the worktree is gone, and says so', () => {
+    // The live bug: an agent's worktree was handed to the spawn unchecked, so a
+    // worktree cleaned up after its branch merged was spawned into anyway.
+    expect(resumeCwdFor(agent, has('/repo'))).toEqual({
+      cwd: '/repo',
+      fellBackFrom: '/repo/.wt/feature'
+    })
+  })
+
+  it('does not report a fallback when there was nothing more specific to fall from', () => {
+    expect(resumeCwdFor({ projectPath: '/repo' }, has('/repo'))).toEqual({ cwd: '/repo' })
+  })
+
+  it('refuses rather than spawning into nothing when the project is gone too', () => {
+    expect(resumeCwdFor(agent, has())).toBeNull()
+  })
+
+  it('treats a path that is a file as gone', () => {
+    // `isDirectory` answers false for a file, a broken link and a missing path
+    // alike -- this only asks one question, so all three are the same answer.
+    expect(resumeCwdFor(agent, (at) => at === '/repo')).toEqual({
+      cwd: '/repo',
+      fellBackFrom: '/repo/.wt/feature'
+    })
+  })
+})

--- a/tests/resume-cwd.test.ts
+++ b/tests/resume-cwd.test.ts
@@ -23,6 +23,13 @@ describe('where a session resumes into', () => {
     )
   })
 
+  it('falls from a missing shell directory to a worktree that is still there', () => {
+    expect(resumeCwdFor(shell, has('/repo', '/repo/.wt/feature'))).toEqual({
+      cwd: '/repo/.wt/feature',
+      fellBackFrom: '/repo/.wt/feature/src'
+    })
+  })
+
   it('falls back to the project when the worktree is gone, and says so', () => {
     // The live bug: an agent's worktree was handed to the spawn unchecked, so a
     // worktree cleaned up after its branch merged was spawned into anyway.

--- a/tests/settings-start-at-login.test.tsx
+++ b/tests/settings-start-at-login.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { AppConfig } from '../src/shared/types'
+
+const config = (defaults: Partial<AppConfig['defaults']> = {}): AppConfig =>
+  ({
+    version: 1,
+    defaults: { shell: '/bin/zsh', fontSize: 13, theme: 'dark', ...defaults },
+    workflows: []
+  }) as unknown as AppConfig
+
+const mockStore = { config: config(), setConfig: vi.fn() }
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockStore) : mockStore
+}))
+
+const platform = { isElectron: true }
+vi.mock('../src/renderer/lib/platform', () => ({
+  get isElectron() {
+    return platform.isElectron
+  },
+  isMac: true,
+  isWeb: false,
+  MOD: 'Cmd'
+}))
+
+vi.mock('../src/renderer/hooks/useAgentInstallStatus', () => ({
+  useAgentInstallStatus: () => ({ status: {} })
+}))
+vi.mock('../src/renderer/components/settings/ShellPicker', () => ({
+  ShellPicker: () => <div />
+}))
+
+import { GeneralSettings } from '../src/renderer/components/settings/GeneralSettings'
+
+const saveConfig = vi.fn()
+beforeEach(() => {
+  mockStore.config = config()
+  mockStore.setConfig.mockReset()
+  saveConfig.mockReset()
+  platform.isElectron = true
+  ;(window as unknown as { api: unknown }).api = { saveConfig }
+})
+
+const row = (label: string) => screen.getByText(label).closest('div')!
+
+describe('Start Vorn When I Sign In', () => {
+  it('sits directly above Reopen Sessions', () => {
+    render(<GeneralSettings />)
+    const start = row('Start Vorn When I Sign In')
+    const reopen = row('Reopen Sessions on Startup')
+    expect(start.compareDocumentPosition(reopen) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('is off until asked, and saves the choice', () => {
+    render(<GeneralSettings />)
+    const toggle = screen.getAllByRole('switch')[0]
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    fireEvent.click(toggle)
+    expect(saveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ defaults: expect.objectContaining({ startAtLogin: true }) })
+    )
+  })
+
+  it('warns what reopen makes it mean, only while reopen is on', () => {
+    const note = /agents start again at sign-in/
+    const { unmount } = render(<GeneralSettings />)
+    expect(screen.getByText(note)).toBeInTheDocument()
+    unmount()
+    mockStore.config = config({ reopenSessions: false })
+    render(<GeneralSettings />)
+    expect(screen.queryByText(note)).not.toBeInTheDocument()
+  })
+
+  it('is not offered on the web, which has no sign-in to open at', () => {
+    platform.isElectron = false
+    render(<GeneralSettings />)
+    expect(screen.queryByText('Start Vorn When I Sign In')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
PR A of the reboot plan: the two steps that stand on their own.

## Resume checks the worktree

`sessions:resume` had two branches deciding where a session lands. The shell branch checked its remembered directory before spawning; the agent branch handed `previous.worktreePath` to the spawn unchecked. A worktree removed while the machine was off, or cleaned up after its branch merged, was spawned into anyway.

Both branches now call `resumeCwdFor(previous, isDirectory)`:

- the most specific place that still exists wins: shell cwd, then worktree, then project;
- a missing worktree resumes into the project and reports `fellBackFrom`, so the agent record is grounded (`worktreePath` cleared) before `buildRestorePayload` reads it;
- a missing project refuses with `{ ok: false, reason: 'workspace-gone', message }` rather than spawning into nothing. The renderer's existing fallback toasts the message.

## Start Vorn When I Sign In

New General setting, off until asked, directly above Reopen Sessions with a note saying what the pair means together: agents start at sign-in rather than when the app is next opened. Not shown on the web.

`applyLoginItem` runs at startup and on every `CONFIG_CHANGED`, so a choice made in an earlier run survives. `loginItemFor` returns `null` outside a packaged build, and null means the OS record is left alone. A dev build must not write "on" (it would register `node_modules`' Electron) and must not write "off" either (it would unset what the packaged app set). The record is only written when it differs.

## Tests

- `tests/resume-cwd.test.ts`: the six landing cases, including the live bug.
- `tests/login-item.test.ts`: off by default, on when asked, null without config, null in dev either way.
- `tests/settings-start-at-login.test.tsx`: row order, toggle saves `startAtLogin: true`, note tied to reopen being on, absent on the web.

No RPC-level test drives `sessions:resume`; the wiring at both call sites is a three-line call into the tested helper and is typechecked.

Not tested by hand: the login item needs a packaged build to write anything, and the row's behaviour on a real sign-in is a reboot away. The plan's by-hand sequence is scheduled for after PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT
