### PR TITLE
Hand a refreshed catalog to the lists already reading the old one

### DIFF
--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -524,8 +524,7 @@ function adopt(
   resolvedMcpServers = mcpServers
   resolvedAt = at
   const signature = JSON.stringify([connectors, resolvedTemplates, mcpServers])
-  // Nothing was held before, so there is nobody holding the old one to tell.
-  const changed = resolvedSignature !== undefined && resolvedSignature !== signature
+  const changed = resolvedSignature !== signature
   resolvedSignature = signature
   return { items: resolved, changed }
 }
@@ -542,8 +541,6 @@ export function catalogItems(options: CatalogOptions = {}): ConnectorCatalogItem
   if (!resolved) {
     const now = options.now ?? Date.now()
     const cache = readCache(options.cachePath ?? CACHE_PATH)
-    // A cached document that predates templates falls back to the seed rather
-    // than to nothing, so the start-from list is never empty on an old cache.
     const { items } = adopt(
       cache?.connectors ?? CONNECTOR_CATALOG,
       cache?.templates ?? [],

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -18,6 +18,7 @@
  * needs is still read by probing the installed package, so nothing here is
  * trusted once a connector is actually being set up.
  */
+import { EventEmitter } from 'node:events'
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
 import os from 'os'
@@ -33,6 +34,7 @@ import type {
   McpServerCatalogEntry,
   WorkflowTemplate
 } from '@vornrun/shared/types'
+import { IPC } from '@vornrun/shared/types'
 import {
   PORTABLE_FORMAT_VERSION,
   type PortableRequirement,
@@ -505,6 +507,28 @@ let resolved: ConnectorCatalogItem[] | undefined
 let resolvedTemplates: WorkflowTemplate[] | undefined
 let resolvedMcpServers: McpServerCatalogEntry[] | undefined
 let resolvedAt: number | undefined
+let resolvedSignature: string | undefined
+
+// Says when a background refresh brought back a different catalog, so a list already on screen can re-read it.
+export const catalogEvents = new EventEmitter()
+
+/** Hold a catalog as the resolved one, with whether it differs from the one held before. */
+function adopt(
+  connectors: ConnectorCatalogEntry[],
+  templates: WorkflowTemplate[],
+  mcpServers: McpServerCatalogEntry[],
+  at: number | undefined
+): { items: ConnectorCatalogItem[]; changed: boolean } {
+  resolved = withLaunch(connectors)
+  resolvedTemplates = templates.length > 0 ? templates : TEMPLATE_SEED
+  resolvedMcpServers = mcpServers
+  resolvedAt = at
+  const signature = JSON.stringify([connectors, resolvedTemplates, mcpServers])
+  // Nothing was held before, so there is nobody holding the old one to tell.
+  const changed = resolvedSignature !== undefined && resolvedSignature !== signature
+  resolvedSignature = signature
+  return { items: resolved, changed }
+}
 
 /**
  * The catalog as the UI consumes it.
@@ -518,13 +542,16 @@ export function catalogItems(options: CatalogOptions = {}): ConnectorCatalogItem
   if (!resolved) {
     const now = options.now ?? Date.now()
     const cache = readCache(options.cachePath ?? CACHE_PATH)
-    resolved = withLaunch(cache?.connectors ?? CONNECTOR_CATALOG)
     // A cached document that predates templates falls back to the seed rather
     // than to nothing, so the start-from list is never empty on an old cache.
-    resolvedTemplates = cache?.templates?.length ? cache.templates : TEMPLATE_SEED
-    resolvedMcpServers = cache?.mcpServers ?? []
-    resolvedAt = cache?.fetchedAt
+    const { items } = adopt(
+      cache?.connectors ?? CONNECTOR_CATALOG,
+      cache?.templates ?? [],
+      cache?.mcpServers ?? [],
+      cache?.fetchedAt
+    )
     if (!cache || now - cache.fetchedAt > MAX_AGE_MS) void refreshCatalog(options)
+    return items
   }
   return resolved
 }
@@ -569,10 +596,9 @@ export async function refreshCatalog(options: CatalogOptions = {}): Promise<bool
   if (!document) return false
   const now = options.now ?? Date.now()
   writeCache(options.cachePath ?? CACHE_PATH, document, now)
-  resolved = withLaunch(document.connectors)
-  resolvedTemplates = document.templates.length > 0 ? document.templates : TEMPLATE_SEED
-  resolvedMcpServers = document.mcpServers
-  resolvedAt = now
+  if (adopt(document.connectors, document.templates, document.mcpServers, now).changed) {
+    catalogEvents.emit(IPC.CONNECTOR_CATALOG_CHANGED)
+  }
   return true
 }
 
@@ -586,4 +612,5 @@ export function resetCatalogCache(): void {
   resolvedTemplates = undefined
   resolvedMcpServers = undefined
   resolvedAt = undefined
+  resolvedSignature = undefined
 }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -167,7 +167,7 @@ import { probeAuth, type BorrowSource } from './connectors/auth-rung'
 import { resolveConnectorAuth } from './connectors/connector-auth'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { isImplicitConnection, type ConnectorPackSource } from '@vornrun/shared/types'
-import { catalogSnapshot, refreshCatalog } from './connectors/catalog'
+import { catalogEvents, catalogSnapshot, refreshCatalog } from './connectors/catalog'
 import { forEachConnectorItem } from './connectors/paging'
 import { buildConnectorSeededWorkflow } from './default-workflows'
 import { connectorSeededWorkflowId, connectorSeededWorkflowIdPrefix } from '@vornrun/shared/types'
@@ -1992,6 +1992,11 @@ export function registerAllMethods(): void {
   })
   scheduler.on('client-message', (channel: string, payload: unknown) => {
     clientRegistry.broadcast(channel, payload)
+  })
+
+  // A background refresh found a different catalog: hand it over rather than let a list on screen keep the old one.
+  catalogEvents.on(IPC.CONNECTOR_CATALOG_CHANGED, () => {
+    clientRegistry.broadcast(IPC.CONNECTOR_CATALOG_CHANGED, catalogSnapshot())
   })
 
   scriptRunnerEvents.on(IPC.SCRIPT_DATA, (payload) => {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1115,6 +1115,7 @@ export interface ServerNotifications {
   'config:changed': AppConfig
   /** How far a connector pack install has got, while it runs. */
   'connector:installProgress': ConnectorInstallProgress
+  'connector:catalogChanged': ConnectorCatalogSnapshot
   'widget:status-update': WidgetAgentInfo[]
   'widget:permission-request': PermissionRequestInfo
   'widget:permission-cancelled': string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1825,7 +1825,8 @@ export const IPC = {
   CONNECTOR_REMOVE_PACK: 'connector:removePack',
   CONNECTOR_ROLLBACK_PACK: 'connector:rollbackPack',
   CONNECTOR_LIST_PACKS: 'connector:listPacks',
-  CONNECTOR_INSTALL_PROGRESS: 'connector:installProgress'
+  CONNECTOR_INSTALL_PROGRESS: 'connector:installProgress',
+  CONNECTOR_CATALOG_CHANGED: 'connector:catalogChanged'
 } as const
 
 /**

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -766,6 +766,8 @@ export function createApiShim(wsUrl: string) {
     listConnectorPacks: () => rpc.invoke('connector:listPacks'),
     onConnectorInstallProgress: (cb: (progress: unknown) => void) =>
       rpc.on('connector:installProgress', cb),
+    onConnectorCatalogChanged: (cb: (snapshot: unknown) => void) =>
+      rpc.on('connector:catalogChanged', cb),
     detectRepo: (projectPath: string) => rpc.invoke('connector:detectRepo', projectPath),
     seedConnectorWorkflow: (connectionId: string, event: string) =>
       rpc.invoke('connector:seedWorkflow', { connectionId, event }),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -936,6 +936,19 @@ const api = {
     import('../../packages/shared/src/types').InstalledConnectorPack[]
   > => ipcRenderer.invoke(IPC.CONNECTOR_LIST_PACKS),
 
+  onConnectorCatalogChanged: (
+    callback: (snapshot: import('../../packages/shared/src/types').ConnectorCatalogSnapshot) => void
+  ) => {
+    const listener = (
+      _: Electron.IpcRendererEvent,
+      snapshot: import('../../packages/shared/src/types').ConnectorCatalogSnapshot
+    ): void => callback(snapshot)
+    ipcRenderer.on(IPC.CONNECTOR_CATALOG_CHANGED, listener)
+    return () => {
+      ipcRenderer.removeListener(IPC.CONNECTOR_CATALOG_CHANGED, listener)
+    }
+  },
+
   onConnectorInstallProgress: (
     callback: (progress: import('../../packages/shared/src/types').ConnectorInstallProgress) => void
   ) => {

--- a/src/renderer/lib/use-connector-catalog.ts
+++ b/src/renderer/lib/use-connector-catalog.ts
@@ -58,11 +58,7 @@ function watchForChanges(): void {
     // Newer than any read in flight, which must not overwrite it.
     generation += 1
     inFlight = undefined
-    if (next) publish(next)
-    else {
-      cache = undefined
-      void load()
-    }
+    publish(next)
   })
 }
 
@@ -90,10 +86,12 @@ export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
 // "Check now": ask the publisher again rather than re-read the copy this process holds.
 export async function refreshConnectorCatalog(): Promise<CatalogSnapshot> {
   cache = undefined
-  generation += 1
+  const started = ++generation
   const fetched = await Promise.resolve(window.api?.refreshConnectorCatalog?.()).catch(
     () => undefined
   )
+  // A broadcast that landed meanwhile is newer than this answer.
+  if (started !== generation) return cache ?? load()
   return fetched ? publish(fetched) : load()
 }
 

--- a/src/renderer/lib/use-connector-catalog.ts
+++ b/src/renderer/lib/use-connector-catalog.ts
@@ -49,6 +49,23 @@ async function load(): Promise<CatalogSnapshot> {
   return inFlight
 }
 
+// Subscribed once, so a catalog the server refreshed in the background reaches a list already on screen.
+let unsubscribeCatalogChange: (() => void) | undefined
+function watchForChanges(): void {
+  if (unsubscribeCatalogChange || typeof window.api?.onConnectorCatalogChanged !== 'function')
+    return
+  unsubscribeCatalogChange = window.api.onConnectorCatalogChanged((next) => {
+    // Newer than any read in flight, which must not overwrite it.
+    generation += 1
+    inFlight = undefined
+    if (next) publish(next)
+    else {
+      cache = undefined
+      void load()
+    }
+  })
+}
+
 // `enabled` is how a closed panel says nobody is looking yet.
 export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
   const [snapshot, setSnapshot] = useState<CatalogSnapshot>(() => cache ?? EMPTY)
@@ -56,6 +73,7 @@ export function useConnectorCatalog(enabled: boolean = true): CatalogSnapshot {
   useEffect(() => {
     if (!enabled) return
     let live = true
+    watchForChanges()
     listeners.add(setSnapshot)
     void load().then((next) => {
       if (live) setSnapshot(next)
@@ -84,4 +102,6 @@ export function __resetCatalogCacheForTests(): void {
   cache = undefined
   inFlight = undefined
   listeners.clear()
+  unsubscribeCatalogChange?.()
+  unsubscribeCatalogChange = undefined
 }

--- a/tests/connector-catalog-changed.test.tsx
+++ b/tests/connector-catalog-changed.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { ConnectorCatalogSnapshot } from '../src/shared/types'
+
+const listConnectorCatalog = vi.fn()
+const onConnectorCatalogChanged = vi.fn()
+let announce: ((snapshot: ConnectorCatalogSnapshot | undefined) => void) | undefined
+const unsubscribe = vi.fn()
+
+;(window as unknown as { api: unknown }).api = {
+  listConnectorCatalog,
+  onConnectorCatalogChanged
+}
+
+const { useConnectorCatalog, __resetCatalogCacheForTests } =
+  await import('../src/renderer/lib/use-connector-catalog')
+
+const snapshot = (id: string): ConnectorCatalogSnapshot => ({
+  items: [
+    {
+      id,
+      name: id,
+      description: '',
+      packageName: `@vornrun/connector-${id}`,
+      capabilities: [],
+      launch: { command: 'node', args: [] }
+    }
+  ],
+  templates: [],
+  mcpServers: [],
+  fetchedAt: 1
+})
+
+function Probe(): React.ReactElement {
+  const catalog = useConnectorCatalog()
+  return <span data-testid="ids">{catalog.items.map((i) => i.id).join(',') || 'none'}</span>
+}
+
+beforeEach(() => {
+  __resetCatalogCacheForTests()
+  vi.clearAllMocks()
+  listConnectorCatalog.mockResolvedValue(snapshot('slack'))
+  onConnectorCatalogChanged.mockImplementation((cb: typeof announce) => {
+    announce = cb
+    return unsubscribe
+  })
+})
+
+describe('a catalog the server refreshed on its own', () => {
+  it('reaches a list already on screen, without anyone pressing refresh', async () => {
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('ids')).toHaveTextContent('slack'))
+
+    await act(async () => announce?.(snapshot('gitlab')))
+
+    expect(screen.getByTestId('ids')).toHaveTextContent('gitlab')
+    // The list came with the news, so nothing had to be asked for it again.
+    expect(listConnectorCatalog).toHaveBeenCalledTimes(1)
+  })
+
+  it('asks again when the news arrives without a catalog', async () => {
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('ids')).toHaveTextContent('slack'))
+    listConnectorCatalog.mockResolvedValue(snapshot('postgres'))
+
+    await act(async () => announce?.(undefined))
+
+    await waitFor(() => expect(screen.getByTestId('ids')).toHaveTextContent('postgres'))
+  })
+
+  it('subscribes once however many panels are open', async () => {
+    render(<Probe />)
+    render(<Probe />)
+    await waitFor(() => expect(screen.getAllByTestId('ids')).toHaveLength(2))
+
+    expect(onConnectorCatalogChanged).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/connector-catalog-changed.test.tsx
+++ b/tests/connector-catalog-changed.test.tsx
@@ -6,9 +6,7 @@ import type { ConnectorCatalogSnapshot } from '../src/shared/types'
 
 const listConnectorCatalog = vi.fn()
 const onConnectorCatalogChanged = vi.fn()
-let announce: ((snapshot: ConnectorCatalogSnapshot | undefined) => void) | undefined
-const unsubscribe = vi.fn()
-
+let announce: ((snapshot: ConnectorCatalogSnapshot) => void) | undefined
 ;(window as unknown as { api: unknown }).api = {
   listConnectorCatalog,
   onConnectorCatalogChanged
@@ -44,7 +42,7 @@ beforeEach(() => {
   listConnectorCatalog.mockResolvedValue(snapshot('slack'))
   onConnectorCatalogChanged.mockImplementation((cb: typeof announce) => {
     announce = cb
-    return unsubscribe
+    return () => {}
   })
 })
 
@@ -58,16 +56,6 @@ describe('a catalog the server refreshed on its own', () => {
     expect(screen.getByTestId('ids')).toHaveTextContent('gitlab')
     // The list came with the news, so nothing had to be asked for it again.
     expect(listConnectorCatalog).toHaveBeenCalledTimes(1)
-  })
-
-  it('asks again when the news arrives without a catalog', async () => {
-    render(<Probe />)
-    await waitFor(() => expect(screen.getByTestId('ids')).toHaveTextContent('slack'))
-    listConnectorCatalog.mockResolvedValue(snapshot('postgres'))
-
-    await act(async () => announce?.(undefined))
-
-    await waitFor(() => expect(screen.getByTestId('ids')).toHaveTextContent('postgres'))
   })
 
   it('subscribes once however many panels are open', async () => {

--- a/tests/connector-catalog.test.ts
+++ b/tests/connector-catalog.test.ts
@@ -3,8 +3,10 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { defineConnector } from '../packages/connector-sdk/src'
+import { IPC } from '../packages/shared/src/types'
 import {
   CONNECTOR_CATALOG,
+  catalogEvents,
   catalogItems,
   catalogLaunchSpec,
   catalogSnapshot,
@@ -318,6 +320,52 @@ describe('refreshCatalog', () => {
     // Emptying the connector list because a proxy blocked one request would
     // make the app look broken.
     expect(catalogItems({ ...offline(), cachePath }).length).toBeGreaterThan(0)
+  })
+
+  it('says so once when the published catalog has changed, so an open list can re-read it', async () => {
+    resetCatalogCache()
+    const cachePath = emptyCache()
+    const announced: unknown[] = []
+    const listener = () => announced.push(1)
+    catalogEvents.on(IPC.CONNECTOR_CATALOG_CHANGED, listener)
+    try {
+      const serve = (id: string) =>
+        (async () =>
+          new Response(
+            JSON.stringify({ version: 1, connectors: [published(id)] })
+          )) as unknown as typeof fetch
+
+      // The first catalog this process holds: nobody is holding an older one to tell.
+      expect(await refreshCatalog({ fetchImpl: serve('one'), cachePath, now: 1 })).toBe(true)
+      expect(announced).toHaveLength(0)
+
+      expect(await refreshCatalog({ fetchImpl: serve('two'), cachePath, now: 2 })).toBe(true)
+      expect(announced).toHaveLength(1)
+    } finally {
+      catalogEvents.off(IPC.CONNECTOR_CATALOG_CHANGED, listener)
+    }
+  })
+
+  it('stays quiet when the published catalog is the one already held', async () => {
+    resetCatalogCache()
+    const cachePath = emptyCache()
+    const announced: unknown[] = []
+    const listener = () => announced.push(1)
+    catalogEvents.on(IPC.CONNECTOR_CATALOG_CHANGED, listener)
+    try {
+      const fetchImpl = (async () =>
+        new Response(
+          JSON.stringify({ version: 1, connectors: [published('same')] })
+        )) as unknown as typeof fetch
+
+      await refreshCatalog({ fetchImpl, cachePath, now: 1 })
+      // A second check an hour later that finds the same list is not news.
+      await refreshCatalog({ fetchImpl, cachePath, now: 2 })
+
+      expect(announced).toHaveLength(0)
+    } finally {
+      catalogEvents.off(IPC.CONNECTOR_CATALOG_CHANGED, listener)
+    }
   })
 
   it('refuses a page served where the catalog should be', async () => {

--- a/tests/connector-catalog.test.ts
+++ b/tests/connector-catalog.test.ts
@@ -336,11 +336,12 @@ describe('refreshCatalog', () => {
           )) as unknown as typeof fetch
 
       // The first catalog this process holds: nobody is holding an older one to tell.
+      // The first list this process ever downloads is news to a client holding the seed.
       expect(await refreshCatalog({ fetchImpl: serve('one'), cachePath, now: 1 })).toBe(true)
-      expect(announced).toHaveLength(0)
+      expect(announced).toHaveLength(1)
 
       expect(await refreshCatalog({ fetchImpl: serve('two'), cachePath, now: 2 })).toBe(true)
-      expect(announced).toHaveLength(1)
+      expect(announced).toHaveLength(2)
     } finally {
       catalogEvents.off(IPC.CONNECTOR_CATALOG_CHANGED, listener)
     }
@@ -349,6 +350,7 @@ describe('refreshCatalog', () => {
   it('stays quiet when the published catalog is the one already held', async () => {
     resetCatalogCache()
     const cachePath = emptyCache()
+    catalogItems({ cachePath, now: 0 })
     const announced: unknown[] = []
     const listener = () => announced.push(1)
     catalogEvents.on(IPC.CONNECTOR_CATALOG_CHANGED, listener)
@@ -359,10 +361,10 @@ describe('refreshCatalog', () => {
         )) as unknown as typeof fetch
 
       await refreshCatalog({ fetchImpl, cachePath, now: 1 })
-      // A second check an hour later that finds the same list is not news.
+      // The first check replaced the seed; a second that finds the same list is not news.
       await refreshCatalog({ fetchImpl, cachePath, now: 2 })
 
-      expect(announced).toHaveLength(0)
+      expect(announced).toHaveLength(1)
     } finally {
       catalogEvents.off(IPC.CONNECTOR_CATALOG_CHANGED, listener)
     }

--- a/tests/connector-catalog.test.ts
+++ b/tests/connector-catalog.test.ts
@@ -335,8 +335,7 @@ describe('refreshCatalog', () => {
             JSON.stringify({ version: 1, connectors: [published(id)] })
           )) as unknown as typeof fetch
 
-      // The first catalog this process holds: nobody is holding an older one to tell.
-      // The first list this process ever downloads is news to a client holding the seed.
+      // The first list this process downloads differs from the seed, so it is announced.
       expect(await refreshCatalog({ fetchImpl: serve('one'), cachePath, now: 1 })).toBe(true)
       expect(announced).toHaveLength(1)
 


### PR DESCRIPTION
The server refreshed the connector catalog in the background when its cache was older than six hours, but told nobody: the directory kept showing the rows it had, and two installs this week went to npm because their rows predated the packs.

## What changed

- A refresh that changes the catalog broadcasts `connector:catalogChanged` with the new snapshot, mirroring how a config change reaches clients. The first catalog a process downloads counts as a change against the seed. An unchanged refresh stays silent.
- The renderer catalog hook subscribes once and publishes the snapshot to every mounted consumer, so the directory, the step library and the editor forms re-render without anyone pressing Refresh. A read in flight cannot overwrite what the broadcast brought, and Check now yields to a broadcast that arrived meanwhile.

## How to verify

With a stale cache missing one connector, open Browse: the row appears on its own within a moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
