### PR TITLE
Let a script step's request outlive the bridge's thirty-second deadline

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -232,7 +232,10 @@ export function registerIpcHandlers(): void {
   safeHandle(IPC.HEADLESS_LIST, () => requireBridge().request(IPC.HEADLESS_LIST))
 
   // Scripts
-  safeHandle(IPC.SCRIPT_EXECUTE, (_, config) => requireBridge().request(IPC.SCRIPT_EXECUTE, config))
+  // A script step has no deadline of its own, so its request cannot have one either.
+  safeHandle(IPC.SCRIPT_EXECUTE, (_, config) =>
+    requireBridge().request(IPC.SCRIPT_EXECUTE, config, 0)
+  )
 
   // Workflow runs
   safeHandle(IPC.WORKFLOW_RUN_SAVE, (_, execution) =>

--- a/src/main/server/server-bridge.ts
+++ b/src/main/server/server-bridge.ts
@@ -7,7 +7,7 @@ import log from '../logger'
 interface PendingRequest {
   resolve: (value: unknown) => void
   reject: (error: Error) => void
-  timeout: NodeJS.Timeout
+  timeout: NodeJS.Timeout | undefined
   method: string
 }
 
@@ -183,10 +183,14 @@ export class ServerBridge extends EventEmitter {
 
     const id = ++this.nextId
     return new Promise<T>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error(`Request timed out: ${method} (id=${id})`))
-      }, timeoutMs)
+      // A zero deadline waits as long as the server takes; a disconnect still rejects.
+      const timeout =
+        timeoutMs > 0
+          ? setTimeout(() => {
+              this.pending.delete(id)
+              reject(new Error(`Request timed out: ${method} (id=${id})`))
+            }, timeoutMs)
+          : undefined
 
       this.pending.set(id, {
         resolve: resolve as (v: unknown) => void,

--- a/tests/server-bridge-request-deadline.test.ts
+++ b/tests/server-bridge-request-deadline.test.ts
@@ -4,8 +4,11 @@ import { ServerBridge } from '../src/main/server/server-bridge'
 
 const servers: WebSocketServer[] = []
 const bridges: ServerBridge[] = []
+const timers: NodeJS.Timeout[] = []
 
 afterEach(() => {
+  for (const timer of timers) clearTimeout(timer)
+  timers.length = 0
   for (const bridge of bridges) bridge.close()
   bridges.length = 0
   for (const server of servers) server.close()
@@ -18,9 +21,11 @@ async function bridgeTo(answerAfterMs: number): Promise<ServerBridge> {
   server.on('connection', (socket) => {
     socket.on('message', (raw) => {
       const { id } = JSON.parse(raw.toString()) as { id: number }
-      setTimeout(
-        () => socket.send(JSON.stringify({ jsonrpc: '2.0', id, result: 'done' })),
-        answerAfterMs
+      timers.push(
+        setTimeout(
+          () => socket.send(JSON.stringify({ jsonrpc: '2.0', id, result: 'done' })),
+          answerAfterMs
+        )
       )
     })
   })

--- a/tests/server-bridge-request-deadline.test.ts
+++ b/tests/server-bridge-request-deadline.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { WebSocketServer } from 'ws'
+import { ServerBridge } from '../src/main/server/server-bridge'
+
+const servers: WebSocketServer[] = []
+const bridges: ServerBridge[] = []
+
+afterEach(() => {
+  for (const bridge of bridges) bridge.close()
+  bridges.length = 0
+  for (const server of servers) server.close()
+  servers.length = 0
+})
+
+async function bridgeTo(answerAfterMs: number): Promise<ServerBridge> {
+  const server = new WebSocketServer({ port: 0, host: '127.0.0.1' })
+  servers.push(server)
+  server.on('connection', (socket) => {
+    socket.on('message', (raw) => {
+      const { id } = JSON.parse(raw.toString()) as { id: number }
+      setTimeout(
+        () => socket.send(JSON.stringify({ jsonrpc: '2.0', id, result: 'done' })),
+        answerAfterMs
+      )
+    })
+  })
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()))
+  const address = server.address()
+  const port = typeof address === 'object' && address ? address.port : 0
+  const bridge = new ServerBridge(`ws://127.0.0.1:${port}/ws`)
+  bridges.push(bridge)
+  bridge.connect()
+  await new Promise<void>((resolve) => bridge.once('connected', () => resolve()))
+  return bridge
+}
+
+describe('a request with no deadline', () => {
+  it('waits for an answer that a deadline would have cut off', async () => {
+    const bridge = await bridgeTo(120)
+    await expect(bridge.request('script:execute', undefined, 50)).rejects.toThrow(/timed out/)
+    await expect(bridge.request('script:execute', undefined, 0)).resolves.toBe('done')
+  })
+
+  it('still rejects when the server goes away', async () => {
+    const bridge = await bridgeTo(10_000)
+    const pending = bridge.request('script:execute', undefined, 0)
+    for (const server of servers) for (const client of server.clients) client.terminate()
+    await expect(pending).rejects.toThrow(/disconnected/i)
+  })
+})


### PR DESCRIPTION
The desktop app forwards a script step to the server over the bridge, and every bridge request rejected after thirty seconds. A script has no deadline of its own, so a step that ran longer, say one that waits on a CI run before opening a PR, finished on the server while the run was already marked as an error. The script request now carries no deadline; a lost server connection still rejects it.

Tests: a request with no deadline waits for an answer a deadline would have cut off, and still rejects when the server goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc