### PR TITLE
Give a script step its own file, so a step that reads input keeps its script

### DIFF
--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -277,6 +277,11 @@ export function setLaunchDataDir(dir: string): void {
   launchDataDir = dir
 }
 
+/** Null until the server says where its files live, which only a process that never started one can be. */
+export function getLaunchDataDir(): string | null {
+  return launchDataDir
+}
+
 function isWindowsStylePath(p: string): boolean {
   return /^[a-zA-Z]:[\\/]/.test(p) || p.startsWith('\\\\')
 }

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -1,10 +1,10 @@
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { ScriptConfig, IPC } from '@vornrun/shared/types'
-import { getLaunchEnv } from './process-utils'
+import { getLaunchDataDir, getLaunchEnv } from './process-utils'
 import { getDecryptedCreds } from './connectors/decrypted-creds'
 import { SECRET_ENV_FIELD, isEnvName } from './connectors/keys'
 import log from './logger'
@@ -57,35 +57,45 @@ export interface ScriptExecutionResult {
 
 export const scriptRunnerEvents = new EventEmitter()
 
-/** The name a script of each type is written under, so its interpreter reads a file it recognises. */
-const SCRIPT_FILE: Record<ScriptConfig['scriptType'], string> = {
-  bash: 'script.sh',
-  powershell: 'script.ps1',
-  python: 'script.py',
-  node: 'script.js'
+interface Interpreter {
+  /** Set only where the program must be a file; the rest read it whole from stdin. */
+  file?: string
+  command: (isWin: boolean) => string
+  args: (file: string) => string[]
 }
 
-/** How each interpreter is asked to run that file; user args follow it as `$1`, `argv` and the like. */
-function invocationFor(
-  scriptType: ScriptConfig['scriptType'],
-  file: string
-): { command: string; args: string[] } {
-  const isWin = process.platform === 'win32'
-  switch (scriptType) {
-    case 'bash':
-      return { command: isWin ? 'bash.exe' : 'bash', args: [file] }
-    case 'powershell':
-      return { command: 'pwsh', args: ['-File', file] }
-    case 'python':
-      return { command: isWin ? 'python' : 'python3', args: [file] }
-    case 'node':
-      return { command: 'node', args: [file] }
-  }
+/**
+ * How each script type is run.
+ *
+ * bash and pwsh read their program as they go, so a script arriving on stdin
+ * loses every line below the first that reads input. node and python read the
+ * whole program before running it, and keep resolving imports against the
+ * working directory only while they are given it on stdin.
+ */
+const INTERPRETERS: Record<string, Interpreter | undefined> = Object.assign(Object.create(null), {
+  bash: {
+    file: 'script.sh',
+    command: (w: boolean) => (w ? 'bash.exe' : 'bash'),
+    args: (f: string) => [f]
+  },
+  powershell: { file: 'script.ps1', command: () => 'pwsh', args: (f: string) => ['-File', f] },
+  python: { command: (w: boolean) => (w ? 'python' : 'python3'), args: () => ['-'] },
+  node: { command: () => 'node', args: () => ['-'] }
+} satisfies Record<ScriptConfig['scriptType'], Interpreter>)
+
+/** Under the data directory rather than a shared one, so nothing another account writes is in reach. */
+async function scriptFileFor(name: string, contents: string): Promise<string> {
+  const root = path.join(getLaunchDataDir() ?? os.tmpdir(), 'scripts')
+  await mkdir(root, { recursive: true, mode: 0o700 })
+  const dir = await mkdtemp(path.join(root, 'run-'))
+  const file = path.join(dir, name)
+  await writeFile(file, contents, { mode: 0o600 })
+  return file
 }
 
 export async function executeScript(config: ScriptConfig): Promise<ScriptExecutionResult> {
-  const fileName = SCRIPT_FILE[config.scriptType]
-  if (!fileName) {
+  const interpreter = INTERPRETERS[config.scriptType]
+  if (!interpreter) {
     return {
       success: false,
       output: '',
@@ -94,38 +104,42 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
   }
 
   const runId = config.runId
-  let dir: string
-  try {
-    // A file rather than stdin, so a step that reads input does not swallow the rest of its own script.
-    dir = await mkdtemp(path.join(os.tmpdir(), 'vorn-script-'))
-    await writeFile(path.join(dir, fileName), config.scriptContent, { mode: 0o600 })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    log.error(`[script-runner] could not write the script: ${message}`)
+  const fail = (message: string, output = ''): ScriptExecutionResult => {
+    log.error(`[script-runner] ${message}`)
     if (runId) {
       scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: `Error: ${message}\n` })
       scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: 1 })
     }
-    return { success: false, output: '', error: message }
+    return { success: false, output, error: message }
+  }
+
+  let file = ''
+  if (interpreter.file) {
+    try {
+      file = await scriptFileFor(interpreter.file, config.scriptContent)
+    } catch (err) {
+      return fail(`could not write the script: ${err instanceof Error ? err.message : String(err)}`)
+    }
   }
 
   return new Promise((resolve) => {
-    const { command, args } = invocationFor(config.scriptType, path.join(dir, fileName))
-    if (config.args && config.args.length > 0) args.push(...config.args)
+    const command = interpreter.command(process.platform === 'win32')
+    const args = [...interpreter.args(file), ...(config.args ?? [])]
 
     const cwd = config.cwd || config.projectPath || process.cwd()
 
     log.info(`[script-runner] executing ${config.scriptType} script in ${cwd}`)
 
-    /** The script's own copy goes with it, so nothing is left in the temp directory after the answer. */
+    /** The script's own copy goes with it, so nothing is left behind after the answer. */
     const finish = async (result: ScriptExecutionResult): Promise<void> => {
-      await rm(dir, { recursive: true, force: true }).catch(() => {})
+      if (file) await rm(path.dirname(file), { recursive: true, force: true }).catch(() => {})
       resolve(result)
     }
 
     const child = spawn(command, args, {
       cwd,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      // A script that came as a file has no use for stdin, and cannot block waiting on it.
+      stdio: [file ? 'ignore' : 'pipe', 'pipe', 'pipe'],
       // Only this child sees them: the secrets are read here rather than held
       // anywhere the definition, a run record or an export could reach.
       env: { ...getLaunchEnv(), ...secretEnvFor(config.secretsFrom) },
@@ -135,29 +149,20 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
     let stdout = ''
     let stderr = ''
 
-    child.stdout.on('data', (data) => {
-      const chunk = data.toString()
+    child.stdout?.on('data', (data) => {
+      const chunk = String(data)
       stdout += chunk
       if (runId) scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: chunk })
     })
 
-    child.stderr.on('data', (data) => {
-      const chunk = data.toString()
+    child.stderr?.on('data', (data) => {
+      const chunk = String(data)
       stderr += chunk
       if (runId) scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: chunk })
     })
 
     child.on('error', (err) => {
-      log.error(`[script-runner] spawn error: ${err.message}`)
-      if (runId) {
-        scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: `Error: ${err.message}\n` })
-        scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: 1 })
-      }
-      void finish({
-        success: false,
-        output: stdout,
-        error: err.message
-      })
+      void finish(fail(err.message, stdout))
     })
 
     child.on('close', (code) => {
@@ -170,5 +175,11 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
         exitCode: code ?? undefined
       })
     })
+
+    if (!file) {
+      child.stdin?.on('error', () => {}) // prevent EPIPE if process exits early
+      child.stdin?.write(config.scriptContent)
+      child.stdin?.end()
+    }
   })
 }

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -82,9 +82,13 @@ const INTERPRETERS: Record<string, Interpreter | undefined> = Object.assign(Obje
 
 /** Under the data directory rather than a shared one, so nothing another account writes is in reach. */
 async function scriptFileFor(name: string, contents: string): Promise<string> {
-  const root = path.join(getLaunchDataDir() ?? os.tmpdir(), 'scripts')
-  await mkdir(root, { recursive: true, mode: 0o700 })
-  const dir = await mkdtemp(path.join(root, 'run-'))
+  const dataDir = getLaunchDataDir()
+  let root = os.tmpdir()
+  if (dataDir) {
+    root = path.join(dataDir, 'scripts')
+    await mkdir(root, { recursive: true, mode: 0o700 })
+  }
+  const dir = await mkdtemp(path.join(root, 'vorn-script-'))
   const file = path.join(dir, name)
   try {
     await writeFile(file, contents, { mode: 0o600 })
@@ -95,13 +99,20 @@ async function scriptFileFor(name: string, contents: string): Promise<string> {
   return file
 }
 
-export async function executeScript(config: ScriptConfig): Promise<ScriptExecutionResult> {
-  const known = INTERPRETERS[config.scriptType]
+/** How a script type is run here, or nothing when it is not one this host knows. */
+export function interpreterFor(
+  scriptType: string,
+  isWin: boolean = process.platform === 'win32'
+): Interpreter | undefined {
+  const known = INTERPRETERS[scriptType]
   // On Windows bash.exe is usually the WSL launcher, which cannot open a Windows path, so bash keeps stdin there.
-  const interpreter =
-    known && config.scriptType === 'bash' && process.platform === 'win32'
-      ? { ...known, file: undefined, args: () => ['-s'] }
-      : known
+  if (known && scriptType === 'bash' && isWin)
+    return { ...known, file: undefined, args: () => ['-s'] }
+  return known
+}
+
+export async function executeScript(config: ScriptConfig): Promise<ScriptExecutionResult> {
+  const interpreter = interpreterFor(config.scriptType)
   if (!interpreter) {
     return {
       success: false,
@@ -143,15 +154,22 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
       resolve(result)
     }
 
-    const child = spawn(command, args, {
-      cwd,
-      // A script that came as a file has no use for stdin, and cannot block waiting on it.
-      stdio: [file ? 'ignore' : 'pipe', 'pipe', 'pipe'],
-      // Only this child sees them: the secrets are read here rather than held
-      // anywhere the definition, a run record or an export could reach.
-      env: { ...getLaunchEnv(), ...secretEnvFor(config.secretsFrom) },
-      windowsHide: true
-    })
+    let child: ReturnType<typeof spawn>
+    try {
+      child = spawn(command, args, {
+        cwd,
+        // A script that came as a file has no use for stdin, and cannot block waiting on it.
+        stdio: [file ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+        // Only this child sees them: the secrets are read here rather than held
+        // anywhere the definition, a run record or an export could reach.
+        env: { ...getLaunchEnv(), ...secretEnvFor(config.secretsFrom) },
+        windowsHide: true
+      })
+    } catch (err) {
+      // A bad cwd throws here rather than answering on 'error', and the copy still has to go.
+      void finish(fail(err instanceof Error ? err.message : String(err)))
+      return
+    }
 
     let stdout = ''
     let stderr = ''

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -1,5 +1,8 @@
 import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 import { ScriptConfig, IPC } from '@vornrun/shared/types'
 import { getLaunchEnv } from './process-utils'
 import { getDecryptedCreds } from './connectors/decrypted-creds'
@@ -54,53 +57,75 @@ export interface ScriptExecutionResult {
 
 export const scriptRunnerEvents = new EventEmitter()
 
+/** The name a script of each type is written under, so its interpreter reads a file it recognises. */
+const SCRIPT_FILE: Record<ScriptConfig['scriptType'], string> = {
+  bash: 'script.sh',
+  powershell: 'script.ps1',
+  python: 'script.py',
+  node: 'script.js'
+}
+
+/** How each interpreter is asked to run that file; user args follow it as `$1`, `argv` and the like. */
+function invocationFor(
+  scriptType: ScriptConfig['scriptType'],
+  file: string
+): { command: string; args: string[] } {
+  const isWin = process.platform === 'win32'
+  switch (scriptType) {
+    case 'bash':
+      return { command: isWin ? 'bash.exe' : 'bash', args: [file] }
+    case 'powershell':
+      return { command: 'pwsh', args: ['-File', file] }
+    case 'python':
+      return { command: isWin ? 'python' : 'python3', args: [file] }
+    case 'node':
+      return { command: 'node', args: [file] }
+  }
+}
+
 export async function executeScript(config: ScriptConfig): Promise<ScriptExecutionResult> {
+  const fileName = SCRIPT_FILE[config.scriptType]
+  if (!fileName) {
+    return {
+      success: false,
+      output: '',
+      error: `Unsupported script type: ${config.scriptType}`
+    }
+  }
+
+  const runId = config.runId
+  let dir: string
+  try {
+    // A file rather than stdin, so a step that reads input does not swallow the rest of its own script.
+    dir = await mkdtemp(path.join(os.tmpdir(), 'vorn-script-'))
+    await writeFile(path.join(dir, fileName), config.scriptContent, { mode: 0o600 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    log.error(`[script-runner] could not write the script: ${message}`)
+    if (runId) {
+      scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: `Error: ${message}\n` })
+      scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: 1 })
+    }
+    return { success: false, output: '', error: message }
+  }
+
   return new Promise((resolve) => {
-    let command: string
-    let args: string[]
-
-    const isWin = process.platform === 'win32'
-
-    switch (config.scriptType) {
-      case 'bash':
-        command = isWin ? 'bash.exe' : 'bash'
-        // Run from stdin
-        args = ['-s']
-        break
-      case 'powershell':
-        command = 'pwsh'
-        args = ['-Command', '-']
-        break
-      case 'python':
-        command = isWin ? 'python' : 'python3'
-        args = ['-']
-        break
-      case 'node':
-        command = 'node'
-        args = ['-']
-        break
-      default:
-        resolve({
-          success: false,
-          output: '',
-          error: `Unsupported script type: ${config.scriptType}`
-        })
-        return
-    }
-
-    if (config.args && config.args.length > 0) {
-      // Append user args if the interpreter supports it (bash -s arg1 arg2)
-      args.push(...config.args)
-    }
+    const { command, args } = invocationFor(config.scriptType, path.join(dir, fileName))
+    if (config.args && config.args.length > 0) args.push(...config.args)
 
     const cwd = config.cwd || config.projectPath || process.cwd()
-    const runId = config.runId
 
     log.info(`[script-runner] executing ${config.scriptType} script in ${cwd}`)
 
+    /** The script's own copy goes with it, so nothing is left in the temp directory after the answer. */
+    const finish = async (result: ScriptExecutionResult): Promise<void> => {
+      await rm(dir, { recursive: true, force: true }).catch(() => {})
+      resolve(result)
+    }
+
     const child = spawn(command, args, {
       cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe'],
       // Only this child sees them: the secrets are read here rather than held
       // anywhere the definition, a run record or an export could reach.
       env: { ...getLaunchEnv(), ...secretEnvFor(config.secretsFrom) },
@@ -128,7 +153,7 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
         scriptRunnerEvents.emit(IPC.SCRIPT_DATA, { runId, data: `Error: ${err.message}\n` })
         scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: 1 })
       }
-      resolve({
+      void finish({
         success: false,
         output: stdout,
         error: err.message
@@ -138,17 +163,12 @@ export async function executeScript(config: ScriptConfig): Promise<ScriptExecuti
     child.on('close', (code) => {
       log.info(`[script-runner] exited with code ${code}`)
       if (runId) scriptRunnerEvents.emit(IPC.SCRIPT_EXIT, { runId, exitCode: code ?? 1 })
-      resolve({
+      void finish({
         success: code === 0,
         output: stdout,
         error: code !== 0 ? stderr || `Exited with code ${code}` : undefined,
         exitCode: code ?? undefined
       })
     })
-
-    // Write script content to stdin
-    child.stdin?.on('error', () => {}) // prevent EPIPE if process exits early
-    child.stdin?.write(config.scriptContent)
-    child.stdin?.end()
   })
 }

--- a/packages/server/src/script-runner.ts
+++ b/packages/server/src/script-runner.ts
@@ -64,21 +64,18 @@ interface Interpreter {
   args: (file: string) => string[]
 }
 
-/**
- * How each script type is run.
- *
- * bash and pwsh read their program as they go, so a script arriving on stdin
- * loses every line below the first that reads input. node and python read the
- * whole program before running it, and keep resolving imports against the
- * working directory only while they are given it on stdin.
- */
+// bash and pwsh read their program as they go, so they get a file; node and python read it whole from stdin and keep cwd resolution.
 const INTERPRETERS: Record<string, Interpreter | undefined> = Object.assign(Object.create(null), {
   bash: {
     file: 'script.sh',
     command: (w: boolean) => (w ? 'bash.exe' : 'bash'),
     args: (f: string) => [f]
   },
-  powershell: { file: 'script.ps1', command: () => 'pwsh', args: (f: string) => ['-File', f] },
+  powershell: {
+    file: 'script.ps1',
+    command: () => 'pwsh',
+    args: (f: string) => ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', f]
+  },
   python: { command: (w: boolean) => (w ? 'python' : 'python3'), args: () => ['-'] },
   node: { command: () => 'node', args: () => ['-'] }
 } satisfies Record<ScriptConfig['scriptType'], Interpreter>)
@@ -89,12 +86,22 @@ async function scriptFileFor(name: string, contents: string): Promise<string> {
   await mkdir(root, { recursive: true, mode: 0o700 })
   const dir = await mkdtemp(path.join(root, 'run-'))
   const file = path.join(dir, name)
-  await writeFile(file, contents, { mode: 0o600 })
+  try {
+    await writeFile(file, contents, { mode: 0o600 })
+  } catch (err) {
+    await rm(dir, { recursive: true, force: true }).catch(() => {})
+    throw err
+  }
   return file
 }
 
 export async function executeScript(config: ScriptConfig): Promise<ScriptExecutionResult> {
-  const interpreter = INTERPRETERS[config.scriptType]
+  const known = INTERPRETERS[config.scriptType]
+  // On Windows bash.exe is usually the WSL launcher, which cannot open a Windows path, so bash keeps stdin there.
+  const interpreter =
+    known && config.scriptType === 'bash' && process.platform === 'win32'
+      ? { ...known, file: undefined, args: () => ['-s'] }
+      : known
   if (!interpreter) {
     return {
       success: false,

--- a/tests/script-runner.test.ts
+++ b/tests/script-runner.test.ts
@@ -1,8 +1,28 @@
-import { describe, it, expect } from 'vitest'
-import { existsSync } from 'node:fs'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { executeScript, scriptRunnerEvents } from '../packages/server/src/script-runner'
+import { setLaunchDataDir } from '../packages/server/src/process-utils'
 import { IPC } from '@vornrun/shared/types'
+
+/** Where the server would keep its files, so a script's own copy lands where the real one does. */
+const dataDir = mkdtempSync(path.join(os.tmpdir(), 'vorn-script-test-'))
+
+/** A project with a dependency, to prove a node script still resolves against the directory it runs in. */
+const project = path.join(dataDir, 'project')
+
+beforeAll(() => {
+  setLaunchDataDir(dataDir)
+  const module = path.join(project, 'node_modules', 'vorn-fixture')
+  mkdirSync(module, { recursive: true })
+  writeFileSync(path.join(module, 'package.json'), '{"name":"vorn-fixture","main":"index.js"}')
+  writeFileSync(path.join(module, 'index.js'), 'module.exports = "from the project"')
+})
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true })
+})
 
 describe('script-runner streaming', () => {
   it('does not emit when runId is absent', async () => {
@@ -77,8 +97,33 @@ describe('script-runner streaming', () => {
 
     const script = result.output.trim()
     expect(path.basename(script)).toBe('script.sh')
+    // Under this machine's own data directory, not a directory every account can write.
+    expect(script.startsWith(path.join(dataDir, 'scripts'))).toBe(true)
     expect(existsSync(script)).toBe(false)
     expect(existsSync(path.dirname(script))).toBe(false)
+  })
+
+  it('lets a node script require what the directory it runs in provides', async () => {
+    // A file would resolve against wherever it was written, so node keeps reading its program from stdin.
+    const result = await executeScript({
+      scriptType: 'node',
+      scriptContent: 'console.log(require("vorn-fixture"))',
+      cwd: project
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toContain('from the project')
+  })
+
+  it('runs a node script that never reads the input it was handed', async () => {
+    const result = await executeScript({
+      scriptType: 'node',
+      scriptContent: 'console.log(JSON.stringify(process.argv.slice(2)))',
+      args: ['alpha', 'beta']
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toContain('["alpha","beta"]')
   })
 
   it('emits SCRIPT_EXIT with non-zero code on script failure', async () => {

--- a/tests/script-runner.test.ts
+++ b/tests/script-runner.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { executeScript, scriptRunnerEvents } from '../packages/server/src/script-runner'
+import {
+  executeScript,
+  interpreterFor,
+  scriptRunnerEvents
+} from '../packages/server/src/script-runner'
 import { setLaunchDataDir } from '../packages/server/src/process-utils'
 import { IPC } from '@vornrun/shared/types'
 
@@ -22,6 +26,104 @@ beforeAll(() => {
 
 afterAll(() => {
   rmSync(dataDir, { recursive: true, force: true })
+})
+
+// bash on Windows is usually the WSL launcher, which is handed its script on stdin instead of as a file.
+const onWindows = process.platform === 'win32'
+
+describe('how each script type is run', () => {
+  it('gives a file to the interpreters that read their program as they go', () => {
+    expect(interpreterFor('bash', false)).toMatchObject({ file: 'script.sh' })
+    expect(interpreterFor('bash', false)?.command(false)).toBe('bash')
+    expect(interpreterFor('bash', false)?.args('/tmp/s/script.sh')).toEqual(['/tmp/s/script.sh'])
+
+    const pwsh = interpreterFor('powershell', false)
+    expect(pwsh?.file).toBe('script.ps1')
+    expect(pwsh?.command(false)).toBe('pwsh')
+    // No profile and no policy to refuse it: the script is one this machine just wrote.
+    expect(pwsh?.args('/tmp/s/script.ps1')).toEqual([
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      '/tmp/s/script.ps1'
+    ])
+  })
+
+  it('keeps the interpreters that read their program whole on stdin', () => {
+    for (const type of ['python', 'node']) {
+      const interpreter = interpreterFor(type, false)
+      expect(interpreter?.file).toBeUndefined()
+      expect(interpreter?.args('')).toEqual(['-'])
+    }
+    expect(interpreterFor('python', false)?.command(false)).toBe('python3')
+    expect(interpreterFor('python', true)?.command(true)).toBe('python')
+    expect(interpreterFor('node', false)?.command(false)).toBe('node')
+  })
+
+  it('keeps bash on stdin where bash.exe is the launcher for another filesystem', () => {
+    const onWindows = interpreterFor('bash', true)
+    expect(onWindows?.file).toBeUndefined()
+    expect(onWindows?.args('')).toEqual(['-s'])
+    expect(onWindows?.command(true)).toBe('bash.exe')
+  })
+
+  it('knows nothing of a type it does not run', () => {
+    expect(interpreterFor('ruby', false)).toBeUndefined()
+    // An inherited name is not a script type either.
+    expect(interpreterFor('toString', false)).toBeUndefined()
+  })
+})
+
+describe('when a script cannot be run at all', () => {
+  it('refuses a type it does not know, and says which', async () => {
+    const result = await executeScript({
+      scriptType: 'ruby' as never,
+      scriptContent: 'puts 1'
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Unsupported script type: ruby')
+  })
+
+  it('answers, and takes the copy away, when the interpreter cannot even be started', async () => {
+    const result = await executeScript({
+      scriptType: 'bash',
+      scriptContent: 'echo hi',
+      // A directory no filesystem can name: spawn refuses it before there is a child to hear from.
+      cwd: `${dataDir}/\0`
+    })
+
+    expect(result.success).toBe(false)
+    expect(existsSync(path.join(dataDir, 'scripts'))).toBe(true)
+    expect(readdirSync(path.join(dataDir, 'scripts'))).toEqual([])
+  })
+
+  it('says so on the row when the copy cannot be written', async () => {
+    const blocked = path.join(dataDir, 'blocked')
+    writeFileSync(blocked, 'not a directory')
+    setLaunchDataDir(blocked)
+    const seen: { data: string }[] = []
+    const onData = (payload: { data: string }): void => {
+      seen.push(payload)
+    }
+    scriptRunnerEvents.on(IPC.SCRIPT_DATA, onData)
+
+    try {
+      const result = await executeScript({
+        scriptType: 'bash',
+        scriptContent: 'echo hi',
+        runId: 'run-write-fail'
+      })
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('could not write the script')
+      expect(seen.map((s) => s.data).join('')).toContain('could not write the script')
+    } finally {
+      scriptRunnerEvents.off(IPC.SCRIPT_DATA, onData)
+      setLaunchDataDir(dataDir)
+    }
+  })
 })
 
 describe('script-runner streaming', () => {
@@ -67,7 +169,7 @@ describe('script-runner streaming', () => {
     }
   })
 
-  it('runs the rest of a script whose first line reads input', async () => {
+  it.skipIf(onWindows)('runs the rest of a script whose first line reads input', async () => {
     // The script used to arrive on stdin, so `cat` swallowed everything below it.
     const result = await executeScript({
       scriptType: 'bash',
@@ -79,7 +181,7 @@ describe('script-runner streaming', () => {
     expect(result.output).not.toContain('echo')
   })
 
-  it('hands arguments to the script as its own', async () => {
+  it.skipIf(onWindows)('hands arguments to the script as its own', async () => {
     const result = await executeScript({
       scriptType: 'bash',
       scriptContent: 'echo "first=$1 second=$2"',
@@ -89,7 +191,7 @@ describe('script-runner streaming', () => {
     expect(result.output).toContain('first=alpha second=beta')
   })
 
-  it('takes the copy it wrote away with it', async () => {
+  it.skipIf(onWindows)('takes the copy it wrote away with it', async () => {
     const result = await executeScript({
       scriptType: 'bash',
       scriptContent: 'echo "$0"'

--- a/tests/script-runner.test.ts
+++ b/tests/script-runner.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 import { executeScript, scriptRunnerEvents } from '../packages/server/src/script-runner'
 import { IPC } from '@vornrun/shared/types'
 
@@ -43,6 +45,40 @@ describe('script-runner streaming', () => {
       scriptRunnerEvents.off(IPC.SCRIPT_DATA, onData)
       scriptRunnerEvents.off(IPC.SCRIPT_EXIT, onExit)
     }
+  })
+
+  it('runs the rest of a script whose first line reads input', async () => {
+    // The script used to arrive on stdin, so `cat` swallowed everything below it.
+    const result = await executeScript({
+      scriptType: 'bash',
+      scriptContent: 'cat\necho "the second line ran"'
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.output).toContain('the second line ran')
+    expect(result.output).not.toContain('echo')
+  })
+
+  it('hands arguments to the script as its own', async () => {
+    const result = await executeScript({
+      scriptType: 'bash',
+      scriptContent: 'echo "first=$1 second=$2"',
+      args: ['alpha', 'beta']
+    })
+
+    expect(result.output).toContain('first=alpha second=beta')
+  })
+
+  it('takes the copy it wrote away with it', async () => {
+    const result = await executeScript({
+      scriptType: 'bash',
+      scriptContent: 'echo "$0"'
+    })
+
+    const script = result.output.trim()
+    expect(path.basename(script)).toBe('script.sh')
+    expect(existsSync(script)).toBe(false)
+    expect(existsSync(path.dirname(script))).toBe(false)
   })
 
   it('emits SCRIPT_EXIT with non-zero code on script failure', async () => {


### PR DESCRIPTION
Every script step was fed to its interpreter through stdin, so a bash step whose first line read input swallowed the rest of its own script. The factory workflows carried a `</dev/null` wrapper nobody else would know to add.

## What changed

- bash and pwsh, which read their program as they go, get the script as a file under the data directory (a fresh directory per run, mode 0600, removed on exit or failure) and stdin closed. pwsh runs with the execution policy bypassed and no profile.
- node and python read their whole program before running it, so they stay on stdin and keep resolving imports against the working directory; a file would have moved their module root to the temp directory.
- On Windows, where `bash.exe` is usually the WSL launcher and cannot open a Windows path, bash keeps stdin.
- User arguments still arrive as `$1`, `sys.argv[1]` and `process.argv[2]`.

## How to verify

A bash step with `cat` on its first line runs its second line; a node step requires a module from the project; the run directory is gone once the step answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
