### PR TITLE
Say what a connector action is doing, and where it failed

### DIFF
--- a/src/renderer/components/settings/ActivityLine.tsx
+++ b/src/renderer/components/settings/ActivityLine.tsx
@@ -1,0 +1,21 @@
+import { TONE_DOT, TONE_DOT_MOVING, TONE_TEXT } from '../../lib/status-tone'
+import type { RowState } from '../../lib/use-row-action'
+
+// The same line install writes, for the actions that answer in one step.
+export function ActivityLine({
+  phrase,
+  error,
+  className = ''
+}: RowState & { className?: string }): React.ReactElement | null {
+  if (!phrase && !error) return null
+  return (
+    <span
+      className={`flex items-start gap-1.5 ${phrase ? TONE_TEXT.live : TONE_TEXT.broken} ${className}`}
+    >
+      <span
+        className={`w-1.5 h-1.5 rounded-full shrink-0 mt-1.5 ${phrase ? TONE_DOT_MOVING.live : TONE_DOT.broken}`}
+      />
+      {phrase ?? error}
+    </span>
+  )
+}

--- a/src/renderer/components/settings/AddConnectionForm.tsx
+++ b/src/renderer/components/settings/AddConnectionForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAppStore } from '../../stores'
-import { Check, AlertCircle } from 'lucide-react'
+import { Check, AlertCircle, Loader2 } from 'lucide-react'
 import type { ConnectorManifest, TaskStatus } from '../../../shared/types'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { glyphForConnectorId } from '../../lib/use-connections'
