### PR TITLE
Let an extension declare what it contributes, and check it

### DIFF
--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -424,6 +424,90 @@ reads the manifest.
 Paths are filled with `currentColor`, so the icon picks up the surrounding
 text color instead of fighting the theme.
 
+## Extensions
+
+A connector polls a service. An **extension** contributes to a session card
+instead: a footer band under the status bar, a pane beside the terminal, or a
+handler offered when a link in the terminal is clicked. It is the same pack —
+same manifest, same check, same receipt, same catalog — declared with
+`defineExtension` rather than `defineConnector`.
+
+```ts
+import { defineExtension } from '@vornrun/connector-sdk'
+
+export const connector = defineExtension({
+  id: 'review',
+  name: 'Review',
+  description: 'Reads the session',
+  permissions: ['terminal.read'],
+  activates: { workspaceContains: ['package.json'] },
+  footers: [
+    {
+      id: 'checks',
+      title: 'Checks',
+      every: 30,
+      async run(context) {
+        const output = await context.host.output({ lines: 200 })
+        return [{ label: 'tests', value: /FAIL/.test(output) ? 'failing' : 'passing' }]
+      }
+    }
+  ],
+  panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+})
+```
+
+Start one with `vorn-connector new review --extension`.
+
+### What it may ask the host for
+
+Every method of `context.host` costs one permission, and the manifest has to
+declare it. A call outside what was declared is refused rather than answered —
+by `check` against its stub host, and by Vorn at run time — so what a person
+agreed to when installing is what the extension can reach.
+
+| Permission           | Host method          | What it grants                       |
+| -------------------- | -------------------- | ------------------------------------ |
+| `git.read`           | `diff()`, `status()` | The worktree's diff and status       |
+| `terminal.read`      | `output()`           | The session's recent terminal output |
+| `terminal.selection` | `selection()`        | The text selected in the terminal    |
+| `terminal.send`      | `send(text)`         | Typing into the session's terminal   |
+| `card.rename`        | `rename(name)`       | Naming the session card              |
+| `agent.usage`        | `usage()`            | Context and provider allowance       |
+
+Ask for only what the extension spends: `check` names a permission that was
+declared and never used.
+
+### Where it shows
+
+`activates` on the extension, and `when` on any one contribution, narrow where
+it appears. Every declared field has to hold, and each is satisfied by any one
+of its values, so an extension is simply absent where it has nothing to say.
+
+```ts
+activates: {
+  workspaceContains: ['Cargo.toml'],   // paths relative to the worktree
+  remoteHost: ['github.com'],
+  agent: ['claude', 'shell'],
+  platform: ['darwin', 'linux']
+}
+```
+
+### What a pane is drawn from
+
+A pane is either a page the pack carries or a program it runs. A page lives
+under `web/` in the package and is carried into the pack as it stands, so its
+stylesheet and script travel with it; Vorn serves it a bridge in
+`window.vorn` — `host`, `token` and `sessionId` — granting exactly the declared
+permissions. A program is argv, run in the session's worktree and drawn as a
+terminal.
+
+```ts
+panes: [
+  { id: 'report', title: 'Report', web: 'web/report/index.html' },
+  { id: 'git', title: 'Git', command: ['lazygit'], when: { agent: ['shell'] } }
+]
+```
+
 ## CLI
 
 ```
@@ -436,9 +520,10 @@ vorn-connector pack <module>              Build an installable .vorn.tgz pack
 vorn-connector serve <module>             Serve on stdio (what Vorn runs)
 ```
 
