### PR TITLE
Install a connector from the pack a release published, or say it has none

### DIFF
--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -194,7 +194,7 @@ export function registerConnectorTools(server: McpServer): void {
 
   server.tool(
     'install_connector',
-    'Install a connector from a pack file or from the catalog, creating ' +
+    'Install a connector from a pack file, from the catalog, or by a launch command, creating ' +
       'a connection ready to poll. Call list_connectors for catalog ids and ' +
       'inspect_connector_package to see which environment variables are needed. Secrets cannot ' +
       'be set this way — see the error it returns if the connector requires one.',

--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -194,7 +194,7 @@ export function registerConnectorTools(server: McpServer): void {
 
   server.tool(
     'install_connector',
-    'Install a connector from a pack file, from the catalog, or from an npm package, creating ' +
+    'Install a connector from a pack file or from the catalog, creating ' +
       'a connection ready to poll. Call list_connectors for catalog ids and ' +
       'inspect_connector_package to see which environment variables are needed. Secrets cannot ' +
       'be set this way — see the error it returns if the connector requires one.',
@@ -202,7 +202,9 @@ export function registerConnectorTools(server: McpServer): void {
       connector_id: V.id
         .optional()
         .describe('Catalog connector id (from list_connectors). Use this or package.'),
-      package: V.shortText.optional().describe('npm package name or launch command'),
+      package: V.shortText
+        .optional()
+        .describe('Launch command the connection runs, or a package name to run with npx'),
       pack_path: V.shortText
         .optional()
         .describe(

--- a/packages/server/src/connectors/packs.ts
+++ b/packages/server/src/connectors/packs.ts
@@ -40,8 +40,8 @@ const CURRENT_FILE = 'current.json'
 
 /**
  * Everything a pack may carry, so nothing else can be reached at run time.
- * `package.json` is tolerated because an npm tarball always has one; it is
- * still held to the dependency and script gates below.
+ * `package.json` is tolerated because a tarball built by a packager carries
+ * one; it is still held to the dependency and script gates below.
  */
 const PACK_FILES = [MANIFEST_FILE, ENTRY_FILE, 'package.json']
 
@@ -203,7 +203,7 @@ export function isSafeArchiveEntry(path: string, type: string): boolean {
   return !path.split(/[/\\]/).includes('..')
 }
 
-/** npm tarballs put everything under `package/`; a `.vorn.tgz` does not. */
+/** A tarball may wrap everything in one directory; a `.vorn.tgz` does not. */
 function packRootOf(dir: string): string {
   if (existsSync(join(dir, MANIFEST_FILE))) return dir
   const entries = readdirSync(dir, { withFileTypes: true })
@@ -228,8 +228,7 @@ async function readSource(
   }
 
   const get = options.fetchImpl ?? fetch
-  const url = source.kind === 'url' ? source.url : await resolveNpmTarball(source.packageName, get)
-  const response = await get(url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) })
+  const response = await get(source.url, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) })
   if (!response.ok) throw new Error(`Downloading the pack failed with HTTP ${response.status}`)
 
   const total = Number(response.headers.get('content-length')) || 0
@@ -249,7 +248,7 @@ async function readSource(
   }
 
   const bytes = Buffer.concat(chunks)
-  if (source.kind === 'url' && source.sha256) {
+  if (source.sha256) {
     const digest = createHash('sha256').update(bytes).digest('hex')
     if (digest !== source.sha256.toLowerCase()) {
       throw new Error('The downloaded pack does not match the checksum the catalog published')
@@ -272,22 +271,6 @@ async function* streamOf(response: Response): AsyncGenerator<Uint8Array> {
   }
 }
 
-async function resolveNpmTarball(packageName: string, get: typeof fetch): Promise<string> {
-  const response = await get(
-    `https://registry.npmjs.org/${encodeURIComponent(packageName).replace('%40', '@')}/latest`,
-    { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) }
-  )
-  if (!response.ok) {
-    throw new Error(`${packageName} could not be looked up (HTTP ${response.status})`)
-  }
-  const metadata = (await response.json()) as { dist?: { tarball?: unknown } }
-  const tarball = metadata?.dist?.tarball
-  if (typeof tarball !== 'string' || tarball === '') {
-    throw new Error(`${packageName} published no tarball to install`)
-  }
-  return tarball
-}
-
 function sizeMessage(bytes: number): string {
   return `The pack is ${Math.round(bytes / 1024)} KB; Vorn installs at most ${MAX_PACK_BYTES / 1024 / 1024} MB`
 }
@@ -297,7 +280,6 @@ function unpackedMessage(bytes: number): string {
 }
 
 function describeSource(source: ConnectorPackSource): string {
-  if (source.kind === 'npm') return source.packageName
   if (source.kind === 'staged') return `a checked pack`
   return source.kind === 'file' ? source.path : source.url
 }

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -223,10 +223,6 @@ function unusableSource(source: ConnectorPackSource): string {
   switch (source.kind) {
     case 'file':
       return typeof source.path === 'string' && source.path !== '' ? '' : 'That file path is empty'
-    case 'npm':
-      return typeof source.packageName === 'string' && source.packageName !== ''
-        ? ''
-        : 'That package name is empty'
     case 'staged':
       return typeof source.token === 'string' && source.token !== '' ? '' : 'That pack has expired'
     case 'url': {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2120,7 +2120,6 @@ export interface InstalledConnectorPack {
 export type ConnectorPackSource =
   | { kind: 'file'; path: string }
   | { kind: 'url'; url: string; sha256?: string }
-  | { kind: 'npm'; packageName: string }
   | { kind: 'staged'; token: string }
 
 export type ConnectorPackResult =

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -17,7 +17,12 @@ import {
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
-import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
+import {
+  canAddConnection,
+  describePackStatus,
+  isReleased,
+  packStateFor
+} from '../../lib/pack-status'
 import type { RowState } from '../../lib/use-row-action'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
 import { ActivityLine } from './ActivityLine'
@@ -70,7 +75,8 @@ export function ConnectorDetail({
   const state = packStateFor({
     installed: listing.pack,
     catalogVersion: entry?.version,
-    progress
+    progress,
+    released: isReleased(listing)
   })
   const status = describePackStatus(state)
   const busy = Boolean(activity?.phrase)
@@ -265,7 +271,9 @@ export function ConnectorDetail({
 
         {listing.source === 'catalog' && !listing.pack && (
           <span className="text-[11px] text-gray-600 ml-auto">
-            Nothing is on disk until you install it.
+            {state.kind === 'not-released'
+              ? 'Not released yet, so there is nothing to install.'
+              : 'Nothing is on disk until you install it.'}
           </span>
         )}
       </div>

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -17,12 +17,7 @@ import {
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
-import {
-  canAddConnection,
-  describePackStatus,
-  isReleased,
-  packStateFor
-} from '../../lib/pack-status'
+import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
 import type { RowState } from '../../lib/use-row-action'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
 import { ActivityLine } from './ActivityLine'
@@ -72,12 +67,7 @@ export function ConnectorDetail({
 }) {
   const details = listingDetails(listing, builtIns)
   const entry = listing.catalogItem
-  const state = packStateFor({
-    installed: listing.pack,
-    catalogVersion: entry?.version,
-    progress,
-    released: isReleased(listing)
-  })
+  const state = packStateFor({ installed: listing.pack, catalogItem: entry, progress })
   const status = describePackStatus(state)
   const busy = Boolean(activity?.phrase)
 
@@ -269,11 +259,10 @@ export function ConnectorDetail({
           </a>
         )}
 
-        {listing.source === 'catalog' && !listing.pack && (
+        {/* An unreleased entry says so in the status line above, and says it once. */}
+        {listing.source === 'catalog' && !listing.pack && state.kind === 'absent' && (
           <span className="text-[11px] text-gray-600 ml-auto">
-            {state.kind === 'not-released'
-              ? 'Not released yet, so there is nothing to install.'
-              : 'Nothing is on disk until you install it.'}
+            Nothing is on disk until you install it.
           </span>
         )}
       </div>

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -15,7 +15,12 @@ import {
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
-import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
+import {
+  canAddConnection,
+  describePackStatus,
+  isReleased,
+  packStateFor
+} from '../../lib/pack-status'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
 
 /**
@@ -262,7 +267,8 @@ export function ConnectorRow({
   const state = packStateFor({
     installed: listing.pack,
     catalogVersion: listing.catalogItem?.version,
-    progress
+    progress,
+    released: isReleased(listing)
   })
   const status = describePackStatus(state)
   // An MCP server is a command this machine runs, so there is no pack to install.

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -15,12 +15,7 @@ import {
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
-import {
-  canAddConnection,
-  describePackStatus,
-  isReleased,
-  packStateFor
-} from '../../lib/pack-status'
+import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
 
 /**
@@ -266,9 +261,8 @@ export function ConnectorRow({
   const details = listingDetails(listing, builtIns)
   const state = packStateFor({
     installed: listing.pack,
-    catalogVersion: listing.catalogItem?.version,
-    progress,
-    released: isReleased(listing)
+    catalogItem: listing.catalogItem,
+    progress
   })
   const status = describePackStatus(state)
   // An MCP server is a command this machine runs, so there is no pack to install.
@@ -329,13 +323,14 @@ export function ConnectorRow({
             </span>
           )}
 
-          {/* The only colour on the row: a rejection, or the dot saying it is on disk. */}
+          {/* The only colour on the row: a rejection, an unreleased entry, or the dot saying it is on disk. */}
           {state.kind !== 'absent' && (
             <span
               className={`flex items-center gap-1.5 text-[11px] mt-1.5 ${TONE_TEXT[status.tone]}`}
             >
               <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${TONE_DOT[status.tone]}`} />
-              {status.detail ?? status.label}
+              {/* A row has room for the label; the whole sentence belongs on the page. */}
+              {state.kind === 'not-released' ? status.label : (status.detail ?? status.label)}
             </span>
           )}
 

--- a/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
+++ b/src/renderer/components/workflow-editor/panels/StepLibrary.tsx
@@ -34,7 +34,7 @@ import { connectionConnectorId } from '../../../lib/connection-icon'
 import { HTTP_PROFILE_CONNECTOR } from '../../../../shared/workflow-portability'
 import { ConnectorIcon } from '../../ConnectorIcon'
 import { NODE_GLYPH } from '../node-visuals'
-import { canAddConnection, packStateFor } from '../../../lib/pack-status'
+import { packStateFor } from '../../../lib/pack-status'
 import type { AddableNodeType } from '../WorkflowCanvas'
 import type { LibraryPick } from '../../../lib/library-pick'
 
@@ -300,16 +300,15 @@ export function StepLibrary({
             )
         if (actions.length === 0) continue
         // Say the step someone is about to take: a connector already on disk only wants connecting.
-        const state = packStateFor({ installed: packs.find((pack) => pack.id === entry.id) })
-        const connectable = canAddConnection(state, {
-          source: 'catalog',
-          hasLegacyLaunch: Boolean(entry.packageName)
+        const state = packStateFor({
+          installed: packs.find((pack) => pack.id === entry.id),
+          catalogItem: entry
         })
         const detail =
-          state.kind !== 'installed' && entry.packUrl
-            ? 'install on add'
-            : connectable
-              ? 'add connection'
+          state.kind === 'installed'
+            ? 'add connection'
+            : state.kind === 'not-released'
+              ? 'not released yet'
               : 'install on add'
         const into = entry.verified ? vouched : unvouched
         for (const action of actions) {

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -185,7 +185,7 @@ export function describePackStatus(state: PackState): PackStatusView {
   }
 }
 
-/** A catalog entry with no pack still launches by name, so it stays reachable. */
+/** Whether a connection can be added: an installed pack, a launch by name, or a catalog entry that has a pack. */
 export function canAddConnection(
   state: PackState,
   route: { source: string; hasLegacyLaunch?: boolean }

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -76,24 +76,16 @@ export function isNewerVersion(candidate: string, current: string): boolean {
   return false
 }
 
-/** A catalog entry names a pack only once a release has published one. */
-export function isReleased(listing: {
-  source: string
-  catalogItem?: { packUrl?: string } | undefined
-}): boolean {
-  return listing.source !== 'catalog' || Boolean(listing.catalogItem?.packUrl)
-}
-
 /** A live install outranks a rejection, which outranks what is on disk. */
 export function packStateFor(input: {
   installed?: InstalledConnectorPack | undefined
-  /** Version the catalog publishes, used only to offer an update. */
-  catalogVersion?: string | undefined
+  /** The catalog's own entry: its version offers an update, and it names a pack only once a release published one. */
+  catalogItem?: { version?: string; packUrl?: string } | undefined
   progress?: ConnectorInstallProgress | undefined
-  /** False when the catalog names this connector but no release published a pack. */
-  released?: boolean
 }): PackState {
-  const { installed, catalogVersion, progress, released = true } = input
+  const { installed, catalogItem, progress } = input
+  // Only a listed connector can be unreleased; one that brings its own pack has nothing to wait for.
+  const released = !catalogItem || Boolean(catalogItem.packUrl)
 
   if (progress && progress.phase !== 'installed' && progress.phase !== 'failed') {
     return {
@@ -107,11 +99,15 @@ export function packStateFor(input: {
   }
   if (!installed) return released ? { kind: 'absent' } : { kind: 'not-released' }
 
+  // A catalog that names a newer version but no pack has nothing to update from.
+  const publishedVersion = released ? catalogItem?.version : undefined
   return {
     kind: 'installed',
     version: installed.version,
-    ...(catalogVersion &&
-      isNewerVersion(catalogVersion, installed.version) && { availableVersion: catalogVersion }),
+    ...(publishedVersion &&
+      isNewerVersion(publishedVersion, installed.version) && {
+        availableVersion: publishedVersion
+      }),
     ...(installed.previousVersion !== undefined && { previousVersion: installed.previousVersion })
   }
 }
@@ -131,7 +127,7 @@ export function describePackStatus(state: PackState): PackStatusView {
     case 'not-released':
       return {
         label: 'Not released yet',
-        detail: null,
+        detail: 'Not released yet, so there is nothing to install.',
         tone: 'idle',
         percent: null,
         action: null,
@@ -198,5 +194,7 @@ export function canAddConnection(
   // An MCP server is a command, so there is nothing to install before connecting.
   if (route.source === 'mcp') return true
   if (state.kind === 'installed') return true
+  // Nothing was published to install, so there is nothing to connect to either.
+  if (state.kind === 'not-released') return false
   return route.hasLegacyLaunch === true
 }

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -4,6 +4,7 @@ import type { StatusTone } from './status-tone'
 /** A rejection is session state, not persisted: nothing was written to disk. */
 export type PackState =
   | { kind: 'absent' }
+  | { kind: 'not-released' }
   | { kind: 'installing'; phase: ConnectorInstallProgress['phase']; percent?: number }
   | {
       kind: 'installed'
@@ -75,14 +76,24 @@ export function isNewerVersion(candidate: string, current: string): boolean {
   return false
 }
 
+/** A catalog entry names a pack only once a release has published one. */
+export function isReleased(listing: {
+  source: string
+  catalogItem?: { packUrl?: string } | undefined
+}): boolean {
+  return listing.source !== 'catalog' || Boolean(listing.catalogItem?.packUrl)
+}
+
 /** A live install outranks a rejection, which outranks what is on disk. */
 export function packStateFor(input: {
   installed?: InstalledConnectorPack | undefined
   /** Version the catalog publishes, used only to offer an update. */
   catalogVersion?: string | undefined
   progress?: ConnectorInstallProgress | undefined
+  /** False when the catalog names this connector but no release published a pack. */
+  released?: boolean
 }): PackState {
-  const { installed, catalogVersion, progress } = input
+  const { installed, catalogVersion, progress, released = true } = input
 
   if (progress && progress.phase !== 'installed' && progress.phase !== 'failed') {
     return {
@@ -94,7 +105,7 @@ export function packStateFor(input: {
   if (progress?.phase === 'failed') {
     return { kind: 'rejected', error: progress.error ?? 'The pack could not be installed' }
   }
-  if (!installed) return { kind: 'absent' }
+  if (!installed) return released ? { kind: 'absent' } : { kind: 'not-released' }
 
   return {
     kind: 'installed',
@@ -114,6 +125,16 @@ export function describePackStatus(state: PackState): PackStatusView {
         tone: 'idle',
         percent: null,
         action: 'install',
+        busy: false
+      }
+
+    case 'not-released':
+      return {
+        label: 'Not released yet',
+        detail: null,
+        tone: 'idle',
+        percent: null,
+        action: null,
         busy: false
       }
 

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -113,7 +113,9 @@ export function requirementAction(
   // ask about. Settings is where a server gets wired up by hand.
   if (listing.source === 'mcp') return { kind: 'none' }
 
-  const state = packStateFor({ installed: listing.pack })
+  const state = packStateFor({ installed: listing.pack, catalogItem: listing.catalogItem })
+  // No release published a pack, so neither button would do anything.
+  if (state.kind === 'not-released') return { kind: 'none' }
   const route = { source: listing.source, hasLegacyLaunch: !!listing.catalogItem?.packageName }
   return canAddConnection(state, route)
     ? { kind: 'addConnection', listing }

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -141,8 +141,11 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       setPending(null)
       // Busy from the press itself, so the button cannot be pressed twice while the server is still silent.
       const source = sourceFor(listing)
-      // Nothing to fetch until a release publishes one, so the row never says it is working.
-      if (!source) return
+      // Nothing to fetch until a release publishes one; whatever an earlier press left on the row goes too.
+      if (!source) {
+        forget(listing.id)
+        return
+      }
       setProgress((current) => ({
         ...current,
         [listing.id]: { id: listing.id, phase: 'checking' }

--- a/src/renderer/lib/use-pack-install.ts
+++ b/src/renderer/lib/use-pack-install.ts
@@ -44,16 +44,11 @@ export interface PackInstall {
   report: (message: string) => void
 }
 
-/** Where a listing's pack comes from when the caller does not name a source. */
-function sourceFor(listing: ConnectorListing): ConnectorPackSource {
-  if (listing.catalogItem?.packUrl) {
-    return {
-      kind: 'url',
-      url: listing.catalogItem.packUrl,
-      ...(listing.catalogItem.sha256 && { sha256: listing.catalogItem.sha256 })
-    } as ConnectorPackSource
-  }
-  return { kind: 'npm', packageName: listing.catalogItem?.packageName ?? listing.id } as const
+/** Where a listing's pack comes from, or nothing when no release published one. */
+function sourceFor(listing: ConnectorListing): ConnectorPackSource | undefined {
+  const entry = listing.catalogItem
+  if (!entry?.packUrl) return undefined
+  return { kind: 'url', url: entry.packUrl, ...(entry.sha256 && { sha256: entry.sha256 }) }
 }
 
 /** Check a source, answering a refusal rather than throwing one. */
@@ -145,11 +140,14 @@ export function usePackInstall(onInstalled?: () => void | Promise<void>): PackIn
       setError(null)
       setPending(null)
       // Busy from the press itself, so the button cannot be pressed twice while the server is still silent.
+      const source = sourceFor(listing)
+      // Nothing to fetch until a release publishes one, so the row never says it is working.
+      if (!source) return
       setProgress((current) => ({
         ...current,
         [listing.id]: { id: listing.id, phase: 'checking' }
       }))
-      const result = await stage(sourceFor(listing))
+      const result = await stage(source)
       if (!result.ok) {
         // Keyed by the row that asked, which is the row that shows the refusal.
         setProgress((current) => ({

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -58,6 +58,8 @@ const UNRELEASED: ConnectorCatalogItem = {
   ...KUSTO,
   id: 'gitlab',
   name: 'GitLab',
+  packageName: '@vornrun/connector-gitlab',
+  launch: { command: 'npx', args: ['-y', '@vornrun/connector-gitlab'] },
   packUrl: undefined
 }
 

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -17,6 +17,7 @@ const ADO: ConnectorCatalogItem = {
   description: 'Trigger workflows from the work items a WIQL query returns.',
   packageName: '@vornrun/connector-ado',
   version: '0.1.0',
+  packUrl: 'https://packs.test/ado-0.1.0.vorn.tgz',
   capabilities: ['triggers'],
   category: 'Development',
   keywords: ['boards', 'tfs'],
@@ -42,6 +43,7 @@ const KUSTO: ConnectorCatalogItem = {
   description: 'Trigger workflows from the rows a KQL query returns.',
   packageName: '@vornrun/connector-kusto',
   version: '0.6.0',
+  packUrl: 'https://packs.test/kusto-0.6.0.vorn.tgz',
   capabilities: ['triggers', 'actions'],
   category: 'Data & observability',
   keywords: ['kql'],
@@ -49,6 +51,14 @@ const KUSTO: ConnectorCatalogItem = {
   triggers: [{ type: 'queryResult', label: 'Query returns a row' }],
   actions: [{ type: 'runQuery', label: 'Run a KQL query' }],
   env: [{ name: 'KUSTO_CLUSTER', required: true }]
+}
+
+/** A catalog entry no release has published a pack for yet. */
+const UNRELEASED: ConnectorCatalogItem = {
+  ...KUSTO,
+  id: 'gitlab',
+  name: 'GitLab',
+  packUrl: undefined
 }
 
 const listings = (): ConnectorListing[] => buildConnectorListings([], [ADO, KUSTO], [])
@@ -64,6 +74,21 @@ describe('the connector list', () => {
     )
     return { ...utils, onSelect, onAdd }
   }
+
+  it('says a connector no release has published yet is not installable', () => {
+    const { getByText, queryByText } = render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [UNRELEASED], [])}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+        onInstall={vi.fn()}
+      />
+    )
+
+    expect(getByText('Not released yet')).toBeInTheDocument()
+    expect(queryByText('Install')).not.toBeInTheDocument()
+  })
 
   it('calls connecting to an MCP server adding a server, and offers no install', () => {
     const server = { id: 'playwright', name: 'Playwright', command: 'npx', args: [] }
@@ -236,6 +261,24 @@ describe('where a verified pack asks to be kept', () => {
 
     expect(getByText('Install')).toBeInTheDocument()
     expect(order(container, 'Keep this pack?')).toBeGreaterThan(order(container, 'Install'))
+  })
+})
+
+describe('a connector page for something not released', () => {
+  it('offers no install, and says why', () => {
+    const listing = buildConnectorListings([], [UNRELEASED], [])[0]
+    const { getByText, queryByText } = render(
+      <ConnectorDetail
+        listing={listing}
+        builtIns={[]}
+        onAdd={vi.fn()}
+        onClose={vi.fn()}
+        onInstall={vi.fn()}
+      />
+    )
+
+    expect(getByText(/Not released yet/)).toBeInTheDocument()
+    expect(queryByText('Install')).not.toBeInTheDocument()
   })
 })
 

--- a/tests/connector-install-flow.test.tsx
+++ b/tests/connector-install-flow.test.tsx
@@ -19,6 +19,7 @@ const CATALOG: ConnectorCatalogItem = {
   name: 'Acme',
   description: 'Acme tickets',
   packageName: '@vornrun/connector-acme',
+  packUrl: 'https://packs.test/acme-1.2.0.vorn.tgz',
   capabilities: ['actions'],
   category: 'Development',
   keywords: [],

--- a/tests/connector-pack-ui.test.tsx
+++ b/tests/connector-pack-ui.test.tsx
@@ -20,6 +20,7 @@ const catalogEntry: ConnectorCatalogItem = {
   description: 'Acme tickets',
   packageName: '@vornrun/connector-acme',
   version: '1.3.0',
+  packUrl: 'https://packs.test/acme-1.3.0.vorn.tgz',
   capabilities: ['triggers'],
   category: 'Development',
   launch: { command: 'npx', args: ['-y', '@vornrun/connector-acme'] }

--- a/tests/connector-packs.test.ts
+++ b/tests/connector-packs.test.ts
@@ -351,7 +351,7 @@ describe('installPack', () => {
     expect(again.ok && again.pack.previousVersion).toBe('1.0.0')
   })
 
-  it('unwraps an npm tarball that puts everything under package/', async () => {
+  it('unwraps a tarball that puts everything under one directory', async () => {
     const root = tempDir()
     const file = await buildArchive(goodFiles(), 'package')
     const result = await installPack({ kind: 'file', path: file }, { root })
@@ -561,36 +561,6 @@ describe('installPack over the network', () => {
     )
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.error).toMatch(/HTTP 404/)
-  })
-
-  it('resolves an npm package to its published tarball', async () => {
-    const bytes = await archiveBytes(goodFiles())
-    const asked: string[] = []
-    const fetchImpl = (async (url: string) => {
-      asked.push(url)
-      return url.endsWith('/latest')
-        ? Response.json({ dist: { tarball: 'https://registry.test/acme.tgz' } })
-        : respond(bytes)
-    }) as unknown as typeof fetch
-
-    const result = await installPack(
-      { kind: 'npm', packageName: '@vornrun/connector-acme' },
-      { root: tempDir(), fetchImpl }
-    )
-
-    expect(result.ok).toBe(true)
-    expect(asked[0]).toContain('@vornrun%2Fconnector-acme/latest')
-    expect(asked[1]).toBe('https://registry.test/acme.tgz')
-  })
-
-  it('says so when an npm package publishes no tarball', async () => {
-    const fetchImpl = (async () => Response.json({ dist: {} })) as unknown as typeof fetch
-    const result = await installPack(
-      { kind: 'npm', packageName: 'acme' },
-      { root: tempDir(), fetchImpl }
-    )
-    expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.error).toMatch(/published no tarball/)
   })
 
   it('stops a download that grows past the size ceiling', async () => {

--- a/tests/pack-status.test.ts
+++ b/tests/pack-status.test.ts
@@ -52,25 +52,44 @@ describe('isNewerVersion', () => {
   })
 })
 
+/** What the catalog says about a connector a release has published. */
+const listed = (version: string) => ({ version, packUrl: `https://packs.test/acme-${version}.tgz` })
+
 describe('packStateFor', () => {
   it('is absent with nothing installed and nothing running', () => {
     expect(packStateFor({})).toEqual({ kind: 'absent' })
   })
 
   it('reports what is installed, with no update when the catalog matches', () => {
-    expect(packStateFor({ installed: pack(), catalogVersion: '1.2.0' })).toEqual({
+    expect(packStateFor({ installed: pack(), catalogItem: listed('1.2.0') })).toEqual({
       kind: 'installed',
       version: '1.2.0'
     })
   })
 
   it('offers an update only when the catalog publishes something newer', () => {
-    expect(packStateFor({ installed: pack(), catalogVersion: '1.3.0' })).toMatchObject({
+    expect(packStateFor({ installed: pack(), catalogItem: listed('1.3.0') })).toMatchObject({
       availableVersion: '1.3.0'
     })
-    expect(packStateFor({ installed: pack(), catalogVersion: '1.1.0' })).not.toHaveProperty(
+    expect(packStateFor({ installed: pack(), catalogItem: listed('1.1.0') })).not.toHaveProperty(
       'availableVersion'
     )
+  })
+
+  it('says a listed connector is unreleased when no release published a pack', () => {
+    expect(packStateFor({ catalogItem: { version: '1.3.0' } })).toEqual({ kind: 'not-released' })
+  })
+
+  it('offers no update from a catalog entry that names a version but no pack', () => {
+    expect(packStateFor({ installed: pack(), catalogItem: { version: '1.3.0' } })).toEqual({
+      kind: 'installed',
+      version: '1.2.0'
+    })
+  })
+
+  it('leaves a pack the catalog does not carry alone, since it waits on no release', () => {
+    expect(packStateFor({ installed: pack() })).toMatchObject({ kind: 'installed' })
+    expect(packStateFor({})).toEqual({ kind: 'absent' })
   })
 
   it('carries the rollback target when there is one', () => {
@@ -119,6 +138,17 @@ describe('describePackStatus', () => {
       tone: 'idle',
       percent: null,
       action: 'install',
+      busy: false
+    })
+  })
+
+  it('offers nothing for an unreleased entry, and says why in one sentence', () => {
+    expect(describePackStatus({ kind: 'not-released' })).toEqual({
+      label: 'Not released yet',
+      detail: 'Not released yet, so there is nothing to install.',
+      tone: 'idle',
+      percent: null,
+      action: null,
       busy: false
     })
   })
@@ -191,6 +221,12 @@ describe('canAddConnection', () => {
     )
     expect(
       canAddConnection({ kind: 'absent' }, { source: 'catalog', hasLegacyLaunch: false })
+    ).toBe(false)
+  })
+
+  it('refuses an unreleased entry, whose package name would connect to nothing', () => {
+    expect(
+      canAddConnection({ kind: 'not-released' }, { source: 'catalog', hasLegacyLaunch: true })
     ).toBe(false)
   })
 

--- a/tests/use-pack-install.test.tsx
+++ b/tests/use-pack-install.test.tsx
@@ -129,17 +129,18 @@ describe('installing a pack from wherever it was asked for', () => {
     expect(screen.getByTestId('pending')).toHaveTextContent('none')
   })
 
-  it('falls back to the package a catalog entry was built from', async () => {
-    const byName = { ...LISTING, catalogItem: { ...LISTING.catalogItem, packUrl: undefined } }
-    render(<Probe listing={byName as ConnectorListing} />)
+  it('asks for nothing when no release has published a pack', async () => {
+    const unreleased: ConnectorListing = {
+      ...LISTING,
+      catalogItem: { ...LISTING.catalogItem, packUrl: undefined } as ConnectorListing['catalogItem']
+    }
+    render(<Probe listing={unreleased} />)
+
     fireEvent.click(screen.getByText('inspect'))
 
-    await waitFor(() =>
-      expect(inspectConnectorPack).toHaveBeenCalledWith({
-        kind: 'npm',
-        packageName: '@vornrun/connector-slack'
-      })
-    )
+    await waitFor(() => expect(screen.getByTestId('phase')).toHaveTextContent('none'))
+    expect(inspectConnectorPack).not.toHaveBeenCalled()
+    expect(screen.getByTestId('pending')).toHaveTextContent('none')
   })
 
   it('follows an install the server is reporting on', async () => {


### PR DESCRIPTION
A catalog entry without a pack URL fell back to installing from the npm registry, whose tarballs ship `dist/` with no manifest, so the install always failed after a download. Every published entry now has a pack, and nothing else consumed the npm path.

## What changed

- The npm pack source is gone: the type, the registry lookup, its branch in the installer and its validation. Install from file and drag-drop stay.
- A catalog entry without a pack URL is "Not released yet": no Install, no Add, no Update on an installed pack whose catalog lost its release. The page says there is nothing to install; the step library and a template requirement row say the same. The rule lives in one place, derived from the catalog entry.
- The MCP install tool no longer claims to install from an npm package.

## How to verify

A catalog entry with no pack URL shows Not released yet on its row and page, with no action; a released entry installs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc
