### PR TITLE
Ask to keep a pack where the install was asked for, or not at all when the row already said it

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2124,7 +2124,7 @@ export type ConnectorPackPreview =
 /** `id` is the connector's once its manifest is read, and the source label until then. */
 export interface ConnectorInstallProgress {
   id: string
-  phase: 'downloading' | 'verifying' | 'installing' | 'installed' | 'failed'
+  phase: 'checking' | 'downloading' | 'verifying' | 'installing' | 'installed' | 'failed'
   /** Download completion, absent when the size was not advertised. */
   percent?: number
   version?: string

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -37,6 +37,7 @@ export function ConnectorDetail({
   listing,
   builtIns,
   progress,
+  pending,
   onAdd,
   onInstall,
   onRollback,
@@ -48,6 +49,8 @@ export function ConnectorDetail({
   builtIns: BuiltInConnector[]
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
+  /** The confirm sheet for this connector's pack, once it has been verified. */
+  pending?: React.ReactNode
   onAdd: () => void
   onInstall?: () => void
   onRollback?: () => void
@@ -255,6 +258,9 @@ export function ConnectorDetail({
           </span>
         )}
       </div>
+
+      {/* Under the button that raised it, where the answer is looked for. */}
+      {pending && <div className="mt-3">{pending}</div>}
     </div>
   )
 }

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { Search, Plus, RefreshCw, ChevronRight, Check, Download, FolderOpen } from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
 import type { ConnectorAuthRung, ConnectorInstallProgress } from '../../../shared/types'
@@ -39,7 +39,6 @@ export function ConnectorDirectory({
   onPickFile,
   installError,
   pending,
-  pendingRowId,
   progress,
   fetchedAt,
   onRefresh
@@ -55,10 +54,8 @@ export function ConnectorDirectory({
   onPickFile?: () => Promise<string | null>
   /** Why the last file install was refused, for the one that has no row yet. */
   installError?: string | null
-  /** The confirm sheet for a pack that has been verified but not yet kept. */
-  pending?: React.ReactNode
-  /** The connector the sheet belongs to, so it opens under that row. */
-  pendingRowId?: string
+  /** The confirm sheet for a verified pack, and the listing it opens under when one was pressed. */
+  pending?: { sheet: React.ReactNode; rowKey?: string }
   /** Installs running right now, by connector id. */
   progress?: Record<string, ConnectorInstallProgress>
   /** When the published list was last read. Absent until one has been. */
@@ -84,11 +81,10 @@ export function ConnectorDirectory({
   // Sections earn their keep once there is more than one; below that they are
   // a heading over the whole list, which says nothing.
   const sections = useMemo(() => groupListingsByCategory(visible), [visible])
-  // One row owns the sheet: an id can appear installed and in the catalog both.
-  const pendingKey = useMemo(
-    () => (pendingRowId ? visible.find((listing) => listing.id === pendingRowId)?.key : undefined),
-    [visible, pendingRowId]
-  )
+  const pendingKey =
+    pending?.rowKey && visible.some((listing) => listing.key === pending.rowKey)
+      ? pending.rowKey
+      : undefined
 
   const handleDrop = (event: React.DragEvent): void => {
     event.preventDefault()
@@ -187,8 +183,8 @@ export function ConnectorDirectory({
         </p>
       )}
 
-      {/* A verified pack with no row of its own, such as one dropped as a file. */}
-      {pending && !pendingKey && <div className="mt-2">{pending}</div>}
+      {/* A verified pack with no row on screen, such as one dropped as a file. */}
+      {pending && !pendingKey && <div className="mt-2">{pending.sheet}</div>}
 
       {sections.map((section) => (
         <div key={section.category}>
@@ -198,7 +194,7 @@ export function ConnectorDirectory({
             </h3>
           )}
           {section.listings.map((listing) => (
-            <div key={listing.key}>
+            <Fragment key={listing.key}>
               <ConnectorRow
                 listing={listing}
                 builtIns={builtIns}
@@ -207,8 +203,8 @@ export function ConnectorDirectory({
                 onAdd={() => onAdd(listing)}
                 {...(onInstall && { onInstall: () => onInstall(listing) })}
               />
-              {listing.key === pendingKey && <div className="mt-2 mb-3">{pending}</div>}
-            </div>
+              {listing.key === pendingKey && <div className="mt-2 mb-3">{pending?.sheet}</div>}
+            </Fragment>
           ))}
         </div>
       ))}

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -39,6 +39,7 @@ export function ConnectorDirectory({
   onPickFile,
   installError,
   pending,
+  pendingRowId,
   progress,
   fetchedAt,
   onRefresh
@@ -56,6 +57,8 @@ export function ConnectorDirectory({
   installError?: string | null
   /** The confirm sheet for a pack that has been verified but not yet kept. */
   pending?: React.ReactNode
+  /** The connector the sheet belongs to, so it opens under that row. */
+  pendingRowId?: string
   /** Installs running right now, by connector id. */
   progress?: Record<string, ConnectorInstallProgress>
   /** When the published list was last read. Absent until one has been. */
@@ -81,6 +84,11 @@ export function ConnectorDirectory({
   // Sections earn their keep once there is more than one; below that they are
   // a heading over the whole list, which says nothing.
   const sections = useMemo(() => groupListingsByCategory(visible), [visible])
+  // One row owns the sheet: an id can appear installed and in the catalog both.
+  const pendingKey = useMemo(
+    () => (pendingRowId ? visible.find((listing) => listing.id === pendingRowId)?.key : undefined),
+    [visible, pendingRowId]
+  )
 
   const handleDrop = (event: React.DragEvent): void => {
     event.preventDefault()
@@ -179,8 +187,8 @@ export function ConnectorDirectory({
         </p>
       )}
 
-      {/* A verified pack waiting on the decision to keep it. */}
-      {pending && <div className="mt-2">{pending}</div>}
+      {/* A verified pack with no row of its own, such as one dropped as a file. */}
+      {pending && !pendingKey && <div className="mt-2">{pending}</div>}
 
       {sections.map((section) => (
         <div key={section.category}>
@@ -190,15 +198,17 @@ export function ConnectorDirectory({
             </h3>
           )}
           {section.listings.map((listing) => (
-            <ConnectorRow
-              key={listing.key}
-              listing={listing}
-              builtIns={builtIns}
-              {...(progress?.[listing.id] && { progress: progress[listing.id] })}
-              onSelect={() => onSelect(listing)}
-              onAdd={() => onAdd(listing)}
-              {...(onInstall && { onInstall: () => onInstall(listing) })}
-            />
+            <div key={listing.key}>
+              <ConnectorRow
+                listing={listing}
+                builtIns={builtIns}
+                {...(progress?.[listing.id] && { progress: progress[listing.id] })}
+                onSelect={() => onSelect(listing)}
+                onAdd={() => onAdd(listing)}
+                {...(onInstall && { onInstall: () => onInstall(listing) })}
+              />
+              {listing.key === pendingKey && <div className="mt-2 mb-3">{pending}</div>}
+            </div>
           ))}
         </div>
       ))}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -243,7 +243,7 @@ export function ConnectorSettings() {
           onInstallFile={handleInstallFile}
           onPickFile={() => window.api.openFileDialog()}
           installError={fileInstallError}
-          {...(pendingPack && { pending: pendingSheet, pendingRowId: pendingPack.rowId })}
+          pending={pendingPack ? { sheet: pendingSheet, rowKey: pendingPack.rowKey } : undefined}
         />
       )}
 
@@ -254,7 +254,7 @@ export function ConnectorSettings() {
           {...(installProgress[selectedListing.id] && {
             progress: installProgress[selectedListing.id]
           })}
-          {...(pendingPack?.rowId === selectedListing.id && { pending: pendingSheet })}
+          pending={pendingPack?.rowKey === selectedListing.key ? pendingSheet : null}
           onAdd={() => setAdding(selectedListing)}
           onUse={() => openWorkflowEditor(null)}
           onInstall={() => handleInstall(selectedListing)}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -85,6 +85,15 @@ export function ConnectorSettings() {
   const handleInstall = install.inspect
   const handleInstallFile = install.inspectFile
   const handleConfirmPending = install.confirm
+  // One sheet, shown wherever the install was asked for.
+  const pendingSheet = pendingPack && (
+    <PackInstallConfirm
+      preview={pendingPack.preview}
+      busy={installingPending}
+      onConfirm={handleConfirmPending}
+      onCancel={install.cancel}
+    />
+  )
 
   const handleRollback = useCallback(
     async (id: string) => {
@@ -234,16 +243,7 @@ export function ConnectorSettings() {
           onInstallFile={handleInstallFile}
           onPickFile={() => window.api.openFileDialog()}
           installError={fileInstallError}
-          {...(pendingPack && {
-            pending: (
-              <PackInstallConfirm
-                preview={pendingPack.preview}
-                busy={installingPending}
-                onConfirm={handleConfirmPending}
-                onCancel={install.cancel}
-              />
-            )
-          })}
+          {...(pendingPack && { pending: pendingSheet, pendingRowId: pendingPack.rowId })}
         />
       )}
 
@@ -254,6 +254,7 @@ export function ConnectorSettings() {
           {...(installProgress[selectedListing.id] && {
             progress: installProgress[selectedListing.id]
           })}
+          {...(pendingPack?.rowId === selectedListing.id && { pending: pendingSheet })}
           onAdd={() => setAdding(selectedListing)}
           onUse={() => openWorkflowEditor(null)}
           onInstall={() => handleInstall(selectedListing)}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -82,7 +82,11 @@ export function ConnectorSettings() {
     error: fileInstallError,
     installing: installingPending
   } = install
-  const handleInstall = install.inspect
+  // The row and the page both show the version, the sign-in and the receipt, so a pack that matches needs no sheet.
+  const handleInstall = useCallback(
+    (listing: ConnectorListing) => install.inspect(listing, { direct: true }),
+    [install]
+  )
   const handleInstallFile = install.inspectFile
   const handleConfirmPending = install.confirm
   // One sheet, shown wherever the install was asked for.

--- a/src/renderer/components/settings/PackInstallConfirm.tsx
+++ b/src/renderer/components/settings/PackInstallConfirm.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { borrowableFromManifest, type ConnectorPackSummary } from '../../../shared/types'
 import { ConnectorIcon } from '../ConnectorIcon'
 
@@ -22,9 +23,15 @@ export function PackInstallConfirm({
   const replacing = preview.installedVersion && preview.installedVersion !== preview.version
   const required = (preview.env ?? []).filter((entry) => entry.required)
   const borrows = borrowableFromManifest(preview.auth, preview.env ?? [])
+  const root = useRef<HTMLDivElement>(null)
+
+  // It opens beside the button that raised it, which can be below the fold.
+  useEffect(() => {
+    root.current?.scrollIntoView?.({ block: 'nearest' })
+  }, [])
 
   return (
-    <div className="border border-white/[0.1] rounded-sm bg-white/[0.02] p-3">
+    <div ref={root} className="border border-white/[0.1] rounded-sm bg-white/[0.02] p-3">
       <div className="flex items-start gap-2.5">
         <ConnectorIcon
           connectorId={preview.id}

--- a/src/renderer/components/workflow-editor/WorkflowEditor.tsx
+++ b/src/renderer/components/workflow-editor/WorkflowEditor.tsx
@@ -683,6 +683,7 @@ export function WorkflowEditor({ inline = false }: { inline?: boolean } = {}) {
 
   const handleFixRequirement = useCallback(
     (action: RequirementAction) => {
+      // No `direct` here: a requirement row names the connector and nothing else, so the sheet is the disclosure.
       if (action.kind === 'install') void install.inspect(action.listing)
       if (action.kind === 'addConnection') setConnectFor(action.listing)
       if (action.kind === 'createProfile') setProfileFor(action.name)

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -57,7 +57,7 @@ export function matchesListing(preview: ConnectorPackSummary, listing: Connector
     // An absent rung on either side is unknown rather than none, and unknown is what the sheet is for.
     preview.auth?.rung !== undefined &&
     preview.auth.rung === listing.authRung &&
-    listing.verified !== undefined &&
+    listing.verified?.version === preview.version &&
     preview.installedVersion === undefined
   )
 }

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -3,6 +3,7 @@ import type {
   ConnectorCatalogActionInput,
   ConnectorCatalogItem,
   ConnectorCatalogVerification,
+  ConnectorPackSummary,
   InstalledConnectorPack,
   McpServerCatalogEntry,
   SdkConnectorIcon,
@@ -46,6 +47,19 @@ export interface ConnectorListing {
   verified?: ConnectorCatalogVerification
   // Connected without anyone being asked to connect it — a connector that signs in with nothing is ready the moment it.
   implicitlyConnected?: boolean
+}
+
+// Whether a checked pack is the one the row already described, down to the version, the sign-in and the receipt.
+export function matchesListing(preview: ConnectorPackSummary, listing: ConnectorListing): boolean {
+  return (
+    preview.id === listing.id &&
+    preview.version === listing.catalogItem?.version &&
+    // An absent rung on either side is unknown rather than none, and unknown is what the sheet is for.
+    preview.auth?.rung !== undefined &&
+    preview.auth.rung === listing.authRung &&
+    listing.verified !== undefined &&
+    preview.installedVersion === undefined
+  )
 }
 
 export interface BuiltInConnector {

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -84,8 +84,7 @@ export function packStateFor(input: {
 }): PackState {
   const { installed, catalogVersion, progress } = input
 
-  // A reported install stays busy until the files show up, so the row never flashes back to Install.
-  if (progress && progress.phase !== 'failed' && (progress.phase !== 'installed' || !installed)) {
+  if (progress && progress.phase !== 'installed' && progress.phase !== 'failed') {
     return {
       kind: 'installing',
       phase: progress.phase,
@@ -120,6 +119,7 @@ export function describePackStatus(state: PackState): PackStatusView {
 
     case 'installing': {
       const labels: Record<ConnectorInstallProgress['phase'], string> = {
+        checking: 'Checking',
         downloading: 'Downloading',
         verifying: 'Verifying',
         installing: 'Installing',

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -84,7 +84,8 @@ export function packStateFor(input: {
 }): PackState {
   const { installed, catalogVersion, progress } = input
 
-  if (progress && progress.phase !== 'installed' && progress.phase !== 'failed') {
+  // A reported install stays busy until the files show up, so the row never flashes back to Install.
+  if (progress && progress.phase !== 'failed' && (progress.phase !== 'installed' || !installed)) {
     return {
       kind: 'installing',
       phase: progress.phase,

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -105,7 +105,6 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       try {
         const result = await window.api.installConnectorPack(pack.source)
         if (result.ok) {
-          forget(id)
           installed = true
         } else {
           setProgress((current) => ({
@@ -123,8 +122,11 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
         setInstalling(false)
         setPending(null)
       }
-      // Only when something was actually kept: a refusal changed nothing to read.
-      if (installed) await onInstalled?.()
+      // The row keeps saying it is installing until the reload shows it installed; then the record can go.
+      if (installed) {
+        await onInstalled?.()
+        forget(id)
+      }
     },
     [forget, onInstalled]
   )

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -105,6 +105,8 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       try {
         const result = await window.api.installConnectorPack(pack.source)
         if (result.ok) {
+          // Still installing to the row until the reload shows the pack; the server's last word came too early.
+          setProgress((current) => ({ ...current, [id]: { id, phase: 'installing' } }))
           installed = true
         } else {
           setProgress((current) => ({
@@ -122,9 +124,15 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
         setInstalling(false)
         setPending(null)
       }
-      // The row keeps saying it is installing until the reload shows it installed; then the record can go.
-      if (installed) {
+      if (!installed) return
+      try {
         await onInstalled?.()
+      } catch (err) {
+        // Kept on disk, but the list could not be re-read; say so rather than spin forever.
+        setError(
+          `Installed, but the list could not be re-read: ${err instanceof Error ? err.message : String(err)}`
+        )
+      } finally {
         forget(id)
       }
     },
@@ -139,7 +147,7 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       // Busy from the press itself, so the button cannot be pressed twice while the server is still silent.
       setProgress((current) => ({
         ...current,
-        [listing.id]: { id: listing.id, phase: 'downloading' }
+        [listing.id]: { id: listing.id, phase: 'checking' }
       }))
       const result = await stage(sourceFor(listing))
       if (!result.ok) {

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -4,7 +4,7 @@ import type {
   ConnectorPackSource,
   ConnectorPackSummary
 } from '../../shared/types'
-import type { ConnectorListing } from './connector-browse'
+import { matchesListing, type ConnectorListing } from './connector-browse'
 
 /**
  * Installing a pack: inspect first, show what it is, keep it only on confirm.
@@ -32,8 +32,8 @@ export interface PackInstall {
   /** A refusal with no row to land on, such as a dropped file's. */
   error: string | null
   installing: boolean
-  /** Inspect what a catalog row would install; install it, or ask when it differs. */
-  inspect: (listing: ConnectorListing, source?: ConnectorPackSource) => Promise<void>
+  /** Inspect what a catalog row would install; `direct` lets a surface that showed the pack's facts skip the sheet. */
+  inspect: (listing: ConnectorListing, options?: { direct?: boolean }) => Promise<void>
   /** Inspect a pack already on this disk, then ask. */
   inspectFile: (filePath: string) => Promise<void>
   /** Install the files the sheet described. Resolves once they are on disk. */
@@ -56,21 +56,28 @@ function sourceFor(listing: ConnectorListing): ConnectorPackSource {
   return { kind: 'npm', packageName: listing.catalogItem?.packageName ?? listing.id } as const
 }
 
-// The sheet shows what a row could not: a file, a replacement, or a pack unlike its listing; when the row said it all, install.
-export function matchesListing(preview: ConnectorPackSummary, listing: ConnectorListing): boolean {
-  return (
-    preview.id === listing.id &&
-    preview.version === listing.catalogItem?.version &&
-    (preview.auth?.rung ?? 'none') === (listing.authRung ?? 'none') &&
-    preview.installedVersion === undefined
-  )
+/** Check a source, answering a refusal rather than throwing one. */
+async function stage(source: ConnectorPackSource) {
+  return window.api
+    .inspectConnectorPack(source)
+    .catch((e: unknown) => ({ ok: false as const, error: describeFailure(e) }))
+}
+
+/** What was checked, addressed to the row that asked for it. */
+function staged(preview: ConnectorPackSummary, rowId: string, rowKey?: string): PendingPack {
+  return {
+    source: { kind: 'staged', token: preview.token },
+    preview,
+    rowId,
+    ...(rowKey !== undefined && { rowKey })
+  }
 }
 
 export function usePackInstall(onInstalled?: () => void | Promise<void>): PackInstall {
   // Rejections live only here: nothing was written to disk, so they clear on reload.
   const [progress, setProgress] = useState<Record<string, ConnectorInstallProgress>>({})
   const [error, setError] = useState<string | null>(null)
-  const [pending, setPending] = useState<PackInstall['pending']>(null)
+  const [pending, setPending] = useState<PendingPack | null>(null)
   const [installing, setInstalling] = useState(false)
 
   // The unsubscribe is what keeps a reopened panel from stacking a second listener.
@@ -123,14 +130,12 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
   )
 
   const inspect = useCallback(
-    async (listing: ConnectorListing, source?: ConnectorPackSource) => {
+    async (listing: ConnectorListing, options?: { direct?: boolean }) => {
       // Whatever the last attempt said is about that attempt, not this one.
       setError(null)
       setPending(null)
       forget(listing.id)
-      const result = await window.api
-        .inspectConnectorPack(source ?? sourceFor(listing))
-        .catch((e: unknown) => ({ ok: false as const, error: describeFailure(e) }))
+      const result = await stage(sourceFor(listing))
       if (!result.ok) {
         // Keyed by the row that asked, which is the row that shows the refusal.
         setProgress((current) => ({
@@ -139,14 +144,9 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
         }))
         return
       }
-      const pack: PendingPack = {
-        source: { kind: 'staged', token: result.preview.token },
-        preview: result.preview,
-        rowId: listing.id,
-        rowKey: listing.key
-      }
-      // Pressing install on a row that already said all this is the answer.
-      if (matchesListing(result.preview, listing)) {
+      const pack = staged(result.preview, listing.id, listing.key)
+      // Only a surface that showed the pack's facts asks for this; elsewhere the sheet is the only disclosure.
+      if (options?.direct && matchesListing(result.preview, listing)) {
         await keep(pack)
         return
       }
@@ -158,19 +158,13 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
   const inspectFile = useCallback(async (filePath: string) => {
     setError(null)
     setPending(null)
-    const result = await window.api
-      .inspectConnectorPack({ kind: 'file', path: filePath })
-      .catch((e: unknown) => ({ ok: false as const, error: describeFailure(e) }))
+    const result = await stage({ kind: 'file', path: filePath })
     if (!result.ok) {
       setError(result.error)
       return
     }
     // A dropped file has no row; the pack names itself once it is read.
-    setPending({
-      source: { kind: 'staged', token: result.preview.token },
-      preview: result.preview,
-      rowId: result.preview.id
-    })
+    setPending(staged(result.preview, result.preview.id))
   }, [])
 
   const confirm = useCallback(async () => {

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -56,15 +56,7 @@ function sourceFor(listing: ConnectorListing): ConnectorPackSource {
   return { kind: 'npm', packageName: listing.catalogItem?.packageName ?? listing.id } as const
 }
 
-/**
- * Whether the checked pack is the one the row already described.
- *
- * The sheet exists to show what a listing could not: a file nobody has seen, a
- * pack that replaces an installed version, or one whose id, version or sign-in
- * differs from what was advertised. When all of that agrees, the row said it
- * already and asking again only adds a click. A catalog with no version cannot
- * agree, so it is asked about.
- */
+// The sheet shows what a row could not: a file, a replacement, or a pack unlike its listing; when the row said it all, install.
 export function matchesListing(preview: ConnectorPackSummary, listing: ConnectorListing): boolean {
   return (
     preview.id === listing.id &&

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -14,22 +14,25 @@ import type { ConnectorListing } from './connector-browse'
  * connector it needs wants the same three steps, and two copies of a
  * verify-then-commit flow is one too many.
  */
+/** A checked pack, held between the two steps of an install. */
+export interface PendingPack {
+  source: ConnectorPackSource
+  preview: ConnectorPackSummary
+  /** The row this began on, so both steps report their refusals to it. */
+  rowId: string
+  /** The listing that was pressed, so the sheet opens under it; a dropped file has none. */
+  rowKey?: string
+}
+
 export interface PackInstall {
   /** Live install and rejection state, keyed by connector id. */
   progress: Record<string, ConnectorInstallProgress>
-  /** The pack awaiting a yes, with everything the sheet shows. */
-  pending: {
-    source: ConnectorPackSource
-    preview: ConnectorPackSummary
-    /** The row this began on, so both steps report their refusals to it. */
-    rowId: string
-    /** The listing that was pressed, so the sheet opens under it; a dropped file has none. */
-    rowKey?: string
-  } | null
+  /** The pack waiting to be asked about: a file, a replacement, or one unlike its listing. */
+  pending: PendingPack | null
   /** A refusal with no row to land on, such as a dropped file's. */
   error: string | null
   installing: boolean
-  /** Inspect what a catalog row would install, then ask. */
+  /** Inspect what a catalog row would install; install it, or ask when it differs. */
   inspect: (listing: ConnectorListing, source?: ConnectorPackSource) => Promise<void>
   /** Inspect a pack already on this disk, then ask. */
   inspectFile: (filePath: string) => Promise<void>
@@ -51,6 +54,24 @@ function sourceFor(listing: ConnectorListing): ConnectorPackSource {
     } as ConnectorPackSource
   }
   return { kind: 'npm', packageName: listing.catalogItem?.packageName ?? listing.id } as const
+}
+
+/**
+ * Whether the checked pack is the one the row already described.
+ *
+ * The sheet exists to show what a listing could not: a file nobody has seen, a
+ * pack that replaces an installed version, or one whose id, version or sign-in
+ * differs from what was advertised. When all of that agrees, the row said it
+ * already and asking again only adds a click. A catalog with no version cannot
+ * agree, so it is asked about.
+ */
+export function matchesListing(preview: ConnectorPackSummary, listing: ConnectorListing): boolean {
+  return (
+    preview.id === listing.id &&
+    preview.version === listing.catalogItem?.version &&
+    (preview.auth?.rung ?? 'none') === (listing.authRung ?? 'none') &&
+    preview.installedVersion === undefined
+  )
 }
 
 export function usePackInstall(onInstalled?: () => void | Promise<void>): PackInstall {
@@ -75,6 +96,40 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
     })
   }, [])
 
+  // The second step, whether a sheet asked or the pack matched what was pressed.
+  const keep = useCallback(
+    async (pack: PendingPack) => {
+      // The row that asked, so a refusal at either step lands in the same place.
+      const id = pack.rowId
+      let installed = false
+      setInstalling(true)
+      try {
+        const result = await window.api.installConnectorPack(pack.source)
+        if (result.ok) {
+          forget(id)
+          installed = true
+        } else {
+          setProgress((current) => ({
+            ...current,
+            [id]: { id, phase: 'failed', error: result.error }
+          }))
+          setError(result.error)
+        }
+      } catch (err) {
+        // A transport failure lands where a refusal lands, or the sheet never closes.
+        const message = err instanceof Error ? err.message : 'The pack could not be installed'
+        setProgress((current) => ({ ...current, [id]: { id, phase: 'failed', error: message } }))
+        setError(message)
+      } finally {
+        setInstalling(false)
+        setPending(null)
+      }
+      // Only when something was actually kept: a refusal changed nothing to read.
+      if (installed) await onInstalled?.()
+    },
+    [forget, onInstalled]
+  )
+
   const inspect = useCallback(
     async (listing: ConnectorListing, source?: ConnectorPackSource) => {
       // Whatever the last attempt said is about that attempt, not this one.
@@ -92,14 +147,20 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
         }))
         return
       }
-      setPending({
+      const pack: PendingPack = {
         source: { kind: 'staged', token: result.preview.token },
         preview: result.preview,
         rowId: listing.id,
         rowKey: listing.key
-      })
+      }
+      // Pressing install on a row that already said all this is the answer.
+      if (matchesListing(result.preview, listing)) {
+        await keep(pack)
+        return
+      }
+      setPending(pack)
     },
-    [forget]
+    [forget, keep]
   )
 
   const inspectFile = useCallback(async (filePath: string) => {
@@ -121,35 +182,8 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
   }, [])
 
   const confirm = useCallback(async () => {
-    if (!pending) return
-    // The row that asked, so a refusal at either step lands in the same place.
-    const id = pending.rowId
-    let installed = false
-    setInstalling(true)
-    try {
-      const result = await window.api.installConnectorPack(pending.source)
-      if (result.ok) {
-        forget(id)
-        installed = true
-      } else {
-        setProgress((current) => ({
-          ...current,
-          [id]: { id, phase: 'failed', error: result.error }
-        }))
-        setError(result.error)
-      }
-    } catch (err) {
-      // A transport failure lands where a refusal lands, or the sheet never closes.
-      const message = err instanceof Error ? err.message : 'The pack could not be installed'
-      setProgress((current) => ({ ...current, [id]: { id, phase: 'failed', error: message } }))
-      setError(message)
-    } finally {
-      setInstalling(false)
-      setPending(null)
-    }
-    // Only when something was actually kept: a refusal changed nothing to read.
-    if (installed) await onInstalled?.()
-  }, [pending, forget, onInstalled])
+    if (pending) await keep(pending)
+  }, [pending, keep])
 
   const cancel = useCallback(() => setPending(null), [])
   const clearError = useCallback(() => setError(null), [])

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -136,7 +136,11 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       // Whatever the last attempt said is about that attempt, not this one.
       setError(null)
       setPending(null)
-      forget(listing.id)
+      // Busy from the press itself, so the button cannot be pressed twice while the server is still silent.
+      setProgress((current) => ({
+        ...current,
+        [listing.id]: { id: listing.id, phase: 'downloading' }
+      }))
       const result = await stage(sourceFor(listing))
       if (!result.ok) {
         // Keyed by the row that asked, which is the row that shows the refusal.
@@ -152,6 +156,8 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
         await keep(pack)
         return
       }
+      // The sheet takes over; the row is not busy again until a decision is made.
+      forget(listing.id)
       setPending(pack)
     },
     [forget, keep]

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -23,6 +23,8 @@ export interface PackInstall {
     preview: ConnectorPackSummary
     /** The row this began on, so both steps report their refusals to it. */
     rowId: string
+    /** The listing that was pressed, so the sheet opens under it; a dropped file has none. */
+    rowKey?: string
   } | null
   /** A refusal with no row to land on, such as a dropped file's. */
   error: string | null
@@ -93,7 +95,8 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       setPending({
         source: { kind: 'staged', token: result.preview.token },
         preview: result.preview,
-        rowId: listing.id
+        rowId: listing.id,
+        rowKey: listing.key
       })
     },
     [forget]

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -185,6 +185,62 @@ describe('the connector list', () => {
   })
 })
 
+describe('where a verified pack asks to be kept', () => {
+  const sheet = <div>Keep this pack?</div>
+
+  const order = (container: HTMLElement, text: string) => container.textContent!.indexOf(text)
+
+  it('asks under the row the install began on', () => {
+    const { container } = render(
+      <ConnectorDirectory
+        listings={listings()}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+        pending={sheet}
+        pendingRowId="kusto"
+      />
+    )
+
+    // Between its own row and the next, rather than appended after the list.
+    expect(order(container, 'Keep this pack?')).toBeGreaterThan(
+      order(container, 'Azure Data Explorer')
+    )
+    expect(order(container, 'Keep this pack?')).toBeLessThan(order(container, 'Azure DevOps'))
+  })
+
+  it('asks above the list when no row owns the pack, as a dropped file has none', () => {
+    const { container } = render(
+      <ConnectorDirectory
+        listings={listings()}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+        pending={sheet}
+        pendingRowId="dropped-from-a-file"
+      />
+    )
+
+    expect(order(container, 'Keep this pack?')).toBeLessThan(order(container, 'Azure DevOps'))
+  })
+
+  it('asks under the buttons on the page that raised it', () => {
+    const { container, getByText } = render(
+      <ConnectorDetail
+        listing={find('ado')}
+        builtIns={[]}
+        onAdd={vi.fn()}
+        onClose={vi.fn()}
+        onInstall={vi.fn()}
+        pending={sheet}
+      />
+    )
+
+    expect(getByText('Install')).toBeInTheDocument()
+    expect(order(container, 'Keep this pack?')).toBeGreaterThan(order(container, 'Install'))
+  })
+})
+
 describe('the connector detail panel', () => {
   const setup = (listing: ConnectorListing, builtIns: BuiltInConnector[] = []) => {
     const onAdd = vi.fn()

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -197,8 +197,7 @@ describe('where a verified pack asks to be kept', () => {
         builtIns={[]}
         onSelect={vi.fn()}
         onAdd={vi.fn()}
-        pending={sheet}
-        pendingRowId="kusto"
+        pending={{ sheet, rowKey: find('kusto').key }}
       />
     )
 
@@ -216,8 +215,7 @@ describe('where a verified pack asks to be kept', () => {
         builtIns={[]}
         onSelect={vi.fn()}
         onAdd={vi.fn()}
-        pending={sheet}
-        pendingRowId="dropped-from-a-file"
+        pending={{ sheet }}
       />
     )
 

--- a/tests/connector-pack-confirm.test.tsx
+++ b/tests/connector-pack-confirm.test.tsx
@@ -37,19 +37,26 @@ const PREVIEW: ConnectorPackSummary = {
 describe('the sheet shown before a pack is kept', () => {
   it('brings itself into view, since it opens beside the button that raised it', () => {
     const scrollIntoView = vi.fn()
+    const had = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView')
     Element.prototype.scrollIntoView = scrollIntoView
     try {
       render(<PackInstallConfirm preview={PREVIEW} onConfirm={vi.fn()} onCancel={vi.fn()} />)
       expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
     } finally {
-      delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+      if (had) Object.defineProperty(Element.prototype, 'scrollIntoView', had)
+      else delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
     }
   })
 
   it('renders where scrolling an element into view is not implemented', () => {
-    expect(Element.prototype.scrollIntoView).toBeUndefined()
-    render(<PackInstallConfirm preview={PREVIEW} onConfirm={vi.fn()} onCancel={vi.fn()} />)
-    expect(screen.getByText(/Pack Demo/)).toBeInTheDocument()
+    const had = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView')
+    delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+    try {
+      render(<PackInstallConfirm preview={PREVIEW} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+      expect(screen.getByText(/Pack Demo/)).toBeInTheDocument()
+    } finally {
+      if (had) Object.defineProperty(Element.prototype, 'scrollIntoView', had)
+    }
   })
 
   it('says which variables the pack will borrow from a signed-in tool', () => {

--- a/tests/connector-pack-confirm.test.tsx
+++ b/tests/connector-pack-confirm.test.tsx
@@ -35,6 +35,23 @@ const PREVIEW: ConnectorPackSummary = {
 }
 
 describe('the sheet shown before a pack is kept', () => {
+  it('brings itself into view, since it opens beside the button that raised it', () => {
+    const scrollIntoView = vi.fn()
+    Element.prototype.scrollIntoView = scrollIntoView
+    try {
+      render(<PackInstallConfirm preview={PREVIEW} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+    } finally {
+      delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+    }
+  })
+
+  it('renders where scrolling an element into view is not implemented', () => {
+    expect(Element.prototype.scrollIntoView).toBeUndefined()
+    render(<PackInstallConfirm preview={PREVIEW} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText(/Pack Demo/)).toBeInTheDocument()
+  })
+
   it('says which variables the pack will borrow from a signed-in tool', () => {
     const borrowing: ConnectorPackSummary = {
       ...PREVIEW,

--- a/tests/use-pack-install.test.tsx
+++ b/tests/use-pack-install.test.tsx
@@ -2,8 +2,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
-import { usePackInstall } from '../src/renderer/lib/use-pack-install'
+import { usePackInstall, matchesListing } from '../src/renderer/lib/use-pack-install'
 import type { ConnectorListing } from '../src/renderer/lib/connector-browse'
+import type { ConnectorPackSummary } from '../src/shared/types'
 
 const inspectConnectorPack = vi.fn()
 const installConnectorPack = vi.fn()
@@ -26,6 +27,21 @@ const LISTING: ConnectorListing = {
     capabilities: ['actions'],
     launch: { command: 'node', args: [] }
   } as ConnectorListing['catalogItem']
+}
+
+/** A row that already says everything the pack will: version and sign-in both. */
+const DESCRIBED: ConnectorListing = {
+  ...LISTING,
+  authRung: 'key',
+  catalogItem: { ...LISTING.catalogItem, version: '1.2.0' } as ConnectorListing['catalogItem']
+}
+
+const DESCRIBED_PREVIEW = {
+  id: 'slack',
+  name: 'Slack',
+  version: '1.2.0',
+  auth: { rung: 'key' as const, keys: ['botToken'] },
+  token: 'tok-1'
 }
 
 beforeEach(() => {
@@ -207,6 +223,61 @@ describe('installing a pack from wherever it was asked for', () => {
     )
   })
 
+  // Pressing install on a row that already showed the version and the sign-in
+  // is the answer; asking it again only adds a click.
+  it('installs a pack the row already described, without asking again', async () => {
+    inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
+    const onInstalled = vi.fn()
+    render(<Probe onInstalled={onInstalled} listing={DESCRIBED} />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+    expect(installConnectorPack).toHaveBeenCalledTimes(1)
+    expect(installConnectorPack).toHaveBeenCalledWith({ kind: 'staged', token: 'tok-1' })
+    expect(screen.getByTestId('pending')).toHaveTextContent('none')
+  })
+
+  it('asks when the pack is a version the row did not advertise', async () => {
+    inspectConnectorPack.mockResolvedValue({
+      ok: true,
+      preview: { ...DESCRIBED_PREVIEW, version: '1.3.0' }
+    })
+    render(<Probe listing={DESCRIBED} />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.3.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
+  it('asks when the pack signs in differently than the row said', async () => {
+    inspectConnectorPack.mockResolvedValue({
+      ok: true,
+      preview: { ...DESCRIBED_PREVIEW, auth: { rung: 'cli' as const } }
+    })
+    render(<Probe listing={DESCRIBED} />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.2.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
+  // Replacing something already on disk is a decision, not a repeat of the row.
+  it('asks when the pack would replace an installed version', async () => {
+    inspectConnectorPack.mockResolvedValue({
+      ok: true,
+      preview: { ...DESCRIBED_PREVIEW, installedVersion: '1.1.0' }
+    })
+    render(<Probe listing={DESCRIBED} />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.2.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
   it('closes the sheet even when the install call itself fails', async () => {
     installConnectorPack.mockRejectedValue(new Error('the server went away'))
     render(<Probe />)
@@ -219,5 +290,21 @@ describe('installing a pack from wherever it was asked for', () => {
       expect(screen.getByTestId('error')).toHaveTextContent('the server went away')
     )
     expect(screen.getByTestId('pending')).toHaveTextContent('none')
+  })
+})
+
+describe('whether a checked pack is the one the row described', () => {
+  const preview = DESCRIBED_PREVIEW as unknown as ConnectorPackSummary
+
+  it('agrees when the id, the version and the sign-in all do', () => {
+    expect(matchesListing(preview, DESCRIBED)).toBe(true)
+  })
+
+  it('refuses to agree with a catalog that names no version', () => {
+    expect(matchesListing(preview, LISTING)).toBe(false)
+  })
+
+  it('refuses to agree when the pack calls itself something else', () => {
+    expect(matchesListing({ ...preview, id: 'slack-connector' }, DESCRIBED)).toBe(false)
   })
 })

--- a/tests/use-pack-install.test.tsx
+++ b/tests/use-pack-install.test.tsx
@@ -334,6 +334,46 @@ describe('installing a pack from wherever it was asked for', () => {
     expect(installConnectorPack).not.toHaveBeenCalled()
   })
 
+  it('holds the row from the press, before the server has said anything', async () => {
+    let answer: (value: unknown) => void = () => {}
+    inspectConnectorPack.mockReturnValue(new Promise((resolve) => (answer = resolve)))
+    render(<Probe />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    expect(screen.getByTestId('phase')).toHaveTextContent('checking')
+    await act(async () => answer({ ok: true, preview: DESCRIBED_PREVIEW }))
+    // The sheet has the question now, so the row is free again.
+    expect(screen.getByTestId('phase')).toHaveTextContent('none')
+  })
+
+  it('keeps the row installing until the reload has shown the pack', async () => {
+    inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
+    let reloaded: () => void = () => {}
+    const onInstalled = vi.fn(() => new Promise<void>((resolve) => (reloaded = resolve)))
+    render(<Probe onInstalled={onInstalled} listing={DESCRIBED} direct />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(onInstalled).toHaveBeenCalled())
+    expect(screen.getByTestId('phase')).toHaveTextContent('installing')
+    await act(async () => reloaded())
+    await waitFor(() => expect(screen.getByTestId('phase')).toHaveTextContent('none'))
+  })
+
+  it('frees the row and says so when the reload after an install fails', async () => {
+    inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
+    const onInstalled = vi.fn(() => Promise.reject(new Error('server went away')))
+    render(<Probe onInstalled={onInstalled} listing={DESCRIBED} direct />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('phase')).toHaveTextContent('none'))
+    expect(screen.getByTestId('error')).toHaveTextContent(
+      'Installed, but the list could not be re-read'
+    )
+  })
+
   it('closes the sheet even when the install call itself fails', async () => {
     installConnectorPack.mockRejectedValue(new Error('the server went away'))
     render(<Probe />)

--- a/tests/use-pack-install.test.tsx
+++ b/tests/use-pack-install.test.tsx
@@ -402,6 +402,13 @@ describe('whether a checked pack is the one the row described', () => {
 
   it('refuses to agree when the pack calls itself something else', () => {
     expect(matchesListing({ ...preview, id: 'slack-connector' }, DESCRIBED)).toBe(false)
+    // A receipt for an older version vouches for that version, not this one.
+    expect(
+      matchesListing(preview, {
+        ...DESCRIBED,
+        verified: { ...DESCRIBED.verified!, version: '1.1.0' }
+      })
+    ).toBe(false)
   })
 
   it('refuses to read two unstated sign-ins as the same one', () => {

--- a/tests/use-pack-install.test.tsx
+++ b/tests/use-pack-install.test.tsx
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
-import { usePackInstall, matchesListing } from '../src/renderer/lib/use-pack-install'
-import type { ConnectorListing } from '../src/renderer/lib/connector-browse'
+import { usePackInstall } from '../src/renderer/lib/use-pack-install'
+import { matchesListing, type ConnectorListing } from '../src/renderer/lib/connector-browse'
 import type { ConnectorPackSummary } from '../src/shared/types'
 
 const inspectConnectorPack = vi.fn()
@@ -29,10 +29,16 @@ const LISTING: ConnectorListing = {
   } as ConnectorListing['catalogItem']
 }
 
-/** A row that already says everything the pack will: version and sign-in both. */
+/** A row that already says everything the pack will: version, sign-in and receipt. */
 const DESCRIBED: ConnectorListing = {
   ...LISTING,
   authRung: 'key',
+  verified: {
+    schema: 1,
+    version: '1.2.0',
+    checkedAt: '2026-09-04T00:00:00Z',
+    checks: ['manifest']
+  },
   catalogItem: { ...LISTING.catalogItem, version: '1.2.0' } as ConnectorListing['catalogItem']
 }
 
@@ -59,15 +65,20 @@ beforeEach(() => {
 
 function Probe({
   onInstalled,
-  listing = LISTING
+  listing = LISTING,
+  direct
 }: {
   onInstalled?: () => void
   listing?: ConnectorListing
+  /** What a surface that showed the pack's facts passes; the requirement row does not. */
+  direct?: boolean
 }) {
   const install = usePackInstall(onInstalled)
   return (
     <div>
-      <button onClick={() => void install.inspect(listing)}>inspect</button>
+      <button onClick={() => void install.inspect(listing, { ...(direct && { direct }) })}>
+        inspect
+      </button>
       <button onClick={() => void install.inspectFile('/tmp/pack.vorn.tgz')}>inspect file</button>
       <button onClick={() => void install.confirm()}>confirm</button>
       <button onClick={install.cancel}>cancel</button>
@@ -228,7 +239,7 @@ describe('installing a pack from wherever it was asked for', () => {
   it('installs a pack the row already described, without asking again', async () => {
     inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
     const onInstalled = vi.fn()
-    render(<Probe onInstalled={onInstalled} listing={DESCRIBED} />)
+    render(<Probe onInstalled={onInstalled} listing={DESCRIBED} direct />)
 
     fireEvent.click(screen.getByText('inspect'))
 
@@ -238,12 +249,23 @@ describe('installing a pack from wherever it was asked for', () => {
     expect(screen.getByTestId('pending')).toHaveTextContent('none')
   })
 
+  // A requirement row names the connector and nothing else, so it never asks to skip.
+  it('asks from a surface that did not describe the pack, however well it matches', async () => {
+    inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
+    render(<Probe listing={DESCRIBED} />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.2.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
   it('asks when the pack is a version the row did not advertise', async () => {
     inspectConnectorPack.mockResolvedValue({
       ok: true,
       preview: { ...DESCRIBED_PREVIEW, version: '1.3.0' }
     })
-    render(<Probe listing={DESCRIBED} />)
+    render(<Probe listing={DESCRIBED} direct />)
 
     fireEvent.click(screen.getByText('inspect'))
 
@@ -256,7 +278,41 @@ describe('installing a pack from wherever it was asked for', () => {
       ok: true,
       preview: { ...DESCRIBED_PREVIEW, auth: { rung: 'cli' as const } }
     })
-    render(<Probe listing={DESCRIBED} />)
+    render(<Probe listing={DESCRIBED} direct />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.2.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
+  // Absent on either side means nobody stated it, and the row's badge is blank.
+  it('asks when the pack states no sign-in', async () => {
+    inspectConnectorPack.mockResolvedValue({
+      ok: true,
+      preview: { ...DESCRIBED_PREVIEW, auth: undefined }
+    })
+    render(<Probe listing={DESCRIBED} direct />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.2.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
+  it('asks when the row states no sign-in', async () => {
+    inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
+    render(<Probe listing={{ ...DESCRIBED, authRung: undefined }} direct />)
+
+    fireEvent.click(screen.getByText('inspect'))
+
+    await waitFor(() => expect(screen.getByTestId('pending')).toHaveTextContent('1.2.0'))
+    expect(installConnectorPack).not.toHaveBeenCalled()
+  })
+
+  it('asks when nothing vouched for the connector', async () => {
+    inspectConnectorPack.mockResolvedValue({ ok: true, preview: DESCRIBED_PREVIEW })
+    render(<Probe listing={{ ...DESCRIBED, verified: undefined }} direct />)
 
     fireEvent.click(screen.getByText('inspect'))
 
@@ -270,7 +326,7 @@ describe('installing a pack from wherever it was asked for', () => {
       ok: true,
       preview: { ...DESCRIBED_PREVIEW, installedVersion: '1.1.0' }
     })
-    render(<Probe listing={DESCRIBED} />)
+    render(<Probe listing={DESCRIBED} direct />)
 
     fireEvent.click(screen.getByText('inspect'))
 
@@ -296,7 +352,7 @@ describe('installing a pack from wherever it was asked for', () => {
 describe('whether a checked pack is the one the row described', () => {
   const preview = DESCRIBED_PREVIEW as unknown as ConnectorPackSummary
 
-  it('agrees when the id, the version and the sign-in all do', () => {
+  it('agrees when the id, the version, the sign-in and the receipt all do', () => {
     expect(matchesListing(preview, DESCRIBED)).toBe(true)
   })
 
@@ -306,5 +362,14 @@ describe('whether a checked pack is the one the row described', () => {
 
   it('refuses to agree when the pack calls itself something else', () => {
     expect(matchesListing({ ...preview, id: 'slack-connector' }, DESCRIBED)).toBe(false)
+  })
+
+  it('refuses to read two unstated sign-ins as the same one', () => {
+    const unstated = { ...preview, auth: undefined } as unknown as ConnectorPackSummary
+    expect(matchesListing(unstated, { ...DESCRIBED, authRung: undefined })).toBe(false)
+  })
+
+  it('refuses to agree when nothing vouched for the connector', () => {
+    expect(matchesListing(preview, { ...DESCRIBED, verified: undefined })).toBe(false)
   })
 })


### PR DESCRIPTION
Pressing Install on a connector's page showed nothing, and on a row far down the list it put the confirm sheet above the fold: the sheet had one mount point, the top of the directory. Storyboard: https://claude.ai/code/artifact/d4302b09-4d73-4af8-bac3-ca46741e24ff

## What changed

- The confirm sheet opens under the row that was pressed, or under the action row of the connector's page, and scrolls itself into view. A pack dropped as a file, which has no row, keeps the top slot.
- A verified pack that matches its listing installs without the sheet when the surface that asked had shown the pack's facts: the directory row and the connector page opt in; the workflow editor's requirement row does not, since it names the connector and nothing else. The sheet still appears for a replacement, for a mismatch in id, version or sign-in, for a pack or listing that states no sign-in, and for a listing without a receipt.
- The row goes busy from the press, before the server has said anything, and stays busy until the reload shows the pack on disk, so the Install button can neither be pressed twice nor flash back between the install and the list refresh. A reload that fails frees the row and says so.

## How to verify

Settings → Connectors → Browse: Install on a verified row or page goes straight to installed with no gap; Install on an installed pack shows the sheet under it; a dropped `.vorn.tgz` shows the sheet at the top; a template's requirement row still asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