-`new` accepts `--out <dir>`, `--name "Display Name"`, and `--repo-conventions`,
+`new` accepts `--out <dir>`, `--name "Display Name"`, `--repo-conventions`,
 which shapes the package the way the connectors repository expects it (scoped
-name, changelog, compiler and test settings); `pack` accepts `--out <dir>`.
+name, changelog, compiler and test settings), and `--extension`, which
+scaffolds an extension rather than a connector; `pack` accepts `--out <dir>`.
 
 `poll` accepts `--since <iso>` and `--limit <n>`, and reads the connector's
 declared config from your shell environment — the fastest way to confirm

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -495,16 +495,47 @@ activates: {
 ### What a pane is drawn from
 
 A pane is either a page the pack carries or a program it runs. A page lives
-under `web/` in the package and is carried into the pack as it stands, so its
-stylesheet and script travel with it; Vorn serves it a bridge in
-`window.vorn` — `host`, `token` and `sessionId` — granting exactly the declared
-permissions. A program is argv, run in the session's worktree and drawn as a
-terminal.
+under `web/` in the package, and the directory it sits in is carried into the
+pack, so its stylesheet and script travel with it. Vorn serves the page and
+answers `bridge/<method>` beside it, on the page's own origin: the page holds no
+token, and Vorn grants the call exactly the permissions the manifest declared,
+knowing from the origin which pane is asking. A program is argv, run in the
+session's worktree and drawn as a terminal.
+
+```js
+const response = await fetch('bridge/output', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ lines: 200 })
+})
+const output = (await response.json()).result
+```
 
 ```ts
 panes: [
   { id: 'report', title: 'Report', web: 'web/report/index.html' },
-  { id: 'git', title: 'Git', command: ['lazygit'], when: { agent: ['shell'] } }
+  { id: 'git', title: 'Git', command: ['tig'], when: { agent: ['shell'] } }
+]
+```
+
+### What a link handler is offered for
+
+A handler names the pattern it matches against clicked text, and one example
+link it is for. The example is what `check` runs the handler on, so a handler is
+proved against a link it will really be offered for rather than a made-up one.
+
+```ts
+linkHandlers: [
+  {
+    id: 'pull-request',
+    title: 'Pull request',
+    pattern: 'https://github\\.com/[^/]+/[^/]+/pull/\\d+',
+    example: 'https://github.com/vorn-run/vorn/pull/1',
+    async run(context) {
+      await context.host.send(`Look at ${context.url}`)
+      return { openPane: 'report' }
+    }
+  }
 ]
 ```
 

--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -514,7 +514,7 @@ const output = (await response.json()).result
 ```ts
 panes: [
   { id: 'report', title: 'Report', web: 'web/report/index.html' },
-  { id: 'git', title: 'Git', command: ['tig'], when: { agent: ['shell'] } }
+  { id: 'log', title: 'Log', command: ['./bin/log'], when: { agent: ['shell'] } }
 ]
 ```
 

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -6,6 +6,7 @@ import {
   bundledRequireFindings,
   lifecycleScriptFindings,
   packageDirFor,
+  packageRootFor,
   packEntryContents,
   packLaunchFindings,
   readNearestPackageJson,
@@ -245,6 +246,18 @@ function launches(options: CheckOptions): boolean {
 }
 
 /** What the package says about itself, when a check was pointed at one. */
+/**
+ * The package's own root, or nothing when the check was not told where it is.
+ *
+ * A page is authored beside `package.json` while the entry is under `dist/`,
+ * and the command may have been run from anywhere, so every question about
+ * files on disk is asked of this one directory.
+ */
+function packageRootOf(options: CheckOptions): string | undefined {
+  if (options.packageDir === undefined) return undefined
+  return packageRootFor(packageDirFor(options.packageDir, options.entry))
+}
+
 async function packageFindings(
   connector: Connector,
   options: CheckOptions
@@ -277,11 +290,7 @@ async function packageFindings(
     found.push(...bundleDependencyFindings(built.external), ...bundledRequireFindings(built.code))
     // Always, so the receipt's `launch` names a launch that happened rather than one that was skipped.
     if (options.mock) {
-      const dir = await stagePack(
-        connector,
-        built.code,
-        packageDirFor(options.packageDir, options.entry)
-      )
+      const dir = await stagePack(connector, built.code, packageRootOf(options))
       try {
         found.push(...(await packLaunchFindings(dir)))
       } finally {
@@ -393,7 +402,12 @@ const CHECK_SESSION = {
   agent: 'claude' as const
 }
 
-/** A reading a band can actually draw: two strings, and a tone it knows. */
+const FOOTER_TONES = ['default', 'ok', 'danger']
+
+/** A reading is clicked, so where it points has to be somewhere a browser will go. */
+const FOOTER_HREF_PROTOCOLS = ['http:', 'https:']
+
+/** A reading a band can actually draw: two strings, a tone it knows, and a link it can open. */
 function invalidItem(item: unknown): string | undefined {
   if (!item || typeof item !== 'object') return 'is not an object'
   const reading = item as Record<string, unknown>
@@ -402,10 +416,19 @@ function invalidItem(item: unknown): string | undefined {
   if (reading.tone !== undefined && !FOOTER_TONES.includes(reading.tone as string)) {
     return `has unknown tone ${JSON.stringify(reading.tone)}`
   }
+  if (reading.href === undefined) return undefined
+  if (typeof reading.href !== 'string') return 'has a link that is not text'
+  let protocol: string
+  try {
+    protocol = new URL(reading.href).protocol
+  } catch {
+    return `has the link ${JSON.stringify(reading.href)}, which is not a URL`
+  }
+  if (!FOOTER_HREF_PROTOCOLS.includes(protocol)) {
+    return `has the link ${JSON.stringify(reading.href)}; a reading links to ${FOOTER_HREF_PROTOCOLS.join(' or ')} and nothing else`
+  }
   return undefined
 }
-
-const FOOTER_TONES = ['default', 'ok', 'danger']
 
 /**
  * Run every contribution once against a host that answers from fixtures.
@@ -484,22 +507,25 @@ async function contributionFindings(connector: Connector): Promise<CheckFinding[
   }
 
   for (const handler of contributes.linkHandlers ?? []) {
-    // A pattern it cannot match is a handler nothing would ever reach it through.
-    const sample = new RegExp(handler.pattern).source
+    // The author's own example, so the handler is run on a link it will really
+    // be offered for — a URL built from the pattern matches nothing it expects.
     await ran('link handler', handler.id, 'handler-failed', (host) =>
       Promise.resolve(
         handler.run({
           ...CHECK_SESSION,
           host,
           now: () => new Date().toISOString(),
-          url: `https://example.test/${encodeURIComponent(sample).slice(0, 32)}`
+          url: handler.example
         })
       )
     )
   }
 
+  // A page spends its permissions in the browser, where this run cannot watch it.
+  const observable = !(contributes.panes ?? []).some((pane) => pane.web !== undefined)
+
   for (const permission of declared) {
-    if (!spent.has(permission)) {
+    if (observable && !spent.has(permission)) {
       found.push(
         finding(
           'warn',
@@ -515,9 +541,9 @@ async function contributionFindings(connector: Connector): Promise<CheckFinding[
 }
 
 /** A pane's page has to be in the package, or the pack ships a pane that cannot open. */
-function paneFindings(connector: Connector, packageDir: string | undefined): CheckFinding[] {
-  if (packageDir === undefined) return []
-  const root = resolve(packageDir)
+function paneFindings(connector: Connector, packageRoot: string | undefined): CheckFinding[] {
+  if (packageRoot === undefined) return []
+  const root = resolve(packageRoot)
   const found: CheckFinding[] = []
   for (const pane of connector.contributes?.panes ?? []) {
     if (pane.web === undefined) continue
@@ -747,7 +773,7 @@ export async function checkConnector(
   // An extension's credential is the host's own token, so there is no rung to check.
   if (connector.kind !== 'extension') found.push(...authFindings(connector))
   found.push(...secretFindings(connector))
-  found.push(...paneFindings(connector, options.packageDir))
+  found.push(...paneFindings(connector, packageRootOf(options)))
   found.push(...(await contributionFindings(connector)))
   found.push(...(await packageFindings(connector, options)))
   found.push(...(await mockFindings(connector, options)))

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
+import { resolve, sep } from 'node:path'
 import {
   bundleDependencyFindings,
   bundledRequireFindings,
@@ -11,7 +13,8 @@ import {
   type BundleOutput,
   type BundleRequest
 } from './packaging'
-import { escapedMockHttp, withMockHttp, type MockRoute } from './harness'
+import { escapedMockHttp, mockExtensionHost, withMockHttp, type MockRoute } from './harness'
+import { PermissionDeniedError } from './host'
 import { runAction, runPoll, type PollPage } from './runtime'
 import type {
   ActionDefinition,
@@ -19,6 +22,8 @@ import type {
   Connector,
   ConnectorConfig,
   DedupeStrategy,
+  ExtensionHost,
+  ExtensionPermission,
   TriggerDefinition
 } from './types'
 
@@ -55,6 +60,13 @@ export type CheckCode =
   | 'live-action-failed'
   | 'pack-launch'
   | 'pack-too-large'
+  | 'web-entry-missing'
+  | 'web-entry-outside-package'
+  | 'footer-failed'
+  | 'footer-items-invalid'
+  | 'handler-failed'
+  | 'permission-undeclared'
+  | 'permission-unused'
 
 export interface CheckFinding {
   /** `error` means the connector will misbehave in Vorn; `warn` is advisory. */
@@ -265,7 +277,11 @@ async function packageFindings(
     found.push(...bundleDependencyFindings(built.external), ...bundledRequireFindings(built.code))
     // Always, so the receipt's `launch` names a launch that happened rather than one that was skipped.
     if (options.mock) {
-      const dir = await stagePack(connector, built.code)
+      const dir = await stagePack(
+        connector,
+        built.code,
+        packageDirFor(options.packageDir, options.entry)
+      )
       try {
         found.push(...(await packLaunchFindings(dir)))
       } finally {
@@ -367,6 +383,167 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
     }
   }
 
+  return found
+}
+
+/** The session a contribution is run for when the check runs it, named so a fixture can expect it. */
+const CHECK_SESSION = {
+  sessionId: 'check',
+  worktreePath: process.cwd(),
+  agent: 'claude' as const
+}
+
+/** A reading a band can actually draw: two strings, and a tone it knows. */
+function invalidItem(item: unknown): string | undefined {
+  if (!item || typeof item !== 'object') return 'is not an object'
+  const reading = item as Record<string, unknown>
+  if (typeof reading.label !== 'string' || reading.label === '') return 'has no label'
+  if (typeof reading.value !== 'string') return 'has no value'
+  if (reading.tone !== undefined && !FOOTER_TONES.includes(reading.tone as string)) {
+    return `has unknown tone ${JSON.stringify(reading.tone)}`
+  }
+  return undefined
+}
+
+const FOOTER_TONES = ['default', 'ok', 'danger']
+
+/**
+ * Run every contribution once against a host that answers from fixtures.
+ *
+ * Two things are being asked, and neither can be answered by reading the
+ * definition. That a footer or a handler runs at all — until now nothing ever
+ * called one — and that it reaches only what its manifest declared, which is
+ * the whole weight behind showing someone a permission before they install.
+ *
+ * The stub refuses an undeclared permission exactly as the real host will, so
+ * an extension meets that rule here rather than in front of a person.
+ */
+async function contributionFindings(connector: Connector): Promise<CheckFinding[]> {
+  const contributes = connector.contributes
+  if (!contributes) return []
+  const found: CheckFinding[] = []
+  const declared = connector.permissions ?? []
+  const spent = new Set<ExtensionPermission>()
+
+  const ran = async (
+    kind: string,
+    id: string,
+    code: CheckCode,
+    body: (host: ExtensionHost) => Promise<unknown>
+  ): Promise<unknown> => {
+    const { host, used } = mockExtensionHost(declared)
+    try {
+      return await body(host)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      found.push(
+        finding(
+          'error',
+          error instanceof PermissionDeniedError ? 'permission-undeclared' : code,
+          `${kind} ${id}`,
+          error instanceof PermissionDeniedError
+            ? `asked the host for something this extension does not declare: ${reason}`
+            : `threw: ${reason}`
+        )
+      )
+      return undefined
+    } finally {
+      for (const permission of used) spent.add(permission)
+    }
+  }
+
+  for (const footer of contributes.footers ?? []) {
+    const items = await ran('footer', footer.id, 'footer-failed', (host) =>
+      Promise.resolve(footer.run({ ...CHECK_SESSION, host, now: () => new Date().toISOString() }))
+    )
+    if (items === undefined) continue
+    if (!Array.isArray(items)) {
+      found.push(
+        finding(
+          'error',
+          'footer-items-invalid',
+          `footer ${footer.id}`,
+          'returned something that is not a list of readings'
+        )
+      )
+      continue
+    }
+    for (const item of items) {
+      const wrong = invalidItem(item)
+      if (wrong) {
+        found.push(
+          finding(
+            'error',
+            'footer-items-invalid',
+            `footer ${footer.id}`,
+            `returned a reading that ${wrong}`
+          )
+        )
+      }
+    }
+  }
+
+  for (const handler of contributes.linkHandlers ?? []) {
+    // A pattern it cannot match is a handler nothing would ever reach it through.
+    const sample = new RegExp(handler.pattern).source
+    await ran('link handler', handler.id, 'handler-failed', (host) =>
+      Promise.resolve(
+        handler.run({
+          ...CHECK_SESSION,
+          host,
+          now: () => new Date().toISOString(),
+          url: `https://example.test/${encodeURIComponent(sample).slice(0, 32)}`
+        })
+      )
+    )
+  }
+
+  for (const permission of declared) {
+    if (!spent.has(permission)) {
+      found.push(
+        finding(
+          'warn',
+          'permission-unused',
+          `${connector.id} permissions`,
+          `asks for ${permission} but nothing this run exercised used it; ask only for what it spends`
+        )
+      )
+    }
+  }
+
+  return found
+}
+
+/** A pane's page has to be in the package, or the pack ships a pane that cannot open. */
+function paneFindings(connector: Connector, packageDir: string | undefined): CheckFinding[] {
+  if (packageDir === undefined) return []
+  const root = resolve(packageDir)
+  const found: CheckFinding[] = []
+  for (const pane of connector.contributes?.panes ?? []) {
+    if (pane.web === undefined) continue
+    const full = resolve(root, pane.web)
+    if (full !== root && !full.startsWith(`${root}${sep}`)) {
+      found.push(
+        finding(
+          'error',
+          'web-entry-outside-package',
+          `pane ${pane.id}`,
+          `declares the page "${pane.web}", which resolves outside the package`
+        )
+      )
+      continue
+    }
+    if (!existsSync(full)) {
+      found.push(
+        finding(
+          'error',
+          'web-entry-missing',
+          `pane ${pane.id}`,
+          `declares the page "${pane.web}", which the package does not carry`
+        )
+      )
+    }
+  }
   return found
 }
 
@@ -567,8 +744,11 @@ export async function checkConnector(
     )
   }
 
-  found.push(...authFindings(connector))
+  // An extension's credential is the host's own token, so there is no rung to check.
+  if (connector.kind !== 'extension') found.push(...authFindings(connector))
   found.push(...secretFindings(connector))
+  found.push(...paneFindings(connector, options.packageDir))
+  found.push(...(await contributionFindings(connector)))
   found.push(...(await packageFindings(connector, options)))
   found.push(...(await mockFindings(connector, options)))
   found.push(...(await liveFindings(connector, options)))
@@ -695,7 +875,14 @@ export const CHECK_OWNERS: Record<CheckCode, string | null> = {
   'mock-not-observed': 'mock',
   'preflight-failed': 'live',
   'live-action-failed': 'live',
-  'pack-launch': 'launch'
+  'pack-launch': 'launch',
+  'web-entry-missing': 'contributes',
+  'web-entry-outside-package': 'contributes',
+  'footer-failed': 'footers',
+  'footer-items-invalid': 'footers',
+  'handler-failed': 'handlers',
+  'permission-undeclared': 'permissions',
+  'permission-unused': 'permissions'
 }
 
 /**
@@ -708,7 +895,13 @@ export const CHECK_OWNERS: Record<CheckCode, string | null> = {
  * than a long one.
  */
 function checksRun(connector: Connector, options: CheckOptions): string[] {
-  const names = ['manifest', 'auth']
+  const names = ['manifest']
+  if (connector.kind !== 'extension') names.push('auth')
+  const contributes = connector.contributes
+  if (contributes?.panes?.length && options.packageDir !== undefined) names.push('contributes')
+  if (contributes?.footers?.length) names.push('footers')
+  if (contributes?.linkHandlers?.length) names.push('handlers')
+  if (connector.permissions !== undefined) names.push('permissions')
   if (connector.config.length > 0) names.push('secrets')
   if (connector.actions.length > 0) names.push('actions')
   if (connector.triggers.length > 0) names.push('dedupe')

--- a/packages/connector-sdk/src/cli.ts
+++ b/packages/connector-sdk/src/cli.ts
@@ -32,7 +32,8 @@ Options:
   --receipt <file>              Where check writes what it verified, as JSON
   --out <dir>                   Directory new and pack write to
   --name <name>                 Display name for a new connector
-  --repo-conventions            Scaffold a package shaped for the connectors repository`
+  --repo-conventions            Scaffold a package shaped for the connectors repository
+  --extension                   Scaffold an extension — footers, panes and link handlers`
 
 export interface CliDeps {
   load(modulePath: string): Promise<unknown>
@@ -51,7 +52,7 @@ export interface CliDeps {
 }
 
 /** Flags that stand alone; everything else must be followed by a value. */
-const BOOLEAN_FLAGS = new Set(['live', 'mock', 'repo-conventions'])
+const BOOLEAN_FLAGS = new Set(['live', 'mock', 'repo-conventions', 'extension'])
 
 /**
  * Split arguments into flags and positionals in one pass, so a flag's value is
@@ -91,7 +92,7 @@ function pickConnector(loaded: unknown, modulePath: string): Connector {
   const connector = candidate as Connector | undefined
   if (!connector || typeof connector !== 'object' || !Array.isArray(connector.triggers)) {
     throw new Error(
-      `${modulePath} does not export a connector built with defineConnector() (default or named "connector")`
+      `${modulePath} does not export a connector built with defineConnector() or defineExtension() (default or named "connector")`
     )
   }
   return connector
@@ -118,7 +119,8 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
     const files = scaffoldFiles({
       id: modulePath,
       ...(flags.name !== undefined && { name: flags.name }),
-      ...(flags['repo-conventions'] === 'true' && { repoConventions: true })
+      ...(flags['repo-conventions'] === 'true' && { repoConventions: true }),
+      ...(flags.extension === 'true' && { kind: 'extension' as const })
     })
     const root = join(flags.out ?? deps.cwd ?? '.', modulePath)
     if ((deps.exists ?? existsSync)(root)) {

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -49,7 +49,8 @@ export const HOST_PERMISSIONS: Record<ExtensionHostMethod, ExtensionPermission> 
   usage: 'agent.usage'
 }
 
-const EXTENSION_AGENTS: ExtensionAgent[] = [
+/** Session types an extension may name, so a manifest cannot invent one. */
+export const EXTENSION_AGENTS: ExtensionAgent[] = [
   'claude',
   'copilot',
   'codex',
@@ -57,13 +58,16 @@ const EXTENSION_AGENTS: ExtensionAgent[] = [
   'gemini',
   'shell'
 ]
-const EXTENSION_PLATFORMS: ExtensionPlatform[] = ['darwin', 'linux', 'win32']
+export const EXTENSION_PLATFORMS: ExtensionPlatform[] = ['darwin', 'linux', 'win32']
 
 /** A pane's page lives under `web/` in the package, so a pack carries one named directory. */
 const WEB_ENTRY_PATTERN = /^web\/[A-Za-z0-9._/-]+\.html$/
 
 /** Slower than this and a footer is a poller; faster and it is a spinner. */
 const MIN_FOOTER_SECONDS = 5
+
+/** A pattern is matched against clicked text on a person's keystroke, so it stays small enough to bound. */
+const MAX_PATTERN_LENGTH = 256
 
 /** A declared request goes somewhere the connector named: a real URL, … */
 const ABSOLUTE_URL_PATTERN = /^https?:\/\//i
@@ -435,13 +439,33 @@ export function defineExtension(definition: ExtensionDefinition): Connector {
         `Extension ${id} link handler ${handler.id} is missing a run() implementation`
       )
     }
+    if (typeof handler.pattern !== 'string' || handler.pattern.length > MAX_PATTERN_LENGTH) {
+      throw new Error(
+        `Extension ${id} link handler ${handler.id} has a pattern longer than ` +
+          `${MAX_PATTERN_LENGTH} characters; it is matched on every click`
+      )
+    }
+    let matcher: RegExp
     try {
-      new RegExp(handler.pattern)
+      matcher = new RegExp(handler.pattern)
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error)
       throw new Error(
         `Extension ${id} link handler ${handler.id} has a pattern that is not a regular expression: ${reason}`,
         { cause: error }
+      )
+    }
+    // The example is what `check` runs the handler on, so a pattern it does not
+    // match would prove the handler against a link it will never be offered for.
+    if (typeof handler.example !== 'string' || handler.example.trim() === '') {
+      throw new Error(
+        `Extension ${id} link handler ${handler.id} names no example link its pattern matches`
+      )
+    }
+    if (!matcher.test(handler.example)) {
+      throw new Error(
+        `Extension ${id} link handler ${handler.id} has the example ${JSON.stringify(handler.example)}, ` +
+          `which its own pattern ${JSON.stringify(handler.pattern)} does not match`
       )
     }
   }

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -1,9 +1,16 @@
 import type {
+  ActivationPredicate,
   AuthRung,
   Connector,
   ConnectorConfig,
   ConnectorDefinition,
-  DedupeStrategy
+  DedupeStrategy,
+  ExtensionAgent,
+  ExtensionDefinition,
+  ExtensionHostMethod,
+  ExtensionPermission,
+  ExtensionPlatform,
+  PaneContribution
 } from './types'
 
 const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
@@ -20,6 +27,43 @@ const PATH_DATA_PATTERN = /^[MmZzLlHhVvCcSsQqTtAa0-9\s,.\-+eE]+$/
 const VIEW_BOX_PATTERN = /^-?[\d.]+\s+-?[\d.]+\s+-?[\d.]+\s+-?[\d.]+$/
 const DEDUPE_STRATEGIES: DedupeStrategy[] = ['timestamp', 'lastItem']
 const AUTH_RUNGS: AuthRung[] = ['none', 'cli', 'key', 'oauth']
+
+/** Everything an extension may ask the host for; anything else is not grantable. */
+export const EXTENSION_PERMISSIONS: ExtensionPermission[] = [
+  'git.read',
+  'terminal.read',
+  'terminal.selection',
+  'terminal.send',
+  'card.rename',
+  'agent.usage'
+]
+
+/** What each host method costs, read by the bridge that grants it and the check that gates it. */
+export const HOST_PERMISSIONS: Record<ExtensionHostMethod, ExtensionPermission> = {
+  diff: 'git.read',
+  status: 'git.read',
+  output: 'terminal.read',
+  selection: 'terminal.selection',
+  send: 'terminal.send',
+  rename: 'card.rename',
+  usage: 'agent.usage'
+}
+
+const EXTENSION_AGENTS: ExtensionAgent[] = [
+  'claude',
+  'copilot',
+  'codex',
+  'opencode',
+  'gemini',
+  'shell'
+]
+const EXTENSION_PLATFORMS: ExtensionPlatform[] = ['darwin', 'linux', 'win32']
+
+/** A pane's page lives under `web/` in the package, so a pack carries one named directory. */
+const WEB_ENTRY_PATTERN = /^web\/[A-Za-z0-9._/-]+\.html$/
+
+/** Slower than this and a footer is a poller; faster and it is a spinner. */
+const MIN_FOOTER_SECONDS = 5
 
 /** A declared request goes somewhere the connector named: a real URL, … */
 const ABSOLUTE_URL_PATTERN = /^https?:\/\//i
@@ -81,6 +125,36 @@ function assertAuth(definition: ConnectorDefinition): void {
   }
 }
 
+/** The id, name and glyph every pack declares, whichever kind it is. */
+function assertIdentity(
+  kind: string,
+  definition: { id?: string; name?: string; icon?: ConnectorDefinition['icon'] }
+): void {
+  if (!KEY_PATTERN.test(definition.id ?? '')) {
+    throw new Error(`${kind} id "${definition.id}" must start with a letter and be url-safe`)
+  }
+  if (!definition.name?.trim()) {
+    throw new Error(`${kind} ${definition.id} is missing a name`)
+  }
+  if (!definition.icon) return
+
+  const { viewBox, paths } = definition.icon
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error(`${kind} ${definition.id} has an icon with no paths`)
+  }
+  for (const path of paths) {
+    if (typeof path !== 'string' || !PATH_DATA_PATTERN.test(path)) {
+      throw new Error(
+        `${kind} ${definition.id} has an icon path that is not SVG path data. ` +
+          `Only path data is accepted, not markup.`
+      )
+    }
+  }
+  if (viewBox !== undefined && !VIEW_BOX_PATTERN.test(viewBox)) {
+    throw new Error(`${kind} ${definition.id} has an icon viewBox that is not four numbers`)
+  }
+}
+
 /** Environment variable a config field reads from, e.g. `apiToken` → `API_TOKEN`. */
 export function envNameFor(key: string, explicit?: string): string {
   if (explicit) return explicit
@@ -98,30 +172,7 @@ export function envNameFor(key: string, explicit?: string): string {
  * MCP tool once the connector is already installed in someone's app.
  */
 export function defineConnector(definition: ConnectorDefinition): Connector {
-  if (!KEY_PATTERN.test(definition.id ?? '')) {
-    throw new Error(`Connector id "${definition.id}" must start with a letter and be url-safe`)
-  }
-  if (!definition.name?.trim()) {
-    throw new Error(`Connector ${definition.id} is missing a name`)
-  }
-
-  if (definition.icon) {
-    const { viewBox, paths } = definition.icon
-    if (!Array.isArray(paths) || paths.length === 0) {
-      throw new Error(`Connector ${definition.id} has an icon with no paths`)
-    }
-    for (const path of paths) {
-      if (typeof path !== 'string' || !PATH_DATA_PATTERN.test(path)) {
-        throw new Error(
-          `Connector ${definition.id} has an icon path that is not SVG path data. ` +
-            `Only path data is accepted, not markup.`
-        )
-      }
-    }
-    if (viewBox !== undefined && !VIEW_BOX_PATTERN.test(viewBox)) {
-      throw new Error(`Connector ${definition.id} has an icon viewBox that is not four numbers`)
-    }
-  }
+  assertIdentity('Connector', definition)
 
   const triggers = definition.triggers ?? []
   const actions = definition.actions ?? []
@@ -226,10 +277,194 @@ export function defineConnector(definition: ConnectorDefinition): Connector {
 
   return {
     ...definition,
+    kind: 'connector',
     version: definition.version ?? '0.0.0',
     config: definition.config ?? [],
     triggers,
     actions
+  }
+}
+
+/** Each declared value has to be one this build knows, or the predicate silently never matches. */
+function assertPredicate(id: string, where: string, predicate?: ActivationPredicate): void {
+  if (!predicate) return
+  const lists: Array<[string, unknown]> = [
+    ['workspaceContains', predicate.workspaceContains],
+    ['remoteHost', predicate.remoteHost],
+    ['agent', predicate.agent],
+    ['platform', predicate.platform]
+  ]
+  for (const [field, value] of lists) {
+    if (value === undefined) continue
+    if (!Array.isArray(value) || value.length === 0) {
+      throw new Error(`Extension ${id} ${where} declares "${field}" with nothing in it`)
+    }
+    for (const entry of value) {
+      if (typeof entry !== 'string' || entry.trim() === '') {
+        throw new Error(`Extension ${id} ${where} declares an empty "${field}" value`)
+      }
+    }
+  }
+  for (const glob of predicate.workspaceContains ?? []) {
+    // Resolved against the session's worktree, so a path leaving it names a file no session owns.
+    if (glob.startsWith('/') || glob.split('/').includes('..')) {
+      throw new Error(
+        `Extension ${id} ${where} looks for "${glob}", which is not inside the worktree`
+      )
+    }
+  }
+  for (const agent of predicate.agent ?? []) {
+    if (!EXTENSION_AGENTS.includes(agent)) {
+      throw new Error(
+        `Extension ${id} ${where} names unknown agent ${JSON.stringify(agent)}; ` +
+          `expected ${EXTENSION_AGENTS.join(', ')}`
+      )
+    }
+  }
+  for (const platform of predicate.platform ?? []) {
+    if (!EXTENSION_PLATFORMS.includes(platform)) {
+      throw new Error(
+        `Extension ${id} ${where} names unknown platform ${JSON.stringify(platform)}; ` +
+          `expected ${EXTENSION_PLATFORMS.join(', ')}`
+      )
+    }
+  }
+}
+
+/** A pane is a page the pack carries or a program it runs, and the two are told apart here. */
+function assertPane(id: string, pane: PaneContribution): void {
+  const loose = pane as { web?: unknown; command?: unknown }
+  const page = loose.web !== undefined
+  const program = loose.command !== undefined
+  if (page && program) {
+    throw new Error(`Extension ${id} pane ${pane.id} declares both a web page and a command`)
+  }
+  if (!page && !program) {
+    throw new Error(`Extension ${id} pane ${pane.id} declares neither a web page nor a command`)
+  }
+  if (page) {
+    const web = loose.web
+    if (typeof web !== 'string' || !WEB_ENTRY_PATTERN.test(web) || web.split('/').includes('..')) {
+      throw new Error(
+        `Extension ${id} pane ${pane.id} declares the page ${JSON.stringify(web)}; ` +
+          `a page is an .html file under web/ in the package`
+      )
+    }
+    return
+  }
+  const command = loose.command
+  if (!Array.isArray(command) || command.length === 0) {
+    throw new Error(`Extension ${id} pane ${pane.id} declares a command with nothing to run`)
+  }
+  for (const arg of command) {
+    if (typeof arg !== 'string' || arg === '') {
+      throw new Error(`Extension ${id} pane ${pane.id} declares a command with an empty argument`)
+    }
+  }
+}
+
+/**
+ * Validate an extension and fill in its defaults.
+ *
+ * An extension is a pack like a connector, so it goes through the same
+ * manifest, pack, check and catalog; what differs is that it contributes to a
+ * session card rather than polling a service. Failing here — at import time —
+ * keeps a mistyped permission or an unreachable page from reaching a card.
+ */
+export function defineExtension(definition: ExtensionDefinition): Connector {
+  assertIdentity('Extension', definition)
+  const id = definition.id
+
+  const panes = definition.panes ?? []
+  const footers = definition.footers ?? []
+  const linkHandlers = definition.linkHandlers ?? []
+  if (panes.length === 0 && footers.length === 0 && linkHandlers.length === 0) {
+    throw new Error(`Extension ${id} contributes nothing`)
+  }
+
+  const permissions = definition.permissions ?? []
+  if (!Array.isArray(permissions)) {
+    throw new Error(`Extension ${id} declares permissions that are not a list`)
+  }
+  for (const permission of permissions) {
+    if (!EXTENSION_PERMISSIONS.includes(permission)) {
+      throw new Error(
+        `Extension ${id} asks for unknown permission ${JSON.stringify(permission)}; ` +
+          `expected ${EXTENSION_PERMISSIONS.join(', ')}`
+      )
+    }
+  }
+  assertUnique('permission', permissions)
+
+  const contributions = [...panes, ...footers, ...linkHandlers]
+  for (const contribution of contributions) {
+    if (!KEY_PATTERN.test(contribution.id ?? '')) {
+      throw new Error(
+        `Contribution id "${contribution.id}" must start with a letter and be url-safe`
+      )
+    }
+    if (!contribution.title?.trim()) {
+      throw new Error(`Extension ${id} contribution ${contribution.id} is missing a title`)
+    }
+    assertPredicate(id, `contribution ${contribution.id}`, contribution.when)
+  }
+  // One namespace: a pane and a footer sharing an id would be two things the host addresses alike.
+  assertUnique(
+    'contribution',
+    contributions.map((contribution) => contribution.id)
+  )
+  assertPredicate(id, 'activates', definition.activates)
+
+  for (const pane of panes) assertPane(id, pane)
+
+  for (const footer of footers) {
+    if (typeof footer.run !== 'function') {
+      throw new Error(`Extension ${id} footer ${footer.id} is missing a run() implementation`)
+    }
+    if (!Number.isFinite(footer.every) || footer.every < MIN_FOOTER_SECONDS) {
+      throw new Error(
+        `Extension ${id} footer ${footer.id} asks to run every ${footer.every}s; ` +
+          `${MIN_FOOTER_SECONDS}s is the shortest interval a footer may ask for`
+      )
+    }
+  }
+
+  for (const handler of linkHandlers) {
+    if (typeof handler.run !== 'function') {
+      throw new Error(
+        `Extension ${id} link handler ${handler.id} is missing a run() implementation`
+      )
+    }
+    try {
+      new RegExp(handler.pattern)
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        `Extension ${id} link handler ${handler.id} has a pattern that is not a regular expression: ${reason}`,
+        { cause: error }
+      )
+    }
+  }
+
+  return {
+    id,
+    name: definition.name,
+    ...(definition.description !== undefined && { description: definition.description }),
+    ...(definition.icon !== undefined && { icon: definition.icon }),
+    kind: 'extension',
+    version: definition.version ?? '0.0.0',
+    // Its credential is the host's own token, so there is nothing to sign in to.
+    auth: { rung: 'none' },
+    config: [],
+    triggers: [],
+    actions: [],
+    permissions,
+    ...(definition.activates !== undefined && { activates: definition.activates }),
+    contributes: {
+      ...(panes.length > 0 && { panes }),
+      ...(footers.length > 0 && { footers }),
+      ...(linkHandlers.length > 0 && { linkHandlers })
+    }
   }
 }
 

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -1,6 +1,15 @@
+import { HOST_PERMISSIONS } from './define'
+import { PermissionDeniedError } from './host'
 import { drainPoll, runAction, runPoll, type PollPage, type RunPollOptions } from './runtime'
 import { connectorManifest, type ConnectorManifest } from './setup'
-import type { Connector, ConnectorConfig, NormalizedItem } from './types'
+import type {
+  Connector,
+  ConnectorConfig,
+  ExtensionHost,
+  ExtensionHostMethod,
+  ExtensionPermission,
+  NormalizedItem
+} from './types'
 
 export interface HarnessOptions {
   config?: ConnectorConfig
@@ -210,4 +219,62 @@ export function createConnectorHarness(
     },
     withMockHttp
   }
+}
+
+/** Answers a footer or handler from fixtures, and refuses what the manifest never asked for. */
+export interface MockHostRun {
+  host: ExtensionHost
+  /** Permissions the run actually spent, so a declared-but-unused one can be named. */
+  used: Set<ExtensionPermission>
+}
+
+/** Replaces what the stub answers, for a test whose subject is the reading rather than the plumbing. */
+export type MockHostAnswers = Partial<{
+  [K in ExtensionHostMethod]: ExtensionHost[K]
+}>
+
+const HOST_FIXTURES: ExtensionHost = {
+  diff: async () =>
+    'diff --git a/src/index.ts b/src/index.ts\n@@ -1 +1 @@\n-const a = 1\n+const a = 2\n',
+  status: async () => ' M src/index.ts\n',
+  output: async () => '$ yarn test\n  Test Files  1 passed (1)\n',
+  selection: async () => '',
+  send: async () => {},
+  rename: async () => {},
+  usage: async () => ({
+    contextTokens: 130_000,
+    contextWindow: 1_000_000,
+    cacheHitRate: 0.93,
+    limits: [{ window: '5h', remaining: 0.72 }]
+  })
+}
+
+/**
+ * A host that answers from fixtures and enforces the manifest.
+ *
+ * The check runs every footer and handler against this rather than a real
+ * session, which is what lets a conformance run catch an extension reaching
+ * for something it never declared — before a person is asked to grant it.
+ */
+export function mockExtensionHost(
+  granted: readonly ExtensionPermission[],
+  answers: MockHostAnswers = {}
+): MockHostRun {
+  const allowed = new Set(granted)
+  const used = new Set<ExtensionPermission>()
+  const host = {} as Record<ExtensionHostMethod, unknown>
+
+  for (const name of Object.keys(HOST_FIXTURES) as ExtensionHostMethod[]) {
+    const permission = HOST_PERMISSIONS[name]
+    host[name] = async (...args: unknown[]) => {
+      used.add(permission)
+      if (!allowed.has(permission)) {
+        throw new PermissionDeniedError(name, `this extension does not ask for ${permission}`)
+      }
+      const answer = (answers[name] ?? HOST_FIXTURES[name]) as (...rest: unknown[]) => unknown
+      return answer(...args)
+    }
+  }
+
+  return { host: host as unknown as ExtensionHost, used }
 }

--- a/packages/connector-sdk/src/host.ts
+++ b/packages/connector-sdk/src/host.ts
@@ -23,6 +23,14 @@ export class PermissionDeniedError extends Error {
   }
 }
 
+/** The host answered, but with something this bridge cannot read as a result. */
+export class HostReplyError extends Error {
+  constructor(method: string, detail: string) {
+    super(`The host answered ${method} with ${detail}`)
+    this.name = 'HostReplyError'
+  }
+}
+
 export interface HostBridgeOptions {
   sessionId: string
   env?: NodeJS.ProcessEnv
@@ -33,12 +41,28 @@ export interface HostBridgeOptions {
 /** Long enough for a git read on a large tree, short enough to fail a wedged host. */
 const HOST_TIMEOUT_MS = 15_000
 
+/** The bridge is served on this machine, so a token never leaves it. */
+const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '::1']
+
 function endpoint(env: NodeJS.ProcessEnv): { url: string; token: string } {
   const url = env[HOST_URL_ENV]?.trim()
   const token = env[HOST_TOKEN_ENV]?.trim()
   if (!url || !token) {
     throw new Error(
       `This extension was started without a host bridge; ${HOST_URL_ENV} and ${HOST_TOKEN_ENV} are set by Vorn`
+    )
+  }
+  // Checked before the token is sent: a bridge address that is not this machine
+  // would hand the grant to whoever set the variable.
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`${HOST_URL_ENV} is ${JSON.stringify(url)}, which is not a URL`)
+  }
+  if (parsed.protocol !== 'http:' || !LOOPBACK_HOSTS.includes(parsed.hostname)) {
+    throw new Error(
+      `${HOST_URL_ENV} is ${JSON.stringify(url)}; the bridge is served on this machine, over http on ${LOOPBACK_HOSTS.join(', ')}`
     )
   }
   return { url: url.replace(/\/$/, ''), token }
@@ -60,7 +84,17 @@ export function createExtensionHost(options: HostBridgeOptions): ExtensionHost {
     const text = await response.text()
     if (response.status === 403) throw new PermissionDeniedError(method, text || 'not granted')
     if (!response.ok) throw new Error(`The host answered ${method} with HTTP ${response.status}`)
-    return (text === '' ? undefined : (JSON.parse(text) as { result: T }).result) as T
+    if (text === '') return undefined as T
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      throw new HostReplyError(method, 'a body that is not JSON')
+    }
+    if (!parsed || typeof parsed !== 'object' || !('result' in parsed)) {
+      throw new HostReplyError(method, 'a body carrying no result')
+    }
+    return (parsed as { result: T }).result
   }
 
   return {

--- a/packages/connector-sdk/src/host.ts
+++ b/packages/connector-sdk/src/host.ts
@@ -41,8 +41,8 @@ export interface HostBridgeOptions {
 /** Long enough for a git read on a large tree, short enough to fail a wedged host. */
 const HOST_TIMEOUT_MS = 15_000
 
-/** The bridge is served on this machine, so a token never leaves it. */
-const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '::1']
+/** The bridge is served on this machine, so a token never leaves it; a URL keeps IPv6 in brackets. */
+const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '[::1]']
 
 function endpoint(env: NodeJS.ProcessEnv): { url: string; token: string } {
   const url = env[HOST_URL_ENV]?.trim()

--- a/packages/connector-sdk/src/host.ts
+++ b/packages/connector-sdk/src/host.ts
@@ -1,0 +1,75 @@
+import type { ExtensionHost, ExtensionHostMethod, ExtensionUsage } from './types'
+
+/**
+ * How an extension asks the host for what it was granted.
+ *
+ * The extension runs as its own process, so the bridge is an HTTP endpoint the
+ * host serves and names in the environment, with a token that says which
+ * extension is calling. The host grants exactly the permissions the manifest
+ * declared, which is why a call outside them comes back refused rather than
+ * empty — the same answer the check's stub gives, so an extension meets the
+ * rule once rather than twice.
+ */
+
+/** Where the host answers, and the token that says who is asking. */
+export const HOST_URL_ENV = 'VORN_EXTENSION_HOST'
+export const HOST_TOKEN_ENV = 'VORN_EXTENSION_TOKEN'
+
+/** The host refused a call the extension's manifest never asked for. */
+export class PermissionDeniedError extends Error {
+  constructor(method: string, detail: string) {
+    super(`The host refused ${method}: ${detail}`)
+    this.name = 'PermissionDeniedError'
+  }
+}
+
+export interface HostBridgeOptions {
+  sessionId: string
+  env?: NodeJS.ProcessEnv
+  /** Replaced in tests so nothing opens a socket. */
+  fetchImpl?: typeof fetch
+}
+
+/** Long enough for a git read on a large tree, short enough to fail a wedged host. */
+const HOST_TIMEOUT_MS = 15_000
+
+function endpoint(env: NodeJS.ProcessEnv): { url: string; token: string } {
+  const url = env[HOST_URL_ENV]?.trim()
+  const token = env[HOST_TOKEN_ENV]?.trim()
+  if (!url || !token) {
+    throw new Error(
+      `This extension was started without a host bridge; ${HOST_URL_ENV} and ${HOST_TOKEN_ENV} are set by Vorn`
+    )
+  }
+  return { url: url.replace(/\/$/, ''), token }
+}
+
+/** The host as an extension process reaches it, over the bridge Vorn served it. */
+export function createExtensionHost(options: HostBridgeOptions): ExtensionHost {
+  const env = options.env ?? process.env
+  const call = options.fetchImpl ?? fetch
+
+  async function ask<T>(method: ExtensionHostMethod, params: Record<string, unknown>): Promise<T> {
+    const { url, token } = endpoint(env)
+    const response = await call(`${url}/${method}`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ sessionId: options.sessionId, ...params }),
+      signal: AbortSignal.timeout(HOST_TIMEOUT_MS)
+    })
+    const text = await response.text()
+    if (response.status === 403) throw new PermissionDeniedError(method, text || 'not granted')
+    if (!response.ok) throw new Error(`The host answered ${method} with HTTP ${response.status}`)
+    return (text === '' ? undefined : (JSON.parse(text) as { result: T }).result) as T
+  }
+
+  return {
+    diff: () => ask('diff', {}),
+    status: () => ask('status', {}),
+    output: (opts) => ask('output', { ...(opts?.lines !== undefined && { lines: opts.lines }) }),
+    selection: () => ask('selection', {}),
+    send: (text) => ask('send', { text }),
+    rename: (name) => ask('rename', { name }),
+    usage: () => ask<ExtensionUsage>('usage', {})
+  }
+}

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -1,4 +1,13 @@
-export { defineConnector, resolveConfig, envNameFor } from './define'
+export {
+  defineConnector,
+  defineExtension,
+  resolveConfig,
+  envNameFor,
+  EXTENSION_PERMISSIONS,
+  HOST_PERMISSIONS
+} from './define'
+export { createExtensionHost, PermissionDeniedError, HOST_URL_ENV, HOST_TOKEN_ENV } from './host'
+export type { HostBridgeOptions } from './host'
 export { checkConnector, formatFindings, runConformance, CHECK_OWNERS } from './check'
 export type {
   CheckCode,
@@ -26,12 +35,14 @@ export type { RetryPolicy, ResilientFetchOptions } from './resilience'
 export {
   connectionSetup,
   connectorManifest,
+  footerToolName,
+  handlerToolName,
   pollToolName,
   MANIFEST_TOOL,
   OPTIONS_TOOL,
   PREFLIGHT_TOOL
 } from './setup'
-export type { ConnectionSetup, ConnectorManifest } from './setup'
+export type { ConnectionSetup, ConnectorManifest, ManifestContributions } from './setup'
 export { packConnector, packFileName } from './pack'
 export type { PackOptions, PackResult } from './pack'
 export {
@@ -50,10 +61,19 @@ export type { ScaffoldOptions, ScaffoldFile } from './scaffold'
 export {
   createConnectorHarness,
   escapedMockHttp,
+  mockExtensionHost,
   withMockHttp,
   MockRouteMissError
 } from './harness'
-export type { ConnectorHarness, HarnessOptions, MockCall, MockRoute, MockRun } from './harness'
+export type {
+  ConnectorHarness,
+  HarnessOptions,
+  MockCall,
+  MockHostAnswers,
+  MockHostRun,
+  MockRoute,
+  MockRun
+} from './harness'
 export type {
   ActionContext,
   ActionDefinition,
@@ -82,5 +102,23 @@ export type {
   PreflightResult,
   TriggerDefinition,
   StatusSuggestion,
-  DefaultWorkflow
+  DefaultWorkflow,
+  ActivationPredicate,
+  ConnectorKind,
+  ExtensionAgent,
+  ExtensionContext,
+  ExtensionContributions,
+  ExtensionDefinition,
+  ExtensionHost,
+  ExtensionHostMethod,
+  ExtensionPermission,
+  ExtensionPlatform,
+  ExtensionUsage,
+  ExtensionUsageWindow,
+  FooterContribution,
+  FooterItem,
+  LinkContext,
+  LinkHandled,
+  LinkHandlerContribution,
+  PaneContribution
 } from './types'

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -75,8 +75,7 @@ export async function packConnector(
 ): Promise<PackResult> {
   const resolveDir = resolve(options.resolveDir ?? process.cwd())
   const entryDir = packageDirFor(resolveDir, options.entry)
-  // Resolved once and asked of everything below, so the gate and the archive
-  // never judge one package and ship another.
+  // Resolved once, so the gate and the archive never judge different packages.
   const packageRoot = packageRootFor(entryDir)
 
   const findings = await checkConnector(connector, { packageDir: packageRoot })
@@ -98,8 +97,7 @@ export async function packConnector(
     findings.push(...(await (options.launch ?? packLaunchFindings)(staging)))
     if (findings.some((item) => item.level === 'error')) return { findings }
 
-    // Pages compress well, so an archive Vorn accepts can still unpack past what
-    // it will write; the ceiling that refuses the install is the one to hold to.
+    // Pages compress well, so a small archive can still unpack past what Vorn writes.
     const unpacked = await directoryBytes(staging)
     const maxUnpacked = options.maxUnpackedBytes ?? MAX_UNPACKED_BYTES
     if (unpacked > maxUnpacked) {

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -13,7 +13,9 @@ import {
   packLaunchFindings,
   readNearestPackageJson,
   stagePack,
+  directoryBytes,
   MAX_PACK_BYTES,
+  MAX_UNPACKED_BYTES,
   WEB_DIR,
   type BundleOutput,
   type BundleRequest
@@ -25,7 +27,8 @@ export {
   bundledRequireFindings,
   lifecycleScriptFindings,
   readNearestPackageJson,
-  MAX_PACK_BYTES
+  MAX_PACK_BYTES,
+  MAX_UNPACKED_BYTES
 }
 export type { BundleOutput, BundleRequest }
 
@@ -40,6 +43,8 @@ export interface PackOptions {
   sdkModule?: string
   /** Size ceiling for the written archive; defaults to `MAX_PACK_BYTES`. */
   maxBytes?: number
+  /** Size ceiling for what the archive unpacks to; defaults to `MAX_UNPACKED_BYTES`. */
+  maxUnpackedBytes?: number
   /** Replaced in tests so packing does not shell out to a bundler. */
   bundle?(request: BundleRequest): Promise<BundleOutput>
   /** Replaced in tests whose subject is the archive rather than the launch; defaults to starting it for real. */
@@ -70,10 +75,11 @@ export async function packConnector(
 ): Promise<PackResult> {
   const resolveDir = resolve(options.resolveDir ?? process.cwd())
   const entryDir = packageDirFor(resolveDir, options.entry)
+  // Resolved once and asked of everything below, so the gate and the archive
+  // never judge one package and ship another.
+  const packageRoot = packageRootFor(entryDir)
 
-  // Told where the package is, so a pane naming a page nothing ships is caught
-  // here rather than as a missing file at the moment of tarring.
-  const findings = await checkConnector(connector, { packageDir: packageRootFor(entryDir) })
+  const findings = await checkConnector(connector, { packageDir: packageRoot })
   findings.push(...lifecycleScriptFindings(readNearestPackageJson(entryDir)))
   if (findings.some((item) => item.level === 'error')) return { findings }
 
@@ -86,14 +92,31 @@ export async function packConnector(
   const outDir = resolve(options.outDir ?? process.cwd())
   await mkdir(outDir, { recursive: true })
   const file = join(outDir, packFileName(connector))
-  const staging = await stagePack(connector, built.code, entryDir)
+  const staging = await stagePack(connector, built.code, packageRoot)
   try {
     // Asked of the staged files themselves: an artifact that cannot start is not one to ship.
     findings.push(...(await (options.launch ?? packLaunchFindings)(staging)))
     if (findings.some((item) => item.level === 'error')) return { findings }
+
+    // Pages compress well, so an archive Vorn accepts can still unpack past what
+    // it will write; the ceiling that refuses the install is the one to hold to.
+    const unpacked = await directoryBytes(staging)
+    const maxUnpacked = options.maxUnpackedBytes ?? MAX_UNPACKED_BYTES
+    if (unpacked > maxUnpacked) {
+      return {
+        findings: [
+          ...findings,
+          finding(
+            'pack-too-large',
+            'bundle',
+            `The pack unpacks to ${Math.round(unpacked / 1024)} KB; Vorn unpacks at most ${Math.round(maxUnpacked / 1024)} KB`
+          )
+        ]
+      }
+    }
+
     const { create } = await import('tar')
-    // What was staged, not what was declared: the two agree, and tarring a name
-    // that is not there fails with a path rather than with a sentence.
+    // What was staged, not what was declared; tarring a missing name fails with a path.
     await create({ gzip: true, file, cwd: staging }, [
       'manifest.json',
       'index.js',

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -1,13 +1,14 @@
+import { existsSync } from 'node:fs'
 import { mkdir, rm, stat } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { checkConnector, type CheckCode, type CheckFinding } from './check'
 import {
   bundleDependencyFindings,
   bundledRequireFindings,
-  carriesWeb,
   esbuildBundle,
   lifecycleScriptFindings,
   packageDirFor,
+  packageRootFor,
   packEntryContents,
   packLaunchFindings,
   readNearestPackageJson,
@@ -70,7 +71,9 @@ export async function packConnector(
   const resolveDir = resolve(options.resolveDir ?? process.cwd())
   const entryDir = packageDirFor(resolveDir, options.entry)
 
-  const findings = await checkConnector(connector)
+  // Told where the package is, so a pane naming a page nothing ships is caught
+  // here rather than as a missing file at the moment of tarring.
+  const findings = await checkConnector(connector, { packageDir: packageRootFor(entryDir) })
   findings.push(...lifecycleScriptFindings(readNearestPackageJson(entryDir)))
   if (findings.some((item) => item.level === 'error')) return { findings }
 
@@ -89,10 +92,12 @@ export async function packConnector(
     findings.push(...(await (options.launch ?? packLaunchFindings)(staging)))
     if (findings.some((item) => item.level === 'error')) return { findings }
     const { create } = await import('tar')
+    // What was staged, not what was declared: the two agree, and tarring a name
+    // that is not there fails with a path rather than with a sentence.
     await create({ gzip: true, file, cwd: staging }, [
       'manifest.json',
       'index.js',
-      ...(carriesWeb(connector) ? [WEB_DIR] : [])
+      ...(existsSync(join(staging, WEB_DIR)) ? [WEB_DIR] : [])
     ])
   } finally {
     await rm(staging, { recursive: true, force: true })

--- a/packages/connector-sdk/src/pack.ts
+++ b/packages/connector-sdk/src/pack.ts
@@ -4,6 +4,7 @@ import { checkConnector, type CheckCode, type CheckFinding } from './check'
 import {
   bundleDependencyFindings,
   bundledRequireFindings,
+  carriesWeb,
   esbuildBundle,
   lifecycleScriptFindings,
   packageDirFor,
@@ -12,6 +13,7 @@ import {
   readNearestPackageJson,
   stagePack,
   MAX_PACK_BYTES,
+  WEB_DIR,
   type BundleOutput,
   type BundleRequest
 } from './packaging'
@@ -81,13 +83,17 @@ export async function packConnector(
   const outDir = resolve(options.outDir ?? process.cwd())
   await mkdir(outDir, { recursive: true })
   const file = join(outDir, packFileName(connector))
-  const staging = await stagePack(connector, built.code)
+  const staging = await stagePack(connector, built.code, entryDir)
   try {
     // Asked of the staged files themselves: an artifact that cannot start is not one to ship.
     findings.push(...(await (options.launch ?? packLaunchFindings)(staging)))
     if (findings.some((item) => item.level === 'error')) return { findings }
     const { create } = await import('tar')
-    await create({ gzip: true, file, cwd: staging }, ['manifest.json', 'index.js'])
+    await create({ gzip: true, file, cwd: staging }, [
+      'manifest.json',
+      'index.js',
+      ...(carriesWeb(connector) ? [WEB_DIR] : [])
+    ])
   } finally {
     await rm(staging, { recursive: true, force: true })
   }

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -1,6 +1,6 @@
 import { builtinModules } from 'node:module'
 import { existsSync, readFileSync } from 'node:fs'
-import { cp, mkdtemp, writeFile } from 'node:fs/promises'
+import { cp, mkdtemp, readdir, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import type { CheckCode, CheckFinding } from './check'
@@ -17,6 +17,9 @@ import type { Connector } from './types'
 
 /** Largest pack Vorn will install, matched by the server's own verification. */
 export const MAX_PACK_BYTES = 8 * 1024 * 1024
+
+/** Largest the same pack may unpack to, matched by the server's own verification. */
+export const MAX_UNPACKED_BYTES = 32 * 1024 * 1024
 
 /** Scripts npm would run at install time, which a pack must never carry. */
 const LIFECYCLE_SCRIPTS = [
@@ -281,16 +284,37 @@ export function packEntryContents(entry: string, sdkModule = '@vornrun/connector
 /** The directory a pane's page is served from, carried verbatim so the manifest's path still resolves. */
 export const WEB_DIR = 'web'
 
-/** Whether this pack ships pages, which is what makes `web/` part of it. */
-export function carriesWeb(connector: Connector): boolean {
-  return (connector.contributes?.panes ?? []).some((pane) => pane.web !== undefined)
+/** What a staged pack weighs on disk, which is what the host's unpacked ceiling measures. */
+export async function directoryBytes(dir: string): Promise<number> {
+  let total = 0
+  for (const entry of await readdir(dir, { withFileTypes: true, recursive: true })) {
+    if (!entry.isFile()) continue
+    total += (await stat(join(entry.parentPath, entry.name))).size
+  }
+  return total
 }
 
-/** A directory holding nothing but what a pack carries, for tarring or for launching. */
+/** The directory each declared page sits in, relative to the package, without repeats. */
+export function webDirectories(connector: Connector): string[] {
+  const dirs = (connector.contributes?.panes ?? [])
+    .map((pane) => pane.web)
+    .filter((web): web is string => web !== undefined)
+    .map((web) => dirname(web))
+  return [...new Set(dirs)]
+}
+
+/**
+ * A directory holding nothing but what a pack carries, for tarring or launching.
+ *
+ * `packageRoot` is the package's own root, already resolved by the caller.
+ * Pages are copied per declared pane rather than as one `web/` sweep: a page
+ * needs the stylesheet and script beside it, but nothing an author merely left
+ * in the tree is something the pack should publish.
+ */
 export async function stagePack(
   connector: Connector,
   code: string,
-  packageDir?: string
+  packageRoot?: string
 ): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'vorn-pack-'))
   await writeFile(join(dir, 'index.js'), code, 'utf8')
@@ -299,11 +323,11 @@ export async function stagePack(
     `${JSON.stringify(connectorManifest(connector), null, 2)}\n`,
     'utf8'
   )
-  // Copied whole rather than per pane: the manifest names a path inside `web/`,
-  // so the pack has to hold the stylesheet and the script that page asks for too.
-  if (packageDir !== undefined && carriesWeb(connector)) {
-    const from = join(packageRootFor(packageDir), WEB_DIR)
-    if (existsSync(from)) await cp(from, join(dir, WEB_DIR), { recursive: true })
+  if (packageRoot !== undefined) {
+    for (const relative of webDirectories(connector)) {
+      const from = join(packageRoot, relative)
+      if (existsSync(from)) await cp(from, join(dir, relative), { recursive: true })
+    }
   }
   return dir
 }

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -295,7 +295,7 @@ export async function directoryBytes(dir: string): Promise<number> {
 }
 
 /** The directory each declared page sits in, relative to the package, without repeats. */
-export function webDirectories(connector: Connector): string[] {
+function webDirectories(connector: Connector): string[] {
   const dirs = (connector.contributes?.panes ?? [])
     .map((pane) => pane.web)
     .filter((web): web is string => web !== undefined)

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -1,6 +1,6 @@
 import { builtinModules } from 'node:module'
-import { readFileSync } from 'node:fs'
-import { mkdtemp, writeFile } from 'node:fs/promises'
+import { existsSync, readFileSync } from 'node:fs'
+import { cp, mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import type { CheckCode, CheckFinding } from './check'
@@ -261,8 +261,20 @@ export function packEntryContents(entry: string, sdkModule = '@vornrun/connector
   ].join('\n')
 }
 
-/** A directory holding nothing but the two files a pack carries, for tarring or for launching. */
-export async function stagePack(connector: Connector, code: string): Promise<string> {
+/** The directory a pane's page is served from, carried verbatim so the manifest's path still resolves. */
+export const WEB_DIR = 'web'
+
+/** Whether this pack ships pages, which is what makes `web/` part of it. */
+export function carriesWeb(connector: Connector): boolean {
+  return (connector.contributes?.panes ?? []).some((pane) => pane.web !== undefined)
+}
+
+/** A directory holding nothing but what a pack carries, for tarring or for launching. */
+export async function stagePack(
+  connector: Connector,
+  code: string,
+  packageDir?: string
+): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'vorn-pack-'))
   await writeFile(join(dir, 'index.js'), code, 'utf8')
   await writeFile(
@@ -270,6 +282,12 @@ export async function stagePack(connector: Connector, code: string): Promise<str
     `${JSON.stringify(connectorManifest(connector), null, 2)}\n`,
     'utf8'
   )
+  // Copied whole rather than per pane: the manifest names a path inside `web/`,
+  // so the pack has to hold the stylesheet and the script that page asks for too.
+  if (packageDir !== undefined && carriesWeb(connector)) {
+    const from = join(resolve(packageDir), WEB_DIR)
+    if (existsSync(from)) await cp(from, join(dir, WEB_DIR), { recursive: true })
+  }
   return dir
 }
 

--- a/packages/connector-sdk/src/packaging.ts
+++ b/packages/connector-sdk/src/packaging.ts
@@ -245,6 +245,23 @@ export function readNearestPackageJson(fromDir: string): Record<string, unknown>
 }
 
 /**
+ * The package's own root, which is where `web/` sits.
+ *
+ * `packageDirFor` answers where to *start looking* for a package.json, and for
+ * a built entry that is `dist/`. A page is authored beside the package rather
+ * than beside the bundle, so finding it means finishing that walk.
+ */
+export function packageRootFor(fromDir: string): string {
+  let current = resolve(fromDir)
+  for (;;) {
+    if (existsSync(join(current, 'package.json'))) return current
+    const parent = dirname(current)
+    if (parent === current) return resolve(fromDir)
+    current = parent
+  }
+}
+
+/**
  * The stdio entry a pack is built from.
  *
  * `check` bundles exactly this too: a gate that asked a different question than
@@ -285,7 +302,7 @@ export async function stagePack(
   // Copied whole rather than per pane: the manifest names a path inside `web/`,
   // so the pack has to hold the stylesheet and the script that page asks for too.
   if (packageDir !== undefined && carriesWeb(connector)) {
-    const from = join(resolve(packageDir), WEB_DIR)
+    const from = join(packageRootFor(packageDir), WEB_DIR)
     if (existsSync(from)) await cp(from, join(dir, WEB_DIR), { recursive: true })
   }
   return dir

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -310,12 +310,13 @@ function extensionPage(name: string): string {
     <h1>${name}</h1>
     <pre id="output">Reading the session…</pre>
     <script type="module">
-      // Vorn answers on this bridge with exactly the permissions the manifest declared.
+      // Same origin, so the page carries no credential: Vorn knows which pane is
+      // asking and grants exactly the permissions the manifest declared.
       const ask = async (method, body = {}) => {
-        const response = await fetch(new URL(method, window.vorn.host), {
+        const response = await fetch('bridge/' + method, {
           method: 'POST',
-          headers: { authorization: 'Bearer ' + window.vorn.token, 'content-type': 'application/json' },
-          body: JSON.stringify({ sessionId: window.vorn.sessionId, ...body })
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body)
         })
         if (!response.ok) throw new Error(method + ' answered ' + response.status)
         return (await response.json()).result

--- a/packages/connector-sdk/src/scaffold.ts
+++ b/packages/connector-sdk/src/scaffold.ts
@@ -20,7 +20,7 @@ const ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
  * `^0.7.0` matches no prerelease at all — a scaffold pinned to it installs
  * nothing. Bumped with the SDK's own version until a stable one exists.
  */
-const SDK_DEPENDENCY_RANGE = '^0.7.0-beta.9'
+const SDK_DEPENDENCY_RANGE = '^0.7.0-beta.14'
 
 /** What a scaffold starts at, in the package and in the changelog section that must match it. */
 const SCAFFOLD_VERSION = '0.1.0'
@@ -37,6 +37,8 @@ export interface ScaffoldOptions {
   description?: string
   /** Emit the shape the connectors repository expects of a package inside it. */
   repoConventions?: boolean
+  /** What to start: a connector that polls a service, or an extension that contributes to a card. */
+  kind?: 'connector' | 'extension'
 }
 
 export interface ScaffoldFile {
@@ -54,17 +56,29 @@ export function titleCase(id: string): string {
     .join(' ')
 }
 
-function packageJson(id: string, description: string, inRepo: boolean): string {
+function packageJson(
+  id: string,
+  description: string,
+  inRepo: boolean,
+  kind: 'connector' | 'extension'
+): string {
+  const scoped = kind === 'extension' ? 'extension' : 'connector'
   return jsonFile({
-    name: inRepo ? `@vornrun/connector-${id}` : `vorn-connector-${id}`,
+    name: inRepo ? `@vornrun/${scoped}-${id}` : `vorn-${scoped}-${id}`,
     version: SCAFFOLD_VERSION,
     description,
     type: 'module',
     license: 'MIT',
-    bin: { [`vorn-connector-${id}`]: 'dist/index.js' },
+    bin: { [`vorn-${scoped}-${id}`]: 'dist/index.js' },
     main: './dist/index.js',
     types: './dist/index.d.ts',
-    files: ['dist', 'README.md', ...(inRepo ? ['CHANGELOG.md'] : [])],
+    // A pane's page ships beside the bundle, so `web` is published like `dist`.
+    files: [
+      'dist',
+      'README.md',
+      ...(kind === 'extension' ? ['web'] : []),
+      ...(inRepo ? ['CHANGELOG.md'] : [])
+    ],
     ...(inRepo && {
       repository: {
         type: 'git',
@@ -87,11 +101,12 @@ function packageJson(id: string, description: string, inRepo: boolean): string {
       typescript: '^6.0.3',
       vitest: VITEST_RANGE
     },
-    // Read by the catalog build: how this connector is filed, found, and what it asks of you.
+    // Read by the catalog build: how this is filed, found, and what it asks of you.
     vorn: {
-      category: 'Other',
+      category: kind === 'extension' ? 'Extensions' : 'Other',
       keywords: [id],
-      ...(inRepo && { auth: 'Say in one line what signing in takes.' })
+      ...(kind === 'extension' && { kind: 'extension' }),
+      ...(inRepo && kind === 'connector' && { auth: 'Say in one line what signing in takes.' })
     }
   })
 }
@@ -219,11 +234,149 @@ export const connector = defineConnector({
 `
 }
 
-function entrySource(): string {
+function extensionSource(id: string, name: string, description: string): string {
+  return `import { defineExtension } from '@vornrun/connector-sdk'
+// Bundled at build time: a pack is one file, so a version read from disk is not there to read.
+import pkg from '../package.json'
+
+export const connector = defineExtension({
+  id: ${JSON.stringify(id)},
+  name: ${JSON.stringify(name)},
+  description: ${JSON.stringify(description)},
+  version: pkg.version,
+  // Only what this actually spends: the check names one it declared and never used.
+  permissions: ['terminal.read'],
+  // Absent where none of these hold, rather than showing a band with nothing in it.
+  activates: { workspaceContains: ['package.json'] },
+  footers: [
+    {
+      id: 'checks',
+      title: 'Checks',
+      description: 'What the last commands in this session said',
+      every: 30,
+      async run(context) {
+        const output = await context.host.output({ lines: 200 })
+        const failed = /\\b(FAIL|failed|error)\\b/i.test(output)
+        return [
+          {
+            label: 'tests',
+            value: failed ? 'failing' : 'passing',
+            tone: failed ? 'danger' : 'ok'
+          }
+        ]
+      }
+    }
+  ],
+  panes: [
+    {
+      id: 'report',
+      title: 'Report',
+      description: 'The reading, in full, beside the terminal',
+      // Served from the pack; everything the page needs lives under web/.
+      web: 'web/report/index.html'
+    }
+  ]
+})
+`
+}
+
+function extensionPage(name: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${name}</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 12px;
+        font: 12px ui-sans-serif, system-ui, sans-serif;
+        color: #faf9f7;
+        background: #101012;
+      }
+      h1 {
+        font-size: 13px;
+        font-weight: 500;
+        margin: 0 0 8px;
+      }
+      pre {
+        margin: 0;
+        white-space: pre-wrap;
+        color: rgba(255, 255, 255, 0.55);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>${name}</h1>
+    <pre id="output">Reading the session…</pre>
+    <script type="module">
+      // Vorn answers on this bridge with exactly the permissions the manifest declared.
+      const ask = async (method, body = {}) => {
+        const response = await fetch(new URL(method, window.vorn.host), {
+          method: 'POST',
+          headers: { authorization: 'Bearer ' + window.vorn.token, 'content-type': 'application/json' },
+          body: JSON.stringify({ sessionId: window.vorn.sessionId, ...body })
+        })
+        if (!response.ok) throw new Error(method + ' answered ' + response.status)
+        return (await response.json()).result
+      }
+
+      const node = document.getElementById('output')
+      try {
+        node.textContent = await ask('output', { lines: 200 })
+      } catch (error) {
+        node.textContent = String(error)
+      }
+    </script>
+  </body>
+</html>
+`
+}
+
+function extensionTestSource(name: string): string {
+  return `import { describe, expect, it } from 'vitest'
+import { mockExtensionHost } from '@vornrun/connector-sdk'
+import { connector } from './extension'
+
+/** Runs one footer the way the host will, against a stub that enforces the manifest. */
+async function footer(id: string, output: string) {
+  const { host } = mockExtensionHost(connector.permissions ?? [], { output: async () => output })
+  const declared = connector.contributes?.footers?.find((entry) => entry.id === id)
+  if (!declared) throw new Error('no footer ' + id)
+  return declared.run({
+    sessionId: 'test',
+    worktreePath: process.cwd(),
+    agent: 'claude',
+    host,
+    now: () => '2026-01-01T00:00:00.000Z'
+  })
+}
+
+describe(${JSON.stringify(name)}, () => {
+  it('reads the session as passing when nothing failed', async () => {
+    expect(await footer('checks', 'Test Files  1 passed (1)')).toEqual([
+      { label: 'tests', value: 'passing', tone: 'ok' }
+    ])
+  })
+
+  it('reads it as failing when the output says so', async () => {
+    expect(await footer('checks', 'FAIL src/index.test.ts')).toEqual([
+      { label: 'tests', value: 'failing', tone: 'danger' }
+    ])
+  })
+
+  it('asks for nothing it did not declare', () => {
+    expect(connector.permissions).toEqual(['terminal.read'])
+  })
+})
+`
+}
+
+function entrySource(module: string): string {
   return `import { realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { serveConnector } from '@vornrun/connector-sdk'
-import { connector } from './connector'
+import { connector } from './${module}'
 
 /** True when this file was run directly rather than imported. */
 export function isEntryPoint(moduleUrl: string, argv = process.argv): boolean {
@@ -293,8 +446,8 @@ describe('the packaged connector', () => {
 `
 }
 
-function indexSource(): string {
-  return `import { connector } from './connector'
+function indexSource(module: string): string {
+  return `import { connector } from './${module}'
 import { serveIfEntryPoint } from './entry'
 
 export { connector }
@@ -402,23 +555,79 @@ really talks to; the shapes here are a starting point, not a rule.
 `
 }
 
-/** Every file a new connector starts with, ready to build, check and pack. */
+function extensionReadme(id: string, name: string, description: string): string {
+  return `# ${name}
+
+${description}
+
+## Build and check
+
+\`\`\`sh
+yarn install
+yarn build
+yarn check      # verifies the extension against Vorn's contract
+yarn test
+yarn pack       # writes ${id}-${SCAFFOLD_VERSION}.vorn.tgz, installable in Vorn
+\`\`\`
+
+## What it contributes
+
+| Kind | Name | What it does |
+| --- | --- | --- |
+| Footer | Checks | A band under the card's status bar, recomputed every 30s |
+| Pane | Report | A page beside the terminal, served from \`web/report\` |
+
+## What it asks for
+
+| Permission | What it grants |
+| --- | --- |
+| \`terminal.read\` | The session's recent terminal output |
+
+Ask for only what the extension spends: \`check\` names a permission that was
+declared and never used.
+
+## Where it shows
+
+Sessions whose worktree has a \`package.json\`. Widen or narrow that in
+\`activates\`, and narrow one contribution further with its own \`when\`.
+`
+}
+
+/** Every file a new connector or extension starts with, ready to build, check and pack. */
 export function scaffoldFiles(options: ScaffoldOptions): ScaffoldFile[] {
+  const kind = options.kind ?? 'connector'
   if (!ID_PATTERN.test(options.id ?? '')) {
-    throw new Error(`Connector id "${options.id}" must start with a letter and be url-safe`)
+    throw new Error(
+      `${kind === 'extension' ? 'Extension' : 'Connector'} id "${options.id}" must start with a letter and be url-safe`
+    )
   }
   const name = options.name?.trim() || titleCase(options.id)
-  const description = options.description?.trim() || `${name} connector for Vorn`
+  const description = options.description?.trim() || `${name} ${kind} for Vorn`
   const inRepo = options.repoConventions ?? false
+  const module = kind === 'extension' ? 'extension' : 'connector'
 
   return [
-    { path: 'package.json', contents: packageJson(options.id, description, inRepo) },
-    { path: 'src/connector.ts', contents: connectorSource(options.id, name, description) },
-    { path: 'src/entry.ts', contents: entrySource() },
-    { path: 'src/index.ts', contents: indexSource() },
-    { path: 'src/connector.test.ts', contents: testSource(name) },
+    { path: 'package.json', contents: packageJson(options.id, description, inRepo, kind) },
+    kind === 'extension'
+      ? { path: 'src/extension.ts', contents: extensionSource(options.id, name, description) }
+      : { path: 'src/connector.ts', contents: connectorSource(options.id, name, description) },
+    { path: 'src/entry.ts', contents: entrySource(module) },
+    { path: 'src/index.ts', contents: indexSource(module) },
+    kind === 'extension'
+      ? { path: 'src/extension.test.ts', contents: extensionTestSource(name) }
+      : { path: 'src/connector.test.ts', contents: testSource(name) },
     { path: 'src/entry.test.ts', contents: entryTestSource() },
-    { path: 'README.md', contents: readme(options.id, name, description) },
+    // The page a pane is drawn from, carried into the pack as it stands here.
+    ...(kind === 'extension'
+      ? [{ path: 'web/report/index.html', contents: extensionPage(name) }]
+      : []),
+    {
+      path: 'README.md',
+      contents:
+        kind === 'extension'
+          ? extensionReadme(options.id, name, description)
+          : readme(options.id, name, description)
+    },
     // Everywhere: the generated source imports its package.json, which needs resolveJsonModule to compile.
     { path: 'tsconfig.json', contents: tsconfig(inRepo) },
     ...(inRepo

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z, type ZodTypeAny } from 'zod'
-import { resolveConfig } from './define'
+import { EXTENSION_AGENTS, resolveConfig } from './define'
 import { createExtensionHost } from './host'
 import { runAction, runOptions, runPoll } from './runtime'
 import {
@@ -254,15 +254,15 @@ export function createConnectorServer(
   const sessionShape = {
     sessionId: z.string().describe('The session this is being computed for'),
     worktreePath: z.string().describe("Where the session's work is"),
-    agent: z.string().describe('Which agent runs in the session')
+    agent: z.enum(EXTENSION_AGENTS).describe('Which agent runs in the session')
   }
   const sessionContext = (
-    args: { sessionId: string; worktreePath: string; agent: string },
+    args: { sessionId: string; worktreePath: string; agent: ExtensionAgent },
     host: ExtensionHost
   ): ExtensionContext => ({
     sessionId: args.sessionId,
     worktreePath: args.worktreePath,
-    agent: args.agent as ExtensionAgent,
+    agent: args.agent,
     host,
     now: options.now ?? (() => new Date().toISOString())
   })

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -313,7 +313,7 @@ export function createConnectorServer(
             ...sessionContext(args, hostFor(args.sessionId)),
             url: args.url
           })
-          return json({ ...handled })
+          return json({ ...(handled ?? {}) })
         } catch (error) {
           return failure(error)
         }

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -2,15 +2,26 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z, type ZodTypeAny } from 'zod'
 import { resolveConfig } from './define'
+import { createExtensionHost } from './host'
 import { runAction, runOptions, runPoll } from './runtime'
 import {
   MANIFEST_TOOL,
   OPTIONS_TOOL,
   PREFLIGHT_TOOL,
   connectorManifest,
+  footerToolName,
+  handlerToolName,
   pollToolName
 } from './setup'
-import type { ActionInputField, ActionOutputField, Connector, ConnectorConfig } from './types'
+import type {
+  ActionInputField,
+  ActionOutputField,
+  Connector,
+  ConnectorConfig,
+  ExtensionAgent,
+  ExtensionContext,
+  ExtensionHost
+} from './types'
 
 function json(value: Record<string, unknown>): {
   content: Array<{ type: 'text'; text: string }>
@@ -95,6 +106,8 @@ export interface ConnectorServerOptions {
   /** Resolved connector configuration. Defaults to reading `process.env`. */
   config?: ConnectorConfig
   now?: () => string
+  /** The host an extension's contributions talk to; defaults to the bridge Vorn served. */
+  host?(sessionId: string): ExtensionHost
 }
 
 /**
@@ -229,6 +242,78 @@ export function createConnectorServer(
               ...(options.now && { now: options.now })
             })) as unknown as Record<string, unknown>
           )
+        } catch (error) {
+          return failure(error)
+        }
+      }
+    )
+  }
+
+  // An extension's contributions are served the same way a trigger is: one tool
+  // each, called by the host on its own schedule or when someone clicks.
+  const sessionShape = {
+    sessionId: z.string().describe('The session this is being computed for'),
+    worktreePath: z.string().describe("Where the session's work is"),
+    agent: z.string().describe('Which agent runs in the session')
+  }
+  const sessionContext = (
+    args: { sessionId: string; worktreePath: string; agent: string },
+    host: ExtensionHost
+  ): ExtensionContext => ({
+    sessionId: args.sessionId,
+    worktreePath: args.worktreePath,
+    agent: args.agent as ExtensionAgent,
+    host,
+    now: options.now ?? (() => new Date().toISOString())
+  })
+  const hostFor = (sessionId: string): ExtensionHost =>
+    options.host?.(sessionId) ?? createExtensionHost({ sessionId })
+
+  for (const footer of connector.contributes?.footers ?? []) {
+    server.registerTool(
+      footerToolName(footer.id),
+      {
+        title: footer.title,
+        description: footer.description ?? `Recompute ${footer.title} for one session`,
+        inputSchema: sessionShape,
+        outputSchema: z.looseObject({
+          items: z
+            .array(z.looseObject({ label: z.string(), value: z.string() }))
+            .describe('The readings to show in the band')
+        })
+      },
+      async (args) => {
+        try {
+          const items = await footer.run(sessionContext(args, hostFor(args.sessionId)))
+          return json({ items })
+        } catch (error) {
+          return failure(error)
+        }
+      }
+    )
+  }
+
+  for (const handler of connector.contributes?.linkHandlers ?? []) {
+    server.registerTool(
+      handlerToolName(handler.id),
+      {
+        title: handler.title,
+        description: handler.description ?? `Open ${handler.title} for a clicked link`,
+        inputSchema: {
+          ...sessionShape,
+          url: z.string().describe('The clicked text, which matched this handler')
+        },
+        outputSchema: z.looseObject({
+          openPane: z.string().optional().describe("Id of one of this extension's panes to open")
+        })
+      },
+      async (args) => {
+        try {
+          const handled = await handler.run({
+            ...sessionContext(args, hostFor(args.sessionId)),
+            url: args.url
+          })
+          return json({ ...handled })
         } catch (error) {
           return failure(error)
         }

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -115,7 +115,7 @@ interface ManifestContribution {
 export interface ManifestContributions {
   panes?: Array<ManifestContribution & { web?: string; command?: string[] }>
   footers?: Array<ManifestContribution & { every: number }>
-  linkHandlers?: Array<ManifestContribution & { pattern: string }>
+  linkHandlers?: Array<ManifestContribution & { pattern: string; example: string }>
 }
 
 export interface ConnectorManifest {
@@ -193,7 +193,8 @@ function manifestContributions(connector: Connector): ManifestContributions | un
     ...(contributes.linkHandlers !== undefined && {
       linkHandlers: contributes.linkHandlers.map((handler) => ({
         ...shared(handler),
-        pattern: handler.pattern
+        pattern: handler.pattern,
+        example: handler.example
       }))
     })
   }

--- a/packages/connector-sdk/src/setup.ts
+++ b/packages/connector-sdk/src/setup.ts
@@ -1,16 +1,29 @@
 import { envNameFor } from './define'
 import type {
   ActionInputOption,
+  ActivationPredicate,
   Connector,
   ConnectorAuth,
   ConnectorIcon,
+  ConnectorKind,
   DefaultWorkflow,
+  ExtensionPermission,
   StatusSuggestion
 } from './types'
 
 /** MCP tool name a trigger is served under. */
 export function pollToolName(triggerType: string): string {
   return `poll_${triggerType}`
+}
+
+/** MCP tool name a footer is recomputed under. */
+export function footerToolName(footerId: string): string {
+  return `vorn_footer_${footerId}`
+}
+
+/** MCP tool name a link handler is run under. */
+export function handlerToolName(handlerId: string): string {
+  return `vorn_handler_${handlerId}`
 }
 
 /** Tool that reports the connector's manifest and setup hints. */
@@ -91,14 +104,36 @@ export function connectionSetup(connector: Connector, triggerType: string): Conn
   }
 }
 
+/** A contribution as the manifest carries it: everything but the code that runs it. */
+interface ManifestContribution {
+  id: string
+  title: string
+  description?: string
+  when?: ActivationPredicate
+}
+
+export interface ManifestContributions {
+  panes?: Array<ManifestContribution & { web?: string; command?: string[] }>
+  footers?: Array<ManifestContribution & { every: number }>
+  linkHandlers?: Array<ManifestContribution & { pattern: string }>
+}
+
 export interface ConnectorManifest {
   id: string
   name: string
   version: string
+  /** Absent on a manifest written before extensions, which reads as a connector. */
+  kind?: ConnectorKind
   description?: string
   icon?: ConnectorIcon
   /** How the connector signs in, so the app can say so before installing it. */
   auth?: ConnectorAuth
+  /** What an extension adds to a card. Present only on an extension. */
+  contributes?: ManifestContributions
+  /** What an extension may ask the host for. Present only on an extension. */
+  permissions?: ExtensionPermission[]
+  /** Where an extension shows at all. Present only on an extension. */
+  activates?: ActivationPredicate
   triggers: Array<{
     type: string
     label: string
@@ -134,15 +169,50 @@ export interface ConnectorManifest {
   }>
 }
 
+/** Strip the running code off a contribution, leaving what a manifest can carry. */
+function manifestContributions(connector: Connector): ManifestContributions | undefined {
+  const contributes = connector.contributes
+  if (!contributes) return undefined
+  const shared = (contribution: ManifestContribution): ManifestContribution => ({
+    id: contribution.id,
+    title: contribution.title,
+    ...(contribution.description !== undefined && { description: contribution.description }),
+    ...(contribution.when !== undefined && { when: contribution.when })
+  })
+  return {
+    ...(contributes.panes !== undefined && {
+      panes: contributes.panes.map((pane) => ({
+        ...shared(pane),
+        ...(pane.web !== undefined && { web: pane.web }),
+        ...(pane.command !== undefined && { command: pane.command })
+      }))
+    }),
+    ...(contributes.footers !== undefined && {
+      footers: contributes.footers.map((footer) => ({ ...shared(footer), every: footer.every }))
+    }),
+    ...(contributes.linkHandlers !== undefined && {
+      linkHandlers: contributes.linkHandlers.map((handler) => ({
+        ...shared(handler),
+        pattern: handler.pattern
+      }))
+    })
+  }
+}
+
 /** Full machine-readable description of a connector, served over MCP and printed by the CLI. */
 export function connectorManifest(connector: Connector): ConnectorManifest {
+  const contributes = manifestContributions(connector)
   return {
     id: connector.id,
     name: connector.name,
     version: connector.version,
+    kind: connector.kind,
     ...(connector.description !== undefined && { description: connector.description }),
     ...(connector.icon !== undefined && { icon: connector.icon }),
     ...(connector.auth !== undefined && { auth: connector.auth }),
+    ...(contributes !== undefined && { contributes }),
+    ...(connector.permissions !== undefined && { permissions: connector.permissions }),
+    ...(connector.activates !== undefined && { activates: connector.activates }),
     triggers: connector.triggers.map((trigger) => ({
       type: trigger.type,
       label: trigger.label,

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -468,10 +468,197 @@ export interface ConnectorDefinition {
   preflight?(): Promise<PreflightResult> | PreflightResult
 }
 
+/** What a pack is: a connector polls a service, an extension contributes to a session card. */
+export type ConnectorKind = 'connector' | 'extension'
+
 /** A validated definition. Every accessor below is guaranteed non-null. */
 export interface Connector extends ConnectorDefinition {
   readonly version: string
   readonly config: ConnectorConfigField[]
   readonly triggers: TriggerDefinition[]
   readonly actions: ActionDefinition[]
+  readonly kind: ConnectorKind
+  /** What an extension adds to a card. Absent on a connector. */
+  readonly contributes?: ExtensionContributions
+  /** What an extension may ask the host for. Absent on a connector. */
+  readonly permissions?: ExtensionPermission[]
+  /** Where an extension shows at all. Absent on a connector. */
+  readonly activates?: ActivationPredicate
+}
+
+/**
+ * What an extension may ask the host for, named by what it grants rather than
+ * by the method that spends it.
+ *
+ * A closed set on purpose: a permission is shown to a person before they
+ * install, so every one of them has to be a sentence someone can weigh.
+ */
+export type ExtensionPermission =
+  | 'git.read'
+  | 'terminal.read'
+  | 'terminal.selection'
+  | 'terminal.send'
+  | 'card.rename'
+  | 'agent.usage'
+
+/** Session types an extension can name; `shell` is a plain terminal. */
+export type ExtensionAgent = 'claude' | 'copilot' | 'codex' | 'opencode' | 'gemini' | 'shell'
+
+export type ExtensionPlatform = 'darwin' | 'linux' | 'win32'
+
+/**
+ * Where a contribution shows.
+ *
+ * Every declared field must hold for it to show, and each is satisfied by any
+ * one of its values: a Rust footer says `workspaceContains: ['Cargo.toml']`
+ * and is simply absent everywhere else, rather than reporting nothing.
+ */
+export interface ActivationPredicate {
+  /** Paths relative to the session's worktree; any one of them existing is enough. */
+  workspaceContains?: string[]
+  /** Host of the worktree's git remote, e.g. `github.com`. */
+  remoteHost?: string[]
+  agent?: ExtensionAgent[]
+  platform?: ExtensionPlatform[]
+}
+
+interface ContributionBase {
+  /** Stable within the extension; the host addresses the contribution by it. */
+  id: string
+  title: string
+  description?: string
+  /** Narrows where this one shows, inside where the extension is active at all. */
+  when?: ActivationPredicate
+}
+
+/**
+ * A pane the extension adds beside the terminal: either a page it ships or a
+ * program it runs, never both — a union, so the invalid pair is a type error
+ * while the extension is being written.
+ */
+export type PaneContribution = ContributionBase &
+  (
+    | {
+        /** Page inside the pack, under `web/`, rendered in a pane. */
+        web: string
+        command?: never
+      }
+    | {
+        /** Argv run in the session's worktree, drawn as a terminal. */
+        command: string[]
+        web?: never
+      }
+  )
+
+/** One reading in a footer band: a label, its value, and how the value reads. */
+export interface FooterItem {
+  label: string
+  value: string
+  /** `ok` and `danger` colour the value; anything else is ordinary text. */
+  tone?: 'default' | 'ok' | 'danger'
+  /** Opened when the item is clicked, for a reading that points somewhere. */
+  href?: string
+}
+
+/** What the agent's provider says is left, for the windows it publishes. */
+export interface ExtensionUsageWindow {
+  /** The window's own name, e.g. `5h`. */
+  window: string
+  /** How much of the allowance is left, 0 to 1. */
+  remaining: number
+  resetsAt?: string
+}
+
+export interface ExtensionUsage {
+  contextTokens?: number
+  contextWindow?: number
+  /** Session-cumulative prompt-cache hit rate, 0 to 1. */
+  cacheHitRate?: number
+  limits?: ExtensionUsageWindow[]
+}
+
+/**
+ * The host, as an extension sees it.
+ *
+ * Every method costs exactly one permission — `HOST_PERMISSIONS` says which —
+ * and calling one the manifest did not declare is refused rather than ignored,
+ * so an extension cannot quietly reach past what a person agreed to.
+ */
+export interface ExtensionHost {
+  /** The worktree's diff against its base. */
+  diff(): Promise<string>
+  /** Porcelain status of the worktree. */
+  status(): Promise<string>
+  /** The session's recent terminal output, newest last. */
+  output(options?: { lines?: number }): Promise<string>
+  /** The text selected in the terminal, empty when nothing is selected. */
+  selection(): Promise<string>
+  /** Type text into the session's terminal, as a person would. */
+  send(text: string): Promise<void>
+  /** Name the session card, until a person names it themselves. */
+  rename(name: string): Promise<void>
+  /** Context and provider allowance for the session's agent. */
+  usage(): Promise<ExtensionUsage>
+}
+
+/** Every method of the host, so the table naming what each one costs stays complete. */
+export type ExtensionHostMethod = keyof ExtensionHost
+
+/** What a contribution is told about the session it is running for. */
+export interface ExtensionContext {
+  sessionId: string
+  /** Where the session's work is, so a contribution reads the tree it is about. */
+  worktreePath: string
+  agent: ExtensionAgent
+  host: ExtensionHost
+  /** Injectable clock so tests are deterministic. */
+  now(): string
+}
+
+/** What a link handler is told, on top of the session it was clicked in. */
+export interface LinkContext extends ExtensionContext {
+  /** The clicked text, which matched this handler's pattern. */
+  url: string
+}
+
+/** What a link handler asks the app to do once it has run. */
+export interface LinkHandled {
+  /** Id of one of this extension's panes, opened for the session. */
+  openPane?: string
+}
+
+/** A band under the card's status bar, recomputed on its own interval. */
+export interface FooterContribution extends ContributionBase {
+  /** Seconds between calls; the host polls no faster than this. */
+  every: number
+  run(context: ExtensionContext): Promise<FooterItem[]> | FooterItem[]
+}
+
+/** Offers this extension when the clicked text in a terminal matches. */
+export interface LinkHandlerContribution extends ContributionBase {
+  /** Matched against the clicked text as a regular expression. */
+  pattern: string
+  run(context: LinkContext): Promise<LinkHandled | void> | LinkHandled | void
+}
+
+export interface ExtensionContributions {
+  panes?: PaneContribution[]
+  footers?: FooterContribution[]
+  linkHandlers?: LinkHandlerContribution[]
+}
+
+export interface ExtensionDefinition {
+  /** Stable extension id, e.g. `review`. */
+  id: string
+  name: string
+  version?: string
+  description?: string
+  icon?: ConnectorIcon
+  /** Everything this extension may ask the host for, declared rather than inferred. */
+  permissions: ExtensionPermission[]
+  /** Where the extension shows at all; absent means every session. */
+  activates?: ActivationPredicate
+  panes?: PaneContribution[]
+  footers?: FooterContribution[]
+  linkHandlers?: LinkHandlerContribution[]
 }

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -636,8 +636,10 @@ export interface FooterContribution extends ContributionBase {
 
 /** Offers this extension when the clicked text in a terminal matches. */
 export interface LinkHandlerContribution extends ContributionBase {
-  /** Matched against the clicked text as a regular expression. */
+  /** Matched as a regular expression against clicked text, under a bound the app sets. */
   pattern: string
+  /** A link this handler is for, which its pattern must match; `check` runs the handler on it. */
+  example: string
   run(context: LinkContext): Promise<LinkHandled | void> | LinkHandled | void
 }
 

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -298,6 +298,9 @@ function normalizeEntry(raw: unknown): ConnectorCatalogEntry | undefined {
   const adds = extension ? toContributes(contributes) : undefined
   const asks = extension ? toPermissions(permissions) : undefined
   const shows = extension ? toActivation(activates) : undefined
+  // An extension is what it contributes, and the install refuses one that
+  // contributes nothing — so listing it would advertise a row nobody can use.
+  if (extension && adds === undefined) return undefined
 
   return {
     ...rest,

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -31,10 +31,12 @@ import type {
   ConnectorCatalogItem,
   ConnectorCatalogSummary,
   ConnectorCatalogVerification,
+  ConnectorKind,
   McpServerCatalogEntry,
   WorkflowTemplate
 } from '@vornrun/shared/types'
 import { IPC } from '@vornrun/shared/types'
+import { toActivation, toContributes, toPermissions } from './sdk-probe'
 import {
   PORTABLE_FORMAT_VERSION,
   type PortableRequirement,
@@ -275,11 +277,27 @@ function normalizeEntry(raw: unknown): ConnectorCatalogEntry | undefined {
   }
 
   // A conditional spread cannot remove a key the raw entry already carries.
-  const { packUrl, sha256, authRung, verified, ...rest } = entry
+  const {
+    packUrl,
+    sha256,
+    authRung,
+    verified,
+    kind,
+    contributes,
+    permissions,
+    activates,
+    ...rest
+  } = entry
   const rung = AUTH_RUNGS.includes(authRung as ConnectorAuthRung)
     ? (authRung as ConnectorAuthRung)
     : undefined
   const receipt = normalizeVerification(verified)
+  // The same repair the host applies to a pack's own manifest: what the
+  // directory promises before an install has to be what the install honours.
+  const extension = kind === 'extension'
+  const adds = extension ? toContributes(contributes) : undefined
+  const asks = extension ? toPermissions(permissions) : undefined
+  const shows = extension ? toActivation(activates) : undefined
 
   return {
     ...rest,
@@ -288,6 +306,10 @@ function normalizeEntry(raw: unknown): ConnectorCatalogEntry | undefined {
     packageName: entry.packageName,
     description: typeof entry.description === 'string' ? entry.description : '',
     capabilities: list(entry.capabilities) as ConnectorCatalogEntry['capabilities'],
+    ...(extension && { kind: 'extension' as ConnectorKind }),
+    ...(adds !== undefined && { contributes: adds }),
+    ...(asks !== undefined && { permissions: asks }),
+    ...(shows !== undefined && { activates: shows }),
     ...(typeof packUrl === 'string' && packUrl !== '' && { packUrl }),
     ...(typeof sha256 === 'string' && sha256 !== '' && { sha256 }),
     ...(rung !== undefined && { authRung: rung }),

--- a/packages/server/src/connectors/packs.ts
+++ b/packages/server/src/connectors/packs.ts
@@ -45,6 +45,15 @@ const CURRENT_FILE = 'current.json'
  */
 const PACK_FILES = [MANIFEST_FILE, ENTRY_FILE, 'package.json']
 
+/**
+ * Where an extension's pane pages live, served to a pane rather than run.
+ *
+ * A directory rather than named files: a page needs its stylesheet and its
+ * script beside it, and neither the manifest nor this gate can name them all
+ * ahead of time. It is still one named directory, so nothing else is reachable.
+ */
+const WEB_PREFIX = 'web/'
+
 interface CurrentPack {
   version: string
   previousVersion?: string
@@ -183,10 +192,10 @@ export function verifyPackDir(dir: string): SdkConnectorManifest {
 
   // An allowlist rather than a script headcount: a `.cjs`, `.node` or `.wasm`
   // beside the entry is code the entry can reach, so it is code Vorn installed.
-  const strays = files.filter((file) => !PACK_FILES.includes(file))
+  const strays = files.filter((file) => !PACK_FILES.includes(file) && !file.startsWith(WEB_PREFIX))
   if (strays.length > 0) {
     throw new Error(
-      `The pack carries ${strays.join(', ')}; a pack is ${MANIFEST_FILE} and ${ENTRY_FILE} and nothing else`
+      `The pack carries ${strays.join(', ')}; a pack is ${MANIFEST_FILE}, ${ENTRY_FILE} and what an extension serves under ${WEB_PREFIX}`
     )
   }
 

--- a/packages/server/src/connectors/packs.ts
+++ b/packages/server/src/connectors/packs.ts
@@ -50,9 +50,50 @@ const PACK_FILES = [MANIFEST_FILE, ENTRY_FILE, 'package.json']
  *
  * A directory rather than named files: a page needs its stylesheet and its
  * script beside it, and neither the manifest nor this gate can name them all
- * ahead of time. It is still one named directory, so nothing else is reachable.
+ * ahead of time. What bounds it instead is the manifest — only the directories
+ * its own panes name, and only file types a page is drawn from.
  */
 const WEB_PREFIX = 'web/'
+
+/**
+ * What a page may be made of.
+ *
+ * The reason the allowlist exists at all is that a `.cjs`, `.node` or `.wasm`
+ * is code the entry can reach; putting it under `web/` does not make it a page.
+ */
+const WEB_FILE_TYPES = [
+  'html',
+  'css',
+  'js',
+  'mjs',
+  'json',
+  'svg',
+  'png',
+  'jpg',
+  'jpeg',
+  'webp',
+  'gif',
+  'woff',
+  'woff2',
+  'txt',
+  'md'
+]
+
+/** The directories this manifest's own pages sit in, each with its trailing slash. */
+function webDirectories(manifest: SdkConnectorManifest): string[] {
+  if (manifest.kind !== 'extension') return []
+  const pages = (manifest.contributes?.panes ?? [])
+    .map((pane) => pane.web)
+    .filter((web): web is string => typeof web === 'string' && web.startsWith(WEB_PREFIX))
+  return [...new Set(pages.map((web) => `${web.slice(0, web.lastIndexOf('/'))}/`))]
+}
+
+/** Whether a file is a page asset this manifest actually asked to carry. */
+function servesAPage(file: string, directories: string[]): boolean {
+  if (!directories.some((dir) => file.startsWith(dir))) return false
+  const suffix = file.slice(file.lastIndexOf('.') + 1).toLowerCase()
+  return file.includes('.') && WEB_FILE_TYPES.includes(suffix)
+}
 
 interface CurrentPack {
   version: string
@@ -190,19 +231,26 @@ export function verifyPackDir(dir: string): SdkConnectorManifest {
     }
   }
 
+  // Read before the allowlist rather than after it: what a pack may carry under
+  // `web/` is exactly what its own manifest says it draws a pane from.
+  const manifest = readManifest(dir)
+  const directories = webDirectories(manifest)
+
   // An allowlist rather than a script headcount: a `.cjs`, `.node` or `.wasm`
   // beside the entry is code the entry can reach, so it is code Vorn installed.
-  const strays = files.filter((file) => !PACK_FILES.includes(file) && !file.startsWith(WEB_PREFIX))
+  const strays = files.filter(
+    (file) => !PACK_FILES.includes(file) && !servesAPage(file, directories)
+  )
   if (strays.length > 0) {
     throw new Error(
-      `The pack carries ${strays.join(', ')}; a pack is ${MANIFEST_FILE}, ${ENTRY_FILE} and what an extension serves under ${WEB_PREFIX}`
+      `The pack carries ${strays.join(', ')}; a pack is ${MANIFEST_FILE}, ${ENTRY_FILE} and the pages an extension's own panes name under ${WEB_PREFIX}`
     )
   }
 
   const bytes = directoryBytes(dir)
   if (bytes > MAX_UNPACKED_BYTES) throw new Error(unpackedMessage(bytes))
 
-  return readManifest(dir)
+  return manifest
 }
 
 /** Stated rather than inherited from tar: being wrong here writes outside the data dir. */

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -358,6 +358,12 @@ const boundedStrings = (raw: unknown): string[] =>
     .slice(0, MAX_CONTRIBUTIONS)
     .map((entry) => entry.slice(0, MAX_TEXT_LENGTH))
 
+/** A list of names: trimmed, and a blank one dropped rather than kept to match nothing. */
+const boundedNames = (raw: unknown): string[] =>
+  boundedStrings(raw)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== '')
+
 /** Permissions this build can enforce; one it cannot is dropped rather than granted. */
 export function toPermissions(value: unknown): ExtensionPermission[] | undefined {
   if (!Array.isArray(value)) return undefined
@@ -376,14 +382,14 @@ export function toPermissions(value: unknown): ExtensionPermission[] | undefined
  */
 export function toActivation(value: unknown): ExtensionActivation | undefined {
   if (!isRecord(value)) return undefined
-  const workspaceContains = boundedStrings(value.workspaceContains).filter(
+  const workspaceContains = boundedNames(value.workspaceContains).filter(
     (glob) => !glob.startsWith('/') && !glob.split('/').includes('..')
   )
-  const remoteHost = boundedStrings(value.remoteHost)
-  const agent = boundedStrings(value.agent).filter((entry): entry is ExtensionAgent =>
+  const remoteHost = boundedNames(value.remoteHost)
+  const agent = boundedNames(value.agent).filter((entry): entry is ExtensionAgent =>
     EXTENSION_AGENTS.includes(entry as ExtensionAgent)
   )
-  const platform = boundedStrings(value.platform).filter((entry): entry is ExtensionPlatform =>
+  const platform = boundedNames(value.platform).filter((entry): entry is ExtensionPlatform =>
     EXTENSION_PLATFORMS.includes(entry as ExtensionPlatform)
   )
   const activation: ExtensionActivation = {

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -325,7 +325,7 @@ const WEB_ENTRY_PATTERN = /^web\/[A-Za-z0-9._/-]+\.html$/
 const MIN_FOOTER_SECONDS = 5
 
 /** Permissions this build can enforce; one it cannot is dropped rather than granted. */
-function toPermissions(value: unknown): ExtensionPermission[] | undefined {
+export function toPermissions(value: unknown): ExtensionPermission[] | undefined {
   if (!Array.isArray(value)) return undefined
   const kept = value.filter((entry): entry is ExtensionPermission =>
     EXTENSION_PERMISSIONS.includes(entry as ExtensionPermission)
@@ -340,7 +340,7 @@ function toPermissions(value: unknown): ExtensionPermission[] | undefined {
  * contribution shows rather than hiding it — the safe direction for a
  * narrowing rule, since the alternative is an extension nobody can find.
  */
-function toActivation(value: unknown): ExtensionActivation | undefined {
+export function toActivation(value: unknown): ExtensionActivation | undefined {
   if (!isRecord(value)) return undefined
   const workspaceContains = strings(value.workspaceContains).filter(
     (glob) => !glob.startsWith('/') && !glob.split('/').includes('..')
@@ -375,7 +375,7 @@ function toContribution(raw: unknown): ExtensionContributionSummary | undefined 
  * a handler whose pattern is not a regular expression: each is dropped on its
  * own, so one bad contribution costs its own row rather than the extension.
  */
-function toContributes(value: unknown): ExtensionContributions | undefined {
+export function toContributes(value: unknown): ExtensionContributions | undefined {
   if (!isRecord(value)) return undefined
 
   const panes = (Array.isArray(value.panes) ? value.panes : []).flatMap((raw) => {

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -17,6 +17,11 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type {
   ConnectorAuthRung,
+  ConnectorKind,
+  ExtensionActivation,
+  ExtensionContributions,
+  ExtensionContributionSummary,
+  ExtensionPermission,
   SdkActionInput,
   SdkConnectorAuth,
   SdkConnectorIcon,
@@ -304,6 +309,120 @@ function toAuth(value: unknown): SdkConnectorAuth | undefined {
   }
 }
 
+const EXTENSION_PERMISSIONS: ExtensionPermission[] = [
+  'git.read',
+  'terminal.read',
+  'terminal.selection',
+  'terminal.send',
+  'card.rename',
+  'agent.usage'
+]
+
+/** A page inside the pack, under `web/`; anything else names a file the pack does not carry. */
+const WEB_ENTRY_PATTERN = /^web\/[A-Za-z0-9._/-]+\.html$/
+
+/** Slowest a footer may be asked for, so a manifest cannot ask for a poll every second. */
+const MIN_FOOTER_SECONDS = 5
+
+/** Permissions this build can enforce; one it cannot is dropped rather than granted. */
+function toPermissions(value: unknown): ExtensionPermission[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const kept = value.filter((entry): entry is ExtensionPermission =>
+    EXTENSION_PERMISSIONS.includes(entry as ExtensionPermission)
+  )
+  return [...new Set(kept)]
+}
+
+/**
+ * Where a contribution shows.
+ *
+ * A predicate this build cannot evaluate is dropped, which widens where the
+ * contribution shows rather than hiding it — the safe direction for a
+ * narrowing rule, since the alternative is an extension nobody can find.
+ */
+function toActivation(value: unknown): ExtensionActivation | undefined {
+  if (!isRecord(value)) return undefined
+  const workspaceContains = strings(value.workspaceContains).filter(
+    (glob) => !glob.startsWith('/') && !glob.split('/').includes('..')
+  )
+  const activation: ExtensionActivation = {
+    ...(workspaceContains.length > 0 && { workspaceContains }),
+    ...(strings(value.remoteHost).length > 0 && { remoteHost: strings(value.remoteHost) }),
+    ...(strings(value.agent).length > 0 && { agent: strings(value.agent) }),
+    ...(strings(value.platform).length > 0 && { platform: strings(value.platform) })
+  }
+  return Object.keys(activation).length > 0 ? activation : undefined
+}
+
+/** The id, title and where-it-shows every contribution carries, or nothing when it has no id. */
+function toContribution(raw: unknown): ExtensionContributionSummary | undefined {
+  if (!isRecord(raw)) return undefined
+  const id = str(raw.id).trim()
+  if (!id || !/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(id)) return undefined
+  const when = toActivation(raw.when)
+  return {
+    id,
+    title: str(raw.title, id),
+    ...(typeof raw.description === 'string' && { description: raw.description }),
+    ...(when && { when })
+  }
+}
+
+/**
+ * Read what an extension contributes, keeping only what the app could draw.
+ *
+ * A pane naming a page outside the pack, a footer asking to run every second,
+ * a handler whose pattern is not a regular expression: each is dropped on its
+ * own, so one bad contribution costs its own row rather than the extension.
+ */
+function toContributes(value: unknown): ExtensionContributions | undefined {
+  if (!isRecord(value)) return undefined
+
+  const panes = (Array.isArray(value.panes) ? value.panes : []).flatMap((raw) => {
+    const base = toContribution(raw)
+    if (!base || !isRecord(raw)) return []
+    const web = str(raw.web).trim()
+    const command = strings(raw.command)
+    if (web !== '' && WEB_ENTRY_PATTERN.test(web) && !web.split('/').includes('..')) {
+      return [{ ...base, web }]
+    }
+    // Argv, so an empty element would run something the extension did not name.
+    if (command.length > 0 && command.every((arg) => arg !== '')) return [{ ...base, command }]
+    return []
+  })
+
+  const footers = (Array.isArray(value.footers) ? value.footers : []).flatMap((raw) => {
+    const base = toContribution(raw)
+    if (!base || !isRecord(raw)) return []
+    const every = Number(raw.every)
+    if (!Number.isFinite(every) || every < MIN_FOOTER_SECONDS) return []
+    return [{ ...base, every }]
+  })
+
+  const linkHandlers = (Array.isArray(value.linkHandlers) ? value.linkHandlers : []).flatMap(
+    (raw) => {
+      const base = toContribution(raw)
+      if (!base || !isRecord(raw)) return []
+      const pattern = str(raw.pattern)
+      if (pattern === '') return []
+      try {
+        new RegExp(pattern)
+      } catch {
+        // Offered on every click or on none; either way it is not this pattern.
+        return []
+      }
+      return [{ ...base, pattern }]
+    }
+  )
+
+  const contributes: ExtensionContributions = {
+    ...(panes.length > 0 && { panes }),
+    ...(footers.length > 0 && { footers }),
+    ...(linkHandlers.length > 0 && { linkHandlers })
+  }
+  return Object.keys(contributes).length > 0 ? contributes : undefined
+}
+
 /**
  * Validate the manifest into the shape the UI relies on.
  *
@@ -412,24 +531,39 @@ export function toManifest(payload: Record<string, unknown>): SdkConnectorManife
     }))
     .filter((action) => action.type !== '')
 
-  if (triggers.length === 0 && actions.length === 0) {
+  const kind: ConnectorKind = payload.kind === 'extension' ? 'extension' : 'connector'
+  const contributes = kind === 'extension' ? toContributes(payload.contributes) : undefined
+
+  // An extension is what it contributes, so that is what it must have something of.
+  if (kind === 'extension' && !contributes) {
+    throw new Error(`Extension ${name} reports nothing it contributes`)
+  }
+  if (kind === 'connector' && triggers.length === 0 && actions.length === 0) {
     throw new Error(`Connector ${name} reports no triggers and no actions`)
   }
 
   const icon = toIcon(payload.icon)
   const auth = toAuth(payload.auth)
+  const permissions = kind === 'extension' ? toPermissions(payload.permissions) : undefined
+  const activates = kind === 'extension' ? toActivation(payload.activates) : undefined
 
-  log.info(`[sdk-probe] ${id}@${str(payload.version, '0.0.0')}: ${triggers.length} trigger(s)`)
+  log.info(
+    `[sdk-probe] ${id}@${str(payload.version, '0.0.0')}: ${kind === 'extension' ? `${(contributes?.panes?.length ?? 0) + (contributes?.footers?.length ?? 0) + (contributes?.linkHandlers?.length ?? 0)} contribution(s)` : `${triggers.length} trigger(s)`}`
+  )
 
   return {
     id,
     name,
     version: str(payload.version, '0.0.0'),
+    kind,
     ...(typeof payload.description === 'string' && { description: payload.description }),
     ...(icon && { icon }),
     ...(auth && { auth }),
     triggers,
     actions,
-    env: [...env.values()]
+    env: [...env.values()],
+    ...(contributes && { contributes }),
+    ...(permissions && { permissions }),
+    ...(activates && { activates })
   }
 }

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -21,6 +21,7 @@ import type {
   ExtensionActivation,
   ExtensionContributions,
   ExtensionContributionSummary,
+  ExtensionPaneContribution,
   ExtensionPermission,
   SdkActionInput,
   SdkConnectorAuth,
@@ -378,18 +379,20 @@ function toContribution(raw: unknown): ExtensionContributionSummary | undefined 
 export function toContributes(value: unknown): ExtensionContributions | undefined {
   if (!isRecord(value)) return undefined
 
-  const panes = (Array.isArray(value.panes) ? value.panes : []).flatMap((raw) => {
-    const base = toContribution(raw)
-    if (!base || !isRecord(raw)) return []
-    const web = str(raw.web).trim()
-    const command = strings(raw.command)
-    if (web !== '' && WEB_ENTRY_PATTERN.test(web) && !web.split('/').includes('..')) {
-      return [{ ...base, web }]
+  const panes = (Array.isArray(value.panes) ? value.panes : []).flatMap(
+    (raw): ExtensionPaneContribution[] => {
+      const base = toContribution(raw)
+      if (!base || !isRecord(raw)) return []
+      const web = str(raw.web).trim()
+      const command = strings(raw.command)
+      if (web !== '' && WEB_ENTRY_PATTERN.test(web) && !web.split('/').includes('..')) {
+        return [{ ...base, web }]
+      }
+      // Argv, so an empty element would run something the extension did not name.
+      if (command.length > 0 && command.every((arg) => arg !== '')) return [{ ...base, command }]
+      return []
     }
-    // Argv, so an empty element would run something the extension did not name.
-    if (command.length > 0 && command.every((arg) => arg !== '')) return [{ ...base, command }]
-    return []
-  })
+  )
 
   const footers = (Array.isArray(value.footers) ? value.footers : []).flatMap((raw) => {
     const base = toContribution(raw)

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -19,6 +19,8 @@ import type {
   ConnectorAuthRung,
   ConnectorKind,
   ExtensionActivation,
+  ExtensionAgent,
+  ExtensionPlatform,
   ExtensionContributions,
   ExtensionContributionSummary,
   ExtensionPaneContribution,
@@ -319,11 +321,42 @@ const EXTENSION_PERMISSIONS: ExtensionPermission[] = [
   'agent.usage'
 ]
 
+const EXTENSION_AGENTS: ExtensionAgent[] = [
+  'claude',
+  'copilot',
+  'codex',
+  'opencode',
+  'gemini',
+  'shell'
+]
+const EXTENSION_PLATFORMS: ExtensionPlatform[] = ['darwin', 'linux', 'win32']
+
 /** A page inside the pack, under `web/`; anything else names a file the pack does not carry. */
 const WEB_ENTRY_PATTERN = /^web\/[A-Za-z0-9._/-]+\.html$/
 
+/** Same shape the SDK enforces, checked again because a manifest is a file anyone can write. */
+const CONTRIBUTION_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
+
 /** Slowest a footer may be asked for, so a manifest cannot ask for a poll every second. */
 const MIN_FOOTER_SECONDS = 5
+
+/** Matched against clicked text on a keystroke, so what a manifest may ask for stays small. */
+const MAX_PATTERN_LENGTH = 256
+
+/** Enough of a title or a path to be worth showing; past this it is not one. */
+const MAX_TEXT_LENGTH = 500
+
+/** Enough contributions to be an extension; past this it is a list nobody reads. */
+const MAX_CONTRIBUTIONS = 32
+
+/** Kept to a length the app can draw, so a manifest cannot push a wall of text into a card. */
+const text = (value: unknown, fallback = ''): string =>
+  str(value, fallback).slice(0, MAX_TEXT_LENGTH)
+
+const boundedStrings = (raw: unknown): string[] =>
+  strings(raw)
+    .slice(0, MAX_CONTRIBUTIONS)
+    .map((entry) => entry.slice(0, MAX_TEXT_LENGTH))
 
 /** Permissions this build can enforce; one it cannot is dropped rather than granted. */
 export function toPermissions(value: unknown): ExtensionPermission[] | undefined {
@@ -343,14 +376,21 @@ export function toPermissions(value: unknown): ExtensionPermission[] | undefined
  */
 export function toActivation(value: unknown): ExtensionActivation | undefined {
   if (!isRecord(value)) return undefined
-  const workspaceContains = strings(value.workspaceContains).filter(
+  const workspaceContains = boundedStrings(value.workspaceContains).filter(
     (glob) => !glob.startsWith('/') && !glob.split('/').includes('..')
+  )
+  const remoteHost = boundedStrings(value.remoteHost)
+  const agent = boundedStrings(value.agent).filter((entry): entry is ExtensionAgent =>
+    EXTENSION_AGENTS.includes(entry as ExtensionAgent)
+  )
+  const platform = boundedStrings(value.platform).filter((entry): entry is ExtensionPlatform =>
+    EXTENSION_PLATFORMS.includes(entry as ExtensionPlatform)
   )
   const activation: ExtensionActivation = {
     ...(workspaceContains.length > 0 && { workspaceContains }),
-    ...(strings(value.remoteHost).length > 0 && { remoteHost: strings(value.remoteHost) }),
-    ...(strings(value.agent).length > 0 && { agent: strings(value.agent) }),
-    ...(strings(value.platform).length > 0 && { platform: strings(value.platform) })
+    ...(remoteHost.length > 0 && { remoteHost }),
+    ...(agent.length > 0 && { agent }),
+    ...(platform.length > 0 && { platform })
   }
   return Object.keys(activation).length > 0 ? activation : undefined
 }
@@ -359,12 +399,12 @@ export function toActivation(value: unknown): ExtensionActivation | undefined {
 function toContribution(raw: unknown): ExtensionContributionSummary | undefined {
   if (!isRecord(raw)) return undefined
   const id = str(raw.id).trim()
-  if (!id || !/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(id)) return undefined
+  if (!id || !CONTRIBUTION_ID_PATTERN.test(id)) return undefined
   const when = toActivation(raw.when)
   return {
     id,
-    title: str(raw.title, id),
-    ...(typeof raw.description === 'string' && { description: raw.description }),
+    title: text(raw.title, id),
+    ...(typeof raw.description === 'string' && { description: text(raw.description) }),
     ...(when && { when })
   }
 }
@@ -379,22 +419,24 @@ function toContribution(raw: unknown): ExtensionContributionSummary | undefined 
 export function toContributes(value: unknown): ExtensionContributions | undefined {
   if (!isRecord(value)) return undefined
 
-  const panes = (Array.isArray(value.panes) ? value.panes : []).flatMap(
-    (raw): ExtensionPaneContribution[] => {
-      const base = toContribution(raw)
-      if (!base || !isRecord(raw)) return []
-      const web = str(raw.web).trim()
-      const command = strings(raw.command)
-      if (web !== '' && WEB_ENTRY_PATTERN.test(web) && !web.split('/').includes('..')) {
-        return [{ ...base, web }]
-      }
-      // Argv, so an empty element would run something the extension did not name.
-      if (command.length > 0 && command.every((arg) => arg !== '')) return [{ ...base, command }]
-      return []
-    }
-  )
+  /** Each kind is read from at most this many entries, so one manifest cannot flood a card. */
+  const declared = (raw: unknown): unknown[] =>
+    Array.isArray(raw) ? raw.slice(0, MAX_CONTRIBUTIONS) : []
 
-  const footers = (Array.isArray(value.footers) ? value.footers : []).flatMap((raw) => {
+  const panes = declared(value.panes).flatMap((raw): ExtensionPaneContribution[] => {
+    const base = toContribution(raw)
+    if (!base || !isRecord(raw)) return []
+    const web = text(raw.web).trim()
+    const command = boundedStrings(raw.command)
+    if (web !== '' && WEB_ENTRY_PATTERN.test(web) && !web.split('/').includes('..')) {
+      return [{ ...base, web }]
+    }
+    // Argv, so an empty element would run something the extension did not name.
+    if (command.length > 0 && command.every((arg) => arg !== '')) return [{ ...base, command }]
+    return []
+  })
+
+  const footers = declared(value.footers).flatMap((raw) => {
     const base = toContribution(raw)
     if (!base || !isRecord(raw)) return []
     const every = Number(raw.every)
@@ -402,21 +444,20 @@ export function toContributes(value: unknown): ExtensionContributions | undefine
     return [{ ...base, every }]
   })
 
-  const linkHandlers = (Array.isArray(value.linkHandlers) ? value.linkHandlers : []).flatMap(
-    (raw) => {
-      const base = toContribution(raw)
-      if (!base || !isRecord(raw)) return []
-      const pattern = str(raw.pattern)
-      if (pattern === '') return []
-      try {
-        new RegExp(pattern)
-      } catch {
-        // Offered on every click or on none; either way it is not this pattern.
-        return []
-      }
-      return [{ ...base, pattern }]
+  const linkHandlers = declared(value.linkHandlers).flatMap((raw) => {
+    const base = toContribution(raw)
+    if (!base || !isRecord(raw)) return []
+    const pattern = str(raw.pattern)
+    if (pattern === '' || pattern.length > MAX_PATTERN_LENGTH) return []
+    try {
+      new RegExp(pattern)
+    } catch {
+      // Offered on every click or on none; either way it is not this pattern.
+      return []
     }
-  )
+    const example = text(raw.example).trim()
+    return [{ ...base, pattern, ...(example !== '' && { example }) }]
+  })
 
   const contributes: ExtensionContributions = {
     ...(panes.length > 0 && { panes }),

--- a/packages/server/src/connectors/sdk-tools.ts
+++ b/packages/server/src/connectors/sdk-tools.ts
@@ -21,14 +21,17 @@ export function pollToolName(triggerType: string): string {
   return `poll_${triggerType}`
 }
 
+const FOOTER_TOOL_PREFIX = 'vorn_footer_'
+const HANDLER_TOOL_PREFIX = 'vorn_handler_'
+
 /** MCP tool name an extension's footer is recomputed under. */
 export function footerToolName(footerId: string): string {
-  return `vorn_footer_${footerId}`
+  return `${FOOTER_TOOL_PREFIX}${footerId}`
 }
 
 /** MCP tool name an extension's link handler is run under. */
 export function handlerToolName(handlerId: string): string {
-  return `vorn_handler_${handlerId}`
+  return `${HANDLER_TOOL_PREFIX}${handlerId}`
 }
 
 /**
@@ -41,7 +44,7 @@ export function handlerToolName(handlerId: string): string {
 export function isReservedSdkTool(name: string, triggerTypes?: readonly string[]): boolean {
   if (name === MANIFEST_TOOL || name === PREFLIGHT_TOOL || name === OPTIONS_TOOL) return true
   // A contribution is called by the app on its own schedule, never by a step.
-  if (name.startsWith(footerToolName('')) || name.startsWith(handlerToolName(''))) return true
+  if (name.startsWith(FOOTER_TOOL_PREFIX) || name.startsWith(HANDLER_TOOL_PREFIX)) return true
   return triggerTypes
     ? triggerTypes.some((type) => name === pollToolName(type))
     : name.startsWith(pollToolName(''))

--- a/packages/server/src/connectors/sdk-tools.ts
+++ b/packages/server/src/connectors/sdk-tools.ts
@@ -21,6 +21,16 @@ export function pollToolName(triggerType: string): string {
   return `poll_${triggerType}`
 }
 
+/** MCP tool name an extension's footer is recomputed under. */
+export function footerToolName(footerId: string): string {
+  return `vorn_footer_${footerId}`
+}
+
+/** MCP tool name an extension's link handler is run under. */
+export function handlerToolName(handlerId: string): string {
+  return `vorn_handler_${handlerId}`
+}
+
 /**
  * Whether a tool is plumbing rather than something a workflow step can call.
  *
@@ -30,6 +40,8 @@ export function pollToolName(triggerType: string): string {
  */
 export function isReservedSdkTool(name: string, triggerTypes?: readonly string[]): boolean {
   if (name === MANIFEST_TOOL || name === PREFLIGHT_TOOL || name === OPTIONS_TOOL) return true
+  // A contribution is called by the app on its own schedule, never by a step.
+  if (name.startsWith(footerToolName('')) || name.startsWith(handlerToolName(''))) return true
   return triggerTypes
     ? triggerTypes.some((type) => name === pollToolName(type))
     : name.startsWith(pollToolName(''))

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2122,6 +2122,11 @@ export interface SdkAction {
  */
 export type ConnectorKind = 'connector' | 'extension'
 
+/** Session types an extension can name; `shell` is a plain terminal. */
+export type ExtensionAgent = 'claude' | 'copilot' | 'codex' | 'opencode' | 'gemini' | 'shell'
+
+export type ExtensionPlatform = 'darwin' | 'linux' | 'win32'
+
 /** What an extension may ask the host for, shown before anyone installs it. */
 export type ExtensionPermission =
   | 'git.read'
@@ -2142,8 +2147,8 @@ export interface ExtensionActivation {
   /** Paths relative to the session's worktree; any one existing is enough. */
   workspaceContains?: string[]
   remoteHost?: string[]
-  agent?: string[]
-  platform?: string[]
+  agent?: ExtensionAgent[]
+  platform?: ExtensionPlatform[]
 }
 
 /** What every contribution says about itself, whatever kind it is. */
@@ -2171,7 +2176,10 @@ export interface ExtensionFooterContribution extends ExtensionContributionSummar
 
 /** Offers the extension when clicked text in a terminal matches. */
 export interface ExtensionLinkHandlerContribution extends ExtensionContributionSummary {
+  /** Matched as a regular expression against clicked text, under a bound the app sets. */
   pattern: string
+  /** A link this handler is for, which its pattern matches. */
+  example?: string
 }
 
 export interface ExtensionContributions {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2102,10 +2102,77 @@ export interface SdkAction {
   outputs?: Array<{ key: string; type?: string; description?: string }>
 }
 
+/**
+ * What a pack is. A connector polls a service; an extension contributes to a
+ * session card. Absent on a pack built before extensions, which reads as a
+ * connector because that is all there was.
+ */
+export type ConnectorKind = 'connector' | 'extension'
+
+/** What an extension may ask the host for, shown before anyone installs it. */
+export type ExtensionPermission =
+  | 'git.read'
+  | 'terminal.read'
+  | 'terminal.selection'
+  | 'terminal.send'
+  | 'card.rename'
+  | 'agent.usage'
+
+/**
+ * Where a contribution shows.
+ *
+ * Every declared field has to hold, and each is satisfied by any one of its
+ * values — so an extension is simply absent where it has nothing to say,
+ * rather than showing an empty band.
+ */
+export interface ExtensionActivation {
+  /** Paths relative to the session's worktree; any one existing is enough. */
+  workspaceContains?: string[]
+  remoteHost?: string[]
+  agent?: string[]
+  platform?: string[]
+}
+
+/** What every contribution says about itself, whatever kind it is. */
+export interface ExtensionContributionSummary {
+  id: string
+  title: string
+  description?: string
+  /** Narrows where this one shows, inside where the extension is active at all. */
+  when?: ExtensionActivation
+}
+
+/** A pane an extension adds: a page it ships, or a program it runs. */
+export interface ExtensionPaneContribution extends ExtensionContributionSummary {
+  /** Page inside the pack, under `web/`. Set on a pane Vorn renders. */
+  web?: string
+  /** Argv run in the worktree. Set on a pane drawn as a terminal. */
+  command?: string[]
+}
+
+/** A band under the card's status bar, recomputed on its own interval. */
+export interface ExtensionFooterContribution extends ExtensionContributionSummary {
+  /** Seconds between calls; the host polls no faster than this. */
+  every: number
+}
+
+/** Offers the extension when clicked text in a terminal matches. */
+export interface ExtensionLinkHandlerContribution extends ExtensionContributionSummary {
+  pattern: string
+}
+
+export interface ExtensionContributions {
+  panes?: ExtensionPaneContribution[]
+  footers?: ExtensionFooterContribution[]
+  linkHandlers?: ExtensionLinkHandlerContribution[]
+}
+
 export interface SdkConnectorManifest {
   id: string
   name: string
   version: string
+  /** Absent on a pack built before extensions, which reads as a connector. */
+  kind?: ConnectorKind
   description?: string
   icon?: SdkConnectorIcon
   /** Absent on a connector built before rungs existed, which reads as unknown. */
@@ -2114,6 +2181,12 @@ export interface SdkConnectorManifest {
   actions: SdkAction[]
   /** Union of the environment variables the connector reads. */
   env: SdkEnvVar[]
+  /** What an extension adds to a card. Present only on an extension. */
+  contributes?: ExtensionContributions
+  /** What an extension may ask the host for. Present only on an extension. */
+  permissions?: ExtensionPermission[]
+  /** Where an extension shows at all. Present only on an extension. */
+  activates?: ExtensionActivation
 }
 
 /** A connector installed on disk, where `version` is what runs rather than what was asked for. */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1969,6 +1969,11 @@ export interface ConnectorCatalogEntry {
   id: string
   name: string
   description: string
+  /**
+   * Whether this polls a service or contributes to a session card. Absent on an
+   * older catalog, which reads as a connector because that is all there was.
+   */
+  kind?: ConnectorKind
   /** npm package the connector is published as. */
   packageName: string
   /** Published version, so a listing can say what would be installed. */
@@ -2002,6 +2007,14 @@ export interface ConnectorCatalogEntry {
   triggers?: ConnectorCatalogSummary[]
   actions?: ConnectorCatalogAction[]
   env?: Array<{ name: string; required: boolean; description?: string }>
+  /**
+   * What an extension adds, what it may touch, and where it shows — so the
+   * directory can answer all three before anything is downloaded. Present only
+   * on an extension.
+   */
+  contributes?: ExtensionContributions
+  permissions?: ExtensionPermission[]
+  activates?: ExtensionActivation
 }
 
 /**

--- a/tests/connector-catalog.test.ts
+++ b/tests/connector-catalog.test.ts
@@ -179,6 +179,26 @@ describe('parseCatalog', () => {
     expect(overreaching?.contributes?.panes?.map((pane) => pane.id)).toEqual(['report'])
   })
 
+  it('drops an extension whose contributions it could not honour at all', () => {
+    // The install refuses one that contributes nothing, so listing it would
+    // advertise a row whose Install button cannot work.
+    const listed = parseCatalog({
+      version: 1,
+      connectors: [
+        {
+          ...entry,
+          id: 'unusable',
+          kind: 'extension',
+          contributes: { panes: [{ id: 'escape', title: 'Escape', web: '../outside/index.html' }] }
+        },
+        { ...entry, id: 'silent', kind: 'extension' },
+        entry
+      ]
+    })
+
+    expect(listed?.map((row) => row.id)).toEqual([entry.id])
+  })
+
   it('reads an entry with no kind as the connector it was published as', () => {
     const read = parseCatalog({
       version: 1,

--- a/tests/connector-catalog.test.ts
+++ b/tests/connector-catalog.test.ts
@@ -142,6 +142,54 @@ describe('parseCatalog', () => {
     expect(parseCatalog({ version: 1, connectors: [packed] })?.[0]).toEqual(packed)
   })
 
+  it('keeps what an extension adds, asks for and shows on', () => {
+    const extension = {
+      ...entry,
+      kind: 'extension',
+      capabilities: [],
+      permissions: ['terminal.read'],
+      activates: { workspaceContains: ['package.json'] },
+      contributes: {
+        footers: [{ id: 'checks', title: 'Checks', every: 30 }],
+        panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+      }
+    }
+    expect(parseCatalog({ version: 1, connectors: [extension] })?.[0]).toEqual(extension)
+  })
+
+  it('drops what it could not honour, so the listing promises only what an install gives', () => {
+    const overreaching = parseCatalog({
+      version: 1,
+      connectors: [
+        {
+          ...entry,
+          kind: 'extension',
+          permissions: ['terminal.read', 'filesystem.write'],
+          contributes: {
+            panes: [
+              { id: 'escape', title: 'Escape', web: '../outside/index.html' },
+              { id: 'report', title: 'Report', web: 'web/report/index.html' }
+            ]
+          }
+        }
+      ]
+    })?.[0]
+
+    expect(overreaching?.permissions).toEqual(['terminal.read'])
+    expect(overreaching?.contributes?.panes?.map((pane) => pane.id)).toEqual(['report'])
+  })
+
+  it('reads an entry with no kind as the connector it was published as', () => {
+    const read = parseCatalog({
+      version: 1,
+      connectors: [{ ...entry, contributes: { footers: [{ id: 'x', title: 'X', every: 30 }] } }]
+    })?.[0]
+
+    expect(read).not.toHaveProperty('kind')
+    // Only an extension contributes, so a connector claiming to is not read as one.
+    expect(read).not.toHaveProperty('contributes')
+  })
+
   it('drops a pack url that is empty or the wrong kind of value', () => {
     const broken = parseCatalog({
       version: 1,

--- a/tests/connector-check-owners.test.ts
+++ b/tests/connector-check-owners.test.ts
@@ -297,6 +297,7 @@ async function everyCodeAnyRunEmits(): Promise<Set<string>> {
             id: 'pr',
             title: 'Pull request',
             pattern: 'example',
+            example: 'https://example.test/example',
             run: () => {
               throw new Error('nothing to open')
             }

--- a/tests/connector-check-owners.test.ts
+++ b/tests/connector-check-owners.test.ts
@@ -6,6 +6,7 @@ import {
   CHECK_OWNERS,
   checkConnector,
   defineConnector,
+  defineExtension,
   packConnector,
   runConformance
 } from '../packages/connector-sdk/src/index'
@@ -269,6 +270,84 @@ async function everyCodeAnyRunEmits(): Promise<Set<string>> {
     )
   )
 
+  // An extension: a page nobody shipped, a contribution that throws, and a permission
+  // asked for and never spent.
+  collect(
+    await checkConnector(
+      defineExtension({
+        id: 'reaching',
+        name: 'Reaching',
+        description: 'Reaching',
+        permissions: ['terminal.read', 'card.rename'],
+        panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+        footers: [
+          {
+            id: 'checks',
+            title: 'Checks',
+            description: 'Asks for more than it declared',
+            every: 30,
+            async run(context) {
+              await context.host.diff()
+              return 'not a list' as never
+            }
+          }
+        ],
+        linkHandlers: [
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: 'example',
+            run: () => {
+              throw new Error('nothing to open')
+            }
+          }
+        ]
+      }),
+      { packageDir: dir }
+    )
+  )
+
+  // The reading itself, wrong in a way only a run can see.
+  collect(
+    await checkConnector(
+      defineExtension({
+        id: 'mislabelled',
+        name: 'Mislabelled',
+        description: 'Mislabelled',
+        permissions: ['terminal.read'],
+        footers: [
+          {
+            id: 'checks',
+            title: 'Checks',
+            description: 'Returns a reading with no label',
+            every: 30,
+            async run(context) {
+              await context.host.output()
+              return [{ value: 'passing' }] as never
+            }
+          }
+        ]
+      })
+    )
+  )
+
+  // A page that resolves outside the package, which only a hand-built pack reaches.
+  collect(
+    await checkConnector(
+      {
+        ...defineExtension({
+          id: 'escaping',
+          name: 'Escaping',
+          description: 'Escaping',
+          permissions: [],
+          panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+        }),
+        contributes: { panes: [{ id: 'report', title: 'Report', web: '../outside/index.html' }] }
+      },
+      { packageDir: dir }
+    )
+  )
+
   const big = await packConnector(
     defineConnector({
       id: 'big',
@@ -318,6 +397,10 @@ describe('every finding a run can make', () => {
       'launch',
       'mock',
       'live',
+      'contributes',
+      'footers',
+      'handlers',
+      'permissions',
       null
     ])
     for (const owner of Object.values(CHECK_OWNERS)) {

--- a/tests/connector-extension-checks.test.ts
+++ b/tests/connector-extension-checks.test.ts
@@ -146,6 +146,91 @@ describe('checking an extension', () => {
     expect(codes(found)).toContain('handler-failed')
   })
 
+  it('runs a handler on its own example, so a real pattern is not a failure', async () => {
+    const pullRequest = 'https://github\\.com/[^/]+/[^/]+/pull/(\\d+)'
+    const found = await checkConnector(
+      extension({
+        linkHandlers: [
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: pullRequest,
+            example: 'https://github.com/vorn-run/vorn/pull/42',
+            run: (context) => {
+              // What a real handler does: read the capture its own pattern declares.
+              const matched = new RegExp(pullRequest).exec(context.url)
+              if (!matched) throw new Error(`${context.url} is not a pull request`)
+              return { openPane: 'report' }
+            }
+          }
+        ]
+      })
+    )
+
+    expect(codes(found)).toEqual([])
+  })
+
+  it('names a reading whose link is not one a card can open', async () => {
+    const withHref = (href: string) =>
+      extension({
+        footers: [
+          {
+            id: 'checks',
+            title: 'Checks',
+            description: 'Links somewhere',
+            every: 30,
+            async run(context) {
+              await context.host.output()
+              return [{ label: 'ci', value: 'green', href }]
+            }
+          }
+        ]
+      })
+
+    expect(codes(await checkConnector(withHref('javascript:alert(1)')))).toContain(
+      'footer-items-invalid'
+    )
+    expect(codes(await checkConnector(withHref('file:///etc/passwd')))).toContain(
+      'footer-items-invalid'
+    )
+    expect(codes(await checkConnector(withHref('not a url')))).toContain('footer-items-invalid')
+    expect(codes(await checkConnector(withHref('https://example.test/ci')))).toEqual([])
+  })
+
+  it('says nothing about permissions a page spends, since this run cannot watch it', async () => {
+    // Declared, never touched by the footer — but the page is where it is spent.
+    const withPage = await checkConnector(
+      extension({
+        permissions: ['terminal.read', 'git.read'],
+        panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+      }),
+      { packageDir: packageWithPage() }
+    )
+    expect(codes(withPage)).toEqual([])
+
+    // The same extension without a page: nothing spends it, and the check says so.
+    const withoutPage = await checkConnector(
+      extension({ permissions: ['terminal.read', 'git.read'] })
+    )
+    expect(codes(withoutPage)).toEqual(['permission-unused'])
+  })
+
+  it('finds a page from wherever the check was run', async () => {
+    const dir = packageWithPage()
+    const withPage = extension({
+      panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+    })
+
+    // The entry is under dist/ and the command was run from the parent, which is
+    // what `pack` and a monorepo script both do.
+    const found = await checkConnector(withPage, {
+      packageDir: join(dir, '..'),
+      entry: join(dir, 'dist', 'index.js')
+    })
+
+    expect(codes(found)).toEqual([])
+  })
+
   it('names a page the package does not carry, and one that resolves outside it', async () => {
     const dir = packageWithPage()
 

--- a/tests/connector-extension-checks.test.ts
+++ b/tests/connector-extension-checks.test.ts
@@ -134,6 +134,7 @@ describe('checking an extension', () => {
             id: 'pr',
             title: 'Pull request',
             pattern: 'github\\.com',
+            example: 'https://github.com/vorn-run/vorn/pull/1',
             run: () => {
               throw new Error('nothing to open')
             }
@@ -180,7 +181,15 @@ describe("the receipt an extension's check writes", () => {
     const run = await runConformance(
       extension({
         panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
-        linkHandlers: [{ id: 'pr', title: 'Pull request', pattern: 'github\\.com', run: () => {} }]
+        linkHandlers: [
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: 'github\\.com',
+            example: 'https://github.com/vorn-run/vorn/pull/1',
+            run: () => {}
+          }
+        ]
       }),
       { packageDir: packageWithPage() }
     )

--- a/tests/connector-extension-checks.test.ts
+++ b/tests/connector-extension-checks.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  checkConnector,
+  defineExtension,
+  runConformance
+} from '../packages/connector-sdk/src/index'
+import type { CheckFinding } from '../packages/connector-sdk/src/check'
+import type { ExtensionDefinition } from '../packages/connector-sdk/src/types'
+
+function extension(over: Partial<ExtensionDefinition> = {}) {
+  return defineExtension({
+    id: 'review',
+    name: 'Review',
+    description: 'Reads the session',
+    version: '0.1.0',
+    permissions: ['terminal.read'],
+    footers: [
+      {
+        id: 'checks',
+        title: 'Checks',
+        description: 'What the last commands said',
+        every: 30,
+        async run(context) {
+          const output = await context.host.output({ lines: 50 })
+          return [{ label: 'tests', value: output.includes('FAIL') ? 'failing' : 'passing' }]
+        }
+      }
+    ],
+    ...over
+  })
+}
+
+const codes = (findings: CheckFinding[]) => findings.map((item) => item.code)
+
+/** A package on disk carrying the page a pane names, so the filesystem check has something to read. */
+function packageWithPage(page = 'web/report/index.html'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'vorn-extension-'))
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ vorn: { keywords: ['review'] } }))
+  mkdirSync(join(dir, 'web', 'report'), { recursive: true })
+  writeFileSync(join(dir, page), '<!doctype html>')
+  return dir
+}
+
+describe('checking an extension', () => {
+  it('runs every footer against a stub host and says nothing when it behaves', async () => {
+    expect(await checkConnector(extension())).toEqual([])
+  })
+
+  it('names a footer that threw', async () => {
+    const found = await checkConnector(
+      extension({
+        footers: [
+          {
+            id: 'checks',
+            title: 'Checks',
+            description: 'Throws',
+            every: 30,
+            run: () => {
+              throw new Error('no such file')
+            }
+          }
+        ]
+      })
+    )
+
+    expect(codes(found)).toContain('footer-failed')
+    expect(found[0].message).toContain('no such file')
+  })
+
+  it('names a footer returning a reading a band could not draw', async () => {
+    const wrong = async (items: unknown) =>
+      codes(
+        await checkConnector(
+          extension({
+            footers: [
+              {
+                id: 'checks',
+                title: 'Checks',
+                description: 'Wrong shape',
+                every: 30,
+                run: () => items as never
+              }
+            ]
+          })
+        )
+      )
+
+    expect(await wrong('passing')).toContain('footer-items-invalid')
+    expect(await wrong([{ value: 'passing' }])).toContain('footer-items-invalid')
+    expect(await wrong([{ label: 'tests', value: 'ok', tone: 'bright' }])).toContain(
+      'footer-items-invalid'
+    )
+  })
+
+  it('catches a footer reaching for something the extension never declared', async () => {
+    const found = await checkConnector(
+      extension({
+        permissions: ['terminal.read'],
+        footers: [
+          {
+            id: 'checks',
+            title: 'Checks',
+            description: 'Reaches further than it said',
+            every: 30,
+            async run(context) {
+              await context.host.diff()
+              return []
+            }
+          }
+        ]
+      })
+    )
+
+    expect(codes(found)).toContain('permission-undeclared')
+    expect(found[0].message).toContain('git.read')
+  })
+
+  it('names a permission that was asked for and never spent', async () => {
+    const found = await checkConnector(extension({ permissions: ['terminal.read', 'card.rename'] }))
+
+    expect(codes(found)).toEqual(['permission-unused'])
+    expect(found[0].level).toBe('warn')
+    expect(found[0].message).toContain('card.rename')
+  })
+
+  it('names a link handler that threw', async () => {
+    const found = await checkConnector(
+      extension({
+        linkHandlers: [
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: 'github\\.com',
+            run: () => {
+              throw new Error('nothing to open')
+            }
+          }
+        ]
+      })
+    )
+
+    expect(codes(found)).toContain('handler-failed')
+  })
+
+  it('names a page the package does not carry, and one that resolves outside it', async () => {
+    const dir = packageWithPage()
+
+    const missing = await checkConnector(
+      extension({ panes: [{ id: 'report', title: 'Report', web: 'web/absent/index.html' }] }),
+      { packageDir: dir }
+    )
+    expect(codes(missing)).toContain('web-entry-missing')
+
+    // Built by hand: `defineExtension` refuses this, so only a pack that skipped it gets here.
+    const crafted = {
+      ...extension(),
+      contributes: {
+        panes: [{ id: 'report', title: 'Report', web: '../elsewhere/index.html' }]
+      }
+    }
+    const escaped = await checkConnector(crafted, { packageDir: dir })
+    expect(codes(escaped)).toContain('web-entry-outside-package')
+  })
+
+  it('says nothing about a page that is there', async () => {
+    const found = await checkConnector(
+      extension({ panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }] }),
+      { packageDir: packageWithPage() }
+    )
+
+    expect(codes(found)).toEqual([])
+  })
+})
+
+describe("the receipt an extension's check writes", () => {
+  it('vouches for what an extension has, and for nothing a connector would claim', async () => {
+    const run = await runConformance(
+      extension({
+        panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+        linkHandlers: [{ id: 'pr', title: 'Pull request', pattern: 'github\\.com', run: () => {} }]
+      }),
+      { packageDir: packageWithPage() }
+    )
+
+    expect(run.receipt?.checks).toEqual([
+      'manifest',
+      'contributes',
+      'footers',
+      'handlers',
+      'permissions',
+      'no-lifecycle-scripts',
+      'keywords'
+    ])
+    // An extension signs in to nothing, so a receipt saying `auth` would vouch for a question nobody asked.
+    expect(run.receipt?.checks).not.toContain('auth')
+    expect(run.receipt?.checks).not.toContain('dedupe')
+    expect(run.receipt?.checks).not.toContain('actions')
+  })
+
+  it('withholds the name a failing contribution belongs to, and keeps the rest', async () => {
+    const run = await runConformance(
+      extension({
+        footers: [
+          {
+            id: 'checks',
+            title: 'Checks',
+            description: 'Throws',
+            every: 30,
+            run: () => {
+              throw new Error('boom')
+            }
+          }
+        ]
+      })
+    )
+
+    expect(run.passed).toContain('manifest')
+    expect(run.passed).not.toContain('footers')
+    // An error means there is no claim to publish at all.
+    expect(run.receipt).toBeUndefined()
+  })
+})

--- a/tests/connector-extension-host.test.ts
+++ b/tests/connector-extension-host.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createExtensionHost,
+  HostReplyError,
+  HOST_TOKEN_ENV,
+  HOST_URL_ENV,
+  PermissionDeniedError
+} from '../packages/connector-sdk/src/host'
+
+/**
+ * The bridge an extension process reaches the host through.
+ *
+ * Two things are being pinned. That the token goes only to this machine — the
+ * variable naming the bridge is read from the environment, and an address
+ * pointing elsewhere would hand the grant away — and that an answer the bridge
+ * cannot read fails by name rather than as a TypeError from inside JSON.parse.
+ */
+function hostWith(
+  reply: { status?: number; body: string },
+  env: NodeJS.ProcessEnv = {
+    [HOST_URL_ENV]: 'http://127.0.0.1:8931/bridge',
+    [HOST_TOKEN_ENV]: 'secret'
+  }
+) {
+  const fetchImpl = vi.fn(async () =>
+    Promise.resolve({
+      ok: (reply.status ?? 200) < 400,
+      status: reply.status ?? 200,
+      text: async () => Promise.resolve(reply.body)
+    })
+  ) as unknown as typeof fetch
+
+  return { host: createExtensionHost({ sessionId: 's1', env, fetchImpl }), fetchImpl }
+}
+
+describe('the bridge an extension asks the host through', () => {
+  it('sends the session and the token to the address Vorn named', async () => {
+    const { host, fetchImpl } = hostWith({ body: JSON.stringify({ result: 'M src/index.ts' }) })
+
+    expect(await host.status()).toBe('M src/index.ts')
+    const [url, init] = vi.mocked(fetchImpl).mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('http://127.0.0.1:8931/bridge/status')
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer secret')
+    expect(JSON.parse(String(init.body))).toEqual({ sessionId: 's1' })
+  })
+
+  it('refuses to send the token anywhere but this machine', async () => {
+    for (const url of [
+      'https://example.test/bridge',
+      'http://example.test/bridge',
+      'http://127.0.0.1.example.test/bridge',
+      'not a url'
+    ]) {
+      const { host, fetchImpl } = hostWith(
+        { body: '{}' },
+        { [HOST_URL_ENV]: url, [HOST_TOKEN_ENV]: 'secret' }
+      )
+      await expect(host.status()).rejects.toThrow(new RegExp(HOST_URL_ENV))
+      expect(fetchImpl).not.toHaveBeenCalled()
+    }
+
+    for (const url of ['http://localhost:8931', 'http://[::1]:8931']) {
+      const { host } = hostWith(
+        { body: JSON.stringify({ result: '' }) },
+        { [HOST_URL_ENV]: url, [HOST_TOKEN_ENV]: 'secret' }
+      )
+      await expect(host.status()).resolves.toBe('')
+    }
+  })
+
+  it('says the extension was started without a bridge rather than calling nowhere', async () => {
+    const { host } = hostWith({ body: '{}' }, {})
+    await expect(host.status()).rejects.toThrow(/without a host bridge/)
+  })
+
+  it('names a refusal as one, so an extension meets its own manifest', async () => {
+    const { host } = hostWith({ status: 403, body: 'terminal.send was not declared' })
+    await expect(host.send('hello')).rejects.toBeInstanceOf(PermissionDeniedError)
+  })
+
+  it('says the host answered badly rather than failing inside the parse', async () => {
+    const notJson = hostWith({ body: '<html>gateway</html>' })
+    await expect(notJson.host.status()).rejects.toBeInstanceOf(HostReplyError)
+
+    for (const body of ['null', '{"error":"nope"}', '"a string"']) {
+      const noResult = hostWith({ body })
+      await expect(noResult.host.status()).rejects.toThrow(/carrying no result/)
+    }
+  })
+
+  it('reads an empty body as nothing, which is what a write answers with', async () => {
+    const { host } = hostWith({ body: '' })
+    await expect(host.send('hello')).resolves.toBeUndefined()
+  })
+})

--- a/tests/connector-pack.test.ts
+++ b/tests/connector-pack.test.ts
@@ -302,6 +302,39 @@ describe('packing an extension', () => {
     )
   })
 
+  it('finds the page beside the package when the entry is the built bundle', async () => {
+    // What the CLI really passes: `./dist/index.js`, whose directory holds no `web/`.
+    const dir = packageWithPage()
+    mkdirSync(join(dir, 'dist'), { recursive: true })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'review' }))
+
+    const result = await packConnector(extension, {
+      entry: './dist/index.js',
+      resolveDir: dir,
+      outDir: tempDir(),
+      bundle: cleanBundle,
+      launch: starts
+    })
+
+    expect(result.findings.some((item) => item.level === 'error')).toBe(false)
+    const entries: string[] = []
+    await list({ file: result.file as string, onReadEntry: (entry) => entries.push(entry.path) })
+    expect(entries).toContain('web/report/index.html')
+  })
+
+  it('packs nothing when a pane names a page the package does not carry', async () => {
+    const result = await packConnector(extension, {
+      entry: './extension.js',
+      resolveDir: tempDir(),
+      outDir: tempDir(),
+      bundle: cleanBundle,
+      launch: starts
+    })
+
+    expect(result.file).toBeUndefined()
+    expect(result.findings.map((item) => item.code)).toContain('web-entry-missing')
+  })
+
   it('carries no web directory for a connector, which has no pages', async () => {
     const result = await packConnector(connector, {
       entry: './connector.js',

--- a/tests/connector-pack.test.ts
+++ b/tests/connector-pack.test.ts
@@ -6,6 +6,7 @@ import { extract, list } from 'tar'
 import {
   bundleDependencyFindings,
   defineConnector,
+  defineExtension,
   lifecycleScriptFindings,
   packConnector,
   packFileName,
@@ -248,6 +249,72 @@ describe('packConnector', () => {
     await extract({ file: result.file as string, cwd: unpacked })
     expect(readFileSync(join(unpacked, 'index.js'), 'utf8')).toContain('StdioServerTransport')
   }, 60_000)
+})
+
+describe('packing an extension', () => {
+  const extension = defineExtension({
+    id: 'review',
+    name: 'Review',
+    version: '0.1.0',
+    description: 'Reads the session',
+    permissions: [],
+    panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+  })
+
+  /** A package carrying the page, and the stylesheet beside it that the page asks for. */
+  function packageWithPage(): string {
+    const dir = tempDir()
+    mkdirSync(join(dir, 'web', 'report'), { recursive: true })
+    writeFileSync(join(dir, 'web', 'report', 'index.html'), '<!doctype html><link href=x.css>')
+    writeFileSync(join(dir, 'web', 'report', 'x.css'), 'body { margin: 0 }')
+    return dir
+  }
+
+  it('carries the page a pane names, and everything beside it', async () => {
+    const out = tempDir()
+    const result = await packConnector(extension, {
+      entry: './extension.js',
+      resolveDir: packageWithPage(),
+      outDir: out,
+      bundle: cleanBundle,
+      launch: starts
+    })
+
+    expect(result.findings.some((item) => item.level === 'error')).toBe(false)
+    const entries: string[] = []
+    await list({ file: result.file as string, onReadEntry: (entry) => entries.push(entry.path) })
+    expect(entries.sort()).toEqual([
+      'index.js',
+      'manifest.json',
+      'web/',
+      'web/report/',
+      'web/report/index.html',
+      'web/report/x.css'
+    ])
+
+    const unpacked = tempDir()
+    await extract({ file: result.file as string, cwd: unpacked })
+    const manifest = JSON.parse(readFileSync(join(unpacked, 'manifest.json'), 'utf8'))
+    // The manifest's path resolves inside the pack, because the directory was carried as it stood.
+    expect(manifest.kind).toBe('extension')
+    expect(readFileSync(join(unpacked, manifest.contributes.panes[0].web), 'utf8')).toContain(
+      'doctype'
+    )
+  })
+
+  it('carries no web directory for a connector, which has no pages', async () => {
+    const result = await packConnector(connector, {
+      entry: './connector.js',
+      resolveDir: tempDir(),
+      outDir: tempDir(),
+      bundle: cleanBundle,
+      launch: starts
+    })
+
+    const entries: string[] = []
+    await list({ file: result.file as string, onReadEntry: (entry) => entries.push(entry.path) })
+    expect(entries.sort()).toEqual(['index.js', 'manifest.json'])
+  })
 })
 
 describe('vorn-connector pack command', () => {

--- a/tests/connector-pack.test.ts
+++ b/tests/connector-pack.test.ts
@@ -335,6 +335,48 @@ describe('packing an extension', () => {
     expect(result.findings.map((item) => item.code)).toContain('web-entry-missing')
   })
 
+  it('carries only what a pane names, not everything left under web/', async () => {
+    const dir = packageWithPage()
+    // An unrelated build, a scratch page, a stray env file: in the tree, not in the pack.
+    mkdirSync(join(dir, 'web', 'scratch'), { recursive: true })
+    writeFileSync(join(dir, 'web', 'scratch', 'index.html'), '<!doctype html>')
+    writeFileSync(join(dir, 'web', 'notes.txt'), 'todo')
+
+    const result = await packConnector(extension, {
+      entry: './extension.js',
+      resolveDir: dir,
+      outDir: tempDir(),
+      bundle: cleanBundle,
+      launch: starts
+    })
+
+    const entries: string[] = []
+    await list({ file: result.file as string, onReadEntry: (entry) => entries.push(entry.path) })
+    expect(entries).not.toContain('web/scratch/index.html')
+    expect(entries).not.toContain('web/notes.txt')
+    expect(entries).toContain('web/report/index.html')
+  })
+
+  it('refuses a pack that unpacks past what Vorn will write, however well it compresses', async () => {
+    const dir = packageWithPage()
+    // Pages compress well, so the archive can sit under its own ceiling while
+    // the tree it unpacks to does not.
+    writeFileSync(join(dir, 'web', 'report', 'big.txt'), 'a'.repeat(4 * 1024 * 1024))
+
+    const result = await packConnector(extension, {
+      entry: './extension.js',
+      resolveDir: dir,
+      outDir: tempDir(),
+      bundle: cleanBundle,
+      launch: starts,
+      maxUnpackedBytes: 1024 * 1024
+    })
+
+    expect(result.file).toBeUndefined()
+    expect(result.findings.map((item) => item.code)).toContain('pack-too-large')
+    expect(result.findings.at(-1)?.message).toContain('unpacks to')
+  })
+
   it('carries no web directory for a connector, which has no pages', async () => {
     const result = await packConnector(connector, {
       entry: './connector.js',

--- a/tests/connector-packs.test.ts
+++ b/tests/connector-packs.test.ts
@@ -81,6 +81,25 @@ function goodFiles(version = '1.2.0', id = 'acme'): Record<string, string> {
   }
 }
 
+/** An extension pack, whose manifest is what says which pages it may carry. */
+function extensionFiles(panes: Array<Record<string, unknown>>): Record<string, string> {
+  return {
+    'manifest.json': JSON.stringify({
+      id: 'review',
+      name: 'Review',
+      version: '0.1.0',
+      kind: 'extension',
+      permissions: ['terminal.read'],
+      contributes: { panes },
+      triggers: [],
+      actions: []
+    }),
+    'index.js': 'process.stdin.resume()\n'
+  }
+}
+
+const reportPane = [{ id: 'report', title: 'Report', web: 'web/report/index.html' }]
+
 describe('archive entry safety', () => {
   it('accepts ordinary files and directories', () => {
     expect(isSafeArchiveEntry('index.js', 'File')).toBe(true)
@@ -129,15 +148,38 @@ describe('verifyPackDir', () => {
     ).toThrow(/missing an id or a name/)
   })
 
-  it('carries what an extension serves under web/, and nothing beside it', () => {
+  it("carries the pages an extension's own panes name", () => {
     const withPage = verifyPackDir(
       dirWith({
-        ...goodFiles(),
+        ...extensionFiles(reportPane),
         'web/report/index.html': '<!doctype html>',
-        'web/report/report.css': 'body { margin: 0 }'
+        'web/report/report.css': 'body { margin: 0 }',
+        'web/report/report.js': 'export {}'
       })
     )
-    expect(withPage.id).toBe('acme')
+    expect(withPage.id).toBe('review')
+    expect(withPage.kind).toBe('extension')
+  })
+
+  it('refuses pages no pane asked for, and code dressed as one', () => {
+    // A connector has no panes, so `web/` is a directory it has no reason to carry.
+    expect(() =>
+      verifyPackDir(dirWith({ ...goodFiles(), 'web/report/index.html': '<!doctype html>' }))
+    ).toThrow(/carries web\/report\/index.html/)
+
+    // An extension, but a directory none of its panes names.
+    expect(() =>
+      verifyPackDir(
+        dirWith({ ...extensionFiles(reportPane), 'web/other/index.html': '<!doctype html>' })
+      )
+    ).toThrow(/carries web\/other\/index.html/)
+
+    // The right directory, but code the entry could reach rather than a page.
+    for (const smuggled of ['web/report/native.node', 'web/report/hook.cjs', 'web/report/x.wasm']) {
+      expect(() =>
+        verifyPackDir(dirWith({ ...extensionFiles(reportPane), [smuggled]: '' }))
+      ).toThrow(/carries /)
+    }
 
     // One named directory, so a `.node` smuggled in beside the entry is still refused.
     expect(() => verifyPackDir(dirWith({ ...goodFiles(), 'webhook.js': '' }))).toThrow(

--- a/tests/connector-packs.test.ts
+++ b/tests/connector-packs.test.ts
@@ -129,11 +129,29 @@ describe('verifyPackDir', () => {
     ).toThrow(/missing an id or a name/)
   })
 
+  it('carries what an extension serves under web/, and nothing beside it', () => {
+    const withPage = verifyPackDir(
+      dirWith({
+        ...goodFiles(),
+        'web/report/index.html': '<!doctype html>',
+        'web/report/report.css': 'body { margin: 0 }'
+      })
+    )
+    expect(withPage.id).toBe('acme')
+
+    // One named directory, so a `.node` smuggled in beside the entry is still refused.
+    expect(() => verifyPackDir(dirWith({ ...goodFiles(), 'webhook.js': '' }))).toThrow(
+      /carries webhook.js/
+    )
+  })
+
   it('refuses a pack with no entry or with more than one', () => {
     expect(() =>
       verifyPackDir(dirWith({ 'manifest.json': JSON.stringify(manifestFor('acme', '1.0.0')) }))
     ).toThrow(/no entry to run/)
-    expect(() => verifyPackDir(dirWith({ ...goodFiles(), 'other.js': '' }))).toThrow(/nothing else/)
+    expect(() => verifyPackDir(dirWith({ ...goodFiles(), 'other.js': '' }))).toThrow(
+      /carries other.js/
+    )
   })
 
   it('refuses a package that would need an install step', () => {

--- a/tests/connector-sdk-extension.test.ts
+++ b/tests/connector-sdk-extension.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+import {
+  connectorManifest,
+  defineConnector,
+  defineExtension
+} from '../packages/connector-sdk/src/index'
+import type { ExtensionDefinition, FooterItem } from '../packages/connector-sdk/src/types'
+
+/** The shape the scaffold generates, so a test says which one thing it changed. */
+function extension(over: Partial<ExtensionDefinition> = {}) {
+  return defineExtension({
+    id: 'review',
+    name: 'Review',
+    description: 'Reads the session',
+    version: '0.1.0',
+    permissions: ['terminal.read'],
+    footers: [
+      {
+        id: 'checks',
+        title: 'Checks',
+        description: 'What the last commands said',
+        every: 30,
+        async run(context): Promise<FooterItem[]> {
+          await context.host.output()
+          return [{ label: 'tests', value: 'passing', tone: 'ok' }]
+        }
+      }
+    ],
+    ...over
+  })
+}
+
+describe('defineExtension', () => {
+  it('keeps what it was given and fills in what a pack needs', () => {
+    const built = extension()
+
+    expect(built.kind).toBe('extension')
+    expect(built.permissions).toEqual(['terminal.read'])
+    expect(built.contributes?.footers?.[0].id).toBe('checks')
+    // A connector's own shapes, empty rather than absent, so every seam still reads them.
+    expect(built.triggers).toEqual([])
+    expect(built.actions).toEqual([])
+    expect(built.config).toEqual([])
+    // Its credential is the host's own token, so there is nothing to sign in to.
+    expect(built.auth).toEqual({ rung: 'none' })
+  })
+
+  it('refuses an extension that contributes nothing', () => {
+    expect(() => extension({ footers: [] })).toThrow(/contributes nothing/)
+  })
+
+  it('refuses a permission this build cannot enforce', () => {
+    expect(() => extension({ permissions: ['filesystem.write'] as never })).toThrow(
+      /unknown permission/
+    )
+    expect(() => extension({ permissions: ['git.read', 'git.read'] })).toThrow(
+      /Duplicate permission/
+    )
+  })
+
+  it('refuses two contributions that answer to the same id', () => {
+    expect(() =>
+      extension({
+        panes: [{ id: 'checks', title: 'Checks', web: 'web/checks/index.html' }]
+      })
+    ).toThrow(/Duplicate contribution "checks"/)
+  })
+
+  it('refuses a page that is not one the pack would carry', () => {
+    const pane = (web: string) => () =>
+      extension({ panes: [{ id: 'report', title: 'Report', web }] })
+
+    expect(pane('../secrets.html')).toThrow(/a page is an \.html file under web\//)
+    expect(pane('web/../../etc/passwd.html')).toThrow(/a page is an \.html file under web\//)
+    expect(pane('src/report/index.html')).toThrow(/under web\//)
+    expect(pane('web/report/index.js')).toThrow(/\.html file/)
+    expect(pane('web/report/index.html')).not.toThrow()
+  })
+
+  it('refuses a pane that is both a page and a program, or neither', () => {
+    expect(() =>
+      extension({
+        panes: [
+          { id: 'report', title: 'Report', web: 'web/r/index.html', command: ['ls'] } as never
+        ]
+      })
+    ).toThrow(/both a web page and a command/)
+    expect(() => extension({ panes: [{ id: 'report', title: 'Report' } as never] })).toThrow(
+      /neither a web page nor a command/
+    )
+  })
+
+  it('refuses a command with nothing to run, or an empty argument in it', () => {
+    expect(() => extension({ panes: [{ id: 'git', title: 'Git', command: [] }] })).toThrow(
+      /nothing to run/
+    )
+    expect(() =>
+      extension({ panes: [{ id: 'git', title: 'Git', command: ['lazygit', ''] }] })
+    ).toThrow(/empty argument/)
+  })
+
+  it('refuses a link handler whose pattern is not a regular expression', () => {
+    expect(() =>
+      extension({
+        linkHandlers: [{ id: 'pr', title: 'Pull request', pattern: '([', run: () => {} }]
+      })
+    ).toThrow(/not a regular expression/)
+  })
+
+  it('refuses a footer asking to run faster than the host will poll', () => {
+    expect(() =>
+      extension({
+        footers: [{ id: 'spin', title: 'Spin', every: 1, run: () => [] }]
+      })
+    ).toThrow(/shortest interval/)
+  })
+
+  it('refuses a predicate this build cannot evaluate', () => {
+    expect(() => extension({ activates: { agent: ['emacs'] as never } })).toThrow(/unknown agent/)
+    expect(() => extension({ activates: { platform: ['plan9'] as never } })).toThrow(
+      /unknown platform/
+    )
+    expect(() => extension({ activates: { workspaceContains: [] } })).toThrow(/nothing in it/)
+    expect(() => extension({ activates: { workspaceContains: ['../other/Cargo.toml'] } })).toThrow(
+      /not inside the worktree/
+    )
+    expect(() => extension({ activates: { remoteHost: [' '] } })).toThrow(/empty "remoteHost"/)
+  })
+})
+
+describe("the manifest an extension's pack carries", () => {
+  it('says what it contributes, what it asks for, and where it shows — without the code', () => {
+    const manifest = connectorManifest(
+      extension({
+        activates: { workspaceContains: ['package.json'], platform: ['darwin'] },
+        panes: [
+          { id: 'report', title: 'Report', web: 'web/report/index.html' },
+          { id: 'git', title: 'Git', command: ['lazygit'], when: { agent: ['shell'] } }
+        ],
+        linkHandlers: [
+          { id: 'pr', title: 'Pull request', pattern: 'github\\.com/.+/pull/', run: () => {} }
+        ]
+      })
+    )
+
+    expect(manifest.kind).toBe('extension')
+    expect(manifest.permissions).toEqual(['terminal.read'])
+    expect(manifest.activates).toEqual({
+      workspaceContains: ['package.json'],
+      platform: ['darwin']
+    })
+    expect(manifest.contributes?.panes).toEqual([
+      { id: 'report', title: 'Report', web: 'web/report/index.html' },
+      { id: 'git', title: 'Git', command: ['lazygit'], when: { agent: ['shell'] } }
+    ])
+    expect(manifest.contributes?.footers).toEqual([
+      { id: 'checks', title: 'Checks', description: 'What the last commands said', every: 30 }
+    ])
+    expect(manifest.contributes?.linkHandlers).toEqual([
+      { id: 'pr', title: 'Pull request', pattern: 'github\\.com/.+/pull/' }
+    ])
+    // The code stays in the process that runs it; a manifest is what is written to disk.
+    expect(JSON.stringify(manifest)).not.toContain('"run"')
+  })
+
+  it('says a connector is a connector, so the two are told apart by name rather than by shape', () => {
+    const connector = defineConnector({
+      id: 'acme',
+      name: 'Acme',
+      description: 'Acme tickets',
+      triggers: [{ type: 'a', label: 'A', poll: () => ({ items: [] }) }]
+    })
+
+    expect(connectorManifest(connector).kind).toBe('connector')
+    expect(connectorManifest(connector).contributes).toBeUndefined()
+    expect(connectorManifest(connector).permissions).toBeUndefined()
+  })
+})

--- a/tests/connector-sdk-extension.test.ts
+++ b/tests/connector-sdk-extension.test.ts
@@ -95,7 +95,7 @@ describe('defineExtension', () => {
       /nothing to run/
     )
     expect(() =>
-      extension({ panes: [{ id: 'git', title: 'Git', command: ['lazygit', ''] }] })
+      extension({ panes: [{ id: 'git', title: 'Git', command: ['viewer', ''] }] })
     ).toThrow(/empty argument/)
   })
 
@@ -177,7 +177,7 @@ describe("the manifest an extension's pack carries", () => {
         activates: { workspaceContains: ['package.json'], platform: ['darwin'] },
         panes: [
           { id: 'report', title: 'Report', web: 'web/report/index.html' },
-          { id: 'git', title: 'Git', command: ['tig'], when: { agent: ['shell'] } }
+          { id: 'log', title: 'Log', command: ['./bin/log'], when: { agent: ['shell'] } }
         ],
         linkHandlers: [
           {
@@ -199,7 +199,7 @@ describe("the manifest an extension's pack carries", () => {
     })
     expect(manifest.contributes?.panes).toEqual([
       { id: 'report', title: 'Report', web: 'web/report/index.html' },
-      { id: 'git', title: 'Git', command: ['tig'], when: { agent: ['shell'] } }
+      { id: 'log', title: 'Log', command: ['./bin/log'], when: { agent: ['shell'] } }
     ])
     expect(manifest.contributes?.footers).toEqual([
       { id: 'checks', title: 'Checks', description: 'What the last commands said', every: 30 }

--- a/tests/connector-sdk-extension.test.ts
+++ b/tests/connector-sdk-extension.test.ts
@@ -109,6 +109,46 @@ describe('defineExtension', () => {
     ).toThrow(/not a regular expression/)
   })
 
+  it('refuses a link handler whose example its own pattern does not match', () => {
+    expect(() =>
+      extension({
+        linkHandlers: [
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: 'github\\.com/.+/pull/',
+            example: 'https://example.test/nothing',
+            run: () => {}
+          }
+        ]
+      })
+    ).toThrow(/does not match/)
+
+    expect(() =>
+      extension({
+        linkHandlers: [
+          { id: 'pr', title: 'Pull request', pattern: 'x', example: '  ', run: () => {} }
+        ]
+      })
+    ).toThrow(/names no example link/)
+  })
+
+  it('refuses a pattern too long to match on every click', () => {
+    expect(() =>
+      extension({
+        linkHandlers: [
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: `${'a'.repeat(257)}`,
+            example: 'a',
+            run: () => {}
+          }
+        ]
+      })
+    ).toThrow(/longer than 256/)
+  })
+
   it('refuses a footer asking to run faster than the host will poll', () => {
     expect(() =>
       extension({

--- a/tests/connector-sdk-extension.test.ts
+++ b/tests/connector-sdk-extension.test.ts
@@ -102,7 +102,9 @@ describe('defineExtension', () => {
   it('refuses a link handler whose pattern is not a regular expression', () => {
     expect(() =>
       extension({
-        linkHandlers: [{ id: 'pr', title: 'Pull request', pattern: '([', run: () => {} }]
+        linkHandlers: [
+          { id: 'pr', title: 'Pull request', pattern: '([', example: 'x', run: () => {} }
+        ]
       })
     ).toThrow(/not a regular expression/)
   })
@@ -135,10 +137,16 @@ describe("the manifest an extension's pack carries", () => {
         activates: { workspaceContains: ['package.json'], platform: ['darwin'] },
         panes: [
           { id: 'report', title: 'Report', web: 'web/report/index.html' },
-          { id: 'git', title: 'Git', command: ['lazygit'], when: { agent: ['shell'] } }
+          { id: 'git', title: 'Git', command: ['tig'], when: { agent: ['shell'] } }
         ],
         linkHandlers: [
-          { id: 'pr', title: 'Pull request', pattern: 'github\\.com/.+/pull/', run: () => {} }
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: 'github\\.com/.+/pull/',
+            example: 'https://github.com/vorn-run/vorn/pull/1',
+            run: () => {}
+          }
         ]
       })
     )
@@ -151,13 +159,18 @@ describe("the manifest an extension's pack carries", () => {
     })
     expect(manifest.contributes?.panes).toEqual([
       { id: 'report', title: 'Report', web: 'web/report/index.html' },
-      { id: 'git', title: 'Git', command: ['lazygit'], when: { agent: ['shell'] } }
+      { id: 'git', title: 'Git', command: ['tig'], when: { agent: ['shell'] } }
     ])
     expect(manifest.contributes?.footers).toEqual([
       { id: 'checks', title: 'Checks', description: 'What the last commands said', every: 30 }
     ])
     expect(manifest.contributes?.linkHandlers).toEqual([
-      { id: 'pr', title: 'Pull request', pattern: 'github\\.com/.+/pull/' }
+      {
+        id: 'pr',
+        title: 'Pull request',
+        pattern: 'github\\.com/.+/pull/',
+        example: 'https://github.com/vorn-run/vorn/pull/1'
+      }
     ])
     // The code stays in the process that runs it; a manifest is what is written to disk.
     expect(JSON.stringify(manifest)).not.toContain('"run"')

--- a/tests/connector-sdk-integration.test.ts
+++ b/tests/connector-sdk-integration.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import type { SourceConnection } from '../packages/shared/src/types'
-import { createConnectorServer, defineConnector } from '../packages/connector-sdk/src/index'
+import {
+  createConnectorServer,
+  defineConnector,
+  defineExtension
+} from '../packages/connector-sdk/src/index'
 
 vi.mock('../packages/server/src/logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
@@ -214,5 +218,40 @@ describe('an SDK connector behind Vorn’s MCP connector', () => {
     expect(second.events.map((event) => event.id)).toEqual(['r-2'])
 
     await client.close()
+  })
+})
+
+describe('a served link handler', () => {
+  it('answers with an empty result when the handler returns nothing', async () => {
+    const extension = defineExtension({
+      id: 'links',
+      name: 'Links',
+      permissions: [],
+      linkHandlers: [
+        {
+          id: 'pr',
+          title: 'Pull request',
+          pattern: 'github\\.com/.+/pull/\\d+',
+          example: 'https://github.com/vorn-run/vorn/pull/1',
+          run: () => {}
+        }
+      ]
+    })
+    const server = createConnectorServer(extension, { config: {}, now: () => NOW })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    const client = new Client({ name: 'vorn', version: '1.0.0' })
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+    const result = await client.callTool({
+      name: 'vorn_handler_pr',
+      arguments: {
+        sessionId: 's1',
+        worktreePath: '/tmp/w',
+        agent: 'claude',
+        url: 'https://github.com/vorn-run/vorn/pull/1'
+      }
+    })
+    expect(result.isError ?? false).toBe(false)
+    expect(result.structuredContent).toEqual({})
   })
 })

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -40,7 +40,7 @@ describe('the files a new connector starts as', () => {
     expect(pkg.scripts.pack).toBe('vorn-connector pack src/index.ts')
     // Names a prerelease because that is all there is: a bare `^0.7.0` matches
     // no prerelease, so a scaffold pinned to it would install nothing.
-    expect(pkg.dependencies['@vornrun/connector-sdk']).toBe('^0.7.0-beta.9')
+    expect(pkg.dependencies['@vornrun/connector-sdk']).toBe('^0.7.0-beta.14')
     expect(pkg.vorn.keywords).toContain('acme-tickets')
   })
 
@@ -152,6 +152,73 @@ describe('a scaffold shaped for the connectors repository', () => {
   })
 })
 
+describe('the files a new extension starts as', () => {
+  const extensionMap = (id = 'review') =>
+    new Map(scaffoldFiles({ id, kind: 'extension' }).map((file) => [file.path, file.contents]))
+
+  it('writes the definition, the page a pane is drawn from, and a test for the footer', () => {
+    expect([...extensionMap().keys()]).toEqual([
+      'package.json',
+      'src/extension.ts',
+      'src/entry.ts',
+      'src/index.ts',
+      'src/extension.test.ts',
+      'src/entry.test.ts',
+      'web/report/index.html',
+      'README.md',
+      'tsconfig.json'
+    ])
+  })
+
+  it('starts from defineExtension, with one footer, one pane and the permission it spends', () => {
+    const source = extensionMap().get('src/extension.ts') as string
+    expect(source).toContain('defineExtension')
+    expect(source).toContain("permissions: ['terminal.read']")
+    expect(source).toContain("web: 'web/report/index.html'")
+    expect(source).toContain('every: 30')
+    expect(source).toContain('activates:')
+    // Nothing about signing in: an extension's credential is the host's own token.
+    expect(source).not.toContain('auth:')
+  })
+
+  it('publishes the page beside the bundle, and files itself as an extension', () => {
+    const pkg = JSON.parse(extensionMap().get('package.json') as string) as {
+      name: string
+      files: string[]
+      vorn: { kind?: string; auth?: string }
+    }
+
+    expect(pkg.name).toBe('vorn-extension-review')
+    expect(pkg.files).toContain('web')
+    expect(pkg.vorn.kind).toBe('extension')
+    expect(pkg.vorn.auth).toBeUndefined()
+  })
+
+  it('carries a page that asks the host only through the bridge it was given', () => {
+    const page = extensionMap().get('web/report/index.html') as string
+    expect(page).toContain('window.vorn.token')
+    expect(page).toContain('window.vorn.host')
+  })
+
+  it('starts with a test that runs the footer against the stub host', () => {
+    const test = extensionMap().get('src/extension.test.ts') as string
+    expect(test).toContain('mockExtensionHost')
+    expect(test).toContain("footer('checks'")
+  })
+
+  it('takes the scoped name in the repository, and its own module', () => {
+    const files = new Map(
+      scaffoldFiles({ id: 'review', kind: 'extension', repoConventions: true }).map((file) => [
+        file.path,
+        file.contents
+      ])
+    )
+    expect(files.get('package.json')).toContain('"@vornrun/extension-review"')
+    expect(files.get('src/index.ts')).toContain("from './extension'")
+    expect(files.get('src/entry.ts')).toContain("from './extension'")
+  })
+})
+
 describe('vorn-connector new', () => {
   const capture = () => {
     const lines: string[] = []
@@ -219,10 +286,34 @@ describe('vorn-connector new', () => {
     ).rejects.toThrow(/must start with a letter/)
   })
 
+  it('scaffolds an extension when asked, and a connector otherwise', async () => {
+    const written = new Map<string, string>()
+    const writeFile = async (path: string, contents: string) => {
+      written.set(path, contents)
+    }
+    await runCli(['new', 'review', '--extension', '--out', '/tmp/work'], {
+      load,
+      write: capture().write,
+      writeFile
+    })
+    expect([...written.keys()]).toContain('/tmp/work/review/src/extension.ts')
+    expect([...written.keys()]).toContain('/tmp/work/review/web/report/index.html')
+
+    written.clear()
+    await runCli(['new', 'review', '--out', '/tmp/work'], {
+      load,
+      write: capture().write,
+      writeFile
+    })
+    expect([...written.keys()]).toContain('/tmp/work/review/src/connector.ts')
+    expect([...written.keys()]).not.toContain('/tmp/work/review/src/extension.ts')
+  })
+
   it('is listed in the usage text', async () => {
     const help = capture()
     await runCli(['help'], { load, write: help.write })
     expect(help.lines.join('\n')).toContain('new <id>')
     expect(help.lines.join('\n')).toContain('--repo-conventions')
+    expect(help.lines.join('\n')).toContain('--extension')
   })
 })

--- a/tests/connector-sdk-scaffold.test.ts
+++ b/tests/connector-sdk-scaffold.test.ts
@@ -194,10 +194,13 @@ describe('the files a new extension starts as', () => {
     expect(pkg.vorn.auth).toBeUndefined()
   })
 
-  it('carries a page that asks the host only through the bridge it was given', () => {
+  it('carries a page that asks on its own origin and holds no credential', () => {
     const page = extensionMap().get('web/report/index.html') as string
-    expect(page).toContain('window.vorn.token')
-    expect(page).toContain('window.vorn.host')
+
+    expect(page).toContain("fetch('bridge/' + method")
+    // A token in the page is a token every script the page loads inherits.
+    expect(page).not.toContain('token')
+    expect(page).not.toContain('authorization')
   })
 
   it('starts with a test that runs the footer against the stub host', () => {

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -633,7 +633,7 @@ describe('what a probed extension contributes', () => {
         panes: [
           { id: 'escape', title: 'Escape', web: '../outside/index.html' },
           { id: 'absolute', title: 'Absolute', web: '/etc/passwd.html' },
-          { id: 'empty', title: 'Empty', command: ['lazygit', ''] },
+          { id: 'empty', title: 'Empty', command: ['viewer', ''] },
           { id: 'report', title: 'Report', web: 'web/report/index.html' }
         ],
         footers: [

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -670,6 +670,14 @@ describe('what a probed extension contributes', () => {
     })
   })
 
+  it('trims a host name and drops one that is only whitespace', async () => {
+    const result = await probeExtension({
+      activates: { remoteHost: [' github.com ', '   ', ''] }
+    })
+    if (!result.ok) throw new Error(result.error)
+    expect(result.manifest.activates).toEqual({ remoteHost: ['github.com'] })
+  })
+
   it('keeps a predicate naming nothing this build knows from narrowing to nothing', async () => {
     const result = await probeExtension({ activates: { agent: ['emacs'], platform: ['plan9'] } })
     if (!result.ok) throw new Error(result.error)

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -653,6 +653,86 @@ describe('what a probed extension contributes', () => {
     expect(result.manifest.contributes?.linkHandlers?.map((entry) => entry.id)).toEqual(['pr'])
   })
 
+  it('drops an agent or a platform this build cannot evaluate', async () => {
+    const result = await probeExtension({
+      activates: {
+        agent: ['claude', '<img src=x onerror=1>', 'nope'],
+        platform: ['darwin', 'plan9'],
+        remoteHost: ['github.com']
+      }
+    })
+    if (!result.ok) throw new Error(result.error)
+
+    expect(result.manifest.activates).toEqual({
+      remoteHost: ['github.com'],
+      agent: ['claude'],
+      platform: ['darwin']
+    })
+  })
+
+  it('keeps a predicate naming nothing this build knows from narrowing to nothing', async () => {
+    const result = await probeExtension({ activates: { agent: ['emacs'], platform: ['plan9'] } })
+    if (!result.ok) throw new Error(result.error)
+    expect(result.manifest.activates).toBeUndefined()
+  })
+
+  it('holds what it reads to a length a card can draw', async () => {
+    const result = await probeExtension({
+      contributes: {
+        footers: [
+          { id: 'checks', title: 'T'.repeat(5_000), description: 'D'.repeat(5_000), every: 30 }
+        ]
+      }
+    })
+    if (!result.ok) throw new Error(result.error)
+
+    const footer = result.manifest.contributes?.footers?.[0]
+    expect(footer?.title.length).toBe(500)
+    expect(footer?.description?.length).toBe(500)
+  })
+
+  it('reads at most a screenful of contributions of each kind', async () => {
+    const many = (kind: 'panes' | 'footers') =>
+      Array.from({ length: 50 }, (_, index) => ({
+        id: `c${index}`,
+        title: `C${index}`,
+        ...(kind === 'panes' ? { web: 'web/report/index.html' } : { every: 30 })
+      }))
+    const result = await probeExtension({
+      contributes: { panes: many('panes'), footers: many('footers') }
+    })
+    if (!result.ok) throw new Error(result.error)
+
+    expect(result.manifest.contributes?.panes).toHaveLength(32)
+    expect(result.manifest.contributes?.footers).toHaveLength(32)
+  })
+
+  it('drops a pattern too long to match on every click, and keeps the example of one that is not', async () => {
+    const result = await probeExtension({
+      contributes: {
+        linkHandlers: [
+          { id: 'long', title: 'Long', pattern: 'a'.repeat(257) },
+          {
+            id: 'pr',
+            title: 'Pull request',
+            pattern: 'github\\.com',
+            example: 'https://github.com/vorn-run/vorn/pull/1'
+          }
+        ]
+      }
+    })
+    if (!result.ok) throw new Error(result.error)
+
+    expect(result.manifest.contributes?.linkHandlers).toEqual([
+      {
+        id: 'pr',
+        title: 'Pull request',
+        pattern: 'github\\.com',
+        example: 'https://github.com/vorn-run/vorn/pull/1'
+      }
+    ])
+  })
+
   it('reads a manifest with no kind as the connector it was written as', async () => {
     const { probeSdkConnector } = await importProbe()
     callTool.mockResolvedValue({ structuredContent: manifest() })

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -573,3 +573,93 @@ describe('what a probed action returns', () => {
     ])
   })
 })
+
+describe('what a probed extension contributes', () => {
+  const extensionManifest = (overrides: Record<string, unknown> = {}) => ({
+    id: 'review',
+    name: 'Review',
+    version: '0.1.0',
+    kind: 'extension',
+    permissions: ['terminal.read'],
+    activates: { workspaceContains: ['package.json'] },
+    contributes: {
+      footers: [{ id: 'checks', title: 'Checks', every: 30 }],
+      panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+      linkHandlers: [{ id: 'pr', title: 'Pull request', pattern: 'github\\.com' }]
+    },
+    ...overrides
+  })
+
+  const probeExtension = async (overrides: Record<string, unknown> = {}) => {
+    const { probeSdkConnector } = await importProbe()
+    callTool.mockResolvedValue({ structuredContent: extensionManifest(overrides) })
+    return probeSdkConnector({ command: 'npx', args: [] })
+  }
+
+  it('reads an extension that has no triggers and no actions', async () => {
+    const result = await probeExtension()
+    if (!result.ok) throw new Error(result.error)
+
+    expect(result.manifest.kind).toBe('extension')
+    expect(result.manifest.triggers).toEqual([])
+    expect(result.manifest.actions).toEqual([])
+    expect(result.manifest.permissions).toEqual(['terminal.read'])
+    expect(result.manifest.activates).toEqual({ workspaceContains: ['package.json'] })
+    expect(result.manifest.contributes?.footers?.[0]).toEqual({
+      id: 'checks',
+      title: 'Checks',
+      every: 30
+    })
+  })
+
+  it('refuses an extension that contributes nothing, the way a connector with no triggers is refused', async () => {
+    const result = await probeExtension({ contributes: {} })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toMatch(/contributes/)
+  })
+
+  it('drops a permission this build cannot enforce rather than granting it', async () => {
+    const result = await probeExtension({
+      permissions: ['terminal.read', 'filesystem.write', 'terminal.read']
+    })
+    if (!result.ok) throw new Error(result.error)
+    expect(result.manifest.permissions).toEqual(['terminal.read'])
+  })
+
+  it('drops a contribution the app could not draw, and keeps the rest', async () => {
+    const result = await probeExtension({
+      contributes: {
+        panes: [
+          { id: 'escape', title: 'Escape', web: '../outside/index.html' },
+          { id: 'absolute', title: 'Absolute', web: '/etc/passwd.html' },
+          { id: 'empty', title: 'Empty', command: ['lazygit', ''] },
+          { id: 'report', title: 'Report', web: 'web/report/index.html' }
+        ],
+        footers: [
+          { id: 'spin', title: 'Spin', every: 1 },
+          { id: 'checks', title: 'Checks', every: 30 }
+        ],
+        linkHandlers: [
+          { id: 'broken', title: 'Broken', pattern: '([' },
+          { id: 'pr', title: 'Pull request', pattern: 'github\\.com' }
+        ]
+      }
+    })
+    if (!result.ok) throw new Error(result.error)
+
+    expect(result.manifest.contributes?.panes?.map((pane) => pane.id)).toEqual(['report'])
+    expect(result.manifest.contributes?.footers?.map((footer) => footer.id)).toEqual(['checks'])
+    expect(result.manifest.contributes?.linkHandlers?.map((entry) => entry.id)).toEqual(['pr'])
+  })
+
+  it('reads a manifest with no kind as the connector it was written as', async () => {
+    const { probeSdkConnector } = await importProbe()
+    callTool.mockResolvedValue({ structuredContent: manifest() })
+    const result = await probeSdkConnector({ command: 'npx', args: [] })
+    if (!result.ok) throw new Error(result.error)
+
+    expect(result.manifest.kind).toBe('connector')
+    expect(result.manifest.contributes).toBeUndefined()
+  })
+})


### PR DESCRIPTION
First sub-phase of extensions. An extension is a pack, like a connector, that contributes to the session card instead of polling a service: card footers, panes drawn from a page the pack ships or from a terminal program, and link handlers. This adds the SDK side and the small host reads that let such a pack be verified, packed, probed and listed.

- `defineExtension()` beside `defineConnector()`: contributions, a closed permission list (`git.read`, `terminal.read`, `terminal.selection`, `terminal.send`, `card.rename`, `agent.usage`), and activation predicates (`workspaceContains`, `remoteHost`, `agent`, `platform`). Validated at import time; ids unique, patterns bounded, pages relative to the package.
- The manifest carries `kind`, `contributes`, `permissions` and `activates`; each footer and link handler is served as a reserved tool the host can call.
- `check` gains owned findings under `contributes`, `footers`, `handlers` and `permissions`: a page that is missing, a footer that fails or returns bad items, a handler tried on the example link it declares, a permission spent but not declared. Connector receipts are unchanged.
- A pack may carry `web/` pages, only for extensions, only under the directories its panes name, only page file types, and within the unpacked size the host enforces.
- The host reads the new manifest fields repair-or-drop like `toAuth`; the catalog entry gains `kind` and a contributions summary and drops an extension with nothing valid to contribute.
- `vorn-connector new <id> --extension` scaffolds a footer, a pane and its page; the page holds no credential and calls a same-origin bridge.

Verified end to end: a scaffolded extension typechecks, tests, builds, passes `check --mock --receipt` with the receipt `manifest, contributes, footers, permissions, no-lifecycle-scripts, keywords, no-runtime-deps, launch`, and packs with its page.

Server hosting (sub-phase 2), the card and pane rendering (3) and the directory (4) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc