### PR TITLE
Let a gate be answered from MCP, and say what it asked

### DIFF
--- a/packages/mcp/src/data-access.ts
+++ b/packages/mcp/src/data-access.ts
@@ -195,6 +195,11 @@ export async function listWorkflowRunsByTask(
   })
 }
 
+/** Every run parked on a gate, however old: the capped history can lose one that waited a long time. */
+export async function listRunsWithWaitingGates(): Promise<WorkflowExecution[]> {
+  return rpcCall<WorkflowExecution[]>('workflowRun:listWaiting')
+}
+
 export async function listAllWorkflowRuns(
   workspaceId?: string,
   limit = 50

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -497,7 +497,7 @@ export function annotateWaitingGates<T extends WorkflowExecution>(
 }
 
 /** A run to answer a gate on: recent history first, then every parked run, since a gate can wait past the cap. */
-async function runHoldingGate(
+async function runById(
   runId: string
 ): Promise<(WorkflowExecution & { workflowName?: string }) | undefined> {
   const recent = (await listAllWorkflowRuns(undefined, 500)).find((r) => r.runId === runId)
@@ -755,7 +755,7 @@ export function registerWorkflowTools(server: McpServer): void {
       // Scanning recent runs beats broadcasting a typo that nothing answers:
       // the stop is fire-and-forget, so an id that matches nothing would
       // otherwise report success and do nothing at all.
-      const run = (await listAllWorkflowRuns(undefined, 500)).find((r) => r.runId === args.run_id)
+      const run = await runById(args.run_id)
       if (!run) {
         return {
           content: [
@@ -813,7 +813,7 @@ export function registerWorkflowTools(server: McpServer): void {
     },
     async (args) => {
       // The decision is broadcast, so an id nothing matches would report success and answer no gate at all.
-      const run = await runHoldingGate(args.run_id)
+      const run = await runById(args.run_id)
       if (!run) {
         return {
           content: [

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -22,6 +22,7 @@ import {
   listWorkflowRuns,
   listWorkflowRunsByTask,
   listAllWorkflowRuns,
+  listRunsWithWaitingGates,
   dbSignalChange
 } from '../data-access'
 import { rpcCall } from '../ws-client'
@@ -455,14 +456,25 @@ export function resolveWorkflowId(args: {
   return { id }
 }
 
+/** The approval node a gate belongs to, so its question and its name come from one lookup. */
+export function approvalNode(
+  workflow: Pick<WorkflowDefinition, 'nodes'> | undefined,
+  nodeId: string
+): WorkflowNode | undefined {
+  return workflow?.nodes.find((n) => n.id === nodeId && n.type === 'approval')
+}
+
 /** What an approval node asks, so a caller answering a gate can read the question first. */
+export function askedBy(node: WorkflowNode | undefined): string | undefined {
+  return (node?.config as ApprovalConfig | undefined)?.message?.trim() || undefined
+}
+
+/** What the gate on a node asks, for a caller holding the definition rather than the node. */
 export function gateMessage(
   workflow: Pick<WorkflowDefinition, 'nodes'> | undefined,
   nodeId: string
 ): string | undefined {
-  const node = workflow?.nodes.find((n) => n.id === nodeId && n.type === 'approval')
-  const message = (node?.config as ApprovalConfig | undefined)?.message
-  return message?.trim() || undefined
+  return askedBy(approvalNode(workflow, nodeId))
 }
 
 /** A waiting node says it is waiting and nothing else; the gate's own question lives in the definition. */
@@ -484,13 +496,16 @@ export function annotateWaitingGates<T extends WorkflowExecution>(
   })
 }
 
-/**
- * Which gate a decision answers.
- *
- * A run parked on an approval has one waiting node, so naming it is usually
- * redundant. A run inside a parallel branch can have several, and answering
- * "the" gate would then be a guess — so that case asks rather than picks.
- */
+/** A run to answer a gate on: recent history first, then every parked run, since a gate can wait past the cap. */
+async function runHoldingGate(
+  runId: string
+): Promise<(WorkflowExecution & { workflowName?: string }) | undefined> {
+  const recent = (await listAllWorkflowRuns(undefined, 500)).find((r) => r.runId === runId)
+  if (recent) return recent
+  return (await listRunsWithWaitingGates()).find((r) => r.runId === runId)
+}
+
+// Which gate a decision answers: one waiting node needs no naming, several would make picking a guess.
 export function resolveGateTarget(
   run: Pick<WorkflowExecution, 'nodeStates'>,
   nodeId?: string
@@ -697,7 +712,7 @@ export function registerWorkflowTools(server: McpServer): void {
 
   server.tool(
     'list_workflow_runs',
-    'List workflow execution history. Filter by workflow_id or task_id.',
+    'List workflow execution history. Filter by workflow_id or task_id; with neither, lists the runs parked on an approval gate, each waiting node saying what it asks.',
     {
       workflow_id: V.id.optional().describe('Filter by workflow ID'),
       task_id: V.id.optional().describe('Filter by task ID (runs triggered by this task)'),
@@ -724,10 +739,9 @@ export function registerWorkflowTools(server: McpServer): void {
         const runs = await withGates(await listWorkflowRuns(args.workflow_id, args.limit ?? 20))
         return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] }
       }
-      return {
-        content: [{ type: 'text', text: 'Error: provide either workflow_id or task_id' }],
-        isError: true
-      }
+      // Neither filter: the runs someone has to answer, which no other tool can find.
+      const waiting = await withGates(await listRunsWithWaitingGates())
+      return { content: [{ type: 'text', text: JSON.stringify(waiting, null, 2) }] }
     }
   )
 
@@ -798,15 +812,14 @@ export function registerWorkflowTools(server: McpServer): void {
       node_id: V.id.optional().describe('The waiting node, when a run has more than one gate open')
     },
     async (args) => {
-      // The same reason stop_workflow_run scans: the decision is broadcast, so an
-      // id nothing matches would report success and answer no gate at all.
-      const run = (await listAllWorkflowRuns(undefined, 500)).find((r) => r.runId === args.run_id)
+      // The decision is broadcast, so an id nothing matches would report success and answer no gate at all.
+      const run = await runHoldingGate(args.run_id)
       if (!run) {
         return {
           content: [
             {
               type: 'text',
-              text: `Error: no run "${args.run_id}" in the last 500. Check list_workflow_runs.`
+              text: `Error: no run "${args.run_id}" in the recent history, and none parked on a gate. Check list_workflow_runs.`
             }
           ],
           isError: true
@@ -819,8 +832,7 @@ export function registerWorkflowTools(server: McpServer): void {
               type: 'text',
               text: `Run ${args.run_id} already finished (${run.status}) — no gate to answer.`
             }
-          ],
-          isError: true
+          ]
         }
       }
 
@@ -833,7 +845,8 @@ export function registerWorkflowTools(server: McpServer): void {
       }
 
       const workflow = (await dbListWorkflows()).find((w) => w.id === run.workflowId)
-      const asked = gateMessage(workflow, target.nodeId)
+      const gateNode = approvalNode(workflow, target.nodeId)
+      const asked = askedBy(gateNode)
 
       try {
         await rpcCall('workflow:resolveGate', {
@@ -848,7 +861,7 @@ export function registerWorkflowTools(server: McpServer): void {
         }
       }
 
-      const gate = workflow?.nodes.find((n) => n.id === target.nodeId)?.label ?? target.nodeId
+      const gate = gateNode?.label ?? target.nodeId
       return {
         content: [
           {

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -3,7 +3,9 @@ import { z } from 'zod'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { V } from '../validation'
 import type {
+  ApprovalConfig,
   WorkflowDefinition,
+  WorkflowExecution,
   WorkflowNode,
   WorkflowEdge,
   TriggerConfig,
@@ -453,6 +455,60 @@ export function resolveWorkflowId(args: {
   return { id }
 }
 
+/** What an approval node asks, so a caller answering a gate can read the question first. */
+export function gateMessage(
+  workflow: Pick<WorkflowDefinition, 'nodes'> | undefined,
+  nodeId: string
+): string | undefined {
+  const node = workflow?.nodes.find((n) => n.id === nodeId && n.type === 'approval')
+  const message = (node?.config as ApprovalConfig | undefined)?.message
+  return message?.trim() || undefined
+}
+
+/** A waiting node says it is waiting and nothing else; the gate's own question lives in the definition. */
+export function annotateWaitingGates<T extends WorkflowExecution>(
+  runs: T[],
+  workflows: Pick<WorkflowDefinition, 'id' | 'nodes'>[]
+): T[] {
+  return runs.map((run) => {
+    if (!run.nodeStates.some((n) => n.status === 'waiting')) return run
+    const workflow = workflows.find((w) => w.id === run.workflowId)
+    return {
+      ...run,
+      nodeStates: run.nodeStates.map((state) => {
+        if (state.status !== 'waiting') return state
+        const asks = gateMessage(workflow, state.nodeId)
+        return asks ? { ...state, asks } : state
+      })
+    }
+  })
+}
+
+/**
+ * Which gate a decision answers.
+ *
+ * A run parked on an approval has one waiting node, so naming it is usually
+ * redundant. A run inside a parallel branch can have several, and answering
+ * "the" gate would then be a guess — so that case asks rather than picks.
+ */
+export function resolveGateTarget(
+  run: Pick<WorkflowExecution, 'nodeStates'>,
+  nodeId?: string
+): { nodeId: string } | { error: string } {
+  const waiting = run.nodeStates.filter((n) => n.status === 'waiting').map((n) => n.nodeId)
+  if (nodeId) {
+    if (waiting.includes(nodeId)) return { nodeId }
+    return {
+      error: waiting.length
+        ? `node "${nodeId}" is not waiting. Waiting: ${waiting.join(', ')}`
+        : `node "${nodeId}" is not waiting, and neither is any other node in this run`
+    }
+  }
+  if (waiting.length === 1) return { nodeId: waiting[0] }
+  if (waiting.length === 0) return { error: 'no node in this run is waiting on a gate' }
+  return { error: `${waiting.length} nodes are waiting — pass node_id: ${waiting.join(', ')}` }
+}
+
 /** Connections for naming and rebinding requirements; absent ones cost detail, not the export. */
 async function listPortableConnections(): Promise<PortableConnection[]> {
   try {
@@ -654,12 +710,18 @@ export function registerWorkflowTools(server: McpServer): void {
           isError: true
         }
       }
+      // The definitions cost a round trip, so they are read only for a run that is parked on a gate.
+      const withGates = async <T extends WorkflowExecution>(runs: T[]): Promise<T[]> =>
+        runs.some((r) => r.nodeStates.some((n) => n.status === 'waiting'))
+          ? annotateWaitingGates(runs, await dbListWorkflows())
+          : runs
+
       if (args.task_id) {
-        const runs = await listWorkflowRunsByTask(args.task_id, args.limit ?? 20)
+        const runs = await withGates(await listWorkflowRunsByTask(args.task_id, args.limit ?? 20))
         return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] }
       }
       if (args.workflow_id) {
-        const runs = await listWorkflowRuns(args.workflow_id, args.limit ?? 20)
+        const runs = await withGates(await listWorkflowRuns(args.workflow_id, args.limit ?? 20))
         return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] }
       }
       return {
@@ -719,6 +781,79 @@ export function registerWorkflowTools(server: McpServer): void {
           {
             type: 'text',
             text: `Asked to stop run ${args.run_id}${run.workflowName ? ` of "${run.workflowName}"` : ''} — ${live} node(s) were still live.\n\nThe run is stopped by the instance holding it, so confirm with list_workflow_runs.`
+          }
+        ]
+      }
+    }
+  )
+
+  server.tool(
+    'resolve_gate',
+    'Approve or reject the approval gate a workflow run is parked on, the way the Vorn app does. Requires the Vorn app to be running: the decision is broadcast, and the instance holding the run is what resumes it. Read what is being approved first — list_workflow_runs names the waiting node and what it asks.',
+    {
+      run_id: V.id.describe('Run ID (from list_workflow_runs)'),
+      decision: z
+        .enum(['approve', 'reject'])
+        .describe('approve lets the run go on; reject ends it'),
+      node_id: V.id.optional().describe('The waiting node, when a run has more than one gate open')
+    },
+    async (args) => {
+      // The same reason stop_workflow_run scans: the decision is broadcast, so an
+      // id nothing matches would report success and answer no gate at all.
+      const run = (await listAllWorkflowRuns(undefined, 500)).find((r) => r.runId === args.run_id)
+      if (!run) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Error: no run "${args.run_id}" in the last 500. Check list_workflow_runs.`
+            }
+          ],
+          isError: true
+        }
+      }
+      if (run.status !== 'running') {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Run ${args.run_id} already finished (${run.status}) — no gate to answer.`
+            }
+          ],
+          isError: true
+        }
+      }
+
+      const target = resolveGateTarget(run, args.node_id)
+      if ('error' in target) {
+        return {
+          content: [{ type: 'text', text: `Error: ${target.error}` }],
+          isError: true
+        }
+      }
+
+      const workflow = (await dbListWorkflows()).find((w) => w.id === run.workflowId)
+      const asked = gateMessage(workflow, target.nodeId)
+
+      try {
+        await rpcCall('workflow:resolveGate', {
+          runId: args.run_id,
+          nodeId: target.nodeId,
+          decision: args.decision
+        })
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : err}` }],
+          isError: true
+        }
+      }
+
+      const gate = workflow?.nodes.find((n) => n.id === target.nodeId)?.label ?? target.nodeId
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `${args.decision === 'approve' ? 'Approved' : 'Rejected'} "${gate}" on run ${args.run_id}${run.workflowName ? ` of "${run.workflowName}"` : ''}.${asked ? `\n\nWhat it asked: ${asked}` : ''}\n\nThe decision went out; the instance holding the run acts on it, so a desktop has to be open. Confirm with list_workflow_runs.`
           }
         ]
       }

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -740,7 +740,8 @@ export function registerWorkflowTools(server: McpServer): void {
         return { content: [{ type: 'text', text: JSON.stringify(runs, null, 2) }] }
       }
       // Neither filter: the runs someone has to answer, which no other tool can find.
-      const waiting = await withGates(await listRunsWithWaitingGates())
+      const parked = (await listRunsWithWaitingGates()).slice(0, args.limit ?? 20)
+      const waiting = await withGates(parked)
       return { content: [{ type: 'text', text: JSON.stringify(waiting, null, 2) }] }
     }
   )

--- a/tests/mcp-resolve-gate.test.ts
+++ b/tests/mcp-resolve-gate.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type {
+  NodeExecutionState,
+  WorkflowDefinition,
+  WorkflowExecution
+} from '../packages/shared/src/types'
+
+const rpcCall = vi.fn()
+const listAllWorkflowRuns = vi.fn()
+const dbListWorkflows = vi.fn()
+
+vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
+vi.mock('../packages/mcp/src/data-access', () => ({
+  listAllWorkflowRuns: (...a: unknown[]) => listAllWorkflowRuns(...a),
+  dbListWorkflows: (...a: unknown[]) => dbListWorkflows(...a),
+  listWorkflowRuns: vi.fn(),
+  listWorkflowRunsByTask: vi.fn(),
+  dbListProjects: vi.fn(),
+  dbInsertWorkflow: vi.fn(),
+  dbUpdateWorkflow: vi.fn(),
+  dbDeleteWorkflow: vi.fn(),
+  dbSignalChange: vi.fn()
+}))
+
+const { annotateWaitingGates, gateMessage, resolveGateTarget, registerWorkflowTools } =
+  await import('../packages/mcp/src/tools/workflows')
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>
+  isError?: boolean
+}>
+
+/** Collects the tools the module registers so they can be invoked directly. */
+function collect(): Map<string, Handler> {
+  const tools = new Map<string, Handler>()
+  const server = {
+    tool: (name: string, _desc: string, schemaOrHandler: unknown, maybeHandler?: unknown) => {
+      tools.set(name, (maybeHandler ?? schemaOrHandler) as Handler)
+    }
+  } as unknown as McpServer
+  registerWorkflowTools(server)
+  return tools
+}
+
+const node = (nodeId: string, status: NodeExecutionState['status']): NodeExecutionState => ({
+  nodeId,
+  status
+})
+
+const run = (...nodeStates: NodeExecutionState[]): WorkflowExecution => ({
+  runId: 'run-1',
+  workflowId: 'wf-1',
+  startedAt: '2026-09-05T00:00:00.000Z',
+  status: 'running',
+  nodeStates
+})
+
+const workflow = (message?: string): WorkflowDefinition =>
+  ({
+    id: 'wf-1',
+    name: 'Build connector',
+    nodes: [
+      {
+        id: 'develop',
+        type: 'launchAgent',
+        label: 'Develop',
+        config: {},
+        position: { x: 0, y: 0 }
+      },
+      {
+        id: 'approve',
+        type: 'approval',
+        label: 'Approval Gate',
+        config: message === undefined ? {} : { message },
+        position: { x: 0, y: 0 }
+      }
+    ],
+    edges: []
+  }) as unknown as WorkflowDefinition
+
+describe('choosing the gate a decision answers', () => {
+  it('takes the one node that is waiting, since naming it would be redundant', () => {
+    const target = resolveGateTarget(run(node('develop', 'success'), node('approve', 'waiting')))
+    expect(target).toEqual({ nodeId: 'approve' })
+  })
+
+  it('refuses a run where nothing is waiting', () => {
+    const target = resolveGateTarget(run(node('develop', 'running')))
+    expect(target).toEqual({ error: 'no node in this run is waiting on a gate' })
+  })
+
+  it('asks which gate when a run has more than one open', () => {
+    const target = resolveGateTarget(
+      run(node('approve-a', 'waiting'), node('approve-b', 'waiting'))
+    )
+    expect('error' in target && target.error).toContain('pass node_id')
+    expect('error' in target && target.error).toContain('approve-a, approve-b')
+  })
+
+  it('answers the named gate when a run has several', () => {
+    const target = resolveGateTarget(
+      run(node('approve-a', 'waiting'), node('approve-b', 'waiting')),
+      'approve-b'
+    )
+    expect(target).toEqual({ nodeId: 'approve-b' })
+  })
+
+  it('refuses a named node that is not the one waiting, and says which is', () => {
+    const target = resolveGateTarget(
+      run(node('develop', 'success'), node('approve', 'waiting')),
+      'develop'
+    )
+    expect('error' in target && target.error).toBe(
+      'node "develop" is not waiting. Waiting: approve'
+    )
+  })
+})
+
+describe('what a gate asks', () => {
+  it('reads the message the approval node was given', () => {
+    expect(gateMessage(workflow('Read spec.md, then approve.'), 'approve')).toBe(
+      'Read spec.md, then approve.'
+    )
+  })
+
+  it('says nothing for a gate that asks nothing, or for a step that is not one', () => {
+    expect(gateMessage(workflow(), 'approve')).toBeUndefined()
+    expect(gateMessage(workflow('   '), 'approve')).toBeUndefined()
+    expect(gateMessage(workflow('Approve?'), 'develop')).toBeUndefined()
+    expect(gateMessage(undefined, 'approve')).toBeUndefined()
+  })
+})
+
+describe('listing runs', () => {
+  it('puts the question beside the node that is waiting on it', () => {
+    const [listed] = annotateWaitingGates(
+      [run(node('develop', 'success'), node('approve', 'waiting'))],
+      [workflow('Read spec.md, then approve.')]
+    )
+    expect(listed.nodeStates.map((n) => (n as { asks?: string }).asks)).toEqual([
+      undefined,
+      'Read spec.md, then approve.'
+    ])
+  })
+
+  it('leaves a run with nothing waiting exactly as it came', () => {
+    const finished = run(node('develop', 'success'))
+    const [listed] = annotateWaitingGates([finished], [workflow('Approve?')])
+    expect(listed).toBe(finished)
+  })
+})
+
+describe('answering a gate', () => {
+  const parked = { ...run(node('develop', 'success'), node('approve', 'waiting')) }
+
+  beforeEach(() => {
+    rpcCall.mockReset().mockResolvedValue({ accepted: true })
+    listAllWorkflowRuns.mockReset().mockResolvedValue([{ ...parked, workflowName: 'Build' }])
+    dbListWorkflows.mockReset().mockResolvedValue([workflow('Read spec.md, then approve.')])
+  })
+
+  const resolve = async (args: Record<string, unknown>) => {
+    const tool = collect().get('resolve_gate')
+    if (!tool) throw new Error('resolve_gate was not registered')
+    return tool(args)
+  }
+
+  it('approves the node that was waiting, and says what it answered', async () => {
+    const result = await resolve({ run_id: 'run-1', decision: 'approve' })
+
+    expect(rpcCall).toHaveBeenCalledWith('workflow:resolveGate', {
+      runId: 'run-1',
+      nodeId: 'approve',
+      decision: 'approve'
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.content[0].text).toContain('Approved "Approval Gate"')
+    expect(result.content[0].text).toContain('Read spec.md, then approve.')
+  })
+
+  it('rejects when that is the decision', async () => {
+    const result = await resolve({ run_id: 'run-1', decision: 'reject' })
+
+    expect(rpcCall).toHaveBeenCalledWith('workflow:resolveGate', {
+      runId: 'run-1',
+      nodeId: 'approve',
+      decision: 'reject'
+    })
+    expect(result.content[0].text).toContain('Rejected "Approval Gate"')
+  })
+
+  it('refuses a run that already finished, rather than broadcasting at nothing', async () => {
+    listAllWorkflowRuns.mockResolvedValue([{ ...parked, status: 'success' }])
+
+    const result = await resolve({ run_id: 'run-1', decision: 'approve' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('already finished (success)')
+    expect(rpcCall).not.toHaveBeenCalled()
+  })
+
+  it('refuses a run it cannot find', async () => {
+    listAllWorkflowRuns.mockResolvedValue([])
+
+    const result = await resolve({ run_id: 'run-9', decision: 'approve' })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('no run "run-9"')
+    expect(rpcCall).not.toHaveBeenCalled()
+  })
+
+  it('asks which gate when a run has two open, and answers the named one', async () => {
+    listAllWorkflowRuns.mockResolvedValue([run(node('a', 'waiting'), node('b', 'waiting'))])
+
+    const asked = await resolve({ run_id: 'run-1', decision: 'approve' })
+    expect(asked.isError).toBe(true)
+    expect(asked.content[0].text).toContain('pass node_id')
+    expect(rpcCall).not.toHaveBeenCalled()
+
+    await resolve({ run_id: 'run-1', decision: 'approve', node_id: 'b' })
+    expect(rpcCall).toHaveBeenCalledWith('workflow:resolveGate', {
+      runId: 'run-1',
+      nodeId: 'b',
+      decision: 'approve'
+    })
+  })
+})

--- a/tests/mcp-resolve-gate.test.ts
+++ b/tests/mcp-resolve-gate.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { z } from 'zod'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type {
   NodeExecutionState,
@@ -8,11 +9,13 @@ import type {
 
 const rpcCall = vi.fn()
 const listAllWorkflowRuns = vi.fn()
+const listRunsWithWaitingGates = vi.fn()
 const dbListWorkflows = vi.fn()
 
 vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
 vi.mock('../packages/mcp/src/data-access', () => ({
   listAllWorkflowRuns: (...a: unknown[]) => listAllWorkflowRuns(...a),
+  listRunsWithWaitingGates: (...a: unknown[]) => listRunsWithWaitingGates(...a),
   dbListWorkflows: (...a: unknown[]) => dbListWorkflows(...a),
   listWorkflowRuns: vi.fn(),
   listWorkflowRunsByTask: vi.fn(),
@@ -31,12 +34,17 @@ type Handler = (args: Record<string, unknown>) => Promise<{
   isError?: boolean
 }>
 
-/** Collects the tools the module registers so they can be invoked directly. */
-function collect(): Map<string, Handler> {
-  const tools = new Map<string, Handler>()
+type Registered = { handler: Handler; schema?: z.ZodRawShape }
+
+/** Collects the tools the module registers, with the shape each declares, so both can be exercised. */
+function collect(): Map<string, Registered> {
+  const tools = new Map<string, Registered>()
   const server = {
     tool: (name: string, _desc: string, schemaOrHandler: unknown, maybeHandler?: unknown) => {
-      tools.set(name, (maybeHandler ?? schemaOrHandler) as Handler)
+      tools.set(name, {
+        handler: (maybeHandler ?? schemaOrHandler) as Handler,
+        ...(maybeHandler ? { schema: schemaOrHandler as z.ZodRawShape } : {})
+      })
     }
   } as unknown as McpServer
   registerWorkflowTools(server)
@@ -157,14 +165,17 @@ describe('answering a gate', () => {
   beforeEach(() => {
     rpcCall.mockReset().mockResolvedValue({ accepted: true })
     listAllWorkflowRuns.mockReset().mockResolvedValue([{ ...parked, workflowName: 'Build' }])
+    listRunsWithWaitingGates.mockReset().mockResolvedValue([])
     dbListWorkflows.mockReset().mockResolvedValue([workflow('Read spec.md, then approve.')])
   })
 
-  const resolve = async (args: Record<string, unknown>) => {
+  const registered = () => {
     const tool = collect().get('resolve_gate')
     if (!tool) throw new Error('resolve_gate was not registered')
-    return tool(args)
+    return tool
   }
+
+  const resolve = async (args: Record<string, unknown>) => registered().handler(args)
 
   it('approves the node that was waiting, and says what it answered', async () => {
     const result = await resolve({ run_id: 'run-1', decision: 'approve' })
@@ -190,24 +201,64 @@ describe('answering a gate', () => {
     expect(result.content[0].text).toContain('Rejected "Approval Gate"')
   })
 
-  it('refuses a run that already finished, rather than broadcasting at nothing', async () => {
+  it('says a run already finished rather than broadcasting at nothing, the way stopping one does', async () => {
     listAllWorkflowRuns.mockResolvedValue([{ ...parked, status: 'success' }])
 
     const result = await resolve({ run_id: 'run-1', decision: 'approve' })
 
-    expect(result.isError).toBe(true)
+    expect(result.isError).toBeUndefined()
     expect(result.content[0].text).toContain('already finished (success)')
     expect(rpcCall).not.toHaveBeenCalled()
   })
 
-  it('refuses a run it cannot find', async () => {
+  it('refuses a run it cannot find, having asked for the parked ones too', async () => {
     listAllWorkflowRuns.mockResolvedValue([])
 
     const result = await resolve({ run_id: 'run-9', decision: 'approve' })
 
+    expect(listRunsWithWaitingGates).toHaveBeenCalled()
     expect(result.isError).toBe(true)
     expect(result.content[0].text).toContain('no run "run-9"')
     expect(rpcCall).not.toHaveBeenCalled()
+  })
+
+  it('answers a gate that waited past the recent history', async () => {
+    listAllWorkflowRuns.mockResolvedValue([])
+    listRunsWithWaitingGates.mockResolvedValue([parked])
+
+    const result = await resolve({ run_id: 'run-1', decision: 'approve' })
+
+    expect(result.isError).toBeUndefined()
+    expect(rpcCall).toHaveBeenCalledWith('workflow:resolveGate', {
+      runId: 'run-1',
+      nodeId: 'approve',
+      decision: 'approve'
+    })
+  })
+
+  it('lists the runs parked on a gate when asked for no workflow in particular', async () => {
+    const tool = collect().get('list_workflow_runs')
+    if (!tool) throw new Error('list_workflow_runs was not registered')
+    listRunsWithWaitingGates.mockResolvedValue([parked])
+
+    const result = await tool.handler({})
+
+    expect(result.isError).toBeUndefined()
+    const [listed] = JSON.parse(result.content[0].text) as WorkflowExecution[]
+    expect(listed.runId).toBe('run-1')
+    expect(listed.nodeStates.find((n) => n.nodeId === 'approve')).toMatchObject({
+      status: 'waiting',
+      asks: 'Read spec.md, then approve.'
+    })
+  })
+
+  it('takes only the two decisions it declares', () => {
+    const schema = registered().schema
+    if (!schema) throw new Error('resolve_gate registered no schema')
+    const shape = z.object(schema)
+
+    expect(shape.safeParse({ run_id: 'run-1', decision: 'maybe' }).success).toBe(false)
+    expect(shape.safeParse({ run_id: 'run-1', decision: 'approve' }).success).toBe(true)
   })
 
   it('asks which gate when a run has two open, and answers the named one', async () => {

--- a/tests/mcp-resolve-gate.test.ts
+++ b/tests/mcp-resolve-gate.test.ts
@@ -7,10 +7,14 @@ import type {
   WorkflowExecution
 } from '../packages/shared/src/types'
 
-const rpcCall = vi.fn()
-const listAllWorkflowRuns = vi.fn()
-const listRunsWithWaitingGates = vi.fn()
-const dbListWorkflows = vi.fn()
+const { rpcCall, listAllWorkflowRuns, listRunsWithWaitingGates, dbListWorkflows } = vi.hoisted(
+  () => ({
+    rpcCall: vi.fn(),
+    listAllWorkflowRuns: vi.fn(),
+    listRunsWithWaitingGates: vi.fn(),
+    dbListWorkflows: vi.fn()
+  })
+)
 
 vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
 vi.mock('../packages/mcp/src/data-access', () => ({


### PR DESCRIPTION
A gate could only be answered from the desktop; an agent driving a workflow through MCP had to call the server by hand.

## What changed

- `resolve_gate` answers an approval on a run: `run_id`, `decision` approve or reject, and `node_id` when more than one gate waits. It finds the waiting node, reads what the gate asked from the definition, and reports the decision and the question, with the note that a desktop must be open for the run to move.
- `list_workflow_runs` with no filter lists the runs parked on a gate, each annotated with what it asks; a waiting node carries `asks` in every listing.
- Both this tool and `stop_workflow_run` find a run that waited past the 500-run history through the server list of parked runs.
- The tool is not advertised to agents running inside a workflow; a gate is there to hold them.

## How to verify

Run a workflow with an approval, call `list_workflow_runs` with no arguments, then `resolve_gate` on it; the run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
