### PR TITLE
Let a workflow run more than once at a time

### DIFF
--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -748,7 +748,7 @@ export function registerWorkflowTools(server: McpServer): void {
 
   server.tool(
     'stop_workflow_run',
-    'Stop a workflow run that is still going, including one parked on an approval gate. Kills the agents it started, marks its unfinished nodes, and closes the run as cancelled. Requires the Vorn app to be running. A workflow will not start a new run while an old one sits waiting for approval, so this is how you clear that.',
+    'Stop a workflow run that is still going, including one parked on an approval gate. Kills the agents it started, marks its unfinished nodes, and closes the run as cancelled. Requires the Vorn app to be running.',
     {
       run_id: V.id.describe('Run ID (from list_workflow_runs)')
     },
@@ -919,7 +919,7 @@ export function registerWorkflowTools(server: McpServer): void {
 
   server.tool(
     'execute_workflow',
-    "Run a workflow now, as if triggered manually. Supply values for any parameters the workflow declares (see the trigger node's inputs); declared defaults fill in anything omitted. Requires the Vorn app to be running. Returns as soon as the run is queued — poll list_workflow_runs for the outcome.",
+    "Run a workflow now, as if triggered manually. Supply values for any parameters the workflow declares (see the trigger node's inputs); declared defaults fill in anything omitted. Requires the Vorn app to be running. Returns as soon as the run is queued — poll list_workflow_runs for the outcome. Runs of one workflow go side by side; only a run repeating one started in the last ten seconds with the same inputs is refused as a duplicate.",
     {
       workflow_id: V.id.describe('Workflow ID (from list_workflows)'),
       inputs: z

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -37,11 +37,11 @@ const INBOX_BATCH_SIZE = 50
 const MAX_POLL_PAGES_PER_TICK = 20
 
 /**
- * Try to acquire an execution lock for a workflow run.
+ * Try to acquire a tick lock for a workflow's schedule.
  * Uses exclusive file creation (wx flag) keyed by the current minute
- * so it's atomic across processes and auto-expires for the next run.
+ * so it's atomic across processes and auto-expires for the next tick.
  */
-function acquireExecutionLock(workflowId: string): boolean {
+function acquireTickLock(workflowId: string): boolean {
   // Key by current minute so the lock naturally expires for the next scheduled run
   const minuteKey = Math.floor(Date.now() / 60_000)
   const lockFile = path.join(LOCK_DIR, `scheduler-${workflowId}-${minuteKey}.lock`)
@@ -239,7 +239,7 @@ class Scheduler extends EventEmitter {
           continue
         }
         try {
-          const task = cron.schedule(trigger.cron, () => this.executeWorkflow(wf.id), {
+          const task = cron.schedule(trigger.cron, () => this.executeWorkflow(wf.id, 'cron'), {
             timezone: trigger.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
           })
           this.cronJobs.set(wf.id, task)
@@ -279,7 +279,7 @@ class Scheduler extends EventEmitter {
               this.timeouts.delete(wf.id)
               this.syncSchedules(configManager.loadConfig().workflows ?? [])
             } else {
-              this.executeWorkflow(wf.id)
+              this.executeWorkflow(wf.id, 'cron')
             }
           }, safeDelay)
           this.timeouts.set(wf.id, timer)
@@ -288,9 +288,15 @@ class Scheduler extends EventEmitter {
     }
   }
 
-  private executeWorkflow(workflowId: string, inputs?: Record<string, unknown>): void {
-    if (!acquireExecutionLock(workflowId)) {
-      log.info(`[scheduler] skipping workflow ${workflowId} — already executed by another instance`)
+  // Only a tick takes the lock: two runs someone asked for are two runs, and the duplicate an
+  // impatient click makes is caught where the run is claimed, by its inputs rather than its minute.
+  private executeWorkflow(
+    workflowId: string,
+    source: 'cron' | 'manual',
+    inputs?: Record<string, unknown>
+  ): void {
+    if (source === 'cron' && !acquireTickLock(workflowId)) {
+      log.info(`[scheduler] skipping workflow ${workflowId} — already fired this minute`)
       this.timeouts.delete(workflowId)
       return
     }
@@ -457,16 +463,14 @@ class Scheduler extends EventEmitter {
   }
 
   /**
-   * Trigger a workflow manually, bypassing the cron tick. Used by "Run now"
-   * in settings for connector-seeded workflows: the same dispatch path as
-   * cron, so no hidden logic — just a forced tick. The minute-key lock still
-   * applies so repeated clicks within the same minute fold into one run.
+   * Trigger a workflow now, bypassing the schedule: the same dispatch path as a
+   * tick, so no hidden logic — just a forced fire.
    *
    * `inputs` carries the values a manual run was started with, forwarded to
    * the renderer so `{{inputs.*}}` resolves the same as a direct run.
    */
   triggerWorkflow(workflowId: string, inputs?: Record<string, unknown>): void {
-    this.executeWorkflow(workflowId, inputs)
+    this.executeWorkflow(workflowId, 'manual', inputs)
   }
 
   /**

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -488,6 +488,7 @@ class Scheduler extends EventEmitter {
     for (const [, timer] of this.timeouts) clearTimeout(timer)
     this.cronJobs.clear()
     this.connectorPollWorkflowIds.clear()
+    this.pollsInFlight.clear()
     this.timeouts.clear()
     if (this.inboxTimer) clearInterval(this.inboxTimer)
     this.inboxTimer = null

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -310,8 +310,7 @@ class Scheduler extends EventEmitter {
     const trigger = getTriggerConfig(wf)
 
     if (trigger?.triggerType === 'connectorPoll') {
-      // A poll calls the connector and writes the inbox here, before any run
-      // claim exists to catch a repeat, so one workflow polls one at a time.
+      // A poll works here, before any run claim exists to catch a repeat.
       if (this.pollsInFlight.has(workflowId)) {
         log.info(`[scheduler] skipping poll for ${workflowId} — one is already in flight`)
         return

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -288,8 +288,7 @@ class Scheduler extends EventEmitter {
     }
   }
 
-  // Only a tick takes the lock: two runs someone asked for are two runs, and the duplicate an
-  // impatient click makes is caught where the run is claimed, by its inputs rather than its minute.
+  // Only a tick takes the lock; a repeated manual run is caught by the run claim on its inputs.
   private executeWorkflow(
     workflowId: string,
     source: 'cron' | 'manual',

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -106,6 +106,8 @@ class Scheduler extends EventEmitter {
   /** Of those, the ones that do real work here rather than in a renderer. */
   private connectorPollWorkflowIds = new Set<string>()
   private timeouts = new Map<string, NodeJS.Timeout>()
+  /** Polls run server-side, before any run claim, so they serialize here. */
+  private pollsInFlight = new Set<string>()
   private inboxTimer: NodeJS.Timeout | null = null
 
   startInboxWorker(): void {
@@ -239,7 +241,7 @@ class Scheduler extends EventEmitter {
           continue
         }
         try {
-          const task = cron.schedule(trigger.cron, () => this.executeWorkflow(wf.id, 'cron'), {
+          const task = cron.schedule(trigger.cron, () => this.fireScheduled(wf.id), {
             timezone: trigger.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
           })
           this.cronJobs.set(wf.id, task)
@@ -279,7 +281,7 @@ class Scheduler extends EventEmitter {
               this.timeouts.delete(wf.id)
               this.syncSchedules(configManager.loadConfig().workflows ?? [])
             } else {
-              this.executeWorkflow(wf.id, 'cron')
+              this.fireScheduled(wf.id)
             }
           }, safeDelay)
           this.timeouts.set(wf.id, timer)
@@ -288,41 +290,45 @@ class Scheduler extends EventEmitter {
     }
   }
 
-  // Only a tick takes the lock; a repeated manual run is caught by the run claim on its inputs.
-  private executeWorkflow(
-    workflowId: string,
-    source: 'cron' | 'manual',
-    inputs?: Record<string, unknown>
-  ): void {
-    if (source === 'cron' && !acquireTickLock(workflowId)) {
+  /** A schedule reaching its time: one tick, however many instances hear it. */
+  private fireScheduled(workflowId: string): void {
+    this.timeouts.delete(workflowId)
+    if (!acquireTickLock(workflowId)) {
       log.info(`[scheduler] skipping workflow ${workflowId} — already fired this minute`)
-      this.timeouts.delete(workflowId)
       return
     }
+    this.executeWorkflow(workflowId)
+  }
 
+  // Runs of one workflow go side by side; a repeat is caught by the run claim on its inputs.
+  private executeWorkflow(workflowId: string, inputs?: Record<string, unknown>): void {
     // Look up the workflow to decide whether this is a connector-poll fan-out
     // or a normal single-execution fire.
     const workflows = configManager.loadConfig().workflows ?? []
     const wf = workflows.find((w) => w.id === workflowId)
-    if (!wf) {
-      this.timeouts.delete(workflowId)
-      return
-    }
+    if (!wf) return
     const trigger = getTriggerConfig(wf)
 
     if (trigger?.triggerType === 'connectorPoll') {
+      // A poll calls the connector and writes the inbox here, before any run
+      // claim exists to catch a repeat, so one workflow polls one at a time.
+      if (this.pollsInFlight.has(workflowId)) {
+        log.info(`[scheduler] skipping poll for ${workflowId} — one is already in flight`)
+        return
+      }
       // Fire-and-forget — the dispatcher emits N SCHEDULER_EXECUTE events, one
       // per new item. Cursor advance and error recording happen inside.
-      this.dispatchConnectorPoll(workflowId, trigger).catch((err) => {
-        log.error(`[scheduler] connectorPoll dispatch failed for ${workflowId}:`, err)
-      })
-      this.timeouts.delete(workflowId)
+      this.pollsInFlight.add(workflowId)
+      this.dispatchConnectorPoll(workflowId, trigger)
+        .catch((err) => {
+          log.error(`[scheduler] connectorPoll dispatch failed for ${workflowId}:`, err)
+        })
+        .finally(() => this.pollsInFlight.delete(workflowId))
       return
     }
 
     log.info(`[scheduler] executing workflow ${workflowId}`)
     this.emit('client-message', IPC.SCHEDULER_EXECUTE, { workflowId, inputs })
-    this.timeouts.delete(workflowId)
   }
 
   /**
@@ -461,15 +467,9 @@ class Scheduler extends EventEmitter {
     return null
   }
 
-  /**
-   * Trigger a workflow now, bypassing the schedule: the same dispatch path as a
-   * tick, so no hidden logic — just a forced fire.
-   *
-   * `inputs` carries the values a manual run was started with, forwarded to
-   * the renderer so `{{inputs.*}}` resolves the same as a direct run.
-   */
+  /** `inputs` are forwarded to the renderer so `{{inputs.*}}` resolves as it does for a direct run. */
   triggerWorkflow(workflowId: string, inputs?: Record<string, unknown>): void {
-    this.executeWorkflow(workflowId, 'manual', inputs)
+    this.executeWorkflow(workflowId, inputs)
   }
 
   /**

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -396,20 +396,8 @@ export function App() {
         const context = schedulerExecutionContext(connectorItem, inputs)
         try {
           const execution = await runWorkflow(workflow, context, { source: 'scheduler' })
-          // A different run may be parked on an approval gate. It did not
-          // accept this event, so release the row for a short retry instead of
-          // holding its full delivery lease.
+          // The server may have re-leased the row while the run was starting.
           if (
-            connectorInboxId !== undefined &&
-            connectorInboxLeaseToken &&
-            execution.connectorInboxId !== connectorInboxId
-          ) {
-            await window.api.completeConnectorInbox({
-              id: connectorInboxId,
-              leaseToken: connectorInboxLeaseToken,
-              disposition: 'defer'
-            })
-          } else if (
             connectorItem &&
             connectorInboxLeaseToken &&
             execution.connectorInboxLeaseToken !== connectorInboxLeaseToken

--- a/src/renderer/lib/workflow-execution.ts
+++ b/src/renderer/lib/workflow-execution.ts
@@ -1544,18 +1544,6 @@ export async function executeWorkflow(
     }
   }
 
-  // A run parked on an approval gate still owns the workflow's queue position —
-  // starting another now would race two runs through the same gate.
-  const waiting = runsForWorkflow(workflow.id).find((e) =>
-    e.nodeStates.some((ns) => ns.status === 'waiting')
-  )
-  if (waiting) {
-    console.warn(
-      `[workflow] skipping execution of "${workflow.name}" — existing run is waiting for approval`
-    )
-    return waiting
-  }
-
   // Ask the core, not this window, whether we own this trigger. Every instance
   // hears the same scheduler tick; only the one granted the claim runs it.
   const dedupeParams = options?.targetNodeId

--- a/tests/scheduler-connector-poll.test.ts
+++ b/tests/scheduler-connector-poll.test.ts
@@ -91,18 +91,6 @@ vi.mock('../packages/server/src/connectors/mcp', async (importOriginal) => {
 
 // Import after mocks are set up.
 import { scheduler } from '../packages/server/src/scheduler'
-import fs from 'node:fs'
-import path from 'node:path'
-import os from 'node:os'
-
-// The execution lock writes a file; point it at an empty tmp dir per-test so
-// no two tests collide on filenames.
-const LOCK_DIR = path.join(os.homedir(), '.vorn')
-try {
-  fs.mkdirSync(LOCK_DIR, { recursive: true })
-} catch {
-  /* ignore */
-}
 
 function makeConn(overrides: Partial<SourceConnection> = {}): SourceConnection {
   return {
@@ -157,17 +145,6 @@ beforeEach(() => {
   clientRegistryMock.size = 1
   connectorGetMock.mockReset()
   pollMcpConnectionMock.mockReset()
-  // Clean up any stale lock files from previous tests to avoid the minute-key
-  // dedup blocking subsequent triggerWorkflow() calls in the same minute.
-  try {
-    for (const f of fs.readdirSync(LOCK_DIR)) {
-      if (f.startsWith('scheduler-wf-') && f.endsWith('.lock')) {
-        fs.unlinkSync(path.join(LOCK_DIR, f))
-      }
-    }
-  } catch {
-    /* ignore */
-  }
 })
 
 describe('scheduler.triggerWorkflow for connectorPoll', () => {
@@ -554,6 +531,34 @@ describe('scheduler.triggerWorkflow for connectorPoll', () => {
 
     expect(pollMcpConnectionMock).not.toHaveBeenCalled()
     expect(dbRecordConnectorPollPageMock).not.toHaveBeenCalled()
+  })
+
+  it('polls one at a time, however often it is asked', async () => {
+    // A poll calls the connector and writes the inbox here, before any run
+    // claim exists, so two fires would otherwise read the same cursor twice.
+    const wf = makePollWorkflow('wf-serial')
+    loadConfigMock.mockReturnValue({ workflows: [wf] })
+    dbGetSourceConnectionMock.mockReturnValue(makeConn())
+    let release: () => void = () => {}
+    const inFlight = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const poll = vi.fn().mockImplementation(() => inFlight.then(() => ({ events: [] })))
+    connectorGetMock.mockReturnValue({ poll })
+
+    scheduler.triggerWorkflow('wf-serial')
+    scheduler.triggerWorkflow('wf-serial')
+    await new Promise((r) => setImmediate(r))
+    expect(poll).toHaveBeenCalledTimes(1)
+
+    release()
+    await new Promise((r) => setImmediate(r))
+    await new Promise((r) => setImmediate(r))
+
+    // The next ask, once the first has finished, polls again.
+    scheduler.triggerWorkflow('wf-serial')
+    await new Promise((r) => setImmediate(r))
+    expect(poll).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,20 +1,16 @@
-import { describe, it, expect, afterAll, vi } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import type { WorkflowDefinition, WorkflowNode, TriggerConfig } from '../src/shared/types'
 
 // The tick lock writes under the home directory, which the scheduler reads once
 // at import; point it somewhere disposable before that happens.
-const lockHome = vi.hoisted(() => {
-  const dir = `${process.env.TMPDIR?.replace(/\/$/, '') ?? '/tmp'}/vorn-scheduler-${process.pid}`
-  const real = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE }
-  process.env.HOME = dir
-  process.env.USERPROFILE = dir
-  return { dir, real }
-})
-afterAll(() => {
-  process.env.HOME = lockHome.real.HOME
-  process.env.USERPROFILE = lockHome.real.USERPROFILE
+const lockHome = vi.hoisted(
+  () => `${process.env.TMPDIR?.replace(/\/$/, '') ?? '/tmp'}/vorn-scheduler-${process.pid}`
+)
+vi.mock('node:os', async (importOriginal) => {
+  const os = await importOriginal<typeof import('node:os')>()
+  return { ...os, default: { ...os, homedir: () => lockHome }, homedir: () => lockHome }
 })
 
 // Mock dependencies before importing
@@ -146,7 +142,7 @@ describe('getNextRun', () => {
 })
 
 describe('firing a workflow', () => {
-  const LOCK_DIR = path.join(lockHome.dir, '.vorn')
+  const LOCK_DIR = path.join(lockHome, '.vorn')
 
   function clearLocks(workflowId: string): void {
     fs.mkdirSync(LOCK_DIR, { recursive: true })

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import type { WorkflowDefinition, WorkflowNode, TriggerConfig } from '../src/shared/types'
 
 // Mock dependencies before importing
@@ -17,7 +20,9 @@ vi.mock('../packages/server/src/schedule-log', () => ({
   scheduleLogManager: { addEntry: vi.fn() }
 }))
 
+import cron from 'node-cron'
 import { scheduler } from '../packages/server/src/scheduler'
+import { configManager } from '../packages/server/src/config-manager'
 
 function makeTriggerNode(config: TriggerConfig): WorkflowNode {
   return {
@@ -124,6 +129,64 @@ describe('getNextRun', () => {
   it('returns null for manual schedule', () => {
     const wf = makeWorkflow({ triggerConfig: { triggerType: 'manual' } })
     expect(scheduler.getNextRun('wf-1', [wf])).toBeNull()
+  })
+})
+
+describe('firing a workflow', () => {
+  // The tick lock is a file; the directory is the server's own and may not exist yet.
+  const LOCK_DIR = path.join(os.homedir(), '.vorn')
+
+  function clearLocks(workflowId: string): void {
+    fs.mkdirSync(LOCK_DIR, { recursive: true })
+    for (const f of fs.readdirSync(LOCK_DIR)) {
+      if (f.startsWith(`scheduler-${workflowId}-`) && f.endsWith('.lock')) {
+        fs.unlinkSync(path.join(LOCK_DIR, f))
+      }
+    }
+  }
+
+  function watch(): { seen: unknown[]; stop: () => void } {
+    const seen: unknown[] = []
+    const listener = (method: string, params: unknown): void => {
+      if (method === 'scheduler:execute') seen.push(params)
+    }
+    scheduler.on('client-message', listener)
+    return { seen, stop: () => scheduler.off('client-message', listener) }
+  }
+
+  it('runs a workflow as often as it is asked to, within one minute', () => {
+    const wf = makeWorkflow({ id: 'wf-asked', triggerConfig: { triggerType: 'manual' } })
+    vi.mocked(configManager.loadConfig).mockReturnValue({ workflows: [wf] } as never)
+    const { seen, stop } = watch()
+
+    scheduler.triggerWorkflow('wf-asked', { which: 'first' })
+    scheduler.triggerWorkflow('wf-asked', { which: 'second' })
+
+    stop()
+    expect(seen).toEqual([
+      { workflowId: 'wf-asked', inputs: { which: 'first' } },
+      { workflowId: 'wf-asked', inputs: { which: 'second' } }
+    ])
+  })
+
+  // Every server holding the schedule wakes on the same minute; only one may fire it.
+  it('fires a schedule once a minute, however many servers hold it', () => {
+    clearLocks('wf-tick')
+    const wf = makeWorkflow({
+      id: 'wf-tick',
+      triggerConfig: { triggerType: 'recurring', cron: '* * * * *' }
+    })
+    vi.mocked(configManager.loadConfig).mockReturnValue({ workflows: [wf] } as never)
+    scheduler.syncSchedules([wf])
+    const tick = vi.mocked(cron.schedule).mock.calls.at(-1)?.[1] as () => void
+    const { seen, stop } = watch()
+
+    tick()
+    tick()
+
+    stop()
+    clearLocks('wf-tick')
+    expect(seen).toEqual([{ workflowId: 'wf-tick', inputs: undefined }])
   })
 })
 

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi } from 'vitest'
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import type { WorkflowDefinition, WorkflowNode, TriggerConfig } from '../src/shared/types'
+
+// The tick lock writes under the home directory, which the scheduler reads once
+// at import; point it somewhere disposable before that happens.
+const lockHome = vi.hoisted(() => {
+  const dir = `${process.env.TMPDIR?.replace(/\/$/, '') ?? '/tmp'}/vorn-scheduler-${process.pid}`
+  process.env.HOME = dir
+  return dir
+})
 
 // Mock dependencies before importing
 vi.mock('node-cron', () => ({
@@ -133,8 +140,7 @@ describe('getNextRun', () => {
 })
 
 describe('firing a workflow', () => {
-  // The tick lock is a file; the directory is the server's own and may not exist yet.
-  const LOCK_DIR = path.join(os.homedir(), '.vorn')
+  const LOCK_DIR = path.join(lockHome, '.vorn')
 
   function clearLocks(workflowId: string): void {
     fs.mkdirSync(LOCK_DIR, { recursive: true })

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, afterAll, vi } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import type { WorkflowDefinition, WorkflowNode, TriggerConfig } from '../src/shared/types'
@@ -7,8 +7,14 @@ import type { WorkflowDefinition, WorkflowNode, TriggerConfig } from '../src/sha
 // at import; point it somewhere disposable before that happens.
 const lockHome = vi.hoisted(() => {
   const dir = `${process.env.TMPDIR?.replace(/\/$/, '') ?? '/tmp'}/vorn-scheduler-${process.pid}`
+  const real = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE }
   process.env.HOME = dir
-  return dir
+  process.env.USERPROFILE = dir
+  return { dir, real }
+})
+afterAll(() => {
+  process.env.HOME = lockHome.real.HOME
+  process.env.USERPROFILE = lockHome.real.USERPROFILE
 })
 
 // Mock dependencies before importing
@@ -140,7 +146,7 @@ describe('getNextRun', () => {
 })
 
 describe('firing a workflow', () => {
-  const LOCK_DIR = path.join(lockHome, '.vorn')
+  const LOCK_DIR = path.join(lockHome.dir, '.vorn')
 
   function clearLocks(workflowId: string): void {
     fs.mkdirSync(LOCK_DIR, { recursive: true })
@@ -187,8 +193,10 @@ describe('firing a workflow', () => {
     const tick = vi.mocked(cron.schedule).mock.calls.at(-1)?.[1] as () => void
     const { seen, stop } = watch()
 
+    vi.useFakeTimers({ toFake: ['Date'] })
     tick()
     tick()
+    vi.useRealTimers()
 
     stop()
     clearLocks('wf-tick')

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -398,6 +398,39 @@ describe('run concurrency', () => {
     expect(b.runId).toBe(a.runId)
   })
 
+  it('starts beside a run parked on an approval gate', async () => {
+    // The gate used to hold the workflow's queue position, so a second run
+    // could not begin until someone answered the first.
+    const base = makeWorkflow('wf-gate')
+    const workflow = {
+      ...base,
+      nodes: [
+        base.nodes.find((node) => node.id === 'trigger')!,
+        {
+          id: 'approval',
+          type: 'approval',
+          label: 'Approve',
+          position: { x: 0, y: 1 },
+          config: {}
+        },
+        base.nodes.find((node) => node.id === 'agent')!
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'approval' },
+        { id: 'e2', source: 'approval', target: 'agent' }
+      ]
+    } as unknown as WorkflowDefinition
+    mockState.config.workflows = [workflow]
+
+    const parked = await executeWorkflow(workflow, { inputs: { issue: 'gh-7' } })
+    expect(parked.nodeStates.find((n) => n.nodeId === 'approval')?.status).toBe('waiting')
+
+    const second = await executeWorkflow(workflow, { inputs: { issue: 'gh-8' } })
+
+    expect(second.runId).not.toBe(parked.runId)
+    expect(second.nodeStates.find((n) => n.nodeId === 'approval')?.status).toBe('waiting')
+  })
+
   it('collapses two identical triggers fired at once into a single run', async () => {
     const wf = makeWorkflow()
     const ids: string[] = []


### PR DESCRIPTION
Two guards folded every run of a workflow into one: the scheduler's per-minute lock file, taken for manual and MCP runs as well as cron ticks, and a renderer check that refused any new run while another run of the workflow sat on an approval gate. Both are gone. Runs of one workflow now go side by side.

Duplicate protection stays where it belongs:
- The run claim keyed by workflow, trigger and inputs (10 seconds) still collapses an identical run pressed twice.
- The connector inbox UNIQUE key still delivers one event once.
- Cron ticks keep the minute lock, now taken in `fireScheduled` only, so two server instances do not fire one schedule twice. A manual fire no longer drops a pending once-timer's map entry.
- Connector polls serialize on an in-flight set, since a poll runs server-side before any renderer claim.

The `execute_workflow` and `stop_workflow_run` tool descriptions say what actually happens.

Tests: two manual fires in one minute both dispatch; two cron ticks in one minute dispatch once; two poll fires run one poll at a time; a run starts beside a run parked on a gate. The scheduler test no longer writes into the real `~/.vorn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc