### PR TITLE
Say a reboot is a reboot, and check the tree before offering Resume

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -1082,7 +1082,8 @@ function verifySchema(d: Database.Database): void {
       },
       { column: 'worktree_name', ddl: 'ALTER TABLE sessions ADD COLUMN worktree_name TEXT' },
       { column: 'agent_session_id', ddl: 'ALTER TABLE sessions ADD COLUMN agent_session_id TEXT' },
-      { column: 'shell_cwd', ddl: 'ALTER TABLE sessions ADD COLUMN shell_cwd TEXT' }
+      { column: 'shell_cwd', ddl: 'ALTER TABLE sessions ADD COLUMN shell_cwd TEXT' },
+      { column: 'head_commit', ddl: 'ALTER TABLE sessions ADD COLUMN head_commit TEXT' }
     ],
     agent_commands: [
       {
@@ -3123,8 +3124,8 @@ export function saveSessions(sessions: TerminalSession[]): void {
   const run = d.transaction(() => {
     d.prepare('DELETE FROM sessions').run()
     const insert = d.prepare(
-      `INSERT INTO sessions (id, agent_type, project_name, project_path, status, created_at, pid, display_name, branch, worktree_path, is_worktree, remote_host_id, remote_host_label, hook_session_id, status_source, saved_at, sort_order, worktree_name, agent_session_id, shell_cwd)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO sessions (id, agent_type, project_name, project_path, status, created_at, pid, display_name, branch, worktree_path, is_worktree, remote_host_id, remote_host_label, hook_session_id, status_source, saved_at, sort_order, worktree_name, agent_session_id, shell_cwd, head_commit)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (let i = 0; i < sessions.length; i++) {
       const s = sessions[i]
@@ -3153,7 +3154,8 @@ export function saveSessions(sessions: TerminalSession[]): void {
         i,
         s.worktreeName ?? null,
         s.agentSessionId ?? null,
-        s.shellCwd ?? null
+        s.shellCwd ?? null,
+        s.headCommit ?? null
       )
     }
   })
@@ -3180,6 +3182,7 @@ export function getPreviousSessions(): TerminalSession[] {
     status_source: string | null
     saved_at: number | null
     shell_cwd: string | null
+    head_commit: string | null
     worktree_name: string | null
     agent_session_id: string | null
   }>
@@ -3206,7 +3209,8 @@ export function getPreviousSessions(): TerminalSession[] {
     // Selected since this table was written and dropped on the floor until now.
     // It is the only record of when a run ended.
     ...(r.saved_at != null && { savedAt: r.saved_at }),
-    ...(r.shell_cwd != null && { shellCwd: r.shell_cwd })
+    ...(r.shell_cwd != null && { shellCwd: r.shell_cwd }),
+    ...(r.head_commit != null && { headCommit: r.head_commit })
   }))
 }
 

--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -68,6 +68,19 @@ export function getGitBranch(projectPath: string, remote?: RemoteHost): string |
   }
 }
 
+export function getGitHead(projectPath: string, remote?: RemoteHost): string | null {
+  try {
+    return gitExec(['rev-parse', 'HEAD'], projectPath, { timeout: 3000, remote }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+/** Working tree against HEAD, or one commit against another. */
+function diffTarget(range?: { from: string; to: string }): string[] {
+  return range ? [`${range.from}..${range.to}`] : ['HEAD']
+}
+
 /**
  * Pull `owner/repo` out of a git remote URL, for the forms git actually
  * stores: `git@host:owner/repo.git`, `https://host/owner/repo.git`,
@@ -551,10 +564,11 @@ export interface WorktreeEntry {
 
 export function getGitDiffStat(
   cwd: string,
-  remote?: RemoteHost
+  remote?: RemoteHost,
+  range?: { from: string; to: string }
 ): { filesChanged: number; insertions: number; deletions: number } | null {
   try {
-    const output = gitExec(['diff', 'HEAD', '--numstat'], cwd, {
+    const output = gitExec(['diff', ...diffTarget(range), '--numstat'], cwd, {
       timeout: 10000,
       remote
     }).trim()
@@ -583,17 +597,18 @@ export function getGitDiffStat(
 
 export function getGitDiffFull(
   cwd: string,
-  remote?: RemoteHost
+  remote?: RemoteHost,
+  range?: { from: string; to: string }
 ): {
   stat: { filesChanged: number; insertions: number; deletions: number }
   files: GitFileDiff[]
 } | null {
   try {
-    const stat = getGitDiffStat(cwd, remote)
+    const stat = getGitDiffStat(cwd, remote, range)
     if (!stat) return null
 
     const MAX_DIFF_SIZE = 500 * 1024 // 500KB
-    let rawDiff = gitExec(['diff', 'HEAD', '-U3'], cwd, {
+    let rawDiff = gitExec(['diff', ...diffTarget(range), '-U3'], cwd, {
       timeout: 15000,
       maxBuffer: MAX_DIFF_SIZE * 2,
       remote
@@ -603,7 +618,7 @@ export function getGitDiffFull(
       rawDiff = rawDiff.slice(0, MAX_DIFF_SIZE) + '\n\n... diff truncated (too large) ...\n'
     }
 
-    const numstatOutput = gitExec(['diff', 'HEAD', '--numstat'], cwd, {
+    const numstatOutput = gitExec(['diff', ...diffTarget(range), '--numstat'], cwd, {
       timeout: 10000,
       remote
     }).trim()

--- a/packages/server/src/head-commit.ts
+++ b/packages/server/src/head-commit.ts
@@ -1,0 +1,34 @@
+import type { TerminalSession } from '@vornrun/shared/types'
+
+/** Ten sessions on a board would otherwise be ten subprocesses on every save. */
+export const HEAD_REFRESH_MS = 30_000
+
+// Keeps each session's recorded HEAD following the tree, at a bounded cost.
+export class HeadRefresh {
+  private checkedAt = new Map<string, number>()
+
+  constructor(
+    private readonly read: (cwd: string) => string | null,
+    private readonly every: number = HEAD_REFRESH_MS
+  ) {}
+
+  refresh(sessions: TerminalSession[], now: number = Date.now()): void {
+    for (const s of sessions) {
+      if (s.remoteHostId) continue
+      const last = this.checkedAt.get(s.id)
+      if (last !== undefined && now - last < this.every) continue
+      this.checkedAt.set(s.id, now)
+      const head = this.read(s.worktreePath ?? s.projectPath)
+      if (head) s.headCommit = head
+    }
+  }
+
+  /** The next refresh reads this one again, whatever the clock says. */
+  invalidate(id: string): void {
+    this.checkedAt.delete(id)
+  }
+
+  forget(id: string): void {
+    this.checkedAt.delete(id)
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,7 +38,8 @@ import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protoc
 import { ptyManager } from './pty-manager'
 import { configureHistory, flushHistory } from './history/writer'
 import { recoverHistory } from './history/recovery'
-import { seedRestored, markRecovered } from './restored-sessions'
+import { seedRestored, markRecovered, verifyRestored } from './restored-sessions'
+import { getGitBranch, getGitHead } from './git-utils'
 import { sessionManager } from './session-persistence'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
@@ -345,7 +346,9 @@ export async function startServer(
   // next line can launch a workflow session -- so a save can fire from here, and
   // a save is a whole-table replace. Seeding after it would mean the records
   // this is holding had already been erased by the thing it exists to survive.
-  const carriedOver = seedRestored(sessionManager.readPreviousSessions())
+  // Uptime counts through sleep, so a laptop closed overnight is not a reboot.
+  const bootTime = Date.now() - os.uptime() * 1000
+  const carriedOver = seedRestored(sessionManager.readPreviousSessions(), Date.now(), bootTime)
 
   // Register all RPC methods
   registerAllMethods()
@@ -478,6 +481,17 @@ export async function startServer(
   // ask for history that has not been read yet. The cost is that discovery waits
   // on it -- measured at 77ms for fifty terminals.
   markRecovered((await recoverHistory(dataDir, carriedOver)).recovered)
+  verifyRestored({
+    isDirectory: (at) => {
+      try {
+        return fs.statSync(at).isDirectory()
+      } catch {
+        return false
+      }
+    },
+    branch: getGitBranch,
+    head: getGitHead
+  })
 
   // Published together, after the claim, because they are one announcement: the
   // port says where, the credential says how, and a reader that finds one

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import fs from 'node:fs'
 import path from 'node:path'
 import { EventEmitter } from 'node:events'
+import { HeadRefresh } from './head-commit'
 import log from './logger'
 import {
   AiAgentType,
@@ -18,6 +19,7 @@ import {
 import { displayNameFromPrompt } from '@vornrun/shared/string-utils'
 import {
   getGitBranch,
+  getGitHead,
   checkoutBranch,
   createWorktree,
   extractWorktreeName,
@@ -78,6 +80,8 @@ type WorktreeSessionCounter = (
 ) => { count: number; sessionIds: string[] }
 
 class PtyManager extends EventEmitter {
+  /** Recorded HEAD per session, refreshed by the save loop. */
+  readonly heads = new HeadRefresh(getGitHead)
   private ptys = new Map<string, pty.IPty>()
   private sessions = new Map<string, TerminalSession>()
   private normalizedPaths = new Map<string, string>()
@@ -308,6 +312,7 @@ class PtyManager extends EventEmitter {
     this.ptys.set(id, ptyProcess)
 
     const branch = effectiveBranch || getGitBranch(effectivePath)
+    const headCommit = getGitHead(effectivePath)
     const session: TerminalSession = {
       id,
       agentType: payload.agentType,
@@ -324,6 +329,7 @@ class PtyManager extends EventEmitter {
           ? { displayName: displayNameFromPrompt(payload.initialPrompt) }
           : {}),
       ...(branch ? { branch } : {}),
+      ...(headCommit ? { headCommit } : {}),
       ...(worktreePath ? { worktreePath, worktreeName, isWorktree: true } : {}),
       // Don't set statusSource: 'hooks' eagerly — promoteToHookStatus() sets it
       // when the first hook event actually arrives. This provides graceful
@@ -893,6 +899,7 @@ class PtyManager extends EventEmitter {
     this.drainBuffer(id)
     this.clearBuffer(id)
     this.sessions.delete(id)
+    this.heads.forget(id)
     this.normalizedPaths.delete(id)
     this.clearSessionTracking(id)
     this.flushSeq.delete(id)
@@ -931,6 +938,7 @@ class PtyManager extends EventEmitter {
     // Delete-then-check pattern: single removal point prevents races.
     const session = this.sessions.get(id)
     this.sessions.delete(id)
+    this.heads.forget(id)
     this.normalizedPaths.delete(id)
     this.clearSessionTracking(id)
     this.flushSeq.delete(id)
@@ -1152,6 +1160,7 @@ class PtyManager extends EventEmitter {
         if (updates.branch !== undefined) s.branch = updates.branch
         if (updates.worktreeName !== undefined) s.worktreeName = updates.worktreeName
         if (updates.worktreePath !== undefined) s.worktreePath = updates.worktreePath
+        this.heads.invalidate(s.id)
         this.emit('client-message', IPC.SESSION_UPDATED, s)
       }
     }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1240,9 +1240,11 @@ export function registerAllMethods(): void {
     const remote = resolveRemoteHostByPath(cwd)
     return gitUtils.getGitDiffStat(cwd, remote)
   })
-  registerMethod('git:diffFull', (cwd) => {
+  registerMethod('git:diffFull', (req) => {
+    const cwd = typeof req === 'string' ? req : req.cwd
     const remote = resolveRemoteHostByPath(cwd)
-    return gitUtils.getGitDiffFull(cwd, remote)
+    const range = typeof req === 'string' ? undefined : { from: req.from, to: req.to }
+    return gitUtils.getGitDiffFull(cwd, remote, range)
   })
   registerMethod('git:commit', ({ cwd, message, includeUnstaged }) => {
     const remote = resolveRemoteHostByPath(cwd)
@@ -2011,7 +2013,11 @@ export function registerAllMethods(): void {
   // record gone, the next start judged that session's history unreachable and
   // deleted it. Holding them here is what makes a terminal survive more than one
   // restart.
-  sessionManager.startAutoSave(() => [...ptyManager.getActiveSessions(), ...restoredRecords()])
+  sessionManager.startAutoSave(() => {
+    const active = ptyManager.getActiveSessions()
+    ptyManager.heads.refresh(active)
+    return [...active, ...restoredRecords()]
+  })
 
   // ─── Hook server integration ──────────────────────────────────
 

--- a/packages/server/src/restore-environment.ts
+++ b/packages/server/src/restore-environment.ts
@@ -1,0 +1,25 @@
+import type { RestoreEnvironment, TerminalSession } from '@vornrun/shared/types'
+
+export interface EnvironmentProbe {
+  isDirectory(at: string): boolean
+  branch(cwd: string): string | null
+  head(cwd: string): string | null
+}
+
+// What is there now against what the record says, so Resume is offered knowingly.
+export function probeEnvironment(
+  session: Pick<
+    TerminalSession,
+    'projectPath' | 'worktreePath' | 'branch' | 'headCommit' | 'remoteHostId'
+  >,
+  probe: EnvironmentProbe
+): RestoreEnvironment | undefined {
+  if (session.remoteHostId) return undefined
+  const cwd = session.worktreePath ?? session.projectPath
+  const present = probe.isDirectory(cwd)
+  return {
+    worktree: present ? 'ok' : 'missing',
+    branch: { recorded: session.branch ?? null, actual: present ? probe.branch(cwd) : null },
+    head: { recorded: session.headCommit ?? null, actual: present ? probe.head(cwd) : null }
+  }
+}

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -1,5 +1,6 @@
 import type { RestoredSession, TerminalSession } from '@vornrun/shared/types'
 import log from './logger'
+import { probeEnvironment, type EnvironmentProbe } from './restore-environment'
 
 /**
  * The sessions a previous run left behind that no pane has claimed yet.
@@ -66,7 +67,9 @@ const held = new Map<string, RestoredSession>()
  */
 export function seedRestored(
   previous: TerminalSession[] | null,
-  now: number = Date.now()
+  now: number = Date.now(),
+  /** When this machine came up. A record saved before it was interrupted by the machine going down. */
+  bootTime: number = 0
 ): TerminalSession[] | null {
   held.clear()
   if (previous === null) return null
@@ -84,7 +87,8 @@ export function seedRestored(
       endedAt,
       replayable: false,
       partial: false,
-      closedCleanly: false
+      closedCleanly: false,
+      rebooted: endedAt < bootTime
     })
     keep.push(session)
   }
@@ -105,6 +109,18 @@ export function markRecovered(
     entry.replayable = true
     entry.partial = one.stopped !== 'end'
     entry.closedCleanly = one.closedCleanly
+  }
+}
+
+/** Check each record against the tree once, so Resume is offered knowingly. One that throws is left unchecked. */
+export function verifyRestored(probe: EnvironmentProbe): void {
+  for (const entry of held.values()) {
+    try {
+      const environment = probeEnvironment(entry.session, probe)
+      if (environment) entry.environment = environment
+    } catch (err) {
+      log.warn({ err, id: entry.session.id }, '[restored] could not verify a session')
+    }
   }
 }
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -10,6 +10,7 @@ import type {
   FileStamp,
   GitDiffStat,
   GitDiffResult,
+  GitDiffRange,
   WorkflowDefinition,
   WorkflowExecution,
   ScriptConfig,
@@ -624,7 +625,7 @@ export interface RequestMethods {
     result: Array<{ path: string; branch: string; isMain: boolean; name: string }>
   }
   'git:diffStat': { params: string; result: GitDiffStat | null }
-  'git:diffFull': { params: string; result: GitDiffResult | null }
+  'git:diffFull': { params: string | GitDiffRange; result: GitDiffResult | null }
   'git:commit': {
     params: { cwd: string; message: string; includeUnstaged: boolean }
     result: { success: boolean; error?: string }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -113,6 +113,8 @@ export interface TerminalSession {
   rows?: number
   /** Shell session only: working directory the PTY was started in. */
   shellCwd?: string
+  /** HEAD where it was working, refreshed as it works, so a restore can tell the tree moved. */
+  headCommit?: string
   /** Shell session only: PTY exit code once the shell has exited. */
   shellExitCode?: number
   /**
@@ -149,6 +151,23 @@ export interface RestoredSession {
    * ordinary quit.
    */
   closedCleanly: boolean
+  /** The machine went down under it: saved before this boot, and never closed. */
+  rebooted: boolean
+  /** What is there now against what was recorded. Absent for remote sessions. */
+  environment?: RestoreEnvironment
+}
+
+export interface RestoreEnvironment {
+  worktree: 'ok' | 'missing'
+  branch: { recorded: string | null; actual: string | null }
+  head: { recorded: string | null; actual: string | null }
+}
+
+/** Both commits known and different. Unknown on either side is not a move. */
+export function headMoved(env: RestoreEnvironment | undefined): boolean {
+  if (!env) return false
+  const { recorded, actual } = env.head
+  return recorded !== null && actual !== null && recorded !== actual
 }
 
 export type AuthMethod = 'key-file' | 'key-stored' | 'password' | 'agent'
@@ -1416,6 +1435,13 @@ export interface GitFileDiff {
 export interface GitDiffResult {
   stat: GitDiffStat
   files: GitFileDiff[]
+}
+
+/** Two commits rather than the working tree against HEAD. */
+export interface GitDiffRange {
+  cwd: string
+  from: string
+  to: string
 }
 
 export interface GitCommitPayload {

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -1,6 +1,6 @@
 import { CLOSE_CREDENTIAL_REJECTED, RUNTIME_PROTOCOL_VERSION } from '@vornrun/shared/protocol'
 import { captureViewerSettings, withViewerSettings } from '@vornrun/shared/viewer-settings-store'
-import type { AppConfig } from '@vornrun/shared/types'
+import type { GitDiffRange, AppConfig } from '@vornrun/shared/types'
 /**
  * WebSocket RPC shim that implements the same surface as the Electron preload `window.api`.
  * Components and stores call window.api.* exactly as they do in Electron,
@@ -521,7 +521,7 @@ export function createApiShim(wsUrl: string) {
     deleteBranches: (projectPath: string, branches: string[], force?: boolean) =>
       rpc.invoke('git:deleteBranches', { projectPath, branches, force }),
     getGitDiffStat: (cwd: string) => rpc.invoke('git:diffStat', cwd),
-    getGitDiffFull: (cwd: string) => rpc.invoke('git:diffFull', cwd),
+    getGitDiffFull: (req: string | GitDiffRange) => rpc.invoke('git:diffFull', req),
     gitCommit: (payload: unknown) => rpc.invoke('git:commit', payload),
     gitPush: (cwd: string) => rpc.invoke('git:push', cwd),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -16,6 +16,7 @@ import {
   IPC,
   GitDiffStat,
   GitDiffResult,
+  GitDiffRange,
   GitCommitPayload,
   GitCommitResult,
   ScheduleLogEntry,
@@ -311,8 +312,8 @@ const api = {
   getGitDiffStat: (cwd: string): Promise<GitDiffStat | null> =>
     ipcRenderer.invoke(IPC.GIT_DIFF_STAT, cwd),
 
-  getGitDiffFull: (cwd: string): Promise<GitDiffResult | null> =>
-    ipcRenderer.invoke(IPC.GIT_DIFF_FULL, cwd),
+  getGitDiffFull: (req: string | GitDiffRange): Promise<GitDiffResult | null> =>
+    ipcRenderer.invoke(IPC.GIT_DIFF_FULL, req),
 
   gitCommit: (payload: GitCommitPayload): Promise<GitCommitResult> =>
     ipcRenderer.invoke(IPC.GIT_COMMIT, payload),

--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -193,10 +193,17 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   // textarea may already have been removed. State would be stale in that closure.
   const hadFocusRef = useRef(false)
   const draftRef = useRef('')
+  // Re-pointed at another pane without unmounting: take that pane's draft
+  // before the effect below can write this one's under its id.
+  const [draftOwner, setDraftOwner] = useState(terminalId)
+  if (draftOwner !== terminalId) {
+    setDraftOwner(terminalId)
+    setValue(readIntentDraft(terminalId)?.text ?? '')
+  }
   useEffect(() => {
     draftRef.current = value
-    writeIntentDraft(terminalId, value)
-  }, [value, terminalId])
+    if (draftOwner === terminalId) writeIntentDraft(terminalId, value)
+  }, [value, terminalId, draftOwner])
   const [seenState, setSeenState] = useState(inputState)
   if (seenState !== inputState) {
     // Adjusted during render, which React sanctions: an effect writing this

--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -8,6 +8,7 @@ import {
   useSyncExternalStore,
   type KeyboardEvent
 } from 'react'
+import { readIntentDraft, writeIntentDraft } from '../lib/intent-drafts'
 import { createPortal } from 'react-dom'
 import {
   CornerDownLeft,
@@ -148,7 +149,8 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   const [menuPos, setMenuPos] = useState<{ left: number; width: number; bottom: number } | null>(
     null
   )
-  const [value, setValue] = useState('')
+  // Comes back after a reload or a reboot, the way an editor's unsaved edit does.
+  const [value, setValue] = useState(() => readIntentDraft(terminalId)?.text ?? '')
   const [isFocused, setIsFocused] = useState(false)
   const [history, setHistory] = useState<CommandHistoryEntry[]>([])
   const [completions, setCompletions] = useState<Completion[]>([])
@@ -193,7 +195,8 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
   const draftRef = useRef('')
   useEffect(() => {
     draftRef.current = value
-  }, [value])
+    writeIntentDraft(terminalId, value)
+  }, [value, terminalId])
   const [seenState, setSeenState] = useState(inputState)
   if (seenState !== inputState) {
     // Adjusted during render, which React sanctions: an effect writing this

--- a/src/renderer/components/RightPanel.tsx
+++ b/src/renderer/components/RightPanel.tsx
@@ -54,12 +54,15 @@ export function RightPanel() {
   } | null>(null)
 
   const cwd = terminal?.session.worktreePath || terminal?.session.projectPath || ''
+  const range = useAppStore((s) => s.diffRange)
+  const from = range && range.terminalId === terminalId ? range.from : null
+  const to = range && range.terminalId === terminalId ? range.to : null
 
   const fetchDiff = useCallback(async () => {
     if (!cwd) return
     setLoading(true)
     try {
-      const result = await window.api.getGitDiffFull(cwd)
+      const result = await window.api.getGitDiffFull(from && to ? { cwd, from, to } : cwd)
       setDiffResult(result)
       setSelectedFile(null)
       setComments([])
@@ -67,7 +70,7 @@ export function RightPanel() {
     } finally {
       setLoading(false)
     }
-  }, [cwd])
+  }, [cwd, from, to])
 
   useEffect(() => {
     if (terminalId && cwd) {
@@ -203,6 +206,11 @@ export function RightPanel() {
                 <span className="truncate">{terminal.session.branch}</span>
               </span>
             </>
+          )}
+          {from && to && (
+            <span className="ml-auto shrink-0 font-mono text-gray-500" title={`${from} to ${to}`}>
+              {from.slice(0, 8)} · {to.slice(0, 8)}
+            </span>
           )}
         </div>
 

--- a/src/renderer/components/card/EndedStrip.tsx
+++ b/src/renderer/components/card/EndedStrip.tsx
@@ -1,17 +1,28 @@
-import { useState } from 'react'
+import { useState, type ReactElement } from 'react'
 import { Play, Terminal as TerminalIcon, X } from 'lucide-react'
 import type { EndedSession } from '../../stores/types'
 import { useAppStore } from '../../stores'
+import { headMoved } from '../../../shared/types'
 import { shortenCwd } from '../../lib/command-blocks'
 import { formatRelativeTime } from '../../lib/format-time'
 import { resumeEndedSession } from '../../lib/session-resume'
 import { closeTerminalSession } from '../../lib/terminal-close'
+import { readIntentDraft, forgetIntentDraft } from '../../lib/intent-drafts'
+import { pasteToTerminal } from '../../lib/terminal-registry'
 
 interface Props {
   terminalId: string
   ended: EndedSession
   /** Grid-card variant: one line, no room for the directory. */
   compact?: boolean
+}
+
+const sha = (commit: string): string => commit.slice(0, 8)
+
+function formatSpan(ms: number): string {
+  const mins = Math.max(0, Math.floor(ms / 60_000))
+  if (mins < 60) return `${mins}m`
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`
 }
 
 /**
@@ -32,13 +43,31 @@ interface Props {
  * -- which is the dilution the colour rules warn about. The case for using it is
  * real, because resuming *is* a decision only a person can make; it loses to the
  * fact that this state arrives in bulk and the accent does not survive that.
+ *
+ * ## After a reboot
+ *
+ * The record was checked against the tree before it was offered. A worktree
+ * that is gone gets a summary and no Resume, because there is nowhere to resume
+ * into. A HEAD that moved gets both commits and a warning, never a checkout:
+ * the tree is the person's, not the restore's. A shell command typed and not
+ * sent is offered back, and never run on its own.
  */
 export function EndedStrip({ terminalId, ended, compact }: Props) {
   const [busy, setBusy] = useState(false)
-  const isShell = useAppStore((s) => s.terminals.get(terminalId)?.session.agentType === 'shell')
+  const [warningLeft, setWarningLeft] = useState(false)
+  const session = useAppStore((s) => s.terminals.get(terminalId)?.session)
+  const isShell = session?.agentType === 'shell'
   const cwd = shortenCwd(ended.cwd ?? null)
+  const [draft, setDraft] = useState(() =>
+    isShell ? readIntentDraft(terminalId)?.text : undefined
+  )
 
-  // Three endings, and telling them apart is most of the value here. Reporting
+  const env = ended.environment
+  const worktreeGone = env?.worktree === 'missing'
+  const moved = headMoved(env)
+  const finding = worktreeGone ? 'the worktree is gone' : moved ? 'the branch moved' : null
+
+  // Four endings, and telling them apart is most of the value here. Reporting
   // an ordinary quit as though something had stopped the server reads like a
   // fault report for closing an app.
   const cause =
@@ -48,59 +77,202 @@ export function EndedStrip({ terminalId, ended, compact }: Props) {
         : 'exited'
       : ended.reason === 'app-closed'
         ? 'Vorn was closed'
-        : 'the server stopped unexpectedly'
+        : ended.reason === 'machine-restarted'
+          ? 'the machine restarted'
+          : 'the server stopped unexpectedly'
+
+  const resume = async (): Promise<void> => {
+    setBusy(true)
+    try {
+      await resumeEndedSession(terminalId)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Two decisions, made with two clicks: resuming is not agreeing to send.
+  const resumeAndRun = async (): Promise<void> => {
+    const text = draft
+    await resume()
+    if (!text || useAppStore.getState().terminals.get(terminalId)?.ended) return
+    forgetIntentDraft(terminalId)
+    setDraft(undefined)
+    setTimeout(() => {
+      pasteToTerminal(terminalId, text)
+      window.api.writeTerminal(terminalId, '\r')
+    }, 300)
+  }
+
+  const discardDraft = (): void => {
+    forgetIntentDraft(terminalId)
+    setDraft(undefined)
+  }
+
+  const showWhatChanged = (): void => {
+    if (!env || !env.head.recorded || !env.head.actual) return
+    useAppStore.getState().setDiffSidebarTerminalId(terminalId, 'changes', {
+      from: env.head.recorded,
+      to: env.head.actual
+    })
+  }
+
+  const warning = moved && !worktreeGone && !warningLeft
+  const offerDraft = !!draft && !worktreeGone && !warning
+  const showChecks =
+    !compact && env && !isShell && (ended.reason === 'machine-restarted' || finding)
+  const resumeInRow = !worktreeGone && !warning && !offerDraft
+
+  const check = (ok: boolean, label: string, value: string): ReactElement => (
+    <div className="flex gap-2 text-[11px]">
+      <span className={ok ? 'text-ink-faint' : 'text-red-400'} aria-hidden>
+        {ok ? '✓' : '✗'}
+      </span>
+      <span className="w-14 shrink-0 text-ink-faint">{label}</span>
+      <span className={`min-w-0 truncate ${ok ? 'text-ink-secondary' : 'text-ink'}`}>{value}</span>
+    </div>
+  )
+
+  const button = (label: string, onClick: () => void, icon?: ReactElement): ReactElement => (
+    <button
+      key={label}
+      onClick={onClick}
+      disabled={busy}
+      className="flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] text-ink-secondary transition-colors hover:bg-white/[0.08] hover:text-ink disabled:opacity-40"
+    >
+      {icon}
+      {label}
+    </button>
+  )
 
   return (
-    <div
-      className="flex shrink-0 items-center gap-2.5 border-t border-white/[0.06] py-1.5 pl-3 pr-2"
-      role="status"
-    >
-      {/* A square, not a dot. The dot vocabulary belongs to session status, and
-          this is not a status -- it is the absence of one. */}
-      <span aria-hidden className="h-[7px] w-[7px] shrink-0 bg-ink-ghost" />
+    <div className="flex shrink-0 flex-col border-t border-white/[0.06]" role="status">
+      <div className="flex items-center gap-2.5 py-1.5 pl-3 pr-2">
+        {/* A square, not a dot. The dot vocabulary belongs to session status, and
+            this is not a status -- it is the absence of one. */}
+        <span
+          aria-hidden
+          className={`h-[7px] w-[7px] shrink-0 ${finding ? 'bg-red-400' : 'bg-ink-ghost'}`}
+        />
 
-      <span className="min-w-0 flex-1 truncate text-[11px] text-ink-secondary">
-        <span className="text-ink">Ended</span>
-        <span className="text-ink-faint">
-          {' · '}
-          {cause}
-          {' · '}
-          {formatRelativeTime(new Date(ended.at).toISOString())}
+        <span className="min-w-0 flex-1 truncate text-[11px] text-ink-secondary">
+          <span className="text-ink">Ended</span>
+          <span className="text-ink-faint">
+            {' · '}
+            {cause}
+            {' · '}
+            {finding ?? formatRelativeTime(new Date(ended.at).toISOString())}
+          </span>
+          {!ended.replayed && (
+            <span className="text-ink-faint">{' · nothing of its screen was kept'}</span>
+          )}
+          {ended.partial && (
+            <span className="text-ink-faint">{' · the last moments were not recorded'}</span>
+          )}
+          {!compact && isShell && cwd && <span className="text-ink-faint">{` · ${cwd}`}</span>}
         </span>
-        {!ended.replayed && (
-          <span className="text-ink-faint">{' · nothing of its screen was kept'}</span>
-        )}
-        {ended.partial && (
-          <span className="text-ink-faint">{' · the last moments were not recorded'}</span>
-        )}
-        {!compact && isShell && cwd && <span className="text-ink-faint">{` · ${cwd}`}</span>}
-      </span>
 
-      <button
-        onClick={async () => {
-          setBusy(true)
-          try {
-            await resumeEndedSession(terminalId)
-          } finally {
-            setBusy(false)
-          }
-        }}
-        disabled={busy}
-        className="flex shrink-0 items-center gap-1.5 rounded px-2 py-1 text-[11px] text-ink-secondary transition-colors hover:bg-white/[0.08] hover:text-ink disabled:opacity-40"
-      >
-        {isShell ? <TerminalIcon size={11} /> : <Play size={11} />}
-        {isShell ? 'New shell here' : 'Resume'}
-      </button>
+        {resumeInRow &&
+          button(
+            isShell ? 'New shell here' : 'Resume',
+            () => void resume(),
+            isShell ? <TerminalIcon size={11} /> : <Play size={11} />
+          )}
 
-      <button
-        onClick={() => void closeTerminalSession(terminalId)}
-        disabled={busy}
-        title="Close this pane"
-        aria-label="Close this pane"
-        className="shrink-0 rounded p-1 text-ink-faint transition-colors hover:bg-white/[0.08] hover:text-ink disabled:opacity-40"
-      >
-        <X size={11} />
-      </button>
+        <button
+          onClick={() => void closeTerminalSession(terminalId)}
+          disabled={busy}
+          title="Close this pane"
+          aria-label="Close this pane"
+          className="shrink-0 rounded p-1 text-ink-faint transition-colors hover:bg-white/[0.08] hover:text-ink disabled:opacity-40"
+        >
+          <X size={11} />
+        </button>
+      </div>
+
+      {showChecks && env && (
+        <div className="flex flex-col gap-0.5 px-3 pb-2">
+          {check(
+            !worktreeGone,
+            'worktree',
+            `${shortenCwd(session?.worktreePath ?? session?.projectPath ?? null) ?? ''}${worktreeGone ? ' — missing' : ''}`
+          )}
+          {!worktreeGone &&
+            check(
+              env.branch.actual === null || env.branch.recorded === env.branch.actual,
+              'branch',
+              env.branch.actual ?? env.branch.recorded ?? '—'
+            )}
+          {!worktreeGone &&
+            env.head.recorded &&
+            check(
+              !moved,
+              'HEAD',
+              moved && env.head.actual
+                ? `was ${sha(env.head.recorded)} · now ${sha(env.head.actual)}`
+                : `${sha(env.head.recorded)} · unchanged`
+            )}
+        </div>
+      )}
+
+      {/* A summary, not an error. Says what the session was, which is what is left. */}
+      {worktreeGone && session && !compact && (
+        <div className="flex flex-col gap-1 px-3 pb-2 text-[11px] text-ink-secondary">
+          <div className="flex gap-2">
+            <span className="w-14 shrink-0 text-ink-faint">agent</span>
+            <span>{session.agentType}</span>
+          </div>
+          {session.branch && (
+            <div className="flex gap-2">
+              <span className="w-14 shrink-0 text-ink-faint">branch</span>
+              <span className="truncate">{session.branch}</span>
+            </div>
+          )}
+          {session.displayName && (
+            <div className="flex gap-2">
+              <span className="w-14 shrink-0 text-ink-faint">last turn</span>
+              <span className="truncate">{session.displayName}</span>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <span className="w-14 shrink-0 text-ink-faint">ran</span>
+            <span>{formatSpan(ended.at - session.createdAt)}</span>
+          </div>
+          <p className="mt-1 text-ink-faint">
+            Cleaned up after it merged, most likely. Nothing to resume into. The conversation is
+            still readable, and this pane can be closed.
+          </p>
+        </div>
+      )}
+
+      {/* A warning, not a lock. Never resolved by checking anything out. */}
+      {warning && (
+        <div className="flex flex-col gap-1.5 px-3 pb-2">
+          <p className="text-[11px] text-ink-secondary">
+            Something changed the tree while you were away. Resuming would put an agent back into a
+            conversation about a tree that no longer matches it.
+          </p>
+          <div className="flex gap-1">
+            {button('Resume anyway', () => void resume(), <Play size={11} />)}
+            {button('Show what changed', showWhatChanged)}
+            {button('Leave it', () => setWarningLeft(true))}
+          </div>
+        </div>
+      )}
+
+      {/* Offered back, never run on its own. */}
+      {offerDraft && (
+        <div className="flex flex-col gap-1.5 px-3 pb-2">
+          <span className="text-[11px] text-ink-faint">You were writing</span>
+          <pre className="max-h-24 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] text-ink">
+            {draft}
+          </pre>
+          <div className="flex gap-1">
+            {button('New shell and run it', () => void resumeAndRun(), <TerminalIcon size={11} />)}
+            {button('New shell without it', () => void resume())}
+            {button('Discard', discardDraft)}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -1,4 +1,5 @@
 import type { RestoredSession, TerminalSession } from '../../shared/types'
+import { endedFromRestored } from './ended-from-restored'
 import { useAppStore } from '../stores'
 import { coldSessions } from './session-utils'
 import { resumeEndedSession } from './session-resume'
@@ -76,16 +77,13 @@ async function reconcile(options: { showCold: boolean; resume: boolean }): Promi
     if (live.has(id) || term.ended) continue
     const held = heldById.get(id)
     justEnded.push(id)
+    // Without a record the best available answer is when this pane last saw
+    // anything, and there is no rebuilt screen behind it.
+    const base = held
+      ? endedFromRestored(held)
+      : { reason: 'server-stopped' as const, at: term.lastOutputTimestamp, replayed: false }
     useAppStore.getState().markEnded(id, {
-      reason: held?.closedCleanly ? 'app-closed' : 'server-stopped',
-      // A held record knows when its run ended. Without one the best available
-      // answer is when this pane last saw anything.
-      at: held?.endedAt ?? term.lastOutputTimestamp,
-      // Whether there is a rebuilt screen behind it. False means the pane is
-      // showing what it happens to still have in its own buffer and nothing
-      // more, which the strip says out loud.
-      replayed: held?.replayable ?? false,
-      ...(held?.partial !== undefined && { partial: held.partial }),
+      ...base,
       ...(term.session.shellCwd !== undefined && { cwd: term.session.shellCwd })
     })
   }
@@ -95,13 +93,7 @@ async function reconcile(options: { showCold: boolean; resume: boolean }): Promi
     for (const one of coldSessions(active, carried)) {
       if (useAppStore.getState().terminals.has(one.session.id)) continue
       justEnded.push(one.session.id)
-      useAppStore.getState().addTerminal(one.session, {
-        reason: one.closedCleanly ? 'app-closed' : 'server-stopped',
-        at: one.endedAt,
-        replayed: one.replayable,
-        partial: one.partial,
-        ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
-      })
+      useAppStore.getState().addTerminal(one.session, endedFromRestored(one))
     }
 
   // Everything the server has, running or ended -- not what the board ended up

--- a/src/renderer/lib/ended-from-restored.ts
+++ b/src/renderer/lib/ended-from-restored.ts
@@ -1,0 +1,18 @@
+import type { RestoredSession } from '../../shared/types'
+import type { EndedSession } from '../stores/types'
+
+// One reading of a record, so the board, the banner and the strip cannot disagree.
+export function endedFromRestored(one: RestoredSession): EndedSession {
+  return {
+    reason: one.closedCleanly
+      ? 'app-closed'
+      : one.rebooted
+        ? 'machine-restarted'
+        : 'server-stopped',
+    at: one.endedAt,
+    replayed: one.replayable,
+    partial: one.partial,
+    ...(one.environment !== undefined && { environment: one.environment }),
+    ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
+  }
+}

--- a/src/renderer/lib/intent-drafts.ts
+++ b/src/renderer/lib/intent-drafts.ts
@@ -1,0 +1,62 @@
+const STORAGE_KEY = 'vorn:intentDrafts'
+
+/** Typed into a pane's composer and not yet sent. Kept the way editor drafts are. */
+export interface IntentDraft {
+  text: string
+  savedAt: number
+}
+
+type Drafts = Record<string, IntentDraft>
+
+function load(): Drafts {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+    const out: Drafts = {}
+    for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+      const draft = value as Partial<IntentDraft>
+      if (typeof draft?.text !== 'string' || !draft.text) continue
+      out[id] = { text: draft.text, savedAt: typeof draft.savedAt === 'number' ? draft.savedAt : 0 }
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+function save(drafts: Drafts): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(drafts))
+  } catch {
+    // Storage full: the text is still in the composer, only its survival is lost.
+  }
+}
+
+export function readIntentDraft(sessionId: string): IntentDraft | null {
+  return load()[sessionId] ?? null
+}
+
+export function writeIntentDraft(sessionId: string, text: string): void {
+  if (!text) return forgetIntentDraft(sessionId)
+  const drafts = load()
+  drafts[sessionId] = { text, savedAt: Date.now() }
+  save(drafts)
+}
+
+export function forgetIntentDraft(sessionId: string): void {
+  const drafts = load()
+  if (!(sessionId in drafts)) return
+  delete drafts[sessionId]
+  save(drafts)
+}
+
+/** Drop drafts for sessions that are gone, alongside their panes. */
+export function pruneIntentDrafts(liveSessionIds: Set<string>): void {
+  const drafts = load()
+  const dead = Object.keys(drafts).filter((id) => !liveSessionIds.has(id))
+  if (!dead.length) return
+  for (const id of dead) delete drafts[id]
+  save(drafts)
+}

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '../stores'
+import { endedFromRestored } from './ended-from-restored'
 import { toast } from '../components/Toast'
 
 /**
@@ -21,17 +22,7 @@ export async function showEndedSession(id: string): Promise<void> {
   const carried = await window.api.getRestoredSessions()
   const one = carried.find((r) => r.session.id === id)
   if (!one) return
-  useAppStore.getState().addTerminal(one.session, {
-    // The record says which ending this was; `board-sync` reads it and this did
-    // not. Taking the banner's offer after an ordinary quit therefore produced a
-    // pane reporting that the server had stopped unexpectedly -- a fault report
-    // for closing an app.
-    reason: one.closedCleanly ? 'app-closed' : 'server-stopped',
-    at: one.endedAt,
-    replayed: one.replayable,
-    partial: one.partial,
-    ...(one.session.shellCwd !== undefined && { cwd: one.session.shellCwd })
-  })
+  useAppStore.getState().addTerminal(one.session, endedFromRestored(one))
 }
 
 /**

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -8,6 +8,7 @@ import {
   WorkspaceConfig,
   RemoteHost,
   TerminalSession,
+  RestoreEnvironment,
   HeadlessSession,
   GitDiffStat,
   TaskConfig,
@@ -224,9 +225,10 @@ export interface EndedSession {
    * `app-closed` — Vorn was quit and its server went with it.
    * `server-stopped` — it stopped without getting to shut down: a crash, a kill,
    *   a machine losing power.
+   * `machine-restarted` — the record was saved before this boot and never closed.
    * `exited` — the terminal's own process finished while somebody was watching.
    */
-  reason: 'app-closed' | 'server-stopped' | 'exited'
+  reason: 'app-closed' | 'server-stopped' | 'machine-restarted' | 'exited'
   /** Unix ms. The last save the previous run managed, or when the PTY exited. */
   at: number
   /** A screen was replayed into this pane, so it is showing something real. */
@@ -237,6 +239,8 @@ export interface EndedSession {
   exitCode?: number
   /** Shells only: the directory a fresh one would start in. */
   cwd?: string
+  /** What the server found when it checked the record against the tree. */
+  environment?: RestoreEnvironment
 }
 
 export interface TerminalState {
@@ -428,6 +432,8 @@ export interface UISlice {
   sessionDockCollapsed: boolean
   isOnboardingOpen: boolean
   diffSidebarTerminalId: string | null
+  /** Two commits to show instead of the working tree, for one pane. */
+  diffRange: { terminalId: string; from: string; to: string } | null
   gitDiffStats: Map<string, GitDiffStat>
   rightPanelTab: PanelTab
   isDiffPanelMaximized: boolean
@@ -637,7 +643,11 @@ export interface UISlice {
   closeCard: (cardId: string) => void
   toggleSessionDockCollapsed: () => void
   setOnboardingOpen: (open: boolean) => void
-  setDiffSidebarTerminalId: (id: string | null, tab?: PanelTab) => void
+  setDiffSidebarTerminalId: (
+    id: string | null,
+    tab?: PanelTab,
+    range?: { from: string; to: string }
+  ) => void
   updateGitDiffStat: (terminalId: string, stat: GitDiffStat) => void
   updateGitDiffStats: (stats: Map<string, GitDiffStat>) => void
   setRightPanelTab: (tab: PanelTab) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -30,6 +30,7 @@ import {
 import { normalizeUrl } from '../lib/browser-url'
 import { pruneScrollAnchors } from '../lib/scroll-anchor'
 import { pruneDrafts } from '../lib/editor-drafts'
+import { pruneIntentDrafts } from '../lib/intent-drafts'
 import { confirmDiscard, confirmDiscardAll, clearDirty } from '../lib/editor-dirty'
 import { clampSplitRatio, sanitizePaneWeights, DEVICE_SPLIT_RATIO } from '../lib/split-ratio'
 
@@ -460,6 +461,7 @@ function reconcilePanes(
   // the sessions -- an editor popped out into a card outlives its owner's pane
   // and its draft has to outlive it too.
   pruneDrafts(new Set(nextEditors.keys()))
+  pruneIntentDrafts(liveSessionIds)
   const nextBrowsers = new Map([...browserPanes].filter(([, b]) => liveSessionIds.has(b.sessionId)))
   // Tabs remembered for a closed pane die with their session as well. This is
   // the path `removeTerminal` cannot cover: a session that simply never came
@@ -851,6 +853,7 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   sessionDockCollapsed: false,
   isOnboardingOpen: false,
   diffSidebarTerminalId: null,
+  diffRange: null,
   gitDiffStats: new Map(),
   rightPanelTab: 'changes',
   isDiffPanelMaximized: false,
@@ -1519,9 +1522,10 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
     set((state) => ({ sessionDockCollapsed: !state.sessionDockCollapsed })),
 
   setOnboardingOpen: (open) => set({ isOnboardingOpen: open }),
-  setDiffSidebarTerminalId: (id, tab) =>
+  setDiffSidebarTerminalId: (id, tab, range) =>
     set({
       diffSidebarTerminalId: id,
+      diffRange: id && range ? { terminalId: id, ...range } : null,
       rightPanelTab: tab ?? 'changes',
       isDiffPanelMaximized: false
     }),

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -50,6 +50,7 @@ function held(id: string, over: Partial<RestoredSession> = {}): RestoredSession 
     replayable: true,
     partial: false,
     closedCleanly: false,
+    rebooted: false,
     ...over
   }
 }
@@ -291,5 +292,39 @@ describe('bringing an ended pane in from the banner', () => {
     await showEndedSession('crashed')
 
     expect(ended('crashed')).toMatchObject({ reason: 'server-stopped' })
+  })
+})
+
+describe('a machine that restarted', () => {
+  it('is named as such, which a stopped server is not', async () => {
+    useAppStore.getState().addTerminal(session({ id: 'one' }))
+    getRestoredSessions.mockResolvedValue([held('one', { rebooted: true })])
+
+    await syncBoard({ showCold: true, resume: false })
+
+    expect(ended('one')).toMatchObject({ reason: 'machine-restarted' })
+  })
+
+  it('still calls a clean quit a quit, even across a reboot', async () => {
+    getRestoredSessions.mockResolvedValue([held('one', { rebooted: true, closedCleanly: true })])
+
+    await syncBoard({ showCold: true, resume: false })
+
+    expect(ended('one')).toMatchObject({ reason: 'app-closed' })
+  })
+
+  it('carries what the server found on the tree to the pane, by every door', async () => {
+    const environment = {
+      worktree: 'missing' as const,
+      branch: { recorded: 'x', actual: null },
+      head: { recorded: 'a', actual: null }
+    }
+    getRestoredSessions.mockResolvedValue([held('cold', { environment })])
+    await syncBoard({ showCold: true, resume: false })
+    expect(ended('cold')?.environment).toEqual(environment)
+
+    useAppStore.setState({ terminals: new Map(), terminalOrder: [] })
+    await showEndedSession('cold')
+    expect(ended('cold')?.environment).toEqual(environment)
   })
 })

--- a/tests/ended-strip.test.tsx
+++ b/tests/ended-strip.test.tsx
@@ -304,3 +304,123 @@ describe('when a pane came back from a previous run', () => {
     expect(useAppStore.getState().terminals.get(ID)?.lastOutputTimestamp).not.toBe(0)
   })
 })
+
+/** After a reboot the record was checked against the tree before it was offered. */
+const RESTARTED = { reason: 'machine-restarted' as const, at: 2_000_000, replayed: true }
+const okEnv = {
+  worktree: 'ok' as const,
+  branch: { recorded: 'feature', actual: 'feature' },
+  head: { recorded: 'aaaa1111bbbb', actual: 'aaaa1111bbbb' }
+}
+
+describe('what a pane says after the machine restarted', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    ;(window.api as unknown as { writeTerminal: unknown }).writeTerminal = vi.fn()
+  })
+
+  it('names the reboot, and shows the three checks when they pass', () => {
+    useAppStore.getState().addTerminal(session(), { ...RESTARTED, environment: okEnv })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(/the machine restarted/)).toBeInTheDocument()
+    expect(screen.getByText(/aaaa1111 · unchanged/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument()
+  })
+
+  it('offers no Resume when the worktree is gone, and says what the session was', () => {
+    useAppStore
+      .getState()
+      .addTerminal(
+        session({ worktreePath: '/dev/vorn/.wt/x', branch: 'deps/x', displayName: 'bump them' }),
+        { ...RESTARTED, environment: { ...okEnv, worktree: 'missing' } }
+      )
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(/the worktree is gone/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Resume' })).not.toBeInTheDocument()
+    expect(screen.getByText('bump them')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close this pane' })).toBeInTheDocument()
+  })
+
+  it('warns with both commits when HEAD moved, and never checks anything out', async () => {
+    useAppStore.getState().addTerminal(session(), {
+      ...RESTARTED,
+      environment: { ...okEnv, head: { recorded: 'aaaa1111bbbb', actual: 'cccc2222dddd' } }
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(/the branch moved/)).toBeInTheDocument()
+    expect(screen.getByText(/was aaaa1111 · now cccc2222/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Resume' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show what changed' }))
+    expect(useAppStore.getState().diffRange).toEqual({
+      terminalId: ID,
+      from: 'aaaa1111bbbb',
+      to: 'cccc2222dddd'
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume anyway' }))
+    await waitFor(() => expect(resumeMocks.resumeEndedSession).toHaveBeenCalledWith(ID))
+  })
+
+  it('leaves the warning behind on request, with Resume still there', () => {
+    useAppStore.getState().addTerminal(session(), {
+      ...RESTARTED,
+      environment: { ...okEnv, head: { recorded: 'aaaa1111bbbb', actual: 'cccc2222dddd' } }
+    })
+    render(<SessionComposer terminalId={ID} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Leave it' }))
+    expect(screen.queryByRole('button', { name: 'Leave it' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument()
+  })
+
+  it('offers a shell its unsent command back, and runs it only when asked', async () => {
+    const command = 'rebase onto main'
+    localStorage.setItem(
+      'vorn:intentDrafts',
+      JSON.stringify({ [ID]: { text: command, savedAt: 1 } })
+    )
+    useAppStore.getState().addTerminal(session({ agentType: 'shell' }), RESTARTED)
+    resumeMocks.resumeEndedSession.mockImplementationOnce(async () => {
+      useAppStore.setState((s) => {
+        const term = s.terminals.get(ID)!
+        return { terminals: new Map(s.terminals).set(ID, { ...term, ended: undefined }) }
+      })
+    })
+    render(<SessionComposer terminalId={ID} />)
+
+    expect(screen.getByText(command)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New shell here' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New shell and run it' }))
+    await waitFor(() => expect(registryMocks.pasteToTerminal).toHaveBeenCalledWith(ID, command))
+    expect(window.api.writeTerminal).toHaveBeenCalledWith(ID, '\r')
+    expect(localStorage.getItem('vorn:intentDrafts')).not.toContain(command)
+  })
+
+  it('never runs the command when the shell comes back without it', async () => {
+    localStorage.setItem(
+      'vorn:intentDrafts',
+      JSON.stringify({ [ID]: { text: 'rm -rf build', savedAt: 1 } })
+    )
+    useAppStore.getState().addTerminal(session({ agentType: 'shell' }), RESTARTED)
+    render(<SessionComposer terminalId={ID} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New shell without it' }))
+    await waitFor(() => expect(resumeMocks.resumeEndedSession).toHaveBeenCalledWith(ID))
+    expect(registryMocks.pasteToTerminal).not.toHaveBeenCalled()
+  })
+
+  it('discards it on request', () => {
+    localStorage.setItem('vorn:intentDrafts', JSON.stringify({ [ID]: { text: 'ls', savedAt: 1 } }))
+    useAppStore.getState().addTerminal(session({ agentType: 'shell' }), RESTARTED)
+    render(<SessionComposer terminalId={ID} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }))
+    expect(screen.queryByText('ls')).not.toBeInTheDocument()
+    expect(localStorage.getItem('vorn:intentDrafts')).not.toContain('ls')
+    expect(screen.getByRole('button', { name: 'New shell here' })).toBeInTheDocument()
+  })
+})

--- a/tests/head-commit.test.ts
+++ b/tests/head-commit.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { TerminalSession } from '@vornrun/shared/types'
+import { HeadRefresh, HEAD_REFRESH_MS } from '../packages/server/src/head-commit'
+
+const session = (over: Partial<TerminalSession> = {}): TerminalSession =>
+  ({ id: 'a', projectPath: '/repo', ...over }) as TerminalSession
+
+describe('keeping the recorded HEAD following the tree', () => {
+  it('reads it the first time and writes it onto the session', () => {
+    const read = vi.fn(() => 'abc123')
+    const s = session()
+    new HeadRefresh(read).refresh([s], 1000)
+    expect(read).toHaveBeenCalledWith('/repo')
+    expect(s.headCommit).toBe('abc123')
+  })
+
+  it('prefers the worktree over the project', () => {
+    const read = vi.fn(() => 'abc123')
+    new HeadRefresh(read).refresh([session({ worktreePath: '/repo/.wt/x' })], 1000)
+    expect(read).toHaveBeenCalledWith('/repo/.wt/x')
+  })
+
+  it('does not ask again inside the window, however many saves fire', () => {
+    // Saves run every 500 ms on a busy board; ten sessions would be ten
+    // subprocesses a second without this.
+    const read = vi.fn(() => 'abc123')
+    const heads = new HeadRefresh(read)
+    const s = session()
+    heads.refresh([s], 1000)
+    heads.refresh([s], 1500)
+    heads.refresh([s], 1000 + HEAD_REFRESH_MS - 1)
+    expect(read).toHaveBeenCalledTimes(1)
+    heads.refresh([s], 1000 + HEAD_REFRESH_MS)
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('follows a commit the agent made', () => {
+    let head = 'before'
+    const heads = new HeadRefresh(() => head)
+    const s = session()
+    heads.refresh([s], 1000)
+    head = 'after'
+    heads.refresh([s], 1000 + HEAD_REFRESH_MS)
+    expect(s.headCommit).toBe('after')
+  })
+
+  it('asks again at once after being invalidated', () => {
+    const read = vi.fn(() => 'abc123')
+    const heads = new HeadRefresh(read)
+    const s = session()
+    heads.refresh([s], 1000)
+    heads.invalidate('a')
+    heads.refresh([s], 1001)
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the last known value when git cannot answer', () => {
+    let head: string | null = 'abc123'
+    const heads = new HeadRefresh(() => head)
+    const s = session()
+    heads.refresh([s], 1000)
+    head = null
+    heads.refresh([s], 1000 + HEAD_REFRESH_MS)
+    expect(s.headCommit).toBe('abc123')
+  })
+
+  it('never runs git for a remote session', () => {
+    const read = vi.fn(() => 'abc123')
+    new HeadRefresh(read).refresh([session({ remoteHostId: 'box' })], 1000)
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('throttles per session, not across them', () => {
+    const read = vi.fn(() => 'abc123')
+    new HeadRefresh(read).refresh([session({ id: 'a' }), session({ id: 'b' })], 1000)
+    expect(read).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/intent-bar.test.tsx
+++ b/tests/intent-bar.test.tsx
@@ -735,3 +735,31 @@ describe('the composer while a full-screen program is up', () => {
     expect(pty).not.toHaveBeenCalled()
   })
 })
+
+describe('IntentBar keeps what was typed', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    resetCommandHistoryCache()
+    seedStore()
+  })
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('brings a half-typed command back after the pane is rebuilt', () => {
+    const first = render(<IntentBar terminalId="term-1" />)
+    fireEvent.change(getInput(), { target: { value: 'rebase onto ma' } })
+    first.unmount()
+
+    render(<IntentBar terminalId="term-1" />)
+    expect(getInput().value).toBe('rebase onto ma')
+  })
+
+  it('keeps nothing once the command is sent', () => {
+    render(<IntentBar terminalId="term-1" />)
+    fireEvent.change(getInput(), { target: { value: 'pwd' } })
+    fireEvent.keyDown(getInput(), { key: 'Enter' })
+    expect(localStorage.getItem('vorn:intentDrafts') ?? '{}').not.toContain('pwd')
+  })
+})

--- a/tests/intent-drafts.test.ts
+++ b/tests/intent-drafts.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  readIntentDraft,
+  writeIntentDraft,
+  forgetIntentDraft,
+  pruneIntentDrafts
+} from '../src/renderer/lib/intent-drafts'
+
+beforeEach(() => localStorage.clear())
+
+describe('a command typed and not sent', () => {
+  it('comes back for the same session', () => {
+    writeIntentDraft('s1', 'git rebase main')
+    expect(readIntentDraft('s1')?.text).toBe('git rebase main')
+    expect(readIntentDraft('s2')).toBeNull()
+  })
+
+  it('is forgotten when emptied, so a sent command leaves nothing behind', () => {
+    writeIntentDraft('s1', 'ls')
+    writeIntentDraft('s1', '')
+    expect(readIntentDraft('s1')).toBeNull()
+  })
+
+  it('can be discarded outright', () => {
+    writeIntentDraft('s1', 'ls')
+    forgetIntentDraft('s1')
+    expect(readIntentDraft('s1')).toBeNull()
+  })
+
+  it('goes with its session', () => {
+    writeIntentDraft('gone', 'ls')
+    writeIntentDraft('here', 'pwd')
+    pruneIntentDrafts(new Set(['here']))
+    expect(readIntentDraft('gone')).toBeNull()
+    expect(readIntentDraft('here')?.text).toBe('pwd')
+  })
+
+  it('treats a corrupt store as empty rather than throwing at render', () => {
+    localStorage.setItem('vorn:intentDrafts', '{not json')
+    expect(readIntentDraft('s1')).toBeNull()
+    localStorage.setItem('vorn:intentDrafts', JSON.stringify({ s1: { text: 42 } }))
+    expect(readIntentDraft('s1')).toBeNull()
+  })
+})

--- a/tests/pty-manager-recovery.test.ts
+++ b/tests/pty-manager-recovery.test.ts
@@ -89,6 +89,7 @@ vi.mock('../packages/server/src/config-manager', () => ({
 
 vi.mock('../packages/server/src/git-utils', () => ({
   getGitBranch: vi.fn(() => 'main'),
+  getGitHead: vi.fn(() => 'cafe0000'),
   checkoutBranch: vi.fn(),
   createWorktree: vi.fn(),
   extractWorktreeName: vi.fn((p: string) => path.basename(p)),

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -104,6 +104,7 @@ vi.mock('../packages/server/src/config-manager', () => ({
 
 vi.mock('../packages/server/src/git-utils', () => ({
   getGitBranch: vi.fn(() => 'main'),
+  getGitHead: vi.fn(() => 'cafe0000'),
   checkoutBranch: vi.fn(),
   createWorktree: vi.fn(),
   extractWorktreeName: vi.fn((p: string) => path.basename(p)),

--- a/tests/pty-session-id.test.ts
+++ b/tests/pty-session-id.test.ts
@@ -35,6 +35,7 @@ vi.mock('../packages/server/node_modules/node-pty', () => ({
 }))
 vi.mock('../packages/server/src/git-utils', () => ({
   getGitBranch: vi.fn(() => 'main'),
+  getGitHead: vi.fn(() => 'cafe0000'),
   checkoutBranch: vi.fn(),
   createWorktree: vi.fn(),
   isGitRepo: vi.fn(() => false)

--- a/tests/restore-environment.test.ts
+++ b/tests/restore-environment.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { headMoved } from '@vornrun/shared/types'
+import { probeEnvironment } from '../packages/server/src/restore-environment'
+
+const tree = (over: Partial<Record<'dirs' | 'branch' | 'head', unknown>> = {}) => ({
+  isDirectory: (at: string) => ((over.dirs as string[]) ?? ['/repo', '/repo/.wt/f']).includes(at),
+  branch: vi.fn(() => (over.branch as string | null) ?? 'feature'),
+  head: vi.fn(() => (over.head as string | null) ?? 'aaaa1111')
+})
+
+const agent = {
+  projectPath: '/repo',
+  worktreePath: '/repo/.wt/f',
+  branch: 'feature',
+  headCommit: 'aaaa1111'
+}
+
+describe('checking a record against the tree before offering Resume', () => {
+  it('reports the ordinary case: everything where it was left', () => {
+    expect(probeEnvironment(agent, tree())).toEqual({
+      worktree: 'ok',
+      branch: { recorded: 'feature', actual: 'feature' },
+      head: { recorded: 'aaaa1111', actual: 'aaaa1111' }
+    })
+  })
+
+  it('names both commits when HEAD moved', () => {
+    const env = probeEnvironment(agent, tree({ head: 'bbbb2222' }))
+    expect(env?.head).toEqual({ recorded: 'aaaa1111', actual: 'bbbb2222' })
+    expect(headMoved(env)).toBe(true)
+  })
+
+  it('says the worktree is missing and asks git nothing about it', () => {
+    const probe = tree({ dirs: ['/repo'] })
+    const env = probeEnvironment(agent, probe)
+    expect(env?.worktree).toBe('missing')
+    expect(env?.head.actual).toBeNull()
+    expect(probe.head).not.toHaveBeenCalled()
+    expect(probe.branch).not.toHaveBeenCalled()
+  })
+
+  it('checks the project when there is no worktree', () => {
+    const probe = tree()
+    probeEnvironment({ projectPath: '/repo' }, probe)
+    expect(probe.head).toHaveBeenCalledWith('/repo')
+  })
+
+  it('does not call an unknown commit a move', () => {
+    // Records written before HEAD was recorded have nothing to compare.
+    expect(headMoved(probeEnvironment({ projectPath: '/repo' }, tree()))).toBe(false)
+    expect(headMoved(probeEnvironment(agent, tree({ head: null })))).toBe(false)
+    expect(headMoved(undefined)).toBe(false)
+  })
+
+  it('leaves a remote session unchecked rather than probing this machine', () => {
+    const probe = tree()
+    expect(probeEnvironment({ ...agent, remoteHostId: 'box' }, probe)).toBeUndefined()
+    expect(probe.head).not.toHaveBeenCalled()
+  })
+})

--- a/tests/restored-sessions.test.ts
+++ b/tests/restored-sessions.test.ts
@@ -8,6 +8,7 @@ import {
   consumeRestored,
   consumeAllRestored,
   resetRestored,
+  verifyRestored,
   MAX_RESTORED_AGE_MS
 } from '../packages/server/src/restored-sessions'
 
@@ -134,5 +135,60 @@ describe('what a pane is told about one', () => {
     expect(byId.get('torn')).toMatchObject({ replayable: true, partial: true })
     // Nothing was rebuilt for this one, so the pane must not promise a screen.
     expect(byId.get('none')).toMatchObject({ replayable: false, partial: false })
+  })
+})
+
+describe('a machine that went down under it', () => {
+  it('is told apart from a server that stopped: the record predates this boot', () => {
+    seedRestored([session({ savedAt: NOW - 60_000 })], NOW, NOW - 10_000)
+    expect(listRestored()[0].rebooted).toBe(true)
+  })
+
+  it('is not claimed when the record was written after the machine came up', () => {
+    seedRestored([session({ savedAt: NOW - 60_000 })], NOW, NOW - 3_600_000)
+    expect(listRestored()[0].rebooted).toBe(false)
+  })
+
+  it('is not claimed by default, for callers that do not know the boot time', () => {
+    seedRestored([session()], NOW)
+    expect(listRestored()[0].rebooted).toBe(false)
+  })
+})
+
+describe('checking each record against the tree', () => {
+  const probe = {
+    isDirectory: (at: string) => at !== '/gone',
+    branch: () => 'main',
+    head: () => 'cafe0000'
+  }
+
+  it('records what it found beside the record', () => {
+    seedRestored([session({ headCommit: 'cafe0000', branch: 'main' })], NOW)
+    verifyRestored(probe)
+    expect(listRestored()[0].environment).toEqual({
+      worktree: 'ok',
+      branch: { recorded: 'main', actual: 'main' },
+      head: { recorded: 'cafe0000', actual: 'cafe0000' }
+    })
+  })
+
+  it('marks a worktree that is no longer there', () => {
+    seedRestored([session({ worktreePath: '/gone' })], NOW)
+    verifyRestored(probe)
+    expect(listRestored()[0].environment?.worktree).toBe('missing')
+  })
+
+  it('does not let one record that throws take the launch down with it', () => {
+    seedRestored([session({ id: 'bad', projectPath: '/boom' }), session({ id: 'good' })], NOW)
+    verifyRestored({
+      ...probe,
+      isDirectory: (at) => {
+        if (at === '/boom') throw new Error('EACCES')
+        return true
+      }
+    })
+    const byId = new Map(listRestored().map((r) => [r.session.id, r]))
+    expect(byId.get('bad')?.environment).toBeUndefined()
+    expect(byId.get('good')?.environment?.worktree).toBe('ok')
   })
 })

--- a/tests/session-restore-flow.test.ts
+++ b/tests/session-restore-flow.test.ts
@@ -146,7 +146,8 @@ describe('what is left of what is not running', () => {
     endedAt: Date.now() - 3_600_000,
     replayable: true,
     partial: false,
-    closedCleanly: false
+    closedCleanly: false,
+    rebooted: false
   })
 
   it('is what the server holds, minus anything that has a process', () => {


### PR DESCRIPTION
PR B of the reboot plan: what a reboot needs that a crash did not.

## Record HEAD with the session

`TerminalSession.headCommit`, column `head_commit`, read at creation via `getGitHead` and refreshed by the save loop through `HeadRefresh`: at most once per session per 30 s, at once when the worktree changes, never for remote sessions. An agent that commits moves the record with it.

## Say a reboot is a reboot

The server computes boot time from `os.uptime()`. A record saved before this boot and not closed cleanly is `rebooted`; the strip says "the machine restarted". A clean quit followed by a reboot still reads as a quit. Uptime counts through sleep on macOS, so a laptop closed overnight is not a reboot.

## Verify before offering Resume

`verifyRestored` runs once at launch, after history recovery and before the port is published. Each record gets `environment`: whether the worktree is a directory, the branch checked out, and HEAD now against HEAD recorded. A record whose probe throws is left unchecked; the rest are not affected.

The strip draws it:

- all matching: three check rows, Resume as before;
- HEAD moved: both commits named, then Resume anyway, Show what changed, Leave it. "Show what changed" opens the existing diff pane on that commit range (`git:diffFull` now accepts `{ cwd, from, to }`). Nothing is ever checked out;
- worktree missing: a summary (agent, branch, last turn, how long it ran) and no Resume. Close remains.

All three sites that build an ended pane from a restored record now go through one `endedFromRestored`, so they cannot disagree.

## Keep the unsent command

The shell composer's draft lives in `vorn:intentDrafts`, following `editor-drafts` (defensive read, pruned with the session). It comes back when the pane is rebuilt and, after an ending, is offered as New shell and run it / New shell without it / Discard. It is never run on its own.

The storyboard drew the draft on an agent card. An agent's TUI owns its own input, so Vorn has no draft to keep there; this applies to shells, where the composer is.

## Tests

New: `head-commit`, `restore-environment`, `intent-drafts`. Extended: `restored-sessions` (rebooted, verification, a throwing probe), `board-sync` (reason mapping by every door), `ended-strip` (all four states and the three draft buttons), `intent-bar` (draft round trip). Three pty-manager suites gained `getGitHead` in their git-utils mock.

Tested by hand in dev from this worktree: a cleanly quit app with one worktree deleted and one branch advanced came back as the three panes above, with the shell offering its command back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT
