### PR TITLE
Let a step that says its failure is survivable leave the run successful

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -171,10 +171,17 @@ export function App() {
       if (!isAtPrompt(getShellInputState(terminalId))) return false
       return focusIntentBar(terminalId)
     })
-    const configLoaded = (async () => {
+    // Held open only until the config is in the store: what waits on it wants the
+    // workflows, not the sessions and panes the rest of this restores.
+    let configIsSet: () => void = () => {}
+    const configReady = new Promise<void>((resolve) => {
+      configIsSet = resolve
+    })
+    void (async () => {
       try {
         const config = await window.api.loadConfig()
         useAppStore.getState().setConfig(config)
+        configIsSet()
         if (config.defaults.fontSize) {
           setDefaultFontSize(config.defaults.fontSize)
         }
@@ -223,6 +230,9 @@ export function App() {
         }
       } catch (err) {
         console.error('[App] startup initialization failed:', err)
+      } finally {
+        // A config that never arrived still lets the rest go; it reads an empty list.
+        configIsSet()
       }
     })()
 
@@ -541,7 +551,7 @@ export function App() {
     // keeps headless agents alive past a renderer reload, but the in-memory
     // exit-promise dies — the run wedges. Reconcile against session_events
     // and close out anything that already exited.
-    configLoaded
+    configReady
       .then(() => window.api.listRunningWorkflowRuns())
       .then((runs) => {
         const store = useAppStore.getState()

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -171,7 +171,7 @@ export function App() {
       if (!isAtPrompt(getShellInputState(terminalId))) return false
       return focusIntentBar(terminalId)
     })
-    ;(async () => {
+    const configLoaded = (async () => {
       try {
         const config = await window.api.loadConfig()
         useAppStore.getState().setConfig(config)
@@ -377,7 +377,7 @@ export function App() {
         if (existingExecution && connectorItem) {
           await adoptConnectorInboxLease(existingExecution, connectorItem)
           rescheduleWaitingGateTimers([existingExecution], [workflow])
-          await reconcileRunningExecutions([existingExecution])
+          await reconcileRunningExecutions([existingExecution], [workflow])
           return
         }
 
@@ -541,8 +541,8 @@ export function App() {
     // keeps headless agents alive past a renderer reload, but the in-memory
     // exit-promise dies — the run wedges. Reconcile against session_events
     // and close out anything that already exited.
-    window.api
-      .listRunningWorkflowRuns()
+    configLoaded
+      .then(() => window.api.listRunningWorkflowRuns())
       .then((runs) => {
         const store = useAppStore.getState()
         for (const run of runs) {
@@ -550,7 +550,8 @@ export function App() {
             store.setWorkflowExecution(run.runId, run)
           }
         }
-        return reconcileRunningExecutions(runs)
+        // After the config, so a step that said its failure was survivable is read that way.
+        return reconcileRunningExecutions(runs, store.config?.workflows ?? [])
       })
       .catch((err) => console.error('[App] failed to reconcile running runs:', err))
 

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -14,7 +14,11 @@ import {
 import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import { WORKFLOW_STATUS_DOT_PULSE, WORKFLOW_STATUS_DOT } from '../../lib/workflow-status'
 import { Tooltip } from '../Tooltip'
-import { approveWorkflowGate, rejectWorkflowGate } from '../../lib/workflow-execution'
+import {
+  approveWorkflowGate,
+  hasFailedStep,
+  rejectWorkflowGate
+} from '../../lib/workflow-execution'
 import { StopRunButton } from '../workflow-runs/StopRunButton'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { connectorLookFor, useConnections, type ConnectorLook } from '../../lib/use-connections'
@@ -532,7 +536,7 @@ export function RunEntry({
             {formatRunDuration(execution.startedAt, execution.completedAt)}
           </span>
         </button>
-        {execution.status === 'error' && onRetryRun && (
+        {hasFailedStep(execution) && onRetryRun && (
           <span className="shrink-0">
             <Tooltip label="Retry from failed step" position="top">
               <button

--- a/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
+++ b/src/renderer/components/workflow-editor/panels/NodeConfigPanel.tsx
@@ -275,7 +275,7 @@ export function NodeConfigPanel({
             <p className="text-[10px] text-gray-600 mt-1.5">
               {(node.onError ?? 'stop') === 'stop'
                 ? 'Everything downstream is skipped and the run ends as failed.'
-                : 'Later steps run as if this one had succeeded — for a step whose failure does not invalidate the rest.'}
+                : 'Later steps run as if this one had succeeded, and the run still counts as successful — for a step whose failure does not invalidate the rest.'}
             </p>
           </div>
         )}

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -16,7 +16,8 @@ import {
   approveWorkflowGate,
   rejectWorkflowGate,
   retryRunFromFailure,
-  rerunWorkflowRun
+  rerunWorkflowRun,
+  hasFailedStep
 } from '../../lib/workflow-execution'
 import { RunStepsList, StatusDot } from '../workflow-editor/RunEntry'
 import { RunIcon } from './RunIcon'
@@ -113,7 +114,7 @@ export function RunDetailPane({
             </span>
           )}
           <span className="flex-1" />
-          {run.status === 'error' && fullWorkflow && (
+          {hasFailedStep(run) && fullWorkflow && (
             <button
               aria-label="Retry from failed step"
               title="Retry from failed step"

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -243,7 +243,7 @@ export async function reconcileRunningExecutions(
       const { ns } = probe
       if (probe.kind === 'no-session') {
         ns.status = 'error'
-        ns.error = 'Run abandoned (no session id recorded)'
+        ns.error = ABANDONED
         ns.completedAt = new Date().toISOString()
         dirty = true
         anyResolvedHere = true
@@ -1417,9 +1417,12 @@ export function stopsRunOnError(node: Partial<Pick<WorkflowNode, 'onError'>>): b
   return (node.onError ?? 'stop') === 'stop'
 }
 
+/** A step the engine wrote off rather than ran: the reconciler never saw it start. */
+const ABANDONED = 'Run abandoned (no session id recorded)'
+
 /** A step that never ran, so no policy of its own has anything to say about it. */
 function neverRan(state: NodeExecutionState): boolean {
-  return state.error?.startsWith('Skipped:') === true
+  return state.error?.startsWith('Skipped:') === true || state.error === ABANDONED
 }
 
 /** A step that failed on its own terms, which is what a retry has somewhere to start from. */

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -267,9 +267,7 @@ export async function reconcileRunningExecutions(
         }
         execution.status = 'error'
       } else {
-        execution.status = execution.nodeStates.some((ns) => ns.status === 'error')
-          ? 'error'
-          : 'success'
+        execution.status = runEndedInError(execution, nodesOfRun(execution)) ? 'error' : 'success'
       }
       execution.completedAt = new Date().toISOString()
       dirty = true
@@ -1411,6 +1409,28 @@ export function stopsRunOnError(node: Partial<Pick<WorkflowNode, 'onError'>>): b
   return (node.onError ?? 'stop') === 'stop'
 }
 
+// Whether the run failed, rather than merely holding a step that failed and said so survivably.
+export function runEndedInError(
+  execution: WorkflowExecution,
+  nodes: Map<string, WorkflowNode>,
+  skipped?: ReadonlySet<string>
+): boolean {
+  return execution.nodeStates.some(
+    (ns) =>
+      ns.status === 'error' &&
+      !skipped?.has(ns.nodeId) &&
+      stopsRunOnError(nodes.get(ns.nodeId) ?? {})
+  )
+}
+
+/** The nodes of a run's workflow, so a failure can be read against its own policy. */
+function nodesOfRun(execution: WorkflowExecution): Map<string, WorkflowNode> {
+  const workflow = (useAppStore.getState().config?.workflows || []).find(
+    (w) => w.id === execution.workflowId
+  )
+  return new Map((workflow?.nodes ?? []).map((n) => [n.id, n]))
+}
+
 export function buildGraph(edges: readonly { source: string; target: string }[]): {
   successors: Map<string, string[]>
   predecessors: Map<string, string[]>
@@ -1985,10 +2005,7 @@ async function runExecution(
       persistExecution(execution)
     }
 
-    const hasErrors = execution.nodeStates.some(
-      (ns) => ns.status === 'error' && !skippedByCondition.has(ns.nodeId)
-    )
-    execution.status = hasErrors ? 'error' : 'success'
+    execution.status = runEndedInError(execution, nodeMap, skippedByCondition) ? 'error' : 'success'
     execution.completedAt = new Date().toISOString()
   } catch (err) {
     console.error(`[workflow] execution error:`, err)

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -107,7 +107,10 @@ function monitorRestoredConnectorExecution(execution: WorkflowExecution): void {
   const timer = setInterval(() => {
     if (reconciling) return
     reconciling = true
-    void reconcileRunningExecutions([execution]).finally(() => {
+    void reconcileRunningExecutions(
+      [execution],
+      useAppStore.getState().config?.workflows ?? []
+    ).finally(() => {
       reconciling = false
     })
   }, RESTORED_CONNECTOR_POLL_INTERVAL_MS)
@@ -196,8 +199,13 @@ function scheduleGateTimeout(
  * the user can re-run.
  */
 export async function reconcileRunningExecutions(
-  executions: Iterable<WorkflowExecution>
+  executions: Iterable<WorkflowExecution>,
+  workflows: WorkflowDefinition[]
 ): Promise<void> {
+  const nodesOf = (execution: WorkflowExecution): Map<string, WorkflowNode> =>
+    new Map(
+      (workflows.find((w) => w.id === execution.workflowId)?.nodes ?? []).map((n) => [n.id, n])
+    )
   for (const execution of executions) {
     if (execution.completedAt && execution.status !== 'running') {
       stopConnectorLeaseHeartbeat(execution.runId)
@@ -267,7 +275,7 @@ export async function reconcileRunningExecutions(
         }
         execution.status = 'error'
       } else {
-        execution.status = runEndedInError(execution, nodesOfRun(execution)) ? 'error' : 'success'
+        execution.status = runEndedInError(execution, nodesOf(execution)) ? 'error' : 'success'
       }
       execution.completedAt = new Date().toISOString()
       dirty = true
@@ -1409,26 +1417,33 @@ export function stopsRunOnError(node: Partial<Pick<WorkflowNode, 'onError'>>): b
   return (node.onError ?? 'stop') === 'stop'
 }
 
+/** A step that never ran, so no policy of its own has anything to say about it. */
+function neverRan(state: NodeExecutionState): boolean {
+  return state.error?.startsWith('Skipped:') === true
+}
+
+/** A step that failed on its own terms, which is what a retry has somewhere to start from. */
+export function hasFailedStep(execution: WorkflowExecution): boolean {
+  return execution.nodeStates.some((ns) => ns.status === 'error' && !neverRan(ns))
+}
+
 // Whether the run failed, rather than merely holding a step that failed and said so survivably.
-export function runEndedInError(
+function runEndedInError(
   execution: WorkflowExecution,
   nodes: Map<string, WorkflowNode>,
   skipped?: ReadonlySet<string>
 ): boolean {
-  return execution.nodeStates.some(
-    (ns) =>
-      ns.status === 'error' &&
-      !skipped?.has(ns.nodeId) &&
-      stopsRunOnError(nodes.get(ns.nodeId) ?? {})
-  )
+  return execution.nodeStates.some((ns) => {
+    if (ns.status !== 'error' || skipped?.has(ns.nodeId)) return false
+    if (neverRan(ns)) return true
+    const node = nodes.get(ns.nodeId)
+    return !node || stopsRunOnError(node)
+  })
 }
 
-/** The nodes of a run's workflow, so a failure can be read against its own policy. */
-function nodesOfRun(execution: WorkflowExecution): Map<string, WorkflowNode> {
-  const workflow = (useAppStore.getState().config?.workflows || []).find(
-    (w) => w.id === execution.workflowId
-  )
-  return new Map((workflow?.nodes ?? []).map((n) => [n.id, n]))
+/** The definition a run came from, which the store holds once the config has loaded. */
+function workflowById(id: string): WorkflowDefinition | undefined {
+  return (useAppStore.getState().config?.workflows || []).find((w) => w.id === id)
 }
 
 export function buildGraph(edges: readonly { source: string; target: string }[]): {
@@ -1775,9 +1790,7 @@ export async function stopWorkflowRun(runId: string): Promise<void> {
 
   // Release immediately rather than at the dedupe window's expiry, so stopping
   // a run and starting it again is not blocked by the run just stopped.
-  const workflow = (useAppStore.getState().config?.workflows || []).find(
-    (w) => w.id === execution.workflowId
-  )
+  const workflow = workflowById(execution.workflowId)
   await Promise.allSettled([
     window.api.releaseWorkflowRun({
       workflowId: execution.workflowId,
@@ -1949,6 +1962,22 @@ async function runExecution(
               status: 'skipped',
               completedAt: new Date().toISOString(),
               error: `Skipped: "${node.label}" failed`
+            })
+          }
+          persistExecution(execution)
+          return
+        }
+
+        // A condition that failed answered nothing, so neither branch is the one it chose.
+        if (node.type === 'condition' && postState?.status === 'error') {
+          for (const edge of workflow.edges) {
+            if (edge.source === node.id && edge.conditionBranch) markSkippedBranch(edge.target)
+          }
+          for (const skippedId of skippedByCondition) {
+            updateNodeState(execution, skippedId, {
+              status: 'skipped',
+              skipReason: 'branch',
+              completedAt: new Date().toISOString()
             })
           }
           persistExecution(execution)
@@ -2168,9 +2197,7 @@ function resolveWaitingGate(
   nodeId: string,
   caller: 'approve' | 'reject'
 ): { workflow: WorkflowDefinition } | null {
-  const workflow = (useAppStore.getState().config?.workflows || []).find(
-    (w) => w.id === execution.workflowId
-  )
+  const workflow = workflowById(execution.workflowId)
   if (!workflow) {
     console.warn(`[workflow] ${caller}WorkflowGate: workflow ${execution.workflowId} not found`)
     return null

--- a/tests/run-detail-pane.test.tsx
+++ b/tests/run-detail-pane.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import type { WorkflowExecution, WorkflowNode } from '../src/shared/types'
 import type { RunListEntry } from '../src/renderer/hooks/useAllWorkflowRuns'
+import { useAppStore } from '../src/renderer/stores'
 
 const approveMock = vi.fn()
 const rejectMock = vi.fn()
@@ -114,6 +115,19 @@ describe('RunDetailPane', () => {
     expect(screen.getByRole('heading', { name: 'PR #309' })).toBeInTheDocument()
     expect(screen.getByText('clean branches')).toBeInTheDocument()
     expect(screen.getByText('refactor: split workflow runs panel')).toBeInTheDocument()
+  })
+
+  it('offers a retry from the failed step when a step failed but the run went on', () => {
+    useAppStore.setState({
+      config: {
+        ...(useAppStore.getState().config ?? {}),
+        workflows: [{ id: 'wf-a', name: 'clean branches', nodes: NODES, edges: [] }]
+      }
+    } as never)
+    renderPane(
+      makeRun({ status: 'success', nodeStates: [{ nodeId: 'n1', status: 'error', error: 'boom' }] })
+    )
+    expect(screen.getByLabelText('Retry from failed step')).toBeInTheDocument()
   })
 
   it('summarises a run that finished every stage without pausing', () => {

--- a/tests/run-detail-pane.test.tsx
+++ b/tests/run-detail-pane.test.tsx
@@ -9,7 +9,10 @@ const approveMock = vi.fn()
 const rejectMock = vi.fn()
 vi.mock('../src/renderer/lib/workflow-execution', () => ({
   approveWorkflowGate: (...args: unknown[]) => approveMock(...args),
-  rejectWorkflowGate: (...args: unknown[]) => rejectMock(...args)
+  rejectWorkflowGate: (...args: unknown[]) => rejectMock(...args),
+  // The real rule, so a retry control is exercised the way the pane gates it.
+  hasFailedStep: (e: { nodeStates: Array<{ status: string; error?: string }> }) =>
+    e.nodeStates.some((ns) => ns.status === 'error' && !ns.error?.startsWith('Skipped:'))
 }))
 
 vi.mock('../src/renderer/components/workflow-runs/StopRunButton', () => ({

--- a/tests/run-detail-pane.test.tsx
+++ b/tests/run-detail-pane.test.tsx
@@ -7,12 +7,12 @@ import type { RunListEntry } from '../src/renderer/hooks/useAllWorkflowRuns'
 
 const approveMock = vi.fn()
 const rejectMock = vi.fn()
-vi.mock('../src/renderer/lib/workflow-execution', () => ({
+// The real module but for the two calls this asserts, so the retry control is
+// gated by the rule the pane really uses.
+vi.mock('../src/renderer/lib/workflow-execution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/renderer/lib/workflow-execution')>()),
   approveWorkflowGate: (...args: unknown[]) => approveMock(...args),
-  rejectWorkflowGate: (...args: unknown[]) => rejectMock(...args),
-  // The real rule, so a retry control is exercised the way the pane gates it.
-  hasFailedStep: (e: { nodeStates: Array<{ status: string; error?: string }> }) =>
-    e.nodeStates.some((ns) => ns.status === 'error' && !ns.error?.startsWith('Skipped:'))
+  rejectWorkflowGate: (...args: unknown[]) => rejectMock(...args)
 }))
 
 vi.mock('../src/renderer/components/workflow-runs/StopRunButton', () => ({

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -72,6 +72,19 @@ describe('RunEntry — approval gate controls', () => {
     expect(reject).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-1' }), 'gate')
   })
 
+  it('offers a retry from the failed step when a step failed but the run went on', () => {
+    const onRetryRun = vi.fn()
+    const execution = makeExec({
+      status: 'success',
+      nodeStates: [{ nodeId: 'gate', status: 'error', error: 'boom' }]
+    })
+    const { getByLabelText } = render(
+      <RunEntry execution={execution} nodes={[approvalNode]} onRetryRun={onRetryRun} />
+    )
+    fireEvent.click(getByLabelText('Retry from failed step'))
+    expect(onRetryRun).toHaveBeenCalledWith(execution)
+  })
+
   it('does not render approval controls for non-approval waiting nodes', () => {
     const nonApproval: WorkflowNode = {
       id: 'gate',

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -5,13 +5,13 @@ import '@testing-library/jest-dom/vitest'
 
 const approve = vi.fn()
 const reject = vi.fn()
-vi.mock('../src/renderer/lib/workflow-execution', () => ({
+// The real module but for the calls this asserts, so the retry control is gated
+// by the rule the entry really uses.
+vi.mock('../src/renderer/lib/workflow-execution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/renderer/lib/workflow-execution')>()),
   approveWorkflowGate: (...args: unknown[]) => approve(...args),
   rejectWorkflowGate: (...args: unknown[]) => reject(...args),
   isRunStoppable: (e: { status: string }) => e.status === 'running',
-  // The real rule, so a retry control is exercised the way the pane gates it.
-  hasFailedStep: (e: { nodeStates: Array<{ status: string; error?: string }> }) =>
-    e.nodeStates.some((ns) => ns.status === 'error' && !ns.error?.startsWith('Skipped:')),
   stopWorkflowRun: vi.fn()
 }))
 

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../src/renderer/lib/workflow-execution', () => ({
   approveWorkflowGate: (...args: unknown[]) => approve(...args),
   rejectWorkflowGate: (...args: unknown[]) => reject(...args),
   isRunStoppable: (e: { status: string }) => e.status === 'running',
+  // The real rule, so a retry control is exercised the way the pane gates it.
+  hasFailedStep: (e: { nodeStates: Array<{ status: string; error?: string }> }) =>
+    e.nodeStates.some((ns) => ns.status === 'error' && !ns.error?.startsWith('Skipped:')),
   stopWorkflowRun: vi.fn()
 }))
 

--- a/tests/run-follow.test.tsx
+++ b/tests/run-follow.test.tsx
@@ -10,7 +10,8 @@ vi.mock('../src/renderer/lib/use-connections', () => ({
   // A step with no connection draws its node-type glyph instead.
   connectorLookFor: () => undefined
 }))
-vi.mock('../src/renderer/lib/workflow-execution', () => ({
+vi.mock('../src/renderer/lib/workflow-execution', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/renderer/lib/workflow-execution')>()),
   isRunStoppable: () => false,
   stopWorkflowRun: vi.fn(),
   approveWorkflowGate: vi.fn(),

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -571,6 +571,72 @@ describe('rejecting an approval gate', () => {
   })
 })
 
+describe('a step that declared its failure survivable', () => {
+  /** The same workflow, with the agent free to fail without ending the run. */
+  function makeSurvivableWorkflow(id = 'wf-1'): WorkflowDefinition {
+    const wf = makeWorkflow(id)
+    const agent = wf.nodes.find((n) => n.id === 'agent')!
+    return { ...wf, nodes: [wf.nodes[0], { ...agent, onError: 'continue' }] } as WorkflowDefinition
+  }
+
+  it('leaves the run successful, and the step itself failed', async () => {
+    const wf = makeSurvivableWorkflow()
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      emitExit(id, 1)
+    }
+
+    const execution = await executeWorkflow(wf)
+
+    expect(execution.status).toBe('success')
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    expect(agent?.status).toBe('error')
+    expect(agent?.error).toBe('Exit code 1')
+  })
+
+  it('still ends the run when the step says a failure stops it', async () => {
+    const wf = makeWorkflow()
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      emitExit(id, 1)
+    }
+
+    const execution = await executeWorkflow(wf)
+
+    expect(execution.status).toBe('error')
+  })
+
+  it('reads the same way for a run closed after a reload', async () => {
+    mockState.config.workflows = [makeSurvivableWorkflow('wf-reloaded')]
+    const execution: WorkflowExecution = {
+      runId: 'run-reloaded',
+      workflowId: 'wf-reloaded',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'running',
+      nodeStates: [
+        { nodeId: 'trigger', status: 'success' },
+        { nodeId: 'agent', status: 'running', sessionId: 'sess-reloaded' }
+      ]
+    }
+    globalThis.window.api.listSessionEventsBySession = vi.fn(
+      () =>
+        Promise.resolve([
+          {
+            eventType: 'exited',
+            timestamp: '2026-04-20T10:01:00Z',
+            metadata: { exitCode: 1 }
+          }
+        ])
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any
+
+    await reconcileRunningExecutions([execution])
+
+    expect(execution.status).toBe('success')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.status).toBe('error')
+  })
+})
+
 describe('connector run recovery', () => {
   it('acknowledges a terminal run restored after persistence', async () => {
     const execution: WorkflowExecution = {

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -740,6 +740,29 @@ describe('a step that declared its failure survivable', () => {
     expect(execution.status).toBe('success')
     expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.status).toBe('error')
   })
+
+  it('fails the run for a step the reconciler found no session for, whatever it declared', async () => {
+    // Nothing was recorded of it starting, so "carry on anyway" speaks for a
+    // failure that never happened.
+    mockState.config.workflows = [makeSurvivableWorkflow('wf-abandoned')]
+    const execution: WorkflowExecution = {
+      runId: 'run-abandoned',
+      workflowId: 'wf-abandoned',
+      startedAt: '2026-04-20T10:00:00Z',
+      status: 'running',
+      nodeStates: [
+        { nodeId: 'trigger', status: 'success' },
+        { nodeId: 'agent', status: 'running' }
+      ]
+    }
+
+    await reconcileRunningExecutions([execution], mockState.config.workflows)
+
+    expect(execution.status).toBe('error')
+    const agent = execution.nodeStates.find((n) => n.nodeId === 'agent')
+    expect(agent?.status).toBe('error')
+    expect(agent?.error).toBe('Run abandoned (no session id recorded)')
+  })
 })
 
 describe('connector run recovery', () => {

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -606,6 +606,111 @@ describe('a step that declared its failure survivable', () => {
     expect(execution.status).toBe('error')
   })
 
+  it('still fails the run for a step that never ran, whatever policy it declared', async () => {
+    // "Carry on anyway" speaks for a failure. A step left unreachable never
+    // failed, so nothing it declared has anything to say about the run.
+    const wf = makeWorkflow('wf-orphan')
+    const orphan = {
+      ...wf.nodes[1],
+      id: 'orphan',
+      label: 'Orphan',
+      onError: 'continue'
+    } as WorkflowDefinition['nodes'][number]
+    const withOrphan = { ...wf, nodes: [...wf.nodes, orphan] } as WorkflowDefinition
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      emitExit(id, 0)
+    }
+
+    const execution = await executeWorkflow(withOrphan)
+
+    expect(execution.status).toBe('error')
+    const left = execution.nodeStates.find((n) => n.nodeId === 'orphan')
+    expect(left?.error).toMatch(/^Skipped:/)
+  })
+
+  it('fails the run when a loop that carries on holds a step that does not', async () => {
+    // The loop excuses its own failure; the body step that stopped still had
+    // the last word about the run.
+    const wf = makeWorkflow('wf-loop')
+    const body = {
+      ...wf.nodes[1],
+      id: 'body',
+      label: 'Body'
+    } as WorkflowDefinition['nodes'][number]
+    const loop = {
+      id: 'loop',
+      type: 'loop',
+      label: 'Until it is clean',
+      position: { x: 0, y: 1 },
+      onError: 'continue',
+      config: { nodeType: 'loop', bodyNodeIds: ['body'], maxIterations: 1 }
+    } as unknown as WorkflowDefinition['nodes'][number]
+    const looping = {
+      ...wf,
+      nodes: [wf.nodes[0], loop, body],
+      edges: [{ id: 'e1', source: 'trigger', target: 'loop' }]
+    } as unknown as WorkflowDefinition
+    onSessionCreated = (id) => {
+      onSessionCreated = null
+      emitExit(id, 1)
+    }
+
+    const execution = await executeWorkflow(looping)
+
+    expect(execution.status).toBe('error')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'loop')?.status).toBe('error')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'body')?.status).toBe('error')
+  })
+
+  it('takes neither branch of a condition that failed', async () => {
+    const wf = makeWorkflow('wf-condition')
+    const agent = wf.nodes[1]
+    const condition = {
+      id: 'condition',
+      type: 'condition',
+      label: 'Is it clean',
+      position: { x: 0, y: 1 },
+      onError: 'continue',
+      // A definition that arrived malformed: resolving this throws, so the
+      // condition answers nothing.
+      config: {
+        nodeType: 'condition',
+        variable: 1 as unknown as string,
+        operator: 'equals',
+        value: 'x'
+      }
+    } as unknown as WorkflowDefinition['nodes'][number]
+    const branching = {
+      ...wf,
+      nodes: [
+        wf.nodes[0],
+        condition,
+        { ...agent, id: 'yes', label: 'Yes' },
+        { ...agent, id: 'no', label: 'No' }
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'condition' },
+        { id: 'e2', source: 'condition', target: 'yes', conditionBranch: 'true' },
+        { id: 'e3', source: 'condition', target: 'no', conditionBranch: 'false' }
+      ]
+    } as unknown as WorkflowDefinition
+    let launched = 0
+    // Exits whatever starts, so a branch taken by mistake fails the assertion
+    // rather than hanging the run.
+    onSessionCreated = (id) => {
+      launched += 1
+      emitExit(id, 0)
+    }
+
+    const execution = await executeWorkflow(branching)
+
+    expect(execution.nodeStates.find((n) => n.nodeId === 'condition')?.status).toBe('error')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'yes')?.status).toBe('skipped')
+    expect(execution.nodeStates.find((n) => n.nodeId === 'no')?.status).toBe('skipped')
+    expect(launched).toBe(0)
+  })
+
   it('reads the same way for a run closed after a reload', async () => {
     mockState.config.workflows = [makeSurvivableWorkflow('wf-reloaded')]
     const execution: WorkflowExecution = {
@@ -630,7 +735,7 @@ describe('a step that declared its failure survivable', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ) as any
 
-    await reconcileRunningExecutions([execution])
+    await reconcileRunningExecutions([execution], mockState.config.workflows)
 
     expect(execution.status).toBe('success')
     expect(execution.nodeStates.find((n) => n.nodeId === 'agent')?.status).toBe('error')
@@ -650,7 +755,7 @@ describe('connector run recovery', () => {
       nodeStates: [{ nodeId: 'agent', status: 'success' }]
     }
 
-    await reconcileRunningExecutions([execution])
+    await reconcileRunningExecutions([execution], [])
 
     expect(window.api.completeConnectorInbox).toHaveBeenCalledWith({
       id: 101,


### PR DESCRIPTION
A step marked continue-on-error failed the whole run: the run verdict read node statuses alone, while the loop node already read them against each step policy.

## What changed

- The run ends in error only when a failed step said stop, or never ran at all. A step that said continue keeps its own error and message; the run is green. The reload path reads the same rule against the definitions the caller loaded, after the config has arrived, instead of racing the store.
- A failed condition takes neither branch, whatever its policy.
- Retry from failed step is offered when a step failed, not when the run did.
- The continue helper text says the run counts as successful too.

## How to verify

A workflow with a failing continue step and a step after it ends green with the first step red and its output present; a failing stop step still ends the run in error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
