### PR TITLE
Let the phone ask for less, and let a workflow decide what a restored session needs

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -34,7 +34,12 @@ import {
   DeviceToken
 } from '@vornrun/shared/types'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
-import { DEFAULT_TASK_WORKFLOW_ID, buildDefaultTaskWorkflow } from './default-workflows'
+import {
+  DEFAULT_TASK_WORKFLOW_ID,
+  DEV_SERVER_WORKFLOW_ID,
+  buildDefaultTaskWorkflow,
+  buildDevServerWorkflow
+} from './default-workflows'
 
 /** Where the data directory lands when nothing overrides it. */
 const DEFAULT_DATA_DIR = path.join(os.homedir(), '.vorn')
@@ -118,11 +123,21 @@ export function initDatabase(dataDir?: string): void {
  * database via `initTestDatabase` without spinning up the full init path.
  */
 export function seedSystemDefaults(): void {
+  seedWorkflowOnce(
+    'hasSeededDefaultTaskWorkflow',
+    DEFAULT_TASK_WORKFLOW_ID,
+    buildDefaultTaskWorkflow
+  )
+  seedWorkflowOnce('hasSeededDevServerWorkflow', DEV_SERVER_WORKFLOW_ID, buildDevServerWorkflow)
+}
+
+/** Once per flag: a deleted seed stays deleted, and an upgrade gets it exactly once. */
+function seedWorkflowOnce(flag: string, id: string, build: () => WorkflowDefinition): void {
   const d = getDb()
 
-  const flagRow = d
-    .prepare("SELECT value FROM defaults WHERE key = 'hasSeededDefaultTaskWorkflow'")
-    .get() as { value: string } | undefined
+  const flagRow = d.prepare('SELECT value FROM defaults WHERE key = ?').get(flag) as
+    | { value: string }
+    | undefined
   if (flagRow) {
     try {
       if (JSON.parse(flagRow.value) === true) return
@@ -133,11 +148,11 @@ export function seedSystemDefaults(): void {
 
   // Safety net: skip if a workflow with the stable id already exists from a
   // manual import or partial upgrade. Still set the flag so we don't retry.
-  const existing = d
-    .prepare('SELECT id FROM workflows WHERE id = ?')
-    .get(DEFAULT_TASK_WORKFLOW_ID) as { id: string } | undefined
+  const existing = d.prepare('SELECT id FROM workflows WHERE id = ?').get(id) as
+    | { id: string }
+    | undefined
   if (!existing) {
-    const w = buildDefaultTaskWorkflow()
+    const w = build()
     d.prepare(
       `INSERT INTO workflows (id, name, icon, icon_color, nodes, edges, enabled, last_run_at, last_run_status, stagger_delay_ms, workspace_id)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -154,12 +169,13 @@ export function seedSystemDefaults(): void {
       w.staggerDelayMs ?? null,
       w.workspaceId ?? 'personal'
     )
-    log.info(`[database] Seeded default task workflow (${DEFAULT_TASK_WORKFLOW_ID})`)
+    log.info(`[database] Seeded workflow ${id}`)
   }
 
-  d.prepare(
-    "INSERT OR REPLACE INTO defaults (key, value) VALUES ('hasSeededDefaultTaskWorkflow', ?)"
-  ).run(JSON.stringify(true))
+  d.prepare('INSERT OR REPLACE INTO defaults (key, value) VALUES (?, ?)').run(
+    flag,
+    JSON.stringify(true)
+  )
 }
 
 /**
@@ -1309,6 +1325,9 @@ function loadDefaults(d: Database.Database): AppConfig['defaults'] {
     }),
     ...(map.headlessRetentionMinutes !== undefined && {
       headlessRetentionMinutes: map.headlessRetentionMinutes as number
+    }),
+    ...(map.hasSeededDevServerWorkflow !== undefined && {
+      hasSeededDevServerWorkflow: map.hasSeededDevServerWorkflow as boolean
     }),
     ...(map.hasSeededDefaultTaskWorkflow !== undefined && {
       hasSeededDefaultTaskWorkflow: map.hasSeededDefaultTaskWorkflow as boolean

--- a/packages/server/src/default-workflows.ts
+++ b/packages/server/src/default-workflows.ts
@@ -6,12 +6,15 @@ import type {
   ConnectorManifest,
   ConnectorPollTriggerConfig,
   CreateTaskFromItemConfig,
-  TaskStatus
+  TaskStatus,
+  SessionRestoredTriggerConfig,
+  ScriptConfig
 } from '@vornrun/shared/types'
 import { connectorSeededWorkflowId } from '@vornrun/shared/types'
 
 /** Stable id of the seeded "Default Task Workflow". */
 export const DEFAULT_TASK_WORKFLOW_ID = 'system:default-task-workflow'
+export const DEV_SERVER_WORKFLOW_ID = 'system:dev-server-on-restore'
 
 /**
  * Factory for the default task workflow seeded on first launch.
@@ -147,5 +150,43 @@ export function buildConnectorSeededWorkflow(
       }
     ],
     edges: [{ id: 'e1', source: 'trigger-1', target: 'create-1' }]
+  }
+}
+
+/**
+ * A restore workflow to edit rather than to write: disabled until somebody
+ * turns it on, so a person with no interest in it sees no new behaviour.
+ */
+export function buildDevServerWorkflow(): WorkflowDefinition {
+  const triggerConfig: SessionRestoredTriggerConfig = { triggerType: 'sessionRestored' }
+  const scriptConfig: ScriptConfig = {
+    scriptType: 'bash',
+    scriptContent: 'yarn dev',
+    cwd: '{{context.projectPath}}'
+  }
+  return {
+    id: DEV_SERVER_WORKFLOW_ID,
+    name: 'Bring the dev server back',
+    icon: 'RotateCcw',
+    iconColor: '#c9972a',
+    enabled: false,
+    workspaceId: 'personal',
+    nodes: [
+      {
+        id: 'trigger-1',
+        type: 'trigger',
+        label: 'When a session is restored',
+        position: { x: 0, y: 0 },
+        config: triggerConfig
+      },
+      {
+        id: 'script-1',
+        type: 'script',
+        label: 'Start the dev server',
+        position: { x: 0, y: 120 },
+        config: scriptConfig
+      }
+    ],
+    edges: [{ id: 'e1', source: 'trigger-1', target: 'script-1' }]
   }
 }

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -340,6 +340,16 @@ export async function settleHistory(): Promise<void> {
   // no screen falls back to a flush. Bounded so a test hangs on an assertion
   // rather than on this.
   for (let round = 0; round < 16; round++) {
+    // Output the tick has not picked up yet is still unwritten. Waiting only on
+    // the queue let a caller remove a directory a flush then recreated.
+    for (const held of recorded.values()) {
+      if (held.pending.length && held.queued === 0) {
+        void enqueue(held, async () => {
+          await flushPending(held)
+          if (held.logBytes > MAX_LOG_BYTES) await fold(held)
+        })
+      }
+    }
     const tails = [...recorded.values()].map((held) => held.tail)
     if (!tails.length) return
     await Promise.all(tails)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,7 @@
     "./structured-output": "./src/structured-output.ts",
     "./config-scope": "./src/config-scope.ts",
     "./session-restore": "./src/session-restore.ts",
+    "./topics": "./src/topics.ts",
     "./workflow-portability": "./src/workflow-portability.ts",
     "./viewer-settings-store": "./src/viewer-settings-store.ts"
   }

--- a/packages/shared/src/topics.ts
+++ b/packages/shared/src/topics.ts
@@ -1,0 +1,30 @@
+/**
+ * What a phone asks the server for.
+ *
+ * Every namespace the web client registers a handler for, except terminal
+ * bytes: those are asked for one terminal at a time, as cards come on screen.
+ * `terminal:exit` and `terminal:bell` stay by name because the ended strip and
+ * the notification need them for cards that are not on screen.
+ */
+export const PHONE_BASE_TOPICS: readonly string[] = [
+  'config:*',
+  'connector:*',
+  'headless:*',
+  'pairing:*',
+  'scheduler:*',
+  'script:*',
+  'session:*',
+  'workflow:*',
+  'worktree:*',
+  'terminal:exit',
+  'terminal:bell'
+]
+
+/** The instance form the server's filter understands. */
+export function terminalTopic(id: string): string {
+  return `terminal:data#${id}`
+}
+
+export function topicsQuery(topics: readonly string[]): string {
+  return `topics=${encodeURIComponent(topics.join(','))}`
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -678,6 +678,9 @@ export interface WorkflowExecutionContext {
     type: TriggerConfig['triggerType']
     fromStatus?: TaskStatus
     toStatus?: TaskStatus
+    /** Restore runs: how the session came back, and what the reboot check found. */
+    restore?: 'cold' | 'warm'
+    environment?: RestoreEnvironment
     /** Webhook runs: the received request, for {{trigger.body.*}} / {{trigger.headers.*}}. */
     body?: unknown
     headers?: Record<string, string>
@@ -789,6 +792,18 @@ export interface TaskStatusChangedTriggerConfig {
   fromStatus?: TaskStatus
   toStatus?: TaskStatus
 }
+/**
+ * Fires when a session comes back: after a quit, a crash or a reboot. It
+ * describes what happened and decides nothing; the workflow decides.
+ */
+export interface SessionRestoredTriggerConfig {
+  triggerType: 'sessionRestored'
+  projectFilter?: string
+  /** Cold: a process started again. Warm: a pane attached to one still running. Default cold. */
+  restore?: 'cold' | 'any'
+  /** One run per project at a time, so eight sessions do not race for one dev-server port. Default perProject. */
+  concurrency?: 'perProject' | 'unbounded'
+}
 /** Polls a connector on cron. Scheduler calls connector.poll(), updates the
  *  connection's cursor, and fires one workflow execution per new item. */
 export interface ConnectorPollTriggerConfig {
@@ -812,6 +827,7 @@ export type TriggerConfig =
   | RecurringTriggerConfig
   | TaskCreatedTriggerConfig
   | TaskStatusChangedTriggerConfig
+  | SessionRestoredTriggerConfig
   | ConnectorPollTriggerConfig
   | WebhookTriggerConfig
 
@@ -1128,6 +1144,8 @@ export interface WorkflowExecution {
   status: 'running' | 'success' | 'error' | 'cancelled'
   nodeStates: NodeExecutionState[]
   triggerTaskId?: string
+  /** Set for restore-triggered runs, so the row can say which session and how it came back. */
+  triggerSession?: { id: string; label: string; restore: 'cold' | 'warm' }
   /**
    * What this run was triggered *with* — a connector item id, a task id, or
    * `'manual'`. Two runs of one workflow are duplicates only when this matches
@@ -1326,6 +1344,7 @@ export interface AppConfig {
      * the next launch.
      */
     hasSeededDefaultTaskWorkflow?: boolean
+    hasSeededDevServerWorkflow?: boolean
     /** Which worktrees the manager treats as stale, and what counts as build output. */
     worktreeRetention?: WorktreeRetentionConfig
   }

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -91,6 +91,8 @@ class RpcClient {
    */
   private onAuthRequired: (() => void) | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  /** The filter this socket last asked for. A reconnect opens with only the URL's base set. */
+  private topics: readonly string[] | null = null
 
   constructor(url: string) {
     this.url = url
@@ -193,6 +195,9 @@ class RpcClient {
       // so this — not `onopen` — is what settles `_ready`.
       if (msg.method === 'auth:ok') {
         this._resolveReady()
+        // A fresh socket knows only the URL's base topics; the cards on screen
+        // would otherwise go quiet after every network change until scrolled.
+        if (this.topics) this.notify('subscribe:set', { topics: this.topics })
         return
       }
 
@@ -289,6 +294,12 @@ class RpcClient {
   }
 
   /** Fire-and-forget notification (no response expected) */
+  /** Replaces the socket's filter now, and again on every reconnect. */
+  setTopics(topics: readonly string[]): Promise<void> {
+    this.topics = topics
+    return this.invoke('subscribe:set', { topics }).then(() => undefined)
+  }
+
   notify(method: string, params?: unknown): void {
     const msg = JSON.stringify({ jsonrpc: '2.0', method, params })
     if (this.ws.readyState === WebSocket.OPEN) {
@@ -523,8 +534,7 @@ export function createApiShim(wsUrl: string) {
     getGitDiffStat: (cwd: string) => rpc.invoke('git:diffStat', cwd),
     getGitDiffFull: (req: string | GitDiffRange) => rpc.invoke('git:diffFull', req),
     // Replaces the socket's filter in place; the initial one rides on the URL.
-    setTopics: (topics: readonly string[]) =>
-      rpc.invoke('subscribe:set', { topics }).then(() => undefined),
+    setTopics: (topics: readonly string[]) => rpc.setTopics(topics),
     gitCommit: (payload: unknown) => rpc.invoke('git:commit', payload),
     gitPush: (cwd: string) => rpc.invoke('git:push', cwd),
 

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -522,6 +522,9 @@ export function createApiShim(wsUrl: string) {
       rpc.invoke('git:deleteBranches', { projectPath, branches, force }),
     getGitDiffStat: (cwd: string) => rpc.invoke('git:diffStat', cwd),
     getGitDiffFull: (req: string | GitDiffRange) => rpc.invoke('git:diffFull', req),
+    // Replaces the socket's filter in place; the initial one rides on the URL.
+    setTopics: (topics: readonly string[]) =>
+      rpc.invoke('subscribe:set', { topics }).then(() => undefined),
     gitCommit: (payload: unknown) => rpc.invoke('git:commit', payload),
     gitPush: (cwd: string) => rpc.invoke('git:push', cwd),
 

--- a/packages/web/src/env.ts
+++ b/packages/web/src/env.ts
@@ -1,3 +1,5 @@
+import { PHONE_BASE_TOPICS, topicsQuery } from '@vornrun/shared/topics'
+
 /**
  * Detect the WebSocket URL for connecting to the Vorn server.
  *
@@ -6,5 +8,6 @@
  */
 export function getWebSocketUrl(): string {
   const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${protocol}//${location.host}/ws`
+  // Declared on the upgrade, so no PTY byte is sent before the filter is known.
+  return `${protocol}//${location.host}/ws?${topicsQuery(PHONE_BASE_TOPICS)}`
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -136,7 +136,7 @@ function createWindow(): void {
   })
 }
 
-let widgetEnabled = true
+let widgetEnabled = false
 let widgetReady = false
 
 function sendToWidget(channel: string, ...args: unknown[]): void {
@@ -586,7 +586,7 @@ app.whenReady().then(async () => {
   let updateAutoDownload = true
   try {
     const config = await bridge.request<AppConfig>(IPC.CONFIG_LOAD)
-    widgetEnabled = config.defaults.widgetEnabled !== false
+    widgetEnabled = config.defaults.widgetEnabled === true
     updateChannel = config.defaults.updateChannel ?? 'stable'
     updateAutoDownload = config.defaults.updateAutoDownload !== false
     // Primed here, not only from `config:changed`: that fires on save, so a user

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -315,6 +315,9 @@ const api = {
   getGitDiffFull: (req: string | GitDiffRange): Promise<GitDiffResult | null> =>
     ipcRenderer.invoke(IPC.GIT_DIFF_FULL, req),
 
+  // The desktop asks for nothing and is sent everything; only the web narrows.
+  setTopics: (_topics: readonly string[]): Promise<void> => Promise.resolve(),
+
   gitCommit: (payload: GitCommitPayload): Promise<GitCommitResult> =>
     ipcRenderer.invoke(IPC.GIT_COMMIT, payload),
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -52,7 +52,8 @@ import {
   initGlobalDataListener,
   disposeGlobalDataListener,
   setKeyRedirectHandler,
-  setNotLiveReporter
+  setNotLiveReporter,
+  setLiveReporter
 } from './lib/terminal-registry'
 import {
   setCwdReporter,
@@ -76,7 +77,7 @@ import { GridContextMenu } from './components/GridContextMenu'
 import { WindowControls } from './components/WindowControls'
 import { isMac, isWeb, TRAFFIC_LIGHT_PAD_PX } from './lib/platform'
 import { useIsMobile } from './hooks/useIsMobile'
-import { syncBoard } from './lib/board-sync'
+import { syncBoard, reportWarmAttach } from './lib/board-sync'
 import { shouldNotifyBell, sendAgentNotification } from './lib/notifications'
 import { restoreDevicePanes } from './lib/device-restore'
 import { markPaneEnded } from './lib/session-resume'
@@ -153,6 +154,7 @@ export function App() {
     // terminal learns it is looking at a photograph. Start-up reconciliation
     // cannot tell it: the session was not there when this client started.
     setNotLiveReporter(markPaneEnded)
+    setLiveReporter(reportWarmAttach)
     // The capture path has to know before any command finishes, so it is read
     // from config rather than passed down through the view tree.
     setDomBlockRendering(useAppStore.getState().config?.defaults.domBlockRendering ?? true)

--- a/src/renderer/components/TerminalSlot.tsx
+++ b/src/renderer/components/TerminalSlot.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 import { registerSlot, unregisterSlot, focusTerminal } from '../lib/terminal-registry'
 import { useOnScreenOnce } from '../hooks/useOnScreenOnce'
+import { useOnScreen } from '../hooks/useOnScreen'
+import { markVisible, markHidden } from '../lib/visible-terminals'
 
 interface Props {
   terminalId: string
@@ -24,6 +26,14 @@ export function TerminalSlot({ terminalId, isFocused, className, style }: Props)
   // every reconnect, which on a phone is every network change. Waiting until the
   // slot is near the viewport spends that on the cards somebody is looking at.
   const onScreen = useOnScreenOnce(ref)
+  // Tracked, not latched: the web client asks the server only for the bytes of
+  // cards on screen, and that has to follow the scroll both ways.
+  const near = useOnScreen(ref)
+  useEffect(() => {
+    if (!near) return
+    markVisible(terminalId)
+    return () => markHidden(terminalId)
+  }, [terminalId, near])
 
   useEffect(() => {
     const el = ref.current

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -179,7 +179,7 @@ export function GeneralSettings() {
             description="Show agent status widget when app is not focused"
           >
             <ToggleSwitch
-              checked={config.defaults.widgetEnabled !== false}
+              checked={config.defaults.widgetEnabled === true}
               onChange={(enabled) => {
                 updateDefaults({ widgetEnabled: enabled })
                 window.api.setWidgetEnabled(enabled)

--- a/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/TriggerNode.tsx
@@ -6,7 +6,8 @@ import {
   ArrowRightLeft,
   Plug,
   Globe,
-  type LucideIcon
+  type LucideIcon,
+  RotateCcw
 } from 'lucide-react'
 import type {
   TriggerConfig,
@@ -31,6 +32,7 @@ const TRIGGER_ICONS: Record<string, LucideIcon> = {
   recurring: Clock,
   taskCreated: ListPlus,
   taskStatusChanged: ArrowRightLeft,
+  sessionRestored: RotateCcw,
   connectorPoll: Plug,
   webhook: Globe
 }
@@ -70,6 +72,8 @@ function getSubtitle(config: TriggerConfig): string {
       const project = config.projectFilter ? ` · ${config.projectFilter}` : ''
       return transition + project
     }
+    case 'sessionRestored':
+      return `${config.restore === 'any' ? 'cold or warm' : 'cold'}${config.projectFilter ? ` · ${config.projectFilter}` : ' · any project'}`
     case 'connectorPoll':
       return `${config.event} · ${config.cron}`
     case 'webhook':

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -13,7 +13,8 @@ import {
   Clock,
   Calendar,
   ListPlus,
-  ArrowRightLeft
+  ArrowRightLeft,
+  RotateCcw
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type {
@@ -62,6 +63,7 @@ const TRIGGER_ITEMS: {
   { triggerType: 'once', label: 'Schedule once', icon: Calendar },
   { triggerType: 'taskCreated', label: 'Task created', icon: ListPlus },
   { triggerType: 'taskStatusChanged', label: 'Task moved', icon: ArrowRightLeft },
+  { triggerType: 'sessionRestored', label: 'Session restored', icon: RotateCcw },
   { triggerType: 'webhook', label: 'Webhook', icon: Globe }
 ]
 

--- a/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/TriggerConfigForm.tsx
@@ -6,6 +6,7 @@ import {
   ArrowRightLeft,
   Plug,
   Globe,
+  RotateCcw,
   Copy,
   Check
 } from 'lucide-react'
@@ -57,6 +58,12 @@ const TRIGGER_TYPES = [
     label: 'Status Change',
     icon: ArrowRightLeft,
     hint: "Fires when a task's status changes"
+  },
+  {
+    type: 'sessionRestored' as const,
+    label: 'Session Restored',
+    icon: RotateCcw,
+    hint: 'Fires when a session comes back after a quit, a crash or a reboot'
   },
   {
     type: 'connectorPoll' as const,
@@ -243,6 +250,48 @@ export function TriggerConfigForm({ config, onChange, onOpenLibrary }: Props) {
         <ConnectorPollTriggerForm config={config} onChange={onChange} />
       )}
 
+      {config.triggerType === 'sessionRestored' && (
+        <>
+          <div>
+            <label className="text-[13px] text-gray-400 font-medium block mb-2">
+              Project Filter
+            </label>
+            <ProjectPicker
+              currentProject={config.projectFilter || ''}
+              projects={projects}
+              onChange={(name) => onChange({ ...config, projectFilter: name || undefined })}
+              variant="form"
+              allowNone
+            />
+            <p className="text-[11px] text-gray-500 mt-1">
+              Without one, this fires in every project on every start-up
+            </p>
+          </div>
+          <Segmented
+            label="Which restores"
+            value={config.restore ?? 'cold'}
+            options={[
+              { value: 'cold', label: 'Cold only' },
+              { value: 'any', label: 'Warm too' }
+            ]}
+            onChange={(v) => onChange({ ...config, restore: v === 'any' ? 'any' : undefined })}
+            hint="Cold: a process started again. Warm: a pane attached to one still running."
+          />
+          <Segmented
+            label="At a time"
+            value={config.concurrency ?? 'perProject'}
+            options={[
+              { value: 'perProject', label: 'One per project' },
+              { value: 'unbounded', label: 'Any number' }
+            ]}
+            onChange={(v) =>
+              onChange({ ...config, concurrency: v === 'unbounded' ? 'unbounded' : undefined })
+            }
+            hint="Eight sessions in one project make one run, then the next"
+          />
+        </>
+      )}
+
       {config.triggerType === 'webhook' && (
         <WebhookTriggerFields config={config} onChange={onChange} />
       )}
@@ -365,5 +414,42 @@ function WebhookTriggerFields({
         </p>
       </div>
     </>
+  )
+}
+
+function Segmented({
+  label,
+  value,
+  options,
+  onChange,
+  hint
+}: {
+  label: string
+  value: string
+  options: { value: string; label: string }[]
+  onChange: (value: string) => void
+  hint?: string
+}) {
+  return (
+    <div>
+      <label className="text-[13px] text-gray-400 font-medium block mb-2">{label}</label>
+      <div className="flex rounded-lg border border-white/[0.06] overflow-hidden text-[12px]">
+        {options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value)}
+            className={`flex-1 px-2 py-1.5 transition-colors ${
+              o.value === value
+                ? 'bg-white/[0.1] text-gray-200'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.04]'
+            }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+      {hint && <p className="text-[11px] text-gray-500 mt-1">{hint}</p>}
+    </div>
   )
 }

--- a/src/renderer/hooks/useOnScreen.ts
+++ b/src/renderer/hooks/useOnScreen.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+/** The same reach as the attach latch, so a card subscribes before it is drawn. */
+const NEARLY_ON_SCREEN = '400px'
+
+/**
+ * Whether the element is near the viewport right now, both edges reported.
+ *
+ * `useOnScreenOnce` is a latch because attaching is paid once. This is a
+ * tracker because what it drives -- which terminals' bytes this client asks the
+ * server for -- is cheap to change and expensive to leave on. Without an
+ * observer the answer is true, as the latch answers, so nothing is hidden under
+ * test or on a surface that cannot measure.
+ */
+export function useOnScreen(ref: React.RefObject<HTMLElement | null>): boolean {
+  const [near, setNear] = useState(() => typeof IntersectionObserver === 'undefined')
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setNear(true)
+      return
+    }
+    const io = new IntersectionObserver(
+      (entries) => setNear(entries.some((e) => e.isIntersecting)),
+      { rootMargin: NEARLY_ON_SCREEN }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [ref])
+
+  return near
+}

--- a/src/renderer/lib/board-sync.ts
+++ b/src/renderer/lib/board-sync.ts
@@ -1,5 +1,6 @@
 import type { RestoredSession, TerminalSession } from '../../shared/types'
 import { endedFromRestored } from './ended-from-restored'
+import { fireSessionRestoredTrigger } from './workflow-triggers'
 import { useAppStore } from '../stores'
 import { coldSessions } from './session-utils'
 import { resumeEndedSession } from './session-resume'
@@ -68,7 +69,11 @@ async function reconcile(options: { showCold: boolean; resume: boolean }): Promi
   // Anything the server has that this board does not. A session started from a
   // phone, or by a workflow, or before this window existed.
   for (const session of active) {
-    if (!store.terminals.has(session.id)) store.addTerminal(session)
+    if (store.terminals.has(session.id)) continue
+    store.addTerminal(session)
+    // Came from the server, not from this client. When its attach finds the
+    // process running, that is a warm restore and the trigger is told once.
+    restoredIds.add(session.id)
   }
 
   // Panes this board is holding for sessions the server no longer runs. On a
@@ -132,4 +137,21 @@ async function resumeAll(ids: string[]): Promise<void> {
     // the offer to try again by hand. Nothing is said twice.
     await resumeEndedSession(id, { automatic: true })
   }
+}
+
+const restoredIds = new Set<string>()
+
+/**
+ * Wired to the registry's live reporter at start-up. A session this client
+ * created in this lifetime is new, not restored, and is not in the set.
+ */
+export function reportWarmAttach(terminalId: string): void {
+  if (!restoredIds.delete(terminalId)) return
+  const session = useAppStore.getState().terminals.get(terminalId)?.session
+  if (session) fireSessionRestoredTrigger(session, { restore: 'warm' })
+}
+
+/** Test-only. */
+export function resetRestoredIds(): void {
+  restoredIds.clear()
 }

--- a/src/renderer/lib/run-presentation.ts
+++ b/src/renderer/lib/run-presentation.ts
@@ -1,4 +1,4 @@
-import { Zap, Clock, CheckSquare, Play, type LucideIcon } from 'lucide-react'
+import { Zap, Clock, CheckSquare, Play, type LucideIcon, RotateCcw } from 'lucide-react'
 import type {
   ApprovalConfig,
   NodeExecutionState,
@@ -56,7 +56,7 @@ export function bucketOf(execution: WorkflowExecution): RunBucket {
   return execution.status === 'success' ? 'success' : 'error'
 }
 
-export type RunSource = 'manual' | 'schedule' | 'task' | 'connector'
+export type RunSource = 'manual' | 'schedule' | 'task' | 'connector' | 'restore'
 
 /** The parts of a workflow definition a run row needs to render itself. */
 export interface RunWorkflowRef {
@@ -93,7 +93,8 @@ const SOURCE_ICONS: Record<RunSource, LucideIcon> = {
   manual: Zap,
   schedule: Clock,
   task: CheckSquare,
-  connector: Play
+  connector: Play,
+  restore: RotateCcw
 }
 
 function triggerNodeOf(nodes: WorkflowNode[]): WorkflowNode | undefined {
@@ -114,6 +115,7 @@ function sourceOf(
   if (triggerType === 'once' || triggerType === 'recurring') return 'schedule'
   if (triggerType === 'connectorPoll') return 'connector'
   if (triggerType === 'taskCreated' || triggerType === 'taskStatusChanged') return 'task'
+  if (execution.triggerSession || triggerType === 'sessionRestored') return 'restore'
   return 'manual'
 }
 
@@ -168,6 +170,19 @@ export function describeRun(
     }
   }
 
+  if (execution.triggerSession) {
+    const { label, restore } = execution.triggerSession
+    return {
+      title: name ?? label,
+      subtitle: `restore · ${restore} · ${label}`,
+      source: 'restore',
+      sourceLabel: 'restore',
+      iconName,
+      iconColor,
+      fallbackIcon: SOURCE_ICONS.restore
+    }
+  }
+
   if (execution.triggerTaskId) {
     return {
       title: name ?? `Task ${execution.triggerTaskId.slice(0, 6)}`,
@@ -184,7 +199,7 @@ export function describeRun(
     title: name ?? execution.workflowId.slice(0, 8),
     subtitle: undefined,
     source,
-    sourceLabel: source === 'schedule' ? 'scheduled' : 'manual',
+    sourceLabel: source === 'schedule' ? 'scheduled' : source === 'restore' ? 'restore' : 'manual',
     iconName,
     iconColor,
     fallbackIcon: SOURCE_ICONS[source]

--- a/src/renderer/lib/session-resume.ts
+++ b/src/renderer/lib/session-resume.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '../stores'
+import { fireSessionRestoredTrigger } from './workflow-triggers'
 import { endedFromRestored } from './ended-from-restored'
 import { toast } from '../components/Toast'
 
@@ -58,6 +59,7 @@ export async function resumeEndedSession(
   }
 
   const state = useAppStore.getState()
+  const environment = state.terminals.get(terminalId)?.ended?.environment
   // Bound to a session this client already draws: the ended pane goes and the
   // running one is brought forward. Replacing in place would key two panes by
   // one id -- and closing either would then close both.
@@ -74,6 +76,8 @@ export async function resumeEndedSession(
   // Said even for an automatic resume: a pane quietly becoming a second view of
   // a session open elsewhere is the one surprise worth a line.
   if (result.boundTo) toast('That conversation was already running. This pane shows it.')
+  // A bound session was not started again; it was already going elsewhere.
+  if (!result.boundTo) fireSessionRestoredTrigger(result.session, { restore: 'cold', environment })
 }
 
 /**

--- a/src/renderer/lib/template-vars.ts
+++ b/src/renderer/lib/template-vars.ts
@@ -94,6 +94,7 @@ export const TEMPLATE_VARIABLES: TemplateVariable[] = [
   { key: '{{task.projectName}}', label: 'Project', category: 'task' },
   { key: '{{trigger.fromStatus}}', label: 'Previous Status', category: 'trigger' },
   { key: '{{trigger.toStatus}}', label: 'New Status', category: 'trigger' },
+  { key: '{{trigger.restore}}', label: 'Cold or Warm', category: 'trigger' },
   { key: '{{trigger.body}}', label: 'Request Body', category: 'trigger' },
   { key: '{{trigger.headers}}', label: 'Request Headers', category: 'trigger' },
   { key: '{{trigger.query}}', label: 'Query Parameters', category: 'trigger' },
@@ -140,6 +141,10 @@ export function getAvailableContextVars(opts: {
     if (isTaskTrigger && v.category === 'task') return true
     if (isTaskTrigger && v.category === 'trigger' && opts.triggerType === 'taskStatusChanged') {
       return v.key.includes('Status')
+    }
+    if (opts.triggerType === 'sessionRestored') {
+      if (v.category === 'context') return true
+      if (v.category === 'trigger') return v.key.includes('trigger.restore')
     }
     if (opts.triggerType === 'webhook' && v.category === 'trigger') {
       return (

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -235,6 +235,7 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
       // opened onto a terminal that died while it was closed has no start-up
       // reconciliation to tell it -- this is where it finds out.
       if (live === false) reportNotLive?.(terminalId)
+      if (live === true) reportLive?.(terminalId)
     } catch (err) {
       console.error('[terminal] could not attach', terminalId, err)
       if (!stillOurs()) return
@@ -258,6 +259,12 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
  */
 type NotLiveReporter = (terminalId: string) => void
 let reportNotLive: NotLiveReporter | null = null
+/** Told when an attach found a process still running: a warm restore, if the board did not start it. */
+let reportLive: NotLiveReporter | null = null
+
+export function setLiveReporter(fn: NotLiveReporter | null): void {
+  reportLive = fn
+}
 
 export function setNotLiveReporter(fn: NotLiveReporter | null): void {
   reportNotLive = fn

--- a/src/renderer/lib/visible-terminals.ts
+++ b/src/renderer/lib/visible-terminals.ts
@@ -1,0 +1,45 @@
+import { PHONE_BASE_TOPICS, terminalTopic } from '../../shared/topics'
+import { isWeb } from './platform'
+
+/** Long enough to fold a scroll's worth of edges into one message. */
+const SETTLE_MS = 100
+
+const visible = new Set<string>()
+let timer: ReturnType<typeof setTimeout> | null = null
+
+/**
+ * Which terminals' bytes this client asks the server for.
+ *
+ * The desktop asks for nothing and so is sent everything; only the web client
+ * narrows its socket, and it narrows it to the cards that are on screen. The
+ * set is pushed whole each time, because `subscribe:set` replaces the filter
+ * rather than editing it.
+ */
+function schedule(): void {
+  if (!isWeb) return
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(() => {
+    timer = null
+    const api = window.api as { setTopics?: (topics: readonly string[]) => Promise<void> }
+    if (typeof api?.setTopics !== 'function') return
+    void api.setTopics([...PHONE_BASE_TOPICS, ...[...visible].map(terminalTopic)]).catch(() => {})
+  }, SETTLE_MS)
+}
+
+export function markVisible(id: string): void {
+  if (visible.has(id)) return
+  visible.add(id)
+  schedule()
+}
+
+export function markHidden(id: string): void {
+  if (!visible.delete(id)) return
+  schedule()
+}
+
+/** Test-only. */
+export function resetVisible(): void {
+  visible.clear()
+  if (timer) clearTimeout(timer)
+  timer = null
+}

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -1554,6 +1554,14 @@ export async function executeWorkflow(
     }),
     ...(targetSlice && { partial: true }),
     triggerTaskId: context?.task?.id,
+    ...(context?.trigger?.restore &&
+      context.source && {
+        triggerSession: {
+          id: context.source.id,
+          label: context.source.displayName ?? context.source.id.slice(0, 8),
+          restore: context.trigger.restore
+        }
+      }),
     connectorItem: context?.connectorItem,
     connectorInboxId: context?.connectorItem?.inboxId,
     connectorInboxLeaseToken: context?.connectorItem?.inboxLeaseToken,

--- a/src/renderer/lib/workflow-helpers.ts
+++ b/src/renderer/lib/workflow-helpers.ts
@@ -194,6 +194,7 @@ export function getTriggerLabel(wf: WorkflowDefinition): string | undefined {
   if (trigger.triggerType === 'recurring') return 'recurring'
   if (trigger.triggerType === 'taskCreated') return 'on task created'
   if (trigger.triggerType === 'taskStatusChanged') return 'on status change'
+  if (trigger.triggerType === 'sessionRestored') return 'on restore'
   return undefined
 }
 
@@ -447,6 +448,8 @@ export function switchTriggerType(type: TriggerConfig['triggerType']): TriggerCo
       return { triggerType: 'taskCreated' }
     case 'taskStatusChanged':
       return { triggerType: 'taskStatusChanged' }
+    case 'sessionRestored':
+      return { triggerType: 'sessionRestored' }
     case 'connectorPoll':
       return { triggerType: 'connectorPoll', connectionId: '', event: '', cron: '*/5 * * * *' }
     case 'webhook':

--- a/src/renderer/lib/workflow-triggers.ts
+++ b/src/renderer/lib/workflow-triggers.ts
@@ -3,6 +3,8 @@ import {
   TriggerConfig,
   TaskConfig,
   TaskStatus,
+  TerminalSession,
+  RestoreEnvironment,
   WorkflowExecutionContext
 } from '../../shared/types'
 import { executeWorkflow } from './workflow-execution'
@@ -73,4 +75,49 @@ export function fireTaskStatusChangedTrigger(
       console.error(`[triggers] executeWorkflow error:`, err)
     )
   }
+}
+
+/** One chain per project. Serialized because a dev server has one port. */
+const restoreQueues = new Map<string, Promise<unknown>>()
+
+/**
+ * Called after a session comes back. Cold: the server started its process
+ * again. Warm: this client attached to one the server never stopped.
+ *
+ * The trigger reports which; the workflow chooses. A workflow set to cold, the
+ * default, hears nothing about a phone opening a live card.
+ */
+export function fireSessionRestoredTrigger(
+  session: TerminalSession,
+  how: { restore: 'cold' | 'warm'; environment?: RestoreEnvironment }
+): void {
+  const workflows = (useAppStore.getState().config?.workflows || []).filter((wf) => wf.enabled)
+
+  for (const wf of workflows) {
+    const trigger = getTriggerConfig(wf)
+    if (!trigger || trigger.triggerType !== 'sessionRestored') continue
+    if (trigger.projectFilter && trigger.projectFilter !== session.projectName) continue
+    if ((trigger.restore ?? 'cold') === 'cold' && how.restore === 'warm') continue
+
+    const context: WorkflowExecutionContext = {
+      source: session,
+      trigger: { type: 'sessionRestored', restore: how.restore, environment: how.environment }
+    }
+    const start = (): Promise<unknown> =>
+      executeWorkflow(wf, context).catch((err) =>
+        console.error(`[triggers] executeWorkflow error:`, err)
+      )
+    if (trigger.concurrency === 'unbounded') {
+      void start()
+      continue
+    }
+    const key = session.projectName
+    const next = (restoreQueues.get(key) ?? Promise.resolve()).then(start)
+    restoreQueues.set(key, next)
+  }
+}
+
+/** Test-only. */
+export function resetRestoreQueues(): void {
+  restoreQueues.clear()
 }

--- a/src/shared/topics.ts
+++ b/src/shared/topics.ts
@@ -1,0 +1,1 @@
+export * from '@vornrun/shared/topics'

--- a/tests/api-shim-auth.test.ts
+++ b/tests/api-shim-auth.test.ts
@@ -280,3 +280,41 @@ describe('a bundle and a server that disagree', () => {
     expect(ready).not.toHaveBeenCalled()
   })
 })
+
+describe('the filter a phone asked for', () => {
+  const sentMethods = (s: FakeSocket): string[] =>
+    s.sent.map((m) => (JSON.parse(m) as { method: string }).method)
+
+  it('is sent again after a reconnect, which opens with only the base topics', async () => {
+    localStorage.setItem('vorn.deviceToken', 'ok')
+    const api = createApiShim('ws://x/ws')
+    sockets[0].open()
+    sockets[0].authOk()
+    await vi.advanceTimersByTimeAsync(0)
+
+    void api.setTopics(['session:*', 'terminal:data#abc']).catch(() => {})
+    expect(sentMethods(sockets[0])).toContain('subscribe:set')
+
+    sockets[0].closeWith(1006)
+    await vi.advanceTimersByTimeAsync(2000)
+    sockets[1].open()
+    sockets[1].authOk()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const resent = sockets[1].sent
+      .map((m) => JSON.parse(m) as { method: string; params?: { topics?: string[] } })
+      .find((m) => m.method === 'subscribe:set')
+    expect(resent?.params?.topics).toEqual(['session:*', 'terminal:data#abc'])
+  })
+
+  it('is not sent on a reconnect when nothing was ever asked for', async () => {
+    createApiShim('ws://x/ws')
+    sockets[0].open()
+    sockets[0].authOk()
+    sockets[0].closeWith(1006)
+    await vi.advanceTimersByTimeAsync(2000)
+    sockets[1].open()
+    sockets[1].authOk()
+    expect(sentMethods(sockets[1])).not.toContain('subscribe:set')
+  })
+})

--- a/tests/board-sync.test.ts
+++ b/tests/board-sync.test.ts
@@ -328,3 +328,60 @@ describe('a machine that restarted', () => {
     expect(ended('cold')?.environment).toEqual(environment)
   })
 })
+
+// ── the restore trigger hears about sessions coming back ─────────────────
+
+const triggerMocks = vi.hoisted(() => ({ fireSessionRestoredTrigger: vi.fn() }))
+vi.mock('../src/renderer/lib/workflow-triggers', () => triggerMocks)
+
+import { reportWarmAttach, resetRestoredIds } from '../src/renderer/lib/board-sync'
+import { resumeEndedSession } from '../src/renderer/lib/session-resume'
+
+describe('what the restore trigger is told', () => {
+  beforeEach(() => {
+    triggerMocks.fireSessionRestoredTrigger.mockClear()
+    resetRestoredIds()
+  })
+
+  it('hears cold, once, with the reboot check, when a resume starts the process again', async () => {
+    const environment = {
+      worktree: 'ok' as const,
+      branch: { recorded: 'main', actual: 'main' },
+      head: { recorded: 'a', actual: 'a' }
+    }
+    useAppStore.getState().addTerminal(session({ id: 'one' }), {
+      reason: 'machine-restarted',
+      at: 1,
+      replayed: true,
+      environment
+    })
+
+    await resumeEndedSession('one')
+
+    expect(triggerMocks.fireSessionRestoredTrigger).toHaveBeenCalledTimes(1)
+    const [back, how] = triggerMocks.fireSessionRestoredTrigger.mock.calls[0]
+    expect(back.id).toBe('one')
+    expect(how).toEqual({ restore: 'cold', environment })
+  })
+
+  it('hears warm, once, when a session the server had is attached live', async () => {
+    live.push(session({ id: 'from-server' }))
+    await syncBoard({ showCold: false, resume: false })
+
+    reportWarmAttach('from-server')
+    reportWarmAttach('from-server')
+
+    expect(triggerMocks.fireSessionRestoredTrigger).toHaveBeenCalledTimes(1)
+    expect(triggerMocks.fireSessionRestoredTrigger.mock.calls[0][1]).toEqual({ restore: 'warm' })
+  })
+
+  it('hears nothing about a session this client started itself', async () => {
+    useAppStore.getState().addTerminal(session({ id: 'mine' }))
+    live.push(session({ id: 'mine' }))
+    await syncBoard({ showCold: false, resume: false })
+
+    reportWarmAttach('mine')
+
+    expect(triggerMocks.fireSessionRestoredTrigger).not.toHaveBeenCalled()
+  })
+})

--- a/tests/phone-topics.test.ts
+++ b/tests/phone-topics.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { PHONE_BASE_TOPICS, topicsQuery, terminalTopic } from '../packages/shared/src/topics'
+
+/**
+ * A phone that asks for the wrong namespace goes quiet for that feature, with
+ * nothing on screen to say why. So the list is checked against the handlers
+ * the web client actually registers, read from the source.
+ */
+const shim = fs.readFileSync(path.join(__dirname, '../packages/web/src/api-shim.ts'), 'utf8')
+const registered = [...shim.matchAll(/rpc\.on\('([a-z]+:[a-zA-Z-]+)'/g)].map((m) => m[1])
+
+function covered(name: string): boolean {
+  return PHONE_BASE_TOPICS.some((t) =>
+    t.endsWith('*') ? name.startsWith(t.slice(0, -1)) : t === name
+  )
+}
+
+describe("the phone's base topics", () => {
+  it('cover every notification the web client handles, except terminal bytes', () => {
+    expect(registered.length).toBeGreaterThan(5)
+    const missing = registered.filter((name) => name !== 'terminal:data' && !covered(name))
+    expect(missing).toEqual([])
+  })
+
+  it('leave terminal bytes to be asked for one card at a time', () => {
+    expect(covered('terminal:data')).toBe(false)
+    expect(terminalTopic('abc')).toBe('terminal:data#abc')
+  })
+
+  it('travel on the socket URL in the form the server parses', () => {
+    // `parseTopics` splits on commas; the encoding must survive a round trip.
+    const query = topicsQuery(['session:*', 'terminal:data#x'])
+    expect(decodeURIComponent(query.slice('topics='.length)).split(',')).toEqual([
+      'session:*',
+      'terminal:data#x'
+    ])
+  })
+})

--- a/tests/run-presentation.test.ts
+++ b/tests/run-presentation.test.ts
@@ -518,3 +518,24 @@ describe('liveNodeStatus', () => {
     ).toBeUndefined()
   })
 })
+
+describe('a run started by a session coming back', () => {
+  it('names restore, whether it was cold or warm, and the session', () => {
+    const nodes = [node('t', 'trigger', 'Restored', { triggerType: 'sessionRestored' })]
+    const p = describeRun(
+      run({
+        triggerSession: { id: 'abc123def', label: 'attach what you can see', restore: 'cold' }
+      }),
+      { name: 'Bring the dev server back', nodes }
+    )
+    expect(p.title).toBe('Bring the dev server back')
+    expect(p.subtitle).toBe('restore · cold · attach what you can see')
+    expect(p.source).toBe('restore')
+    expect(p.sourceLabel).toBe('restore')
+  })
+
+  it('reads the source from the trigger node when the run predates the session field', () => {
+    const nodes = [node('t', 'trigger', 'Restored', { triggerType: 'sessionRestored' })]
+    expect(describeRun(run(), { name: 'x', nodes }).source).toBe('restore')
+  })
+})

--- a/tests/seed-default-workflow.test.ts
+++ b/tests/seed-default-workflow.test.ts
@@ -15,7 +15,10 @@ import {
   saveConfig,
   dbDeleteWorkflow
 } from '../packages/server/src/database'
-import { DEFAULT_TASK_WORKFLOW_ID } from '../packages/server/src/default-workflows'
+import {
+  DEFAULT_TASK_WORKFLOW_ID,
+  DEV_SERVER_WORKFLOW_ID
+} from '../packages/server/src/default-workflows'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import type { AppConfig } from '@vornrun/shared/types'
 
@@ -144,5 +147,30 @@ describe('seedSystemDefaults', () => {
     const seeded = cfg.workflows?.find((w) => w.id === DEFAULT_TASK_WORKFLOW_ID)
     expect(seeded).toBeDefined()
     expect(cfg.defaults.hasSeededDefaultTaskWorkflow).toBe(true)
+  })
+})
+
+describe('the restore example', () => {
+  it('is seeded beside the task workflow, switched off, so nothing runs until asked', () => {
+    seedSystemDefaults()
+
+    const seeded = loadConfig().workflows?.find((w) => w.id === DEV_SERVER_WORKFLOW_ID)
+    expect(seeded?.name).toBe('Bring the dev server back')
+    expect(seeded?.enabled).toBe(false)
+    const trigger = seeded?.nodes.find((n) => n.type === 'trigger')
+    expect((trigger?.config as { triggerType?: string }).triggerType).toBe('sessionRestored')
+    expect(seeded?.nodes.find((n) => n.type === 'script')).toBeDefined()
+  })
+
+  it('stays deleted once deleted, and its flag survives a config save', () => {
+    seedSystemDefaults()
+    dbDeleteWorkflow(DEV_SERVER_WORKFLOW_ID)
+    saveConfig(loadConfig())
+    seedSystemDefaults()
+
+    const cfg = loadConfig()
+    expect(cfg.workflows?.find((w) => w.id === DEV_SERVER_WORKFLOW_ID)).toBeUndefined()
+    expect(cfg.defaults.hasSeededDevServerWorkflow).toBe(true)
+    expect(cfg.workflows?.find((w) => w.id === DEFAULT_TASK_WORKFLOW_ID)).toBeDefined()
   })
 })

--- a/tests/settings-start-at-login.test.tsx
+++ b/tests/settings-start-at-login.test.tsx
@@ -81,3 +81,12 @@ describe('Start Vorn When I Sign In', () => {
     expect(screen.queryByText('Start Vorn When I Sign In')).not.toBeInTheDocument()
   })
 })
+
+describe('Floating Widget', () => {
+  it('is off until asked', () => {
+    render(<GeneralSettings />)
+    const row = screen.getByText('Floating Widget').closest('div')!
+    const toggle = row.parentElement!.parentElement!.querySelector('[role="switch"]')!
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+})

--- a/tests/step-library-triggers.test.tsx
+++ b/tests/step-library-triggers.test.tsx
@@ -81,6 +81,7 @@ describe('the step library in trigger scope', () => {
       'Schedule once',
       'Task created',
       'Task moved',
+      'Session restored',
       'Webhook'
     ]) {
       expect(screen.getByText(label)).toBeInTheDocument()

--- a/tests/trigger-config-form.test.tsx
+++ b/tests/trigger-config-form.test.tsx
@@ -246,3 +246,28 @@ describe('TriggerConfigForm - webhook fields', () => {
     expect(screen.getByText(/trigger.query/)).toBeInTheDocument()
   })
 })
+
+describe('the session-restored trigger', () => {
+  it('offers project, which restores, and how many at a time', () => {
+    const onChange = vi.fn()
+    render(
+      <TriggerConfigForm
+        config={{ triggerType: 'sessionRestored' } as TriggerConfig}
+        onChange={onChange}
+      />
+    )
+    expect(screen.getByText('Session Restored')).toBeInTheDocument()
+    expect(screen.getByText('Project Filter')).toBeInTheDocument()
+    expect(screen.getByText('Cold only')).toBeInTheDocument()
+    expect(screen.getByText('One per project')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Warm too'))
+    expect(onChange).toHaveBeenCalledWith({ triggerType: 'sessionRestored', restore: 'any' })
+
+    fireEvent.click(screen.getByText('Any number'))
+    expect(onChange).toHaveBeenCalledWith({
+      triggerType: 'sessionRestored',
+      concurrency: 'unbounded'
+    })
+  })
+})

--- a/tests/use-on-screen.test.tsx
+++ b/tests/use-on-screen.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useRef } from 'react'
+import { useOnScreen } from '../src/renderer/hooks/useOnScreen'
+
+/** Drives the observer by hand, since jsdom has none of its own. */
+let fire: ((intersecting: boolean) => void) | null = null
+let disconnects = 0
+
+function installObserver(): void {
+  disconnects = 0
+  fire = null
+  class FakeIO {
+    constructor(private cb: IntersectionObserverCallback) {
+      fire = (intersecting) => this.cb([{ isIntersecting: intersecting }] as never, this as never)
+    }
+    observe(): void {}
+    disconnect(): void {
+      disconnects++
+    }
+  }
+  ;(globalThis as { IntersectionObserver?: unknown }).IntersectionObserver = FakeIO
+}
+
+function Probe({ onValue }: { onValue: (v: boolean) => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  onValue(useOnScreen(ref))
+  return <div ref={ref} />
+}
+
+afterEach(() => {
+  delete (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver
+})
+
+describe('tracking whether a slot is on screen', () => {
+  beforeEach(installObserver)
+
+  it('starts off screen', () => {
+    const seen: boolean[] = []
+    render(<Probe onValue={(v) => seen.push(v)} />)
+    expect(seen[0]).toBe(false)
+  })
+
+  it('reports both edges, unlike the latch', () => {
+    const seen: boolean[] = []
+    render(<Probe onValue={(v) => seen.push(v)} />)
+    act(() => fire!(true))
+    expect(seen.at(-1)).toBe(true)
+    act(() => fire!(false))
+    expect(seen.at(-1)).toBe(false)
+  })
+
+  it('stops watching when the slot unmounts', () => {
+    const { unmount } = render(<Probe onValue={() => {}} />)
+    unmount()
+    expect(disconnects).toBe(1)
+  })
+})
+
+describe('where there is no observer at all', () => {
+  it('answers true, so nothing is hidden on a surface that cannot measure', () => {
+    const seen: boolean[] = []
+    render(<Probe onValue={(v) => seen.push(v)} />)
+    expect(seen.at(-1)).toBe(true)
+  })
+})

--- a/tests/visible-terminals.test.ts
+++ b/tests/visible-terminals.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const platform = { isWeb: true }
+vi.mock('../src/renderer/lib/platform', () => ({
+  get isWeb() {
+    return platform.isWeb
+  },
+  get isElectron() {
+    return !platform.isWeb
+  },
+  isMac: true,
+  MOD: 'Cmd'
+}))
+
+import { markVisible, markHidden, resetVisible } from '../src/renderer/lib/visible-terminals'
+import { PHONE_BASE_TOPICS } from '../packages/shared/src/topics'
+
+const setTopics = vi.fn(async (_topics: readonly string[]) => {})
+Object.defineProperty(window, 'api', { value: { setTopics }, writable: true })
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  resetVisible()
+  setTopics.mockClear()
+  platform.isWeb = true
+})
+afterEach(() => vi.useRealTimers())
+
+const lastTopics = (): readonly string[] => setTopics.mock.calls.at(-1)![0]
+
+describe('what the web client asks the server for', () => {
+  it('asks for the base namespaces plus each card on screen, by instance', () => {
+    markVisible('a')
+    markVisible('b')
+    vi.runAllTimers()
+    expect(lastTopics()).toEqual([...PHONE_BASE_TOPICS, 'terminal:data#a', 'terminal:data#b'])
+  })
+
+  it('folds a scroll into one message', () => {
+    markVisible('a')
+    markVisible('b')
+    markHidden('a')
+    markVisible('c')
+    vi.runAllTimers()
+    expect(setTopics).toHaveBeenCalledTimes(1)
+    expect(lastTopics()).toEqual([...PHONE_BASE_TOPICS, 'terminal:data#b', 'terminal:data#c'])
+  })
+
+  it('drops a card that left the screen', () => {
+    markVisible('a')
+    vi.runAllTimers()
+    markHidden('a')
+    vi.runAllTimers()
+    expect(lastTopics()).toEqual([...PHONE_BASE_TOPICS])
+  })
+
+  it('never asks for terminal bytes by name', () => {
+    markVisible('a')
+    vi.runAllTimers()
+    expect(lastTopics()).not.toContain('terminal:data')
+    expect(lastTopics()).not.toContain('terminal:*')
+  })
+
+  it('says nothing when nothing changed', () => {
+    markVisible('a')
+    vi.runAllTimers()
+    markVisible('a')
+    markHidden('never-shown')
+    vi.runAllTimers()
+    expect(setTopics).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends nothing from the desktop, which is sent everything', () => {
+    platform.isWeb = false
+    markVisible('a')
+    vi.runAllTimers()
+    expect(setTopics).not.toHaveBeenCalled()
+  })
+})

--- a/tests/workflow-triggers-restore.test.ts
+++ b/tests/workflow-triggers-restore.test.ts
@@ -55,6 +55,7 @@ function pendingRun(): { promise: Promise<void>; finish: () => void } {
 const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
 
 beforeEach(() => {
+  vi.restoreAllMocks()
   executeWorkflow.mockReset()
   executeWorkflow.mockResolvedValue(undefined)
   resetRestoreQueues()

--- a/tests/workflow-triggers-restore.test.ts
+++ b/tests/workflow-triggers-restore.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { TerminalSession, WorkflowDefinition } from '../packages/shared/src/types'
+
+const executeWorkflow = vi.fn()
+vi.mock('../src/renderer/lib/workflow-execution', () => ({
+  executeWorkflow: (...args: unknown[]) => executeWorkflow(...args)
+}))
+
+const state = { config: { workflows: [] as WorkflowDefinition[] } }
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: { getState: () => state }
+}))
+
+import {
+  fireSessionRestoredTrigger,
+  resetRestoreQueues
+} from '../src/renderer/lib/workflow-triggers'
+
+function workflow(
+  config: Record<string, unknown>,
+  over: Partial<WorkflowDefinition> = {}
+): WorkflowDefinition {
+  return {
+    id: 'wf',
+    name: 'Bring the dev server back',
+    enabled: true,
+    nodes: [{ id: 't', type: 'trigger', label: 'When a session is restored', config }],
+    edges: [],
+    ...over
+  } as unknown as WorkflowDefinition
+}
+
+function session(over: Partial<TerminalSession> = {}): TerminalSession {
+  return {
+    id: 'a-session',
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/dev/vorn',
+    status: 'running',
+    createdAt: 1,
+    pid: 1,
+    ...over
+  } as TerminalSession
+}
+
+/** A run that finishes when told to, so ordering can be observed. */
+function pendingRun(): { promise: Promise<void>; finish: () => void } {
+  let finish!: () => void
+  const promise = new Promise<void>((resolve) => {
+    finish = resolve
+  })
+  return { promise, finish }
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  executeWorkflow.mockReset()
+  executeWorkflow.mockResolvedValue(undefined)
+  resetRestoreQueues()
+  state.config.workflows = []
+})
+
+describe('a workflow that runs when a session comes back', () => {
+  it('fires for a cold restore, carrying the session and what the reboot check found', async () => {
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored' })]
+    const environment = {
+      worktree: 'ok' as const,
+      branch: { recorded: 'main', actual: 'main' },
+      head: { recorded: 'a', actual: 'a' }
+    }
+    fireSessionRestoredTrigger(session(), { restore: 'cold', environment })
+    await tick()
+
+    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+    const [, context] = executeWorkflow.mock.calls[0]
+    expect(context.source.id).toBe('a-session')
+    expect(context.trigger).toEqual({ type: 'sessionRestored', restore: 'cold', environment })
+  })
+
+  it('hears nothing about a warm attach unless it asked to', async () => {
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored' })]
+    fireSessionRestoredTrigger(session(), { restore: 'warm' })
+    await tick()
+    expect(executeWorkflow).not.toHaveBeenCalled()
+
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored', restore: 'any' })]
+    fireSessionRestoredTrigger(session(), { restore: 'warm' })
+    await tick()
+    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+    expect(executeWorkflow.mock.calls[0][1].trigger.restore).toBe('warm')
+  })
+
+  it('respects the project filter', async () => {
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored', projectFilter: 'other' })]
+    fireSessionRestoredTrigger(session(), { restore: 'cold' })
+    await tick()
+    expect(executeWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('ignores disabled workflows and other trigger types', async () => {
+    state.config.workflows = [
+      workflow({ triggerType: 'sessionRestored' }, { enabled: false }),
+      workflow({ triggerType: 'taskCreated' }, { id: 'other' })
+    ]
+    fireSessionRestoredTrigger(session(), { restore: 'cold' })
+    await tick()
+    expect(executeWorkflow).not.toHaveBeenCalled()
+  })
+
+  it('runs one at a time within a project, in the order the sessions came back', async () => {
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored' })]
+    const first = pendingRun()
+    const second = pendingRun()
+    executeWorkflow.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    fireSessionRestoredTrigger(session({ id: 'one' }), { restore: 'cold' })
+    fireSessionRestoredTrigger(session({ id: 'two' }), { restore: 'cold' })
+    await tick()
+    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+    expect(executeWorkflow.mock.calls[0][1].source.id).toBe('one')
+
+    first.finish()
+    await tick()
+    expect(executeWorkflow).toHaveBeenCalledTimes(2)
+    expect(executeWorkflow.mock.calls[1][1].source.id).toBe('two')
+  })
+
+  it('lets two projects run side by side', async () => {
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored' })]
+    executeWorkflow.mockReturnValue(pendingRun().promise)
+    fireSessionRestoredTrigger(session({ id: 'one', projectName: 'vorn' }), { restore: 'cold' })
+    fireSessionRestoredTrigger(session({ id: 'two', projectName: 'site' }), { restore: 'cold' })
+    await tick()
+    expect(executeWorkflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs any number at once when the author says so', async () => {
+    state.config.workflows = [
+      workflow({ triggerType: 'sessionRestored', concurrency: 'unbounded' })
+    ]
+    executeWorkflow.mockReturnValue(pendingRun().promise)
+    fireSessionRestoredTrigger(session({ id: 'one' }), { restore: 'cold' })
+    fireSessionRestoredTrigger(session({ id: 'two' }), { restore: 'cold' })
+    await tick()
+    expect(executeWorkflow).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a failed run block the next in the project', async () => {
+    state.config.workflows = [workflow({ triggerType: 'sessionRestored' })]
+    executeWorkflow.mockRejectedValueOnce(new Error('port in use')).mockResolvedValueOnce(undefined)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    fireSessionRestoredTrigger(session({ id: 'one' }), { restore: 'cold' })
+    fireSessionRestoredTrigger(session({ id: 'two' }), { restore: 'cold' })
+    await tick()
+    await tick()
+    expect(executeWorkflow).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
The last two items on the durability roadmap, plus a default the dogfooding asked for.

## The phone asks for the terminals on screen

The server has filtered per socket since `broadcast.ts` gained topics: namespaces, exact names, and one terminal's bytes by instance. No client used it. The web client opened a bare socket and received every byte of every PTY on the machine while drawing one card.

- `packages/shared/src/topics.ts`: `PHONE_BASE_TOPICS`, every namespace the web client handles except terminal bytes; `terminalTopic(id)`; `topicsQuery`.
- `packages/web/src/env.ts` declares the base set on the upgrade, so no PTY byte is sent before the filter is known.
- `useOnScreen` beside the attach latch reports both edges; `visible-terminals.ts` folds them into one `subscribe:set` per scroll. Web only: the preload's `setTopics` is a no-op and the desktop is sent everything, as before.
- The shim remembers the last filter and re-sends it after a reconnect, which opens with only the URL's base set.
- `tests/phone-topics.test.ts` reads the shim's `rpc.on` registrations from source and asserts every one is covered, so a namespace added later cannot go quiet on the phone unnoticed.

## A workflow decides what a restored session needs

A "Session Restored" trigger, in the library and the editor, with Project, Cold only / Warm too, and One per project / Any number.

- Cold fires after any resume that starts the process again (`session-resume.ts`), carrying the reboot check the record held. Warm fires once when a card the board received from the server attaches to a live process (`board-sync.ts` `reportWarmAttach`, wired through the registry's live reporter). Sessions this client started never fire; a bound resume never fires.
- Runs serialize per project by default, chained on promises in `workflow-triggers.ts`, since a dev server has one port. A failed run does not block the next.
- Each run remembers which session brought it and how; the run list reads `restore · cold · <session>`.
- "Bring the dev server back" is seeded switched off beside the default task workflow, through one `seedWorkflowOnce` for both, each with its own flag. Its flag is on `AppConfig.defaults` so a config save cannot drop it and re-seed.

Queued runs appear in the run list as they start, not before. The storyboard drew a queued row; that would need the execution store to hold runs that have not claimed yet, and was left out on purpose.

## Floating widget off until asked

Absence now means off, the way the other opt-in settings read. A person who turned it on keeps it.

## Tests

New: `use-on-screen`, `visible-terminals`, `phone-topics`, `workflow-triggers-restore`. Extended: `api-shim-auth` (re-send on reconnect), `board-sync` (cold, warm, never for own sessions), `run-presentation`, `trigger-config-form`, `step-library-triggers`, `seed-default-workflow`, `settings-start-at-login`. Full suite green with `VORN_SESSION_ID` and `VORN_DATA_DIR` unset.

Tested by hand in dev from this worktree: the phone receives one card's bytes and follows the scroll; three cold restores in one project ran one after another; a warm attach fired once with Warm too; the example workflow appears disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZeWAnPFLt2x7TX2bWcdyT