@@ -280,9 +280,10 @@ export function AddConnectionForm({
             <button
               onClick={handleSave}
               disabled={saving || !canSave}
-              className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50"
+              className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
             >
-              {saving ? 'Connecting...' : 'Connect'}
+              {saving && <Loader2 size={12} className="animate-spin" />}
+              {saving ? 'Connecting…' : 'Connect'}
             </button>
             <button
               onClick={onCancel}

--- a/src/renderer/components/settings/AddConnectionForm.tsx
+++ b/src/renderer/components/settings/AddConnectionForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useAppStore } from '../../stores'
-import { Check, AlertCircle, Loader2 } from 'lucide-react'
+import { Check, AlertCircle } from 'lucide-react'
+import { BusyIcon } from './BusyIcon'
 import type { ConnectorManifest, TaskStatus } from '../../../shared/types'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { glyphForConnectorId } from '../../lib/use-connections'
@@ -282,7 +283,7 @@ export function AddConnectionForm({
               disabled={saving || !canSave}
               className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
             >
-              {saving && <Loader2 size={12} className="animate-spin" />}
+              <BusyIcon busy={saving} size={12} />
               {saving ? 'Connecting…' : 'Connect'}
             </button>
             <button

--- a/src/renderer/components/settings/BusyIcon.tsx
+++ b/src/renderer/components/settings/BusyIcon.tsx
@@ -1,0 +1,15 @@
+import { Loader2, type LucideIcon } from 'lucide-react'
+
+// A button says it is working in the place it already draws its icon.
+export function BusyIcon({
+  busy,
+  icon: Icon,
+  size
+}: {
+  busy: boolean
+  icon?: LucideIcon
+  size: number
+}): React.ReactElement | null {
+  if (busy) return <Loader2 size={size} className="animate-spin shrink-0" />
+  return Icon ? <Icon size={size} /> : null
+}

--- a/src/renderer/components/settings/ConnectionGroups.tsx
+++ b/src/renderer/components/settings/ConnectionGroups.tsx
@@ -48,7 +48,7 @@ export function ConnectionGroups({
   activity: RowActivity
   backfillResult: Record<string, { imported: number; updated: number; error?: string }>
   onAdd: (listing: ConnectorListing) => void
-  onRun: (workflowId: string) => void
+  onRun: (workflowId: string, connectionId: string) => void
   onBackfill: (connectionId: string) => void
   onDelete: (connectionId: string) => void
   onResetWorkflow: (connectionId: string, event: string) => void

--- a/src/renderer/components/settings/ConnectionGroups.tsx
+++ b/src/renderer/components/settings/ConnectionGroups.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import { Plus, AlertTriangle } from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { ConnectionRow } from './ConnectionRow'
+import type { RowActivity } from '../../lib/use-row-action'
 import { groupConnections, type ConnectorListing } from '../../lib/connector-browse'
 import type { ConnectorManifest, SourceConnection, WorkflowDefinition } from '../../../shared/types'
 
@@ -29,8 +30,7 @@ export function ConnectionGroups({
   manifests,
   statuses,
   workflows,
-  runningId,
-  backfillingId,
+  activity,
   backfillResult,
   onAdd,
   onRun,
@@ -45,8 +45,7 @@ export function ConnectionGroups({
   manifests: Record<string, ConnectorManifest | undefined>
   statuses: ConnectorStatus[]
   workflows: WorkflowDefinition[]
-  runningId: string | null
-  backfillingId: string | null
+  activity: RowActivity
   backfillResult: Record<string, { imported: number; updated: number; error?: string }>
   onAdd: (listing: ConnectorListing) => void
   onRun: (workflowId: string) => void
@@ -111,8 +110,7 @@ export function ConnectionGroups({
                   manifest={manifest}
                   seededWorkflows={seededFor(workflows, conn)}
                   missingEvents={missingFor(workflows, conn, manifest)}
-                  runningId={runningId}
-                  backfillingId={backfillingId}
+                  activity={activity}
                   backfillResult={backfillResult}
                   onRun={onRun}
                   onBackfill={onBackfill}

--- a/src/renderer/components/settings/ConnectionRow.tsx
+++ b/src/renderer/components/settings/ConnectionRow.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
-import { Play, Trash2, AlertCircle, Workflow, Import, Activity, Loader2 } from 'lucide-react'
+import { Play, Trash2, AlertCircle, Workflow, Import, Activity } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { connectionIcon } from '../../lib/connection-icon'
 import { McpToolsPanel } from './McpToolsPanel'
 import { humanCron } from '../../lib/cron-text'
-import { rowKey, type RowActivity } from '../../lib/use-row-action'
-import { TONE_DOT, TONE_DOT_MOVING, TONE_TEXT } from '../../lib/status-tone'
+import { type RowActivity } from '../../lib/use-row-action'
+import { ActivityLine } from './ActivityLine'
+import { BusyIcon } from './BusyIcon'
 import {
   isImplicitConnection,
   type ConnectorManifest,
@@ -44,7 +45,7 @@ export function ConnectionRow({
   missingEvents: Array<{ name: string; event: string }>
   activity: RowActivity
   backfillResult: Record<string, { imported: number; updated: number; error?: string }>
-  onRun: (workflowId: string) => void
+  onRun: (workflowId: string, connectionId: string) => void
   onBackfill: (connectionId: string) => void
   onDelete: (connectionId: string) => void
   onResetWorkflow: (connectionId: string, event: string) => void
@@ -52,12 +53,10 @@ export function ConnectionRow({
   onRefresh: () => void
 }) {
   const implicit = isImplicitConnection(conn)
-  const backfilling = activity.busy[rowKey('backfill', conn.id)]
-  const deleting = activity.busy[rowKey('delete', conn.id)]
+  const backfilling = Boolean(activity.state(conn.id, ['backfill']).phrase)
+  const deleting = Boolean(activity.state(conn.id, ['delete']).phrase)
   // One line for whichever of this connection's actions is working or last failed.
-  const phrase = backfilling ?? deleting
-  const failure =
-    activity.failed[rowKey('backfill', conn.id)] ?? activity.failed[rowKey('delete', conn.id)]
+  const reporting = activity.state(conn.id, ['backfill', 'delete'])
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean | null; message?: string } | null>(
     null
@@ -93,10 +92,10 @@ export function ConnectionRow({
           <Tooltip label="Import existing items matching this connection's filters. Bypasses the cron cursor.">
             <button
               onClick={() => onBackfill(conn.id)}
-              disabled={Boolean(backfilling)}
+              disabled={backfilling}
               className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-50"
             >
-              {backfilling ? <Loader2 size={13} className="animate-spin" /> : <Import size={13} />}
+              <BusyIcon busy={backfilling} icon={Import} size={13} />
             </button>
           </Tooltip>
           {conn.connectorId === 'http' && (
@@ -119,10 +118,10 @@ export function ConnectionRow({
           >
             <button
               onClick={() => onDelete(conn.id)}
-              disabled={implicit || Boolean(deleting)}
+              disabled={implicit || deleting}
               className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-40 disabled:hover:text-gray-500"
             >
-              {deleting ? <Loader2 size={13} className="animate-spin" /> : <Trash2 size={13} />}
+              <BusyIcon busy={deleting} icon={Trash2} size={13} />
             </button>
           </Tooltip>
         </div>
@@ -137,6 +136,7 @@ export function ConnectionRow({
       {/* Polled-by-workflow rows — make the mechanism visible */}
       <div className="mt-1.5 space-y-1">
         {seededWorkflows.map((wf) => {
+          const polling = Boolean(activity.state(wf.id, ['run']).phrase)
           const trigger = wf.nodes.find((n) => n.type === 'trigger')
           const cron =
             trigger?.config && 'cron' in trigger.config
@@ -161,15 +161,11 @@ export function ConnectionRow({
               </Tooltip>
               <Tooltip label="Poll the connector now instead of waiting for the next cron tick">
                 <button
-                  onClick={() => onRun(wf.id)}
-                  disabled={Boolean(activity.busy[rowKey('run', wf.id)])}
+                  onClick={() => onRun(wf.id, conn.id)}
+                  disabled={polling}
                   className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-50"
                 >
-                  {activity.busy[rowKey('run', wf.id)] ? (
-                    <Loader2 size={11} className="animate-spin" />
-                  ) : (
-                    <Play size={11} />
-                  )}
+                  <BusyIcon busy={polling} icon={Play} size={11} />
                 </button>
               </Tooltip>
             </div>
@@ -197,16 +193,7 @@ export function ConnectionRow({
       </div>
 
       <div className="mt-1 flex items-center gap-2 text-[11px]">
-        {(phrase || failure) && (
-          <span
-            className={`flex items-center gap-1.5 ${phrase ? TONE_TEXT.live : TONE_TEXT.broken}`}
-          >
-            <span
-              className={`w-1.5 h-1.5 rounded-full shrink-0 ${phrase ? TONE_DOT_MOVING.live : TONE_DOT.broken}`}
-            />
-            {phrase ?? failure}
-          </span>
-        )}
+        <ActivityLine {...reporting} />
         {conn.lastSyncAt && (
           <span className="text-gray-600">
             Last synced {new Date(conn.lastSyncAt).toLocaleString()}

--- a/src/renderer/components/settings/ConnectionRow.tsx
+++ b/src/renderer/components/settings/ConnectionRow.tsx
@@ -136,7 +136,8 @@ export function ConnectionRow({
       {/* Polled-by-workflow rows — make the mechanism visible */}
       <div className="mt-1.5 space-y-1">
         {seededWorkflows.map((wf) => {
-          const polling = Boolean(activity.state(wf.id, ['run']).phrase)
+          const poll = activity.state(wf.id, ['run'])
+          const polling = Boolean(poll.phrase)
           const trigger = wf.nodes.find((n) => n.type === 'trigger')
           const cron =
             trigger?.config && 'cron' in trigger.config
@@ -170,6 +171,12 @@ export function ConnectionRow({
               </Tooltip>
             </div>
           )
+        })}
+        {seededWorkflows.map((wf) => {
+          const failed = activity.state(wf.id, ['run']).error
+          return failed ? (
+            <ActivityLine key={`${wf.id}-failed`} error={failed} className="text-[11px]" />
+          ) : null
         })}
 
         {missingEvents.map((e) => (

--- a/src/renderer/components/settings/ConnectionRow.tsx
+++ b/src/renderer/components/settings/ConnectionRow.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
-import { Play, Trash2, AlertCircle, Workflow, Import, Activity } from 'lucide-react'
+import { Play, Trash2, AlertCircle, Workflow, Import, Activity, Loader2 } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { connectionIcon } from '../../lib/connection-icon'
 import { McpToolsPanel } from './McpToolsPanel'
 import { humanCron } from '../../lib/cron-text'
+import { rowKey, type RowActivity } from '../../lib/use-row-action'
+import { TONE_DOT, TONE_DOT_MOVING, TONE_TEXT } from '../../lib/status-tone'
 import {
   isImplicitConnection,
   type ConnectorManifest,
@@ -27,8 +29,7 @@ export function ConnectionRow({
   manifest,
   seededWorkflows,
   missingEvents,
-  runningId,
-  backfillingId,
+  activity,
   backfillResult,
   onRun,
   onBackfill,
@@ -41,8 +42,7 @@ export function ConnectionRow({
   manifest?: ConnectorManifest
   seededWorkflows: WorkflowDefinition[]
   missingEvents: Array<{ name: string; event: string }>
-  runningId: string | null
-  backfillingId: string | null
+  activity: RowActivity
   backfillResult: Record<string, { imported: number; updated: number; error?: string }>
   onRun: (workflowId: string) => void
   onBackfill: (connectionId: string) => void
@@ -52,6 +52,12 @@ export function ConnectionRow({
   onRefresh: () => void
 }) {
   const implicit = isImplicitConnection(conn)
+  const backfilling = activity.busy[rowKey('backfill', conn.id)]
+  const deleting = activity.busy[rowKey('delete', conn.id)]
+  // One line for whichever of this connection's actions is working or last failed.
+  const phrase = backfilling ?? deleting
+  const failure =
+    activity.failed[rowKey('backfill', conn.id)] ?? activity.failed[rowKey('delete', conn.id)]
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean | null; message?: string } | null>(
     null
@@ -87,10 +93,10 @@ export function ConnectionRow({
           <Tooltip label="Import existing items matching this connection's filters. Bypasses the cron cursor.">
             <button
               onClick={() => onBackfill(conn.id)}
-              disabled={backfillingId === conn.id}
+              disabled={Boolean(backfilling)}
               className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-50"
             >
-              <Import size={13} className={backfillingId === conn.id ? 'animate-pulse' : ''} />
+              {backfilling ? <Loader2 size={13} className="animate-spin" /> : <Import size={13} />}
             </button>
           </Tooltip>
           {conn.connectorId === 'http' && (
@@ -113,10 +119,10 @@ export function ConnectionRow({
           >
             <button
               onClick={() => onDelete(conn.id)}
-              disabled={implicit}
+              disabled={implicit || Boolean(deleting)}
               className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-40 disabled:hover:text-gray-500"
             >
-              <Trash2 size={13} />
+              {deleting ? <Loader2 size={13} className="animate-spin" /> : <Trash2 size={13} />}
             </button>
           </Tooltip>
         </div>
@@ -156,10 +162,14 @@ export function ConnectionRow({
               <Tooltip label="Poll the connector now instead of waiting for the next cron tick">
                 <button
                   onClick={() => onRun(wf.id)}
-                  disabled={runningId === wf.id}
+                  disabled={Boolean(activity.busy[rowKey('run', wf.id)])}
                   className="p-1 text-gray-500 hover:text-gray-200 rounded-sm transition-colors disabled:opacity-50"
                 >
-                  <Play size={11} className={runningId === wf.id ? 'animate-pulse' : ''} />
+                  {activity.busy[rowKey('run', wf.id)] ? (
+                    <Loader2 size={11} className="animate-spin" />
+                  ) : (
+                    <Play size={11} />
+                  )}
                 </button>
               </Tooltip>
             </div>
@@ -187,6 +197,16 @@ export function ConnectionRow({
       </div>
 
       <div className="mt-1 flex items-center gap-2 text-[11px]">
+        {(phrase || failure) && (
+          <span
+            className={`flex items-center gap-1.5 ${phrase ? TONE_TEXT.live : TONE_TEXT.broken}`}
+          >
+            <span
+              className={`w-1.5 h-1.5 rounded-full shrink-0 ${phrase ? TONE_DOT_MOVING.live : TONE_DOT.broken}`}
+            />
+            {phrase ?? failure}
+          </span>
+        )}
         {conn.lastSyncAt && (
           <span className="text-gray-600">
             Last synced {new Date(conn.lastSyncAt).toLocaleString()}

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -7,7 +7,8 @@ import {
   RefreshCw,
   Undo2,
   Trash2,
-  Workflow
+  Workflow,
+  Loader2
 } from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
 import type { ConnectorCatalogVerification, ConnectorInstallProgress } from '../../../shared/types'
@@ -18,7 +19,7 @@ import {
   type ConnectorListing
 } from '../../lib/connector-browse'
 import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
-import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
+import { TONE_DOT, TONE_DOT_MOVING, TONE_TEXT } from '../../lib/status-tone'
 
 /**
  * What a connector does, before anything is downloaded.
@@ -37,6 +38,7 @@ export function ConnectorDetail({
   listing,
   builtIns,
   progress,
+  activity,
   onAdd,
   onInstall,
   onRollback,
@@ -48,6 +50,8 @@ export function ConnectorDetail({
   builtIns: BuiltInConnector[]
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
+  /** What this connector's own actions are doing, and what the last one answered. */
+  activity?: { phrase?: string; error?: string }
   onAdd: () => void
   onInstall?: () => void
   onRollback?: () => void
@@ -64,6 +68,7 @@ export function ConnectorDetail({
     progress
   })
   const status = describePackStatus(state)
+  const busy = Boolean(activity?.phrase)
 
   return (
     <div>
@@ -175,6 +180,18 @@ export function ConnectorDetail({
         </p>
       )}
 
+      {/* The same line install writes, for the actions that answer in one step. */}
+      {(activity?.phrase || activity?.error) && (
+        <p
+          className={`flex items-start gap-1.5 text-[12px] mt-4 ${activity.phrase ? TONE_TEXT.live : TONE_TEXT.broken}`}
+        >
+          <span
+            className={`w-1.5 h-1.5 rounded-full shrink-0 mt-1.5 ${activity.phrase ? TONE_DOT_MOVING.live : TONE_DOT.broken}`}
+          />
+          {activity.phrase ?? activity.error}
+        </p>
+      )}
+
       <div className="flex items-center gap-2 mt-6">
         {/* Nothing to connect: installing it was the whole setup, so the next move is the one it exists for. */}
         {listing.implicitlyConnected ? (
@@ -221,20 +238,22 @@ export function ConnectorDetail({
         {onRollback && state.kind === 'installed' && state.previousVersion && (
           <button
             onClick={onRollback}
+            disabled={busy}
             title={`Go back to v${state.previousVersion}`}
-            className="text-xs text-gray-400 hover:text-gray-200 px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+            className="text-xs text-gray-400 hover:text-gray-200 px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
           >
-            <Undo2 size={12} /> Roll back
+            {busy ? <Loader2 size={12} className="animate-spin" /> : <Undo2 size={12} />} Roll back
           </button>
         )}
 
         {onRemove && listing.pack && (
           <button
             onClick={onRemove}
+            disabled={busy}
             title="Delete the installed files"
-            className="text-xs text-danger hover:text-danger px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+            className="text-xs text-danger hover:text-danger px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
           >
-            <Trash2 size={12} /> Remove
+            {busy ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />} Remove
           </button>
         )}
 

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -7,8 +7,7 @@ import {
   RefreshCw,
   Undo2,
   Trash2,
-  Workflow,
-  Loader2
+  Workflow
 } from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
 import type { ConnectorCatalogVerification, ConnectorInstallProgress } from '../../../shared/types'
@@ -19,7 +18,10 @@ import {
   type ConnectorListing
 } from '../../lib/connector-browse'
 import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
-import { TONE_DOT, TONE_DOT_MOVING, TONE_TEXT } from '../../lib/status-tone'
+import type { RowState } from '../../lib/use-row-action'
+import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
+import { ActivityLine } from './ActivityLine'
+import { BusyIcon } from './BusyIcon'
 
 /**
  * What a connector does, before anything is downloaded.
@@ -51,7 +53,7 @@ export function ConnectorDetail({
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
   /** What this connector's own actions are doing, and what the last one answered. */
-  activity?: { phrase?: string; error?: string }
+  activity?: RowState
   onAdd: () => void
   onInstall?: () => void
   onRollback?: () => void
@@ -180,17 +182,7 @@ export function ConnectorDetail({
         </p>
       )}
 
-      {/* The same line install writes, for the actions that answer in one step. */}
-      {(activity?.phrase || activity?.error) && (
-        <p
-          className={`flex items-start gap-1.5 text-[12px] mt-4 ${activity.phrase ? TONE_TEXT.live : TONE_TEXT.broken}`}
-        >
-          <span
-            className={`w-1.5 h-1.5 rounded-full shrink-0 mt-1.5 ${activity.phrase ? TONE_DOT_MOVING.live : TONE_DOT.broken}`}
-          />
-          {activity.phrase ?? activity.error}
-        </p>
-      )}
+      <ActivityLine {...activity} className="text-[12px] mt-4" />
 
       <div className="flex items-center gap-2 mt-6">
         {/* Nothing to connect: installing it was the whole setup, so the next move is the one it exists for. */}
@@ -242,7 +234,7 @@ export function ConnectorDetail({
             title={`Go back to v${state.previousVersion}`}
             className="text-xs text-gray-400 hover:text-gray-200 px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
           >
-            {busy ? <Loader2 size={12} className="animate-spin" /> : <Undo2 size={12} />} Roll back
+            <BusyIcon busy={busy} icon={Undo2} size={12} /> Roll back
           </button>
         )}
 
@@ -253,7 +245,7 @@ export function ConnectorDetail({
             title="Delete the installed files"
             className="text-xs text-danger hover:text-danger px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
           >
-            {busy ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />} Remove
+            <BusyIcon busy={busy} icon={Trash2} size={12} /> Remove
           </button>
         )}
 

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -9,6 +9,7 @@ import { SDK_FILTER_KEYS } from '../../../shared/types'
 import { ConnectorDirectory } from './ConnectorDirectory'
 import { ConnectorDetail } from './ConnectorDetail'
 import { ConnectionGroups, type ConnectorStatus } from './ConnectionGroups'
+import { useRowAction, rowKey } from '../../lib/use-row-action'
 import type { InstalledConnectorPack, SourceConnection } from '../../../shared/types'
 import { SdkConnectorForm } from './SdkConnectorForm'
 import { PackInstallConfirm } from './PackInstallConfirm'
@@ -39,8 +40,7 @@ export function ConnectorSettings() {
   // with, so the catalog opens instead of a second empty-state layout.
   const [view, setView] = useState<'connections' | 'browse'>('connections')
   const [packs, setPacks] = useState<InstalledConnectorPack[]>([])
-  const [runningId, setRunningId] = useState<string | null>(null)
-  const [backfillingId, setBackfillingId] = useState<string | null>(null)
+  const activity = useRowAction()
   const [backfillResult, setBackfillResult] = useState<
     Record<string, { imported: number; updated: number; error?: string }>
   >({})
@@ -88,25 +88,30 @@ export function ConnectorSettings() {
 
   const handleRollback = useCallback(
     async (id: string) => {
-      await window.api.rollbackConnectorPack(id)
+      await activity.run(rowKey('rollback', id), 'Rolling back…', () =>
+        window.api.rollbackConnectorPack(id)
+      )
       await load()
     },
-    [load]
+    [load, activity]
   )
 
   const handleRemovePack = useCallback(
     async (id: string) => {
-      const result = await window.api.removeConnectorPack(id)
-      // Said after the fact rather than asked before it: the count is what the
-      // server counted, and a connection left without files is worth naming.
-      if (result.ok && (result.connections ?? 0) > 0) {
-        install.report(
-          `Removed the files. ${result.connections} connection${result.connections === 1 ? '' : 's'} will stop working until the connector is installed again.`
-        )
-      }
+      await activity.run(rowKey('remove', id), 'Removing…', async () => {
+        const result = await window.api.removeConnectorPack(id)
+        // Said after the fact rather than asked before it: the count is what the
+        // server counted, and a connection left without files is worth naming.
+        if (result.ok && (result.connections ?? 0) > 0) {
+          install.report(
+            `Removed the files. ${result.connections} connection${result.connections === 1 ? '' : 's'} will stop working until the connector is installed again.`
+          )
+        }
+        return result
+      })
       await load()
     },
-    [load, install]
+    [load, install, activity]
   )
 
   const listings = useMemo(
@@ -131,14 +136,17 @@ export function ConnectorSettings() {
   // Every listed server is a connection to the built-in `mcp` connector.
   const mcpConnector = connectors.find((c) => c.id === MCP_CONNECTOR_ID)
 
+  // A pack's own actions, so its page can say which one is running and what it answered.
+  const packPhrase = (id: string): string | undefined =>
+    activity.busy[rowKey('rollback', id)] ?? activity.busy[rowKey('remove', id)]
+  const packFailure = (id: string): string | undefined =>
+    activity.failed[rowKey('rollback', id)] ?? activity.failed[rowKey('remove', id)]
+
   const handleRun = async (workflowId: string) => {
-    setRunningId(workflowId)
-    try {
-      await window.api.runWorkflowManual(workflowId)
-    } finally {
-      setTimeout(() => setRunningId(null), 800)
-      load()
-    }
+    await activity.run(rowKey('run', workflowId), 'Polling…', () =>
+      window.api.runWorkflowManual(workflowId)
+    )
+    load()
   }
 
   const handleReset = async (connectionId: string, event: string) => {
@@ -147,22 +155,21 @@ export function ConnectorSettings() {
   }
 
   const handleBackfill = async (connectionId: string) => {
-    setBackfillingId(connectionId)
     setBackfillResult((prev) => {
       const { [connectionId]: _removed, ...rest } = prev
       return rest
     })
-    try {
+    await activity.run(rowKey('backfill', connectionId), 'Importing…', async () => {
       const result = await window.api.backfillConnection(connectionId)
       setBackfillResult((prev) => ({ ...prev, [connectionId]: result }))
-    } finally {
-      setBackfillingId(null)
-      load()
-    }
+    })
+    load()
   }
 
   const handleDelete = async (connectionId: string) => {
-    await window.api.deleteConnection(connectionId)
+    await activity.run(rowKey('delete', connectionId), 'Removing…', () =>
+      window.api.deleteConnection(connectionId)
+    )
     load()
   }
 
@@ -200,8 +207,7 @@ export function ConnectorSettings() {
             manifests={manifests}
             statuses={statuses}
             workflows={workflows}
-            runningId={runningId}
-            backfillingId={backfillingId}
+            activity={activity}
             backfillResult={backfillResult}
             onAdd={setAdding}
             onRun={handleRun}
@@ -254,6 +260,10 @@ export function ConnectorSettings() {
           {...(installProgress[selectedListing.id] && {
             progress: installProgress[selectedListing.id]
           })}
+          activity={{
+            ...(packPhrase(selectedListing.id) && { phrase: packPhrase(selectedListing.id) }),
+            ...(packFailure(selectedListing.id) && { error: packFailure(selectedListing.id) })
+          }}
           onAdd={() => setAdding(selectedListing)}
           onUse={() => openWorkflowEditor(null)}
           onInstall={() => handleInstall(selectedListing)}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -9,7 +9,8 @@ import { SDK_FILTER_KEYS } from '../../../shared/types'
 import { ConnectorDirectory } from './ConnectorDirectory'
 import { ConnectorDetail } from './ConnectorDetail'
 import { ConnectionGroups, type ConnectorStatus } from './ConnectionGroups'
-import { useRowAction, rowKey } from '../../lib/use-row-action'
+import { useRowAction } from '../../lib/use-row-action'
+import { waitForSync } from '../../lib/connection-sync'
 import type { InstalledConnectorPack, SourceConnection } from '../../../shared/types'
 import { SdkConnectorForm } from './SdkConnectorForm'
 import { PackInstallConfirm } from './PackInstallConfirm'
@@ -88,9 +89,7 @@ export function ConnectorSettings() {
 
   const handleRollback = useCallback(
     async (id: string) => {
-      await activity.run(rowKey('rollback', id), 'Rolling back…', () =>
-        window.api.rollbackConnectorPack(id)
-      )
+      await activity.run('rollback', id, () => window.api.rollbackConnectorPack(id))
       await load()
     },
     [load, activity]
@@ -98,7 +97,7 @@ export function ConnectorSettings() {
 
   const handleRemovePack = useCallback(
     async (id: string) => {
-      await activity.run(rowKey('remove', id), 'Removing…', async () => {
+      await activity.run('remove', id, async () => {
         const result = await window.api.removeConnectorPack(id)
         // Said after the fact rather than asked before it: the count is what the
         // server counted, and a connection left without files is worth naming.
@@ -136,16 +135,12 @@ export function ConnectorSettings() {
   // Every listed server is a connection to the built-in `mcp` connector.
   const mcpConnector = connectors.find((c) => c.id === MCP_CONNECTOR_ID)
 
-  // A pack's own actions, so its page can say which one is running and what it answered.
-  const packPhrase = (id: string): string | undefined =>
-    activity.busy[rowKey('rollback', id)] ?? activity.busy[rowKey('remove', id)]
-  const packFailure = (id: string): string | undefined =>
-    activity.failed[rowKey('rollback', id)] ?? activity.failed[rowKey('remove', id)]
-
-  const handleRun = async (workflowId: string) => {
-    await activity.run(rowKey('run', workflowId), 'Polling…', () =>
-      window.api.runWorkflowManual(workflowId)
-    )
+  const handleRun = async (workflowId: string, connectionId: string) => {
+    const since = connections.find((connection) => connection.id === connectionId)?.lastSyncAt
+    await activity.run('run', workflowId, async () => {
+      await window.api.runWorkflowManual(workflowId)
+      await waitForSync(connectionId, since)
+    })
     load()
   }
 
@@ -159,7 +154,7 @@ export function ConnectorSettings() {
       const { [connectionId]: _removed, ...rest } = prev
       return rest
     })
-    await activity.run(rowKey('backfill', connectionId), 'Importing…', async () => {
+    await activity.run('backfill', connectionId, async () => {
       const result = await window.api.backfillConnection(connectionId)
       setBackfillResult((prev) => ({ ...prev, [connectionId]: result }))
     })
@@ -167,9 +162,7 @@ export function ConnectorSettings() {
   }
 
   const handleDelete = async (connectionId: string) => {
-    await activity.run(rowKey('delete', connectionId), 'Removing…', () =>
-      window.api.deleteConnection(connectionId)
-    )
+    await activity.run('delete', connectionId, () => window.api.deleteConnection(connectionId))
     load()
   }
 
@@ -260,10 +253,7 @@ export function ConnectorSettings() {
           {...(installProgress[selectedListing.id] && {
             progress: installProgress[selectedListing.id]
           })}
-          activity={{
-            ...(packPhrase(selectedListing.id) && { phrase: packPhrase(selectedListing.id) }),
-            ...(packFailure(selectedListing.id) && { error: packFailure(selectedListing.id) })
-          }}
+          activity={activity.state(selectedListing.id, ['rollback', 'remove'])}
           onAdd={() => setAdding(selectedListing)}
           onUse={() => openWorkflowEditor(null)}
           onInstall={() => handleInstall(selectedListing)}

--- a/src/renderer/components/settings/SdkConnectorForm.tsx
+++ b/src/renderer/components/settings/SdkConnectorForm.tsx
@@ -328,11 +328,17 @@ export function SdkConnectorForm({
                 </div>
               ) : (
                 <div className="text-[11px] text-gray-400">
-                  {identity === null
-                    ? 'Checking whether the tool it borrows is signed in…'
-                    : // `ok: null` is an answer — this build cannot ask — and
-                      // leaving the in-flight line up would read as a hang.
-                      (identity.message ?? 'Nothing to check for this connector.')}
+                  {identity === null ? (
+                    <span className="flex items-center gap-1.5">
+                      <Loader2 size={11} className="animate-spin shrink-0" />
+                      Checking whether {manifest.auth?.probe?.command ?? 'the tool it borrows'} is
+                      signed in…
+                    </span>
+                  ) : (
+                    // `ok: null` is an answer — this build cannot ask — and
+                    // leaving the in-flight line up would read as a hang.
+                    (identity.message ?? 'Nothing to check for this connector.')
+                  )}
                   {identity?.installHint && (
                     <span className="block text-gray-600 mt-1">{identity.installHint}</span>
                   )}
@@ -405,8 +411,9 @@ export function SdkConnectorForm({
           // A connector that asks for nothing was connected when it was installed; offering Connect again would make a second one.
           onClick={() => (rung === 'none' ? onDone() : void handleSave())}
           disabled={!manifest || saving || (rung !== 'none' && missing.length > 0)}
-          className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50"
+          className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
         >
+          {saving && <Loader2 size={12} className="animate-spin" />}
           {rung === 'none' ? 'Done' : saving ? 'Connecting…' : 'Connect'}
         </button>
         <button

--- a/src/renderer/components/settings/SdkConnectorForm.tsx
+++ b/src/renderer/components/settings/SdkConnectorForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AlertCircle, Check, Loader2, Search } from 'lucide-react'
+import { BusyIcon } from './BusyIcon'
 import {
   borrowableFromManifest,
   type AuthProbeReport,
@@ -413,7 +414,7 @@ export function SdkConnectorForm({
           disabled={!manifest || saving || (rung !== 'none' && missing.length > 0)}
           className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
         >
-          {saving && <Loader2 size={12} className="animate-spin" />}
+          <BusyIcon busy={saving} size={12} />
           {rung === 'none' ? 'Done' : saving ? 'Connecting…' : 'Connect'}
         </button>
         <button

--- a/src/renderer/lib/connection-sync.ts
+++ b/src/renderer/lib/connection-sync.ts
@@ -1,0 +1,17 @@
+/** How long to keep watching for the sync a manual run started. */
+const GIVE_UP_AFTER_MS = 15_000
+
+/** How often to ask, slow enough that a poll of a few seconds costs a handful of reads. */
+const ASK_EVERY_MS = 500
+
+// `workflow:runManual` answers once the poll is dispatched, so the row watches the connection for the sync it started.
+export async function waitForSync(connectionId: string, since: string | undefined): Promise<void> {
+  const deadline = Date.now() + GIVE_UP_AFTER_MS
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, ASK_EVERY_MS))
+    const connections = await window.api.listConnections()
+    const syncedAt = connections.find((connection) => connection.id === connectionId)?.lastSyncAt
+    // Timestamps are ISO, so they order as text.
+    if (syncedAt && (!since || syncedAt > since)) return
+  }
+}

--- a/src/renderer/lib/use-row-action.ts
+++ b/src/renderer/lib/use-row-action.ts
@@ -1,47 +1,72 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 // What a row's own actions report while they run: a phrase while busy, and a refusal that lands where the press was.
+export type RowAction = 'backfill' | 'delete' | 'run' | 'rollback' | 'remove'
+
+/** Present tense, so a row says what is happening rather than what was pressed. */
+const PHRASES: Record<RowAction, string> = {
+  backfill: 'Importing…',
+  delete: 'Removing…',
+  run: 'Polling…',
+  rollback: 'Rolling back…',
+  remove: 'Removing…'
+}
+
+/** A call that answers with a refusal rather than throwing one. */
+type Refusal = { ok: boolean; error?: string }
+
+/** What a row shows for the actions it owns: one phrase, or one reason it failed. */
+export interface RowState {
+  phrase?: string
+  error?: string
+}
+
 export interface RowActivity {
-  /** Present tense, keyed by row, e.g. `Removing…`. */
+  /** Present tense, keyed by action and row. */
   busy: Record<string, string>
   /** Why the last attempt on that row failed, until the next one starts. */
   failed: Record<string, string>
-  run: (key: string, phrase: string, work: () => Promise<unknown>) => Promise<void>
+  run: (action: RowAction, id: string, work: () => Promise<void | Refusal>) => Promise<void>
+  /** Whichever of a row's actions is working, else whichever of them last failed. */
+  state: (id: string, actions: RowAction[]) => RowState
 }
 
-/** One spelling of a row's key, so a component and its caller cannot disagree. */
-export function rowKey(action: string, id: string): string {
+function keyFor(action: RowAction, id: string): string {
   return `${action}:${id}`
 }
 
-/** A call that answered with a refusal rather than throwing one. */
-function refusalIn(result: unknown): string | undefined {
-  if (typeof result !== 'object' || result === null || !('ok' in result)) return undefined
-  if ((result as { ok: unknown }).ok !== false) return undefined
-  const error = (result as { error?: unknown }).error
-  return typeof error === 'string' && error !== '' ? error : 'It did not say why.'
+/** The fold a row does to show one line, kept here so every surface folds alike. */
+export function rowState(
+  busy: Record<string, string>,
+  failed: Record<string, string>,
+  id: string,
+  actions: RowAction[]
+): RowState {
+  const phrase = actions.map((action) => busy[keyFor(action, id)]).find(Boolean)
+  if (phrase) return { phrase }
+  const error = actions.map((action) => failed[keyFor(action, id)]).find(Boolean)
+  return error ? { error } : {}
 }
 
 export function useRowAction(): RowActivity {
   const [busy, setBusy] = useState<Record<string, string>>({})
   const [failed, setFailed] = useState<Record<string, string>>({})
 
-  const forget = useCallback((key: string) => {
-    setFailed((current) => {
-      if (!(key in current)) return current
-      const { [key]: _cleared, ...rest } = current
-      return rest
-    })
-  }, [])
-
   const run = useCallback(
-    async (key: string, phrase: string, work: () => Promise<unknown>) => {
-      setBusy((current) => ({ ...current, [key]: phrase }))
+    async (action: RowAction, id: string, work: () => Promise<void | Refusal>) => {
+      const key = keyFor(action, id)
+      setBusy((current) => ({ ...current, [key]: PHRASES[action] }))
       // Whatever the last attempt said was about that attempt, not this one.
-      forget(key)
+      setFailed((current) => {
+        if (!(key in current)) return current
+        const { [key]: _cleared, ...rest } = current
+        return rest
+      })
       try {
-        const refusal = refusalIn(await work())
-        if (refusal) setFailed((current) => ({ ...current, [key]: refusal }))
+        const result = await work()
+        if (result && result.ok === false) {
+          setFailed((current) => ({ ...current, [key]: result.error || 'It did not say why.' }))
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         setFailed((current) => ({ ...current, [key]: message }))
@@ -52,8 +77,13 @@ export function useRowAction(): RowActivity {
         })
       }
     },
-    [forget]
+    []
   )
 
-  return { busy, failed, run }
+  const state = useCallback(
+    (id: string, actions: RowAction[]) => rowState(busy, failed, id, actions),
+    [busy, failed]
+  )
+
+  return useMemo(() => ({ busy, failed, run, state }), [busy, failed, run, state])
 }

--- a/src/renderer/lib/use-row-action.ts
+++ b/src/renderer/lib/use-row-action.ts
@@ -1,0 +1,67 @@
+import { useCallback, useState } from 'react'
+
+/**
+ * What a row's own actions report while they run.
+ *
+ * Installing a pack has always said what it was doing — a phrase on the row, a
+ * disabled button, a refusal that lands where the press was. Everything else on
+ * that screen fired its call and showed nothing until it came back, which on a
+ * backfill that spawns the connector's own process reads as a dead button. This
+ * is that reporting, for actions that answer once rather than in phases.
+ */
+export interface RowActivity {
+  /** Present tense, keyed by row, e.g. `Removing…`. */
+  busy: Record<string, string>
+  /** Why the last attempt on that row failed, until the next one starts. */
+  failed: Record<string, string>
+  run: (key: string, phrase: string, work: () => Promise<unknown>) => Promise<void>
+}
+
+/** One spelling of a row's key, so a component and its caller cannot disagree. */
+export function rowKey(action: string, id: string): string {
+  return `${action}:${id}`
+}
+
+/** A call that answered with a refusal rather than throwing one. */
+function refusalIn(result: unknown): string | undefined {
+  if (typeof result !== 'object' || result === null || !('ok' in result)) return undefined
+  if ((result as { ok: unknown }).ok !== false) return undefined
+  const error = (result as { error?: unknown }).error
+  return typeof error === 'string' && error !== '' ? error : 'It did not say why.'
+}
+
+export function useRowAction(): RowActivity {
+  const [busy, setBusy] = useState<Record<string, string>>({})
+  const [failed, setFailed] = useState<Record<string, string>>({})
+
+  const forget = useCallback((key: string) => {
+    setFailed((current) => {
+      if (!(key in current)) return current
+      const { [key]: _cleared, ...rest } = current
+      return rest
+    })
+  }, [])
+
+  const run = useCallback(
+    async (key: string, phrase: string, work: () => Promise<unknown>) => {
+      setBusy((current) => ({ ...current, [key]: phrase }))
+      // Whatever the last attempt said was about that attempt, not this one.
+      forget(key)
+      try {
+        const refusal = refusalIn(await work())
+        if (refusal) setFailed((current) => ({ ...current, [key]: refusal }))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        setFailed((current) => ({ ...current, [key]: message }))
+      } finally {
+        setBusy((current) => {
+          const { [key]: _done, ...rest } = current
+          return rest
+        })
+      }
+    },
+    [forget]
+  )
+
+  return { busy, failed, run }
+}

--- a/src/renderer/lib/use-row-action.ts
+++ b/src/renderer/lib/use-row-action.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 
 // What a row's own actions report while they run: a phrase while busy, and a refusal that lands where the press was.
 export type RowAction = 'backfill' | 'delete' | 'run' | 'rollback' | 'remove'
@@ -52,9 +52,13 @@ export function useRowAction(): RowActivity {
   const [busy, setBusy] = useState<Record<string, string>>({})
   const [failed, setFailed] = useState<Record<string, string>>({})
 
+  // Keys in flight, so a second press before the first render disables the button is dropped.
+  const inFlight = useRef(new Set<string>())
   const run = useCallback(
     async (action: RowAction, id: string, work: () => Promise<void | Refusal>) => {
       const key = keyFor(action, id)
+      if (inFlight.current.has(key)) return
+      inFlight.current.add(key)
       setBusy((current) => ({ ...current, [key]: PHRASES[action] }))
       // Whatever the last attempt said was about that attempt, not this one.
       setFailed((current) => {
@@ -71,6 +75,7 @@ export function useRowAction(): RowActivity {
         const message = err instanceof Error ? err.message : String(err)
         setFailed((current) => ({ ...current, [key]: message }))
       } finally {
+        inFlight.current.delete(key)
         setBusy((current) => {
           const { [key]: _done, ...rest } = current
           return rest

--- a/src/renderer/lib/use-row-action.ts
+++ b/src/renderer/lib/use-row-action.ts
@@ -1,14 +1,6 @@
 import { useCallback, useState } from 'react'
 
-/**
- * What a row's own actions report while they run.
- *
- * Installing a pack has always said what it was doing — a phrase on the row, a
- * disabled button, a refusal that lands where the press was. Everything else on
- * that screen fired its call and showed nothing until it came back, which on a
- * backfill that spawns the connector's own process reads as a dead button. This
- * is that reporting, for actions that answer once rather than in phases.
- */
+// What a row's own actions report while they run: a phrase while busy, and a refusal that lands where the press was.
 export interface RowActivity {
   /** Present tense, keyed by row, e.g. `Removing…`. */
   busy: Record<string, string>

--- a/tests/connection-groups-ui.test.tsx
+++ b/tests/connection-groups-ui.test.tsx
@@ -40,8 +40,7 @@ function setup(
       manifests={{}}
       statuses={statuses}
       workflows={[]}
-      runningId={null}
-      backfillingId={null}
+      activity={{ busy: {}, failed: {}, run: async () => {} }}
       backfillResult={{}}
       onAdd={onAdd}
       onRun={vi.fn()}

--- a/tests/connection-groups-ui.test.tsx
+++ b/tests/connection-groups-ui.test.tsx
@@ -40,7 +40,7 @@ function setup(
       manifests={{}}
       statuses={statuses}
       workflows={[]}
-      activity={{ busy: {}, failed: {}, run: async () => {} }}
+      activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
       backfillResult={{}}
       onAdd={onAdd}
       onRun={vi.fn()}

--- a/tests/connection-row-implicit.test.tsx
+++ b/tests/connection-row-implicit.test.tsx
@@ -36,8 +36,7 @@ function renderRow(filters: Record<string, unknown>) {
       conn={conn}
       seededWorkflows={[]}
       missingEvents={[]}
-      runningId={null}
-      backfillingId={null}
+      activity={{ busy: {}, failed: {}, run: async () => {} }}
       backfillResult={{}}
       onRun={vi.fn()}
       onBackfill={vi.fn()}

--- a/tests/connection-row-implicit.test.tsx
+++ b/tests/connection-row-implicit.test.tsx
@@ -36,7 +36,7 @@ function renderRow(filters: Record<string, unknown>) {
       conn={conn}
       seededWorkflows={[]}
       missingEvents={[]}
-      activity={{ busy: {}, failed: {}, run: async () => {} }}
+      activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
       backfillResult={{}}
       onRun={vi.fn()}
       onBackfill={vi.fn()}

--- a/tests/connection-row-test-button.test.tsx
+++ b/tests/connection-row-test-button.test.tsx
@@ -37,7 +37,7 @@ function renderRow(connectorId = 'http') {
       conn={conn(connectorId)}
       seededWorkflows={[]}
       missingEvents={[]}
-      activity={{ busy: {}, failed: {}, run: async () => {} }}
+      activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
       backfillResult={{}}
       onRun={vi.fn()}
       onBackfill={vi.fn()}

--- a/tests/connection-row-test-button.test.tsx
+++ b/tests/connection-row-test-button.test.tsx
@@ -37,8 +37,7 @@ function renderRow(connectorId = 'http') {
       conn={conn(connectorId)}
       seededWorkflows={[]}
       missingEvents={[]}
-      runningId={null}
-      backfillingId={null}
+      activity={{ busy: {}, failed: {}, run: async () => {} }}
       backfillResult={{}}
       onRun={vi.fn()}
       onBackfill={vi.fn()}

--- a/tests/connection-row.test.tsx
+++ b/tests/connection-row.test.tsx
@@ -27,6 +27,12 @@ beforeEach(() => {
   ;(window as unknown as { api: unknown }).api = {}
 })
 
+const working = (key: string, phrase: string) => ({
+  busy: { [key]: phrase },
+  failed: {},
+  run: async () => {}
+})
+
 function setup(props: Partial<Parameters<typeof ConnectionRow>[0]> = {}) {
   const handlers = {
     onRun: vi.fn(),
@@ -41,8 +47,7 @@ function setup(props: Partial<Parameters<typeof ConnectionRow>[0]> = {}) {
       conn={connection()}
       seededWorkflows={[]}
       missingEvents={[]}
-      runningId={null}
-      backfillingId={null}
+      activity={{ busy: {}, failed: {}, run: async () => {} }}
       backfillResult={{}}
       {...handlers}
       {...props}
@@ -157,5 +162,43 @@ describe('a configured connection', () => {
     const buttons = getAllByRole('button')
     fireEvent.click(buttons[1])
     expect(onDelete).toHaveBeenCalledWith('c1')
+  })
+})
+
+describe('what a connection says while its own actions run', () => {
+  it('says it is importing, and holds the button, while a backfill runs', () => {
+    const { getByText, container } = setup({ activity: working('backfill:c1', 'Importing…') })
+
+    expect(getByText('Importing…')).toBeInTheDocument()
+    const backfill = container.querySelectorAll('button')[0]
+    expect(backfill).toBeDisabled()
+  })
+
+  it('says it is removing while a delete runs', () => {
+    const { getByText } = setup({ activity: working('delete:c1', 'Removing…') })
+
+    expect(getByText('Removing…')).toBeInTheDocument()
+  })
+
+  it('holds the poll button for the workflow being polled, not its neighbour', () => {
+    const { container } = setup({
+      seededWorkflows: [workflow()],
+      activity: working('run:connector:c1:workItem', 'Polling…')
+    })
+
+    const poll = Array.from(container.querySelectorAll('button')).at(-1)
+    expect(poll).toBeDisabled()
+  })
+
+  it('keeps a refusal on the row it was pressed on', () => {
+    const { getByText } = setup({
+      activity: {
+        busy: {},
+        failed: { 'backfill:c1': 'The connector never answered' },
+        run: async () => {}
+      }
+    })
+
+    expect(getByText('The connector never answered')).toBeInTheDocument()
   })
 })

--- a/tests/connection-row.test.tsx
+++ b/tests/connection-row.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { ConnectionRow } from '../src/renderer/components/settings/ConnectionRow'
+import { rowState, type RowAction } from '../src/renderer/lib/use-row-action'
 import type { ConnectorManifest, SourceConnection, WorkflowDefinition } from '../src/shared/types'
 
 const connection = (overrides: Partial<SourceConnection> = {}): SourceConnection =>
@@ -27,10 +28,12 @@ beforeEach(() => {
   ;(window as unknown as { api: unknown }).api = {}
 })
 
-const working = (key: string, phrase: string) => ({
-  busy: { [key]: phrase },
-  failed: {},
-  run: async () => {}
+// Built through the same fold the hook uses, so a key the row cannot read fails the test.
+const reporting = (busy: Record<string, string>, failed: Record<string, string> = {}) => ({
+  busy,
+  failed,
+  run: async () => {},
+  state: (id: string, actions: RowAction[]) => rowState(busy, failed, id, actions)
 })
 
 function setup(props: Partial<Parameters<typeof ConnectionRow>[0]> = {}) {
@@ -47,7 +50,7 @@ function setup(props: Partial<Parameters<typeof ConnectionRow>[0]> = {}) {
       conn={connection()}
       seededWorkflows={[]}
       missingEvents={[]}
-      activity={{ busy: {}, failed: {}, run: async () => {} }}
+      activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
       backfillResult={{}}
       {...handlers}
       {...props}
@@ -79,7 +82,7 @@ describe('a configured connection', () => {
     const { container, onRun } = setup({ seededWorkflows: [workflow()] })
     const run = container.querySelectorAll('button')
     fireEvent.click(run[run.length - 1])
-    expect(onRun).toHaveBeenCalledWith('connector:c1:workItem')
+    expect(onRun).toHaveBeenCalledWith('connector:c1:workItem', 'c1')
   })
 
   it('says when polling has stopped because the workflow was deleted', () => {
@@ -167,7 +170,7 @@ describe('a configured connection', () => {
 
 describe('what a connection says while its own actions run', () => {
   it('says it is importing, and holds the button, while a backfill runs', () => {
-    const { getByText, container } = setup({ activity: working('backfill:c1', 'Importing…') })
+    const { getByText, container } = setup({ activity: reporting({ 'backfill:c1': 'Importing…' }) })
 
     expect(getByText('Importing…')).toBeInTheDocument()
     const backfill = container.querySelectorAll('button')[0]
@@ -175,7 +178,7 @@ describe('what a connection says while its own actions run', () => {
   })
 
   it('says it is removing while a delete runs', () => {
-    const { getByText } = setup({ activity: working('delete:c1', 'Removing…') })
+    const { getByText } = setup({ activity: reporting({ 'delete:c1': 'Removing…' }) })
 
     expect(getByText('Removing…')).toBeInTheDocument()
   })
@@ -183,7 +186,7 @@ describe('what a connection says while its own actions run', () => {
   it('holds the poll button for the workflow being polled, not its neighbour', () => {
     const { container } = setup({
       seededWorkflows: [workflow()],
-      activity: working('run:connector:c1:workItem', 'Polling…')
+      activity: reporting({ 'run:connector:c1:workItem': 'Polling…' })
     })
 
     const poll = Array.from(container.querySelectorAll('button')).at(-1)
@@ -192,11 +195,7 @@ describe('what a connection says while its own actions run', () => {
 
   it('keeps a refusal on the row it was pressed on', () => {
     const { getByText } = setup({
-      activity: {
-        busy: {},
-        failed: { 'backfill:c1': 'The connector never answered' },
-        run: async () => {}
-      }
+      activity: reporting({}, { 'backfill:c1': 'The connector never answered' })
     })
 
     expect(getByText('The connector never answered')).toBeInTheDocument()

--- a/tests/connection-row.test.tsx
+++ b/tests/connection-row.test.tsx
@@ -85,6 +85,14 @@ describe('a configured connection', () => {
     expect(onRun).toHaveBeenCalledWith('connector:c1:workItem', 'c1')
   })
 
+  it('says under the workflow when its poll failed', () => {
+    const { getByText } = setup({
+      seededWorkflows: [workflow()],
+      activity: reporting({}, { 'run:connector:c1:workItem': 'The connector went away' })
+    })
+    expect(getByText('The connector went away')).toBeInTheDocument()
+  })
+
   it('says when polling has stopped because the workflow was deleted', () => {
     // Deleting the seeded workflow silently stops the polling; without this the
     // connection looks configured and does nothing.

--- a/tests/connection-sync.test.ts
+++ b/tests/connection-sync.test.ts
@@ -7,10 +7,11 @@ const listConnections = vi.fn()
 beforeEach(() => {
   vi.useFakeTimers()
   listConnections.mockReset()
-  ;(window as unknown as { api: unknown }).api = { listConnections }
+  vi.stubGlobal('api', { listConnections })
 })
 
 afterEach(() => {
+  vi.unstubAllGlobals()
   vi.useRealTimers()
 })
 

--- a/tests/connection-sync.test.ts
+++ b/tests/connection-sync.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { waitForSync } from '../src/renderer/lib/connection-sync'
+
+const listConnections = vi.fn()
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  listConnections.mockReset()
+  ;(window as unknown as { api: unknown }).api = { listConnections }
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** Lets the awaited reads between two ticks settle. */
+const tick = async (ms: number) => {
+  await vi.advanceTimersByTimeAsync(ms)
+}
+
+describe('waiting for the sync a manual run started', () => {
+  it('returns once the connection reports a later sync than it had', async () => {
+    listConnections
+      .mockResolvedValueOnce([{ id: 'c1', lastSyncAt: '2026-09-04T10:00:00.000Z' }])
+      .mockResolvedValue([{ id: 'c1', lastSyncAt: '2026-09-04T10:05:00.000Z' }])
+    let done = false
+
+    void waitForSync('c1', '2026-09-04T10:00:00.000Z').then(() => {
+      done = true
+    })
+
+    await tick(500)
+    expect(done).toBe(false)
+    await tick(500)
+    expect(done).toBe(true)
+    expect(listConnections).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns on a first sync, when the connection had none', async () => {
+    listConnections.mockResolvedValue([{ id: 'c1', lastSyncAt: '2026-09-04T10:00:00.000Z' }])
+    let done = false
+
+    void waitForSync('c1', undefined).then(() => {
+      done = true
+    })
+
+    await tick(500)
+    expect(done).toBe(true)
+  })
+
+  it('gives up rather than watching forever', async () => {
+    listConnections.mockResolvedValue([{ id: 'c1', lastSyncAt: '2026-09-04T10:00:00.000Z' }])
+    let done = false
+
+    void waitForSync('c1', '2026-09-04T10:00:00.000Z').then(() => {
+      done = true
+    })
+
+    await tick(14_000)
+    expect(done).toBe(false)
+    await tick(2_000)
+    expect(done).toBe(true)
+  })
+})

--- a/tests/connector-pack-ui.test.tsx
+++ b/tests/connector-pack-ui.test.tsx
@@ -223,6 +223,28 @@ describe('ConnectorDetail pack footer', () => {
     expect(within(container).queryByText('Remove')).not.toBeInTheDocument()
   })
 
+  it('says which of its own actions is running, and holds both buttons', () => {
+    const { getByText } = setup(listingFor([installedPack({ previousVersion: '1.1.0' })]), {
+      onRollback: () => {},
+      onRemove: () => {},
+      activity: { phrase: 'Removing…' }
+    })
+
+    expect(getByText('Removing…')).toBeInTheDocument()
+    expect(getByText('Remove').closest('button')).toBeDisabled()
+    expect(getByText('Roll back').closest('button')).toBeDisabled()
+  })
+
+  it('keeps what the last action answered, with the buttons live again', () => {
+    const { getByText } = setup(listingFor([installedPack()]), {
+      onRemove: () => {},
+      activity: { error: 'The files are in use' }
+    })
+
+    expect(getByText('The files are in use')).toBeInTheDocument()
+    expect(getByText('Remove').closest('button')).not.toBeDisabled()
+  })
+
   it('runs the footer actions it is handed', () => {
     const onInstall = vi.fn()
     const onRollback = vi.fn()

--- a/tests/sdk-connector-form-rungs.test.tsx
+++ b/tests/sdk-connector-form-rungs.test.tsx
@@ -73,6 +73,21 @@ describe('a connector that borrows a login', () => {
     })
   })
 
+  it('names the tool it is asking, while the answer is still coming', async () => {
+    let answer = (): void => {}
+    probeConnectorAuth.mockReturnValue(
+      new Promise((resolve) => {
+        answer = () => resolve({ ok: true, identity: 'javier' })
+      })
+    )
+    const { findByText } = setup()
+
+    expect(await findByText(/Checking whether glab is/)).toBeInTheDocument()
+
+    answer()
+    expect(await findByText(/Signed in as javier/)).toBeInTheDocument()
+  })
+
   it('says who you already are instead of asking for a token', async () => {
     const { findByText, queryByDisplayValue, container } = setup()
     expect(await findByText(/Signed in as javier/)).toBeInTheDocument()

--- a/tests/use-row-action.test.tsx
+++ b/tests/use-row-action.test.tsx
@@ -2,17 +2,16 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
-import { useRowAction, rowKey } from '../src/renderer/lib/use-row-action'
+import { useRowAction, rowState } from '../src/renderer/lib/use-row-action'
 
-const KEY = rowKey('remove', 'slack')
-
-function Probe({ work }: { work: () => Promise<unknown> }) {
+function Probe({ work }: { work: () => Promise<void | { ok: boolean; error?: string }> }) {
   const activity = useRowAction()
+  const state = activity.state('slack', ['remove'])
   return (
     <div>
-      <button onClick={() => void activity.run(KEY, 'Removing…', work)}>go</button>
-      <span data-testid="busy">{activity.busy[KEY] ?? 'idle'}</span>
-      <span data-testid="failed">{activity.failed[KEY] ?? 'none'}</span>
+      <button onClick={() => void activity.run('remove', 'slack', work)}>go</button>
+      <span data-testid="busy">{state.phrase ?? 'idle'}</span>
+      <span data-testid="failed">{state.error ?? 'none'}</span>
     </div>
   )
 }
@@ -93,5 +92,29 @@ describe('a row action reporting itself', () => {
 
     await waitFor(() => expect(screen.getByTestId('busy')).toHaveTextContent('idle'))
     expect(screen.getByTestId('failed')).toHaveTextContent('none')
+  })
+})
+
+describe('what a row shows for the actions it owns', () => {
+  it('says the phrase of whichever action is working', () => {
+    expect(rowState({ 'delete:c1': 'Removing…' }, {}, 'c1', ['backfill', 'delete'])).toEqual({
+      phrase: 'Removing…'
+    })
+  })
+
+  it('prefers a working action over a stale failure', () => {
+    const state = rowState({ 'backfill:c1': 'Importing…' }, { 'delete:c1': 'It refused' }, 'c1', [
+      'backfill',
+      'delete'
+    ])
+
+    expect(state).toEqual({ phrase: 'Importing…' })
+  })
+
+  it('reads only the actions it was asked about, and only its own row', () => {
+    const busy = { 'run:c2': 'Polling…', 'backfill:c1': 'Importing…' }
+
+    expect(rowState(busy, {}, 'c1', ['delete'])).toEqual({})
+    expect(rowState(busy, {}, 'c2', ['run'])).toEqual({ phrase: 'Polling…' })
   })
 })

--- a/tests/use-row-action.test.tsx
+++ b/tests/use-row-action.test.tsx
@@ -85,6 +85,25 @@ describe('a row action reporting itself', () => {
     await waitFor(() => expect(screen.getByTestId('failed')).toHaveTextContent('none'))
   })
 
+  it('drops a second press on the same row while the first is still running', async () => {
+    let finish = (): void => {}
+    const work = vi.fn(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          finish = () => resolve({ ok: true })
+        })
+    )
+    render(<Probe work={work} />)
+
+    fireEvent.click(screen.getByText('go'))
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(screen.getByTestId('busy')).toHaveTextContent('Removing…'))
+    expect(work).toHaveBeenCalledTimes(1)
+
+    finish()
+    await waitFor(() => expect(screen.getByTestId('busy')).toHaveTextContent('idle'))
+  })
+
   it('answers a call that reports nothing as a success', async () => {
     render(<Probe work={async () => undefined} />)
 

--- a/tests/use-row-action.test.tsx
+++ b/tests/use-row-action.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { useRowAction, rowKey } from '../src/renderer/lib/use-row-action'
+
+const KEY = rowKey('remove', 'slack')
+
+function Probe({ work }: { work: () => Promise<unknown> }) {
+  const activity = useRowAction()
+  return (
+    <div>
+      <button onClick={() => void activity.run(KEY, 'Removing…', work)}>go</button>
+      <span data-testid="busy">{activity.busy[KEY] ?? 'idle'}</span>
+      <span data-testid="failed">{activity.failed[KEY] ?? 'none'}</span>
+    </div>
+  )
+}
+
+describe('a row action reporting itself', () => {
+  it('says what it is doing until the call answers', async () => {
+    let finish = (): void => {}
+    const work = vi.fn(
+      () =>
+        new Promise<{ ok: true }>((resolve) => {
+          finish = () => resolve({ ok: true })
+        })
+    )
+    render(<Probe work={work} />)
+
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(screen.getByTestId('busy')).toHaveTextContent('Removing…'))
+
+    finish()
+    await waitFor(() => expect(screen.getByTestId('busy')).toHaveTextContent('idle'))
+    expect(screen.getByTestId('failed')).toHaveTextContent('none')
+  })
+
+  it('keeps a refusal the call answered with, on the row it was pressed', async () => {
+    render(<Probe work={async () => ({ ok: false, error: 'The files are in use' })} />)
+
+    fireEvent.click(screen.getByText('go'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('failed')).toHaveTextContent('The files are in use')
+    )
+    expect(screen.getByTestId('busy')).toHaveTextContent('idle')
+  })
+
+  it('names a refusal that arrived without a reason', async () => {
+    render(<Probe work={async () => ({ ok: false })} />)
+
+    fireEvent.click(screen.getByText('go'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('failed')).toHaveTextContent('It did not say why.')
+    )
+  })
+
+  it('keeps a thrown failure, and stops saying it is working', async () => {
+    render(
+      <Probe
+        work={() => {
+          throw new Error('The server went away')
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByText('go'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('failed')).toHaveTextContent('The server went away')
+    )
+    expect(screen.getByTestId('busy')).toHaveTextContent('idle')
+  })
+
+  it('forgets the last failure when the same action runs again', async () => {
+    let fail = true
+    render(<Probe work={async () => (fail ? { ok: false, error: 'Nope' } : { ok: true })} />)
+
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(screen.getByTestId('failed')).toHaveTextContent('Nope'))
+
+    fail = false
+    fireEvent.click(screen.getByText('go'))
+    await waitFor(() => expect(screen.getByTestId('failed')).toHaveTextContent('none'))
+  })
+
+  it('answers a call that reports nothing as a success', async () => {
+    render(<Probe work={async () => undefined} />)
+
+    fireEvent.click(screen.getByText('go'))
+
+    await waitFor(() => expect(screen.getByTestId('busy')).toHaveTextContent('idle'))
+    expect(screen.getByTestId('failed')).toHaveTextContent('none')
+  })
+})


### PR DESCRIPTION
On the connectors screen only Install said anything while it ran. Roll back, Remove, Delete, the poll button and Backfill fired their call and showed nothing until it came back, and the poll button released itself on an 800 ms timer rather than on the poll. A backfill that runs the connector's own process read as a dead button.

## What changed

- A small hook tracks which action is busy or failed on each row; the five actions go through it. While it runs, the button disables with a spinner and the row's own status line pulses with a present-tense phrase; a failure lands on that same line until the action runs again. Both are drawn once, in `ActivityLine` and `BusyIcon`, and the page reuses the line install already writes.
- The poll button stays held until the connection's last-sync time moves, with a bounded wait, since the run call returns as soon as the server has dispatched the poll.
- The CLI login probe on the SDK connection form says what it is checking instead of going blank, and both Connect buttons spin while saving.

## How to verify

Settings → Connectors: Backfill, poll, Delete, Remove and Roll back each show a spinner and a phrase for as long as they run; a refused action leaves its reason on the row; adding an SDK connection with a CLI rung shows "Checking …" before the identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
