### PR TITLE
Put a vorn command on PATH beside the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ brew tap vorn-run/tap && brew install --cask vorn
 
 Or download directly from [GitHub Releases](https://github.com/vorn-run/vorn/releases).
 
+## Command line
+
+The installer also puts a `vorn` command on your PATH. It talks to the same server the app
+does, and starts one if none is running.
+
+```bash
+vorn session start --agent claude --prompt "fix the failing test"
+vorn session list
+vorn session logs <id>
+vorn session send <id> "run the tests"
+vorn workflow list
+vorn server serve          # a server on its own, without the app
+```
+
+`vorn` on its own opens the app. `--json` gives machine-readable output on stdout, with
+notices and errors on stderr, so a command can be piped. If you installed by dragging the
+app across or with Homebrew, Settings → General → Command Line Tool writes the same command.
+
 ## Features
 
 Vorn supports two ways of working. **Interactive**: open a grid of terminals and pair with agents hands-on. **Autonomous**: define tasks and workflows, and let agents run headlessly while you focus on something else. Mix both freely — they share the same projects, tasks, and git integration.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -61,12 +61,6 @@ extraResources:
     to: 'server'
     filter:
       - '**/*'
-      # The standalone CLI re-bundles the whole server (it imports ./index), so
-      # shipping it here would double the server payload in every installer for
-      # a binary the app never runs. Excluded explicitly rather than relying on
-      # which build ran last: `build:server` passes one entry and cleans, while
-      # a workspace build emits both.
-      - '!cli.cjs'
   - from: 'packages/web/dist'
     to: 'web/dist'
     filter:

--- a/install.ps1
+++ b/install.ps1
@@ -61,9 +61,32 @@ try {
         Write-Host "Added $InstallDir to your PATH."
     }
 
+    # The `vorn` command, beside the app and inside the directory just added to
+    # PATH. It runs the app's own Node, so nothing else has to be installed and
+    # the native modules inside the bundle resolve.
+    # Joined with CRLF rather than written as a here-string: this file may be
+    # fetched with LF endings, and cmd.exe is unreliable about a multi-line
+    # block that arrives that way.
+    $ShimLines = @(
+        '@echo off',
+        'setlocal',
+        'set "APPDIR=%~dp0"',
+        'if "%~1"=="" (',
+        '  start "" "%APPDIR%Vorn.exe"',
+        '  exit /b',
+        ')',
+        'set "ELECTRON_RUN_AS_NODE=1"',
+        'set "VORN_NATIVE_MODULES_PATH=%APPDIR%resources\app.asar.unpacked\node_modules"',
+        'set "NODE_PATH=%APPDIR%resources\app.asar\node_modules;%VORN_NATIVE_MODULES_PATH%"',
+        '"%APPDIR%Vorn.exe" "%APPDIR%resources\server\cli.cjs" %*'
+    )
+    $Shim = ($ShimLines -join "`r`n") + "`r`n"
+    Set-Content -Path (Join-Path $InstallDir "vorn.cmd") -Value $Shim -Encoding ASCII -NoNewline
+
     Write-Host ""
     Write-Host "$AppName $Version installed to $InstallDir"
     Write-Host "Launch from Start Menu, desktop shortcut, or run '$AppName' in a new terminal."
+    Write-Host "The vorn command is available in a new terminal: vorn --help"
 } finally {
     Write-Host "Cleaning up..."
     Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,8 @@ choose_bin_dir() {
 }
 
 path_hint() {
-  if ! echo ":$PATH:" | grep -q ":$1:"; then
+  # -F: a directory holding a dot -- ~/.local/bin, say -- is not a regex.
+  if ! echo ":$PATH:" | grep -qF ":$1:"; then
     echo ""
     echo "Add ${1} to your PATH:"
     echo "  export PATH=\"${1}:\$PATH\""

--- a/install.sh
+++ b/install.sh
@@ -14,19 +14,32 @@ get_latest_version() {
     | sed 's/.*"tag_name": *"//;s/".*//'
 }
 
-# Where the `vorn` command goes: a directory already on PATH if we can write to
-# one, otherwise the per-user default, which is printed with a hint.
+# -F: a directory holding a dot -- ~/.local/bin, say -- is not a regex.
+on_path() {
+  echo ":$PATH:" | grep -qF ":$1:"
+}
+
+# Where the `vorn` command goes: a writable directory the shell already searches,
+# or, failing that, the per-user one, which is created and printed with a hint.
 choose_bin_dir() {
-  if [ -w "/usr/local/bin" ]; then
-    echo "/usr/local/bin"
-  else
-    echo "${HOME}/.local/bin"
-  fi
+  user_bin="${HOME}/.local/bin"
+  for dir in "/usr/local/bin" "$user_bin"; do
+    if [ -w "$dir" ] && on_path "$dir"; then
+      echo "$dir"
+      return
+    fi
+  done
+  for dir in "/usr/local/bin" "$user_bin"; do
+    if [ -w "$dir" ]; then
+      echo "$dir"
+      return
+    fi
+  done
+  echo "$user_bin"
 }
 
 path_hint() {
-  # -F: a directory holding a dot -- ~/.local/bin, say -- is not a regex.
-  if ! echo ":$PATH:" | grep -qF ":$1:"; then
+  if ! on_path "$1"; then
     echo ""
     echo "Add ${1} to your PATH:"
     echo "  export PATH=\"${1}:\$PATH\""

--- a/install.sh
+++ b/install.sh
@@ -113,10 +113,11 @@ SHIM
 
     mkdir -p "$BIN_DIR" "$LIB_DIR"
 
-    # Earlier installs put the AppImage itself here. It moves to make room for
-    # the command, which launches the app when given nothing to do.
+    # Earlier installs put the AppImage itself here. The new one is downloaded
+    # to LIB_DIR below, so the old file is removed rather than moved -- said
+    # plainly, because a message about moving would send you looking for it.
     if [ -f "${BIN_DIR}/vorn" ] && [ ! -f "${LIB_DIR}/${APP_NAME}.AppImage" ]; then
-      echo "Moving the app out of ${BIN_DIR} to make room for the vorn command..."
+      echo "Removing the old AppImage at ${BIN_DIR}/vorn; the app now lives in ${LIB_DIR}."
       rm -f "${BIN_DIR}/vorn"
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,26 @@ get_latest_version() {
     | sed 's/.*"tag_name": *"//;s/".*//'
 }
 
+# Where the `vorn` command goes: a directory already on PATH if we can write to
+# one, otherwise the per-user default, which is printed with a hint.
+choose_bin_dir() {
+  if [ -w "/usr/local/bin" ]; then
+    echo "/usr/local/bin"
+  else
+    echo "${HOME}/.local/bin"
+  fi
+}
+
+path_hint() {
+  if ! echo ":$PATH:" | grep -q ":$1:"; then
+    echo ""
+    echo "Add ${1} to your PATH:"
+    echo "  export PATH=\"${1}:\$PATH\""
+    echo ""
+    echo "Add this to your ~/.bashrc or ~/.zshrc to make it permanent."
+  fi
+}
+
 VERSION="${VORN_VERSION:-$(get_latest_version)}"
 
 if [ -z "$VERSION" ]; then
@@ -54,29 +74,76 @@ case "$OS" in
     hdiutil detach "$MOUNT_POINT" -quiet
     rm -rf "$TMPDIR_INSTALL"
 
+    BIN_DIR="$(choose_bin_dir)"
+    mkdir -p "$BIN_DIR"
+
+    # The command runs the app's own Node — the same trick the app uses to start
+    # its server — so nothing else has to be installed and the native modules
+    # inside the bundle resolve.
+    cat > "${BIN_DIR}/vorn" <<'SHIM'
+#!/bin/sh
+APP="/Applications/Vorn.app"
+RESOURCES="${APP}/Contents/Resources"
+
+# No command: open the app, which is what typing `vorn` should mean.
+if [ "$#" -eq 0 ]; then
+  exec open -a "$APP"
+fi
+
+ELECTRON_RUN_AS_NODE=1
+VORN_NATIVE_MODULES_PATH="${RESOURCES}/app.asar.unpacked/node_modules"
+NODE_PATH="${RESOURCES}/app.asar/node_modules:${VORN_NATIVE_MODULES_PATH}"
+export ELECTRON_RUN_AS_NODE VORN_NATIVE_MODULES_PATH NODE_PATH
+
+exec "${APP}/Contents/MacOS/Vorn" "${RESOURCES}/server/cli.cjs" "$@"
+SHIM
+    chmod +x "${BIN_DIR}/vorn"
+
     echo "${APP_NAME} ${VERSION} installed to /Applications/${APP_NAME}.app"
+    echo "The vorn command is at ${BIN_DIR}/vorn"
+    path_hint "$BIN_DIR"
     ;;
 
   Linux)
     ARTIFACT="${APP_NAME}-${VERSION_NUM}.AppImage"
     URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT}"
-    INSTALL_DIR="${HOME}/.local/bin"
+    BIN_DIR="${HOME}/.local/bin"
+    LIB_DIR="${HOME}/.local/lib/vorn"
 
-    mkdir -p "$INSTALL_DIR"
+    mkdir -p "$BIN_DIR" "$LIB_DIR"
 
-    echo "Downloading ${ARTIFACT}..."
-    curl -fSL --progress-bar -o "${INSTALL_DIR}/vorn" "$URL"
-    chmod +x "${INSTALL_DIR}/vorn"
-
-    if ! echo "$PATH" | grep -q "$INSTALL_DIR"; then
-      echo ""
-      echo "Add ${INSTALL_DIR} to your PATH:"
-      echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
-      echo ""
-      echo "Add this to your ~/.bashrc or ~/.zshrc to make it permanent."
+    # Earlier installs put the AppImage itself here. It moves to make room for
+    # the command, which launches the app when given nothing to do.
+    if [ -f "${BIN_DIR}/vorn" ] && [ ! -f "${LIB_DIR}/${APP_NAME}.AppImage" ]; then
+      echo "Moving the app out of ${BIN_DIR} to make room for the vorn command..."
+      rm -f "${BIN_DIR}/vorn"
     fi
 
-    echo "${APP_NAME} ${VERSION} installed to ${INSTALL_DIR}/vorn"
+    echo "Downloading ${ARTIFACT}..."
+    curl -fSL --progress-bar -o "${LIB_DIR}/${APP_NAME}.AppImage" "$URL"
+    chmod +x "${LIB_DIR}/${APP_NAME}.AppImage"
+
+    cat > "${BIN_DIR}/vorn" <<'SHIM'
+#!/bin/sh
+APPIMAGE="${HOME}/.local/lib/vorn/Vorn.AppImage"
+
+# No command: open the app, which is what typing `vorn` should mean.
+if [ "$#" -eq 0 ]; then
+  exec "$APPIMAGE"
+fi
+
+# The CLI lives inside the AppImage, whose mount point is only known once it is
+# running — so the entry point is resolved from APPDIR in there, and spliced
+# into argv where a normally-invoked script would have been.
+BOOTSTRAP='var entry = process.env.APPDIR + "/resources/server/cli.cjs"; process.argv.splice(1, 0, entry); require(entry)'
+
+ELECTRON_RUN_AS_NODE=1 exec "$APPIMAGE" -e "$BOOTSTRAP" "$@"
+SHIM
+    chmod +x "${BIN_DIR}/vorn"
+
+    echo "${APP_NAME} ${VERSION} installed to ${LIB_DIR}/${APP_NAME}.AppImage"
+    echo "The vorn command is at ${BIN_DIR}/vorn"
+    path_hint "$BIN_DIR"
     ;;
 
   *)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "electron-vite dev",
-    "build:server": "cd packages/server && npx tsup src/index.ts --format cjs --target node22 --external node-pty --external libsql --clean",
+    "build:server": "cd packages/server && npx tsup",
     "build:web": "cd packages/web && npx vite build",
     "build": "yarn build:server && yarn build:web && electron-vite build",
     "preview": "electron-vite preview",

--- a/packages/mcp/src/data-access.ts
+++ b/packages/mcp/src/data-access.ts
@@ -6,7 +6,7 @@ import type {
   WorkspaceConfig,
   WorkflowExecution
 } from '@vornrun/shared/types'
-import { rpcCall } from './ws-client'
+import { rpcCall } from '@vornrun/server/rpc-client'
 
 /**
  * Tasks, projects, workspaces and workflows, read and written over the socket.

--- a/packages/mcp/src/tools/browser.ts
+++ b/packages/mcp/src/tools/browser.ts
@@ -10,7 +10,7 @@ import type {
   BrowserTarget
 } from '@vornrun/shared/types'
 import { V } from '../validation'
-import { rpcCall } from '../ws-client'
+import { rpcCall } from '@vornrun/server/rpc-client'
 
 /**
  * The agent's half of the session browser pane.

--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -25,7 +25,7 @@ import type {
   SdkProbeResult,
   SourceConnection
 } from '@vornrun/shared/types'
-import { rpcCall } from '../ws-client'
+import { rpcCall } from '@vornrun/server/rpc-client'
 import { SDK_FILTER_KEYS, connectionConnectorId } from '@vornrun/shared/types'
 
 /**

--- a/packages/mcp/src/tools/device.ts
+++ b/packages/mcp/src/tools/device.ts
@@ -8,7 +8,7 @@ import type {
   DeviceTarget
 } from '@vornrun/shared/types'
 import { V } from '../validation'
-import { rpcCall } from '../ws-client'
+import { rpcCall } from '@vornrun/server/rpc-client'
 import { noSessionResult, errorResult, pageResult, sessionId } from './browser'
 
 /**

--- a/packages/mcp/src/tools/sessions.ts
+++ b/packages/mcp/src/tools/sessions.ts
@@ -9,7 +9,7 @@ import type {
   SessionEvent
 } from '@vornrun/shared/types'
 import { V } from '../validation'
-import { rpcCall, rpcNotify } from '../ws-client'
+import { rpcCall, rpcNotify } from '@vornrun/server/rpc-client'
 
 /**
  * Deliberately `AiAgentType`, not `AgentType`.

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -25,7 +25,7 @@ import {
   listRunsWithWaitingGates,
   dbSignalChange
 } from '../data-access'
-import { rpcCall } from '../ws-client'
+import { rpcCall } from '@vornrun/server/rpc-client'
 import {
   toPortable,
   fromPortable,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./rpc-client": "./src/rpc-client.ts",
     "./config-manager": "./src/config-manager.ts",
     "./pty-manager": "./src/pty-manager.ts",
     "./scheduler": "./src/scheduler.ts",
@@ -13,6 +14,7 @@
     "./git-utils": "./src/git-utils.ts"
   },
   "bin": {
+    "vorn": "./dist/cli.cjs",
     "vorn-server": "./dist/cli.cjs"
   },
   "scripts": {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -252,6 +252,26 @@ export function findCommand(argv: string[]): string | undefined {
   return undefined
 }
 
+const COMMANDS = ['session', 'workflow', 'server', 'serve', 'token', 'help']
+
+/**
+ * An option that swallowed the command, because its own value was missing.
+ *
+ * `vorn --data-dir session list` parses: `--data-dir` takes `session`, and what
+ * is left is `list`, which is not a command. Reported as the missing value it
+ * is, rather than as a mystery about `list`. Only consulted once the command has
+ * failed to resolve, so `--prompt session` on a real command is left alone.
+ */
+function optionAteTheCommand(argv: string[]): { option: string; value: string } | undefined {
+  for (let i = 0; i < argv.length - 1; i++) {
+    const token = argv[i]
+    if (!token.startsWith('--') || token.includes('=')) continue
+    if (!TAKES_VALUE.has(token.slice(2))) continue
+    if (COMMANDS.includes(argv[i + 1])) return { option: token, value: argv[i + 1] }
+  }
+  return undefined
+}
+
 /** The same argv with the command itself taken out, options left where they were. */
 function withoutCommand(argv: string[], command: string): string[] {
   const at = argv.indexOf(command)
@@ -275,6 +295,11 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
       deps.write(USAGE)
       return EXIT_OK
     }
+    const eaten = optionAteTheCommand(argv)
+    if (eaten) {
+      deps.writeErr(`vorn: ${eaten.option} needs a value; it took "${eaten.value}" as one\n`)
+      return EXIT_USAGE
+    }
     deps.writeErr(USAGE)
     return EXIT_USAGE
   }
@@ -293,9 +318,15 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
     case 'session':
     case 'workflow':
       return runClientCommand(argv, deps)
-    default:
+    default: {
+      const eaten = optionAteTheCommand(argv)
+      if (eaten) {
+        deps.writeErr(`vorn: ${eaten.option} needs a value; it took "${eaten.value}" as one\n`)
+        return EXIT_USAGE
+      }
       deps.writeErr(`vorn: unknown command "${command}". Try: session, workflow, server, help\n`)
       return EXIT_USAGE
+    }
   }
 }
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -2,33 +2,66 @@ import { startServer } from './index'
 import { initDatabase, closeDatabase } from './database'
 import { mintOwnerToken, listTokens, hasTokens, revokeToken } from './token-manager'
 import { parseServerArgs, ServerArgsError, type ServerArgs } from './server-args'
+import { parseClientArgs, ClientArgsError } from './client-args'
+import { useDataDir } from './rpc-client'
+import { clientContext, type CliDeps } from './cli/deps'
+import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from './cli/exit'
+import { runSessionCommand } from './cli/session'
+import { runWorkflowCommand } from './cli/workflow'
 
 /**
- * Command line entry point for running Vorn's server on its own, without the
- * desktop app.
+ * The `vorn` command.
  *
- * `runCli` takes its argv and its output sink as arguments and returns an exit
+ * Two halves behind one name. `vorn server` runs a server on this machine,
+ * which is what this file used to be on its own, as `vorn-server`. The rest
+ * talks to a server that is already running — starting one first if there is
+ * none — and every one of those verbs is an RPC the app has always had.
+ *
+ * `runCli` takes its argv and its output sinks as arguments and returns an exit
  * code instead of writing to `process` and calling `process.exit`, so every
  * command is assertable. Same shape as `packages/connector-sdk/src/cli.ts`.
  *
- * The argument grammar lives in `server-args.ts`, shared with the entry point
- * Electron forks, so the two cannot drift.
+ * The two grammars live in `server-args.ts` and `client-args.ts`. The first is
+ * shared with the entry point Electron forks, which is why the flags a person
+ * types are kept out of it.
  */
 
-export interface CliDeps {
-  /** Normal output. Log lines go to stderr (see `logger.ts`), so this is safe to pipe. */
-  write(text: string): void
-  /** Errors and usage shown on failure. */
-  writeErr(text: string): void
+export type { CliDeps }
+
+// Replaced at build time (`tsup.config.ts`); absent when run from source.
+declare const __CLI_VERSION__: string | undefined
+
+function version(): string {
+  return typeof __CLI_VERSION__ === 'undefined' ? 'dev' : __CLI_VERSION__
 }
 
-const USAGE = `vorn-server: run a Vorn server without the desktop app
+const USAGE = `vorn: Vorn from the command line
 
 Usage
-  vorn-server serve [options]              Start the server
-  vorn-server token create --name <name>   Mint a device token
-  vorn-server token list                   List device tokens
-  vorn-server token revoke <id>            Revoke a device token
+  vorn session start --agent <agent> [--prompt <text>]   Start an agent session
+  vorn session list [--recent] [--json]                  What is running
+  vorn session logs|send|kill <id>                       Read, steer, stop one
+  vorn workflow list [--json]                            Workflows
+  vorn workflow runs [--workflow <name>] [--json]        Their runs
+  vorn server serve|token                                Run a server, or its tokens
+  vorn --help | --version
+
+Options common to the commands that talk to a server
+  --json              Machine-readable output on stdout
+  --data-dir <path>   Reach a server started with the same flag
+  --timeout <ms>      Give up on a call after this long
+
+Running \`vorn\` with no command opens the app. With no server running, a command
+starts one and says so.
+`
+
+const SERVER_USAGE = `vorn server: run a Vorn server without the desktop app
+
+Usage
+  vorn server serve [options]              Start the server
+  vorn server token create --name <name>   Mint a device token
+  vorn server token list                   List device tokens
+  vorn server token revoke <id>            Revoke a device token
 
 Options
   --port <port>       Port to listen on (default: chosen by the OS)
@@ -63,47 +96,45 @@ function runTokenCommand(args: ServerArgs, deps: CliDeps): number {
     case 'create': {
       const name = args.name
       if (!name) {
-        deps.writeErr('vorn-server: token create requires --name <name>\n')
-        return 2
+        deps.writeErr('vorn: token create requires --name <name>\n')
+        return EXIT_USAGE
       }
       const { token, plaintext } = withDatabase(args.dataDir, () => mintOwnerToken(name))
       printMintedToken(deps, `Created token "${token.name}" (${token.id})`, plaintext)
-      return 0
+      return EXIT_OK
     }
 
     case 'list': {
       const tokens = withDatabase(args.dataDir, () => listTokens())
       if (tokens.length === 0) {
         deps.write('No device tokens.\n')
-        return 0
+        return EXIT_OK
       }
       for (const t of tokens) {
         const state = t.revokedAt ? 'revoked' : 'active'
         const seen = t.lastSeenAt ?? 'never'
         deps.write(`${t.id}  ${state.padEnd(7)}  last seen ${seen}  ${t.name}\n`)
       }
-      return 0
+      return EXIT_OK
     }
 
     case 'revoke': {
       const id = rest[0]
       if (!id) {
-        deps.writeErr('vorn-server: token revoke requires a token id\n')
-        return 2
+        deps.writeErr('vorn: token revoke requires a token id\n')
+        return EXIT_USAGE
       }
       if (!withDatabase(args.dataDir, () => revokeToken(id))) {
-        deps.writeErr(`vorn-server: no active token with id ${id}\n`)
-        return 1
+        deps.writeErr(`vorn: no active token with id ${id}\n`)
+        return EXIT_FAILURE
       }
       deps.write(`Revoked ${id}\n`)
-      return 0
+      return EXIT_OK
     }
 
     default:
-      deps.writeErr(
-        `vorn-server: unknown token command "${sub ?? ''}". Try: create, list, revoke\n`
-      )
-      return 2
+      deps.writeErr(`vorn: unknown token command "${sub ?? ''}". Try: create, list, revoke\n`)
+      return EXIT_USAGE
   }
 }
 
@@ -123,43 +154,47 @@ async function runServe(args: ServerArgs, deps: CliDeps): Promise<number> {
   // A fresh data directory has no way for anyone to authenticate later, so mint
   // one token now rather than making the operator find the token command first.
   if (!hasTokens()) {
-    const { plaintext } = mintOwnerToken('first-run')
-    printMintedToken(
-      deps,
-      '\nNo device tokens existed, so one was created for this server:',
-      plaintext,
-      'Manage tokens with: vorn-server token list\n\n'
-    )
+    // Auto-start redirects this stream to a log file, and a secret does not go
+    // in one. A person watching a terminal still gets the token.
+    if (deps.isTty ?? Boolean(process.stdout.isTTY)) {
+      const { plaintext } = mintOwnerToken('first-run')
+      printMintedToken(
+        deps,
+        '\nNo device tokens existed, so one was created for this server:',
+        plaintext,
+        'Manage tokens with: vorn server token list\n\n'
+      )
+    } else {
+      deps.write(
+        '\nNo device tokens exist. Mint one with: vorn server token create --name <name>\n'
+      )
+    }
   }
-  return 0
+  return EXIT_OK
 }
 
-/**
- * Run one command. Returns the process exit code; `serve` returns 0 while
- * leaving the server listening, so the caller must not exit on success.
- */
-export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
+/** `vorn server ...`, and the bare `serve`/`token` that `vorn-server` has always taken. */
+async function runServerCommand(argv: string[], deps: CliDeps): Promise<number> {
   let args: ServerArgs
   try {
     args = parseServerArgs(argv)
   } catch (err) {
     if (err instanceof ServerArgsError) {
-      deps.writeErr(`vorn-server: ${err.message}\n`)
-      return 2
+      deps.writeErr(`vorn: ${err.message}\n`)
+      return EXIT_USAGE
     }
     throw err
   }
 
   const command = args.positionals[0]
 
-  // Asking for help is a successful invocation; being run with nothing is not.
   if (args.help || command === 'help') {
-    deps.write(USAGE)
-    return 0
+    deps.write(SERVER_USAGE)
+    return EXIT_OK
   }
   if (!command) {
-    deps.writeErr(USAGE)
-    return 2
+    deps.writeErr(SERVER_USAGE)
+    return EXIT_USAGE
   }
 
   switch (command) {
@@ -168,15 +203,77 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
     case 'token':
       return runTokenCommand(args, deps)
     default:
-      deps.writeErr(`vorn-server: unknown command "${command}". Try: serve, token, help\n`)
-      return 2
+      deps.writeErr(`vorn: unknown server command "${command}". Try: serve, token, help\n`)
+      return EXIT_USAGE
+  }
+}
+
+/** The commands that need a server: one grammar, one context, then the noun. */
+async function runClientCommand(argv: string[], deps: CliDeps): Promise<number> {
+  let args
+  try {
+    args = parseClientArgs(argv)
+  } catch (err) {
+    if (err instanceof ClientArgsError) {
+      deps.writeErr(`vorn: ${err.message}\n`)
+      return EXIT_USAGE
+    }
+    throw err
+  }
+
+  // Discovery reads the port and credential files from here, so this has to be
+  // set before the first call rather than passed down to it.
+  useDataDir(args.dataDir)
+
+  const ctx = clientContext(deps, args)
+  return args.positionals[0] === 'session' ? runSessionCommand(ctx) : runWorkflowCommand(ctx)
+}
+
+/**
+ * Run one command. Returns the process exit code; `serve` returns 0 while
+ * leaving the server listening, so the caller must not exit on success.
+ */
+export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
+  const command = argv[0] && !argv[0].startsWith('-') ? argv[0] : undefined
+
+  if (!command) {
+    if (argv.includes('--version')) {
+      deps.write(`${version()}\n`)
+      return EXIT_OK
+    }
+    // Asking for help is a successful invocation; being run with nothing is not.
+    if (argv.includes('--help') || argv.includes('-h')) {
+      deps.write(USAGE)
+      return EXIT_OK
+    }
+    deps.writeErr(USAGE)
+    return EXIT_USAGE
+  }
+
+  switch (command) {
+    case 'help':
+      deps.write(USAGE)
+      return EXIT_OK
+    case 'server':
+      return runServerCommand(argv.slice(1), deps)
+    // `vorn-server` was called this way for as long as it existed, and scripts
+    // that still do keep working.
+    case 'serve':
+    case 'token':
+      return runServerCommand(argv, deps)
+    case 'session':
+    case 'workflow':
+      return runClientCommand(argv, deps)
+    default:
+      deps.writeErr(`vorn: unknown command "${command}". Try: session, workflow, server, help\n`)
+      return EXIT_USAGE
   }
 }
 
 // Only when run as the binary — guarded the same way as `index.ts`, so importing
-// this module from a test does not start anything. The npm bin resolves through a
-// symlink named `vorn-server`, which is why that name is checked too.
-const isDirectRun = ['cli.ts', 'cli.js', 'cli.cjs', 'vorn-server'].some((name) =>
+// this module from a test does not start anything. The npm bins resolve through
+// symlinks named `vorn` and `vorn-server`, which is why those names are checked.
+const isDirectRun = ['cli.ts', 'cli.js', 'cli.cjs', 'vorn', 'vorn-server'].some((name) =>
   process.argv[1]?.endsWith(name)
 )
 
@@ -189,13 +286,13 @@ if (isDirectRun) {
   runCli(process.argv.slice(2), deps)
     .then((code) => {
       // Exit only on failure. `serve` returns 0 with the server still listening,
-      // and an explicit exit(0) would kill it; the token commands have nothing
+      // and an explicit exit(0) would kill it; the other commands have nothing
       // pending, so the event loop drains and node exits 0 by itself.
       if (code !== 0) process.exit(code)
     })
     .catch((err) => {
       const message = err instanceof Error ? err.stack || err.message : String(err)
-      process.stderr.write(`vorn-server: ${message}\n`)
-      process.exit(1)
+      process.stderr.write(`vorn: ${message}\n`)
+      process.exit(EXIT_FAILURE)
     })
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,8 +1,8 @@
 import { startServer } from './index'
 import { initDatabase, closeDatabase } from './database'
 import { mintOwnerToken, listTokens, hasTokens, revokeToken } from './token-manager'
-import { parseServerArgs, ServerArgsError, type ServerArgs } from './server-args'
-import { parseClientArgs, ClientArgsError } from './client-args'
+import { parseServerArgs, ServerArgsError, SERVER_OPTIONS, type ServerArgs } from './server-args'
+import { parseClientArgs, ClientArgsError, CLIENT_OPTIONS } from './client-args'
 import { useDataDir } from './rpc-client'
 import { clientContext, type CliDeps } from './cli/deps'
 import { EXIT_FAILURE, EXIT_OK, EXIT_USAGE } from './cli/exit'
@@ -229,12 +229,41 @@ async function runClientCommand(argv: string[], deps: CliDeps): Promise<number> 
   return args.positionals[0] === 'session' ? runSessionCommand(ctx) : runWorkflowCommand(ctx)
 }
 
+/** Which option names carry a value, taken from the grammars rather than a list. */
+const TAKES_VALUE = new Set(
+  [...Object.entries(SERVER_OPTIONS), ...Object.entries(CLIENT_OPTIONS)]
+    .filter(([, spec]) => spec.type === 'string')
+    .map(([name]) => name)
+)
+
+/**
+ * The command, wherever it sits.
+ *
+ * `vorn --data-dir /tmp session list` is how a person writes this, and taking
+ * argv[0] alone read the flag as the command and the directory as nothing.
+ * Skipping an option's value is what makes the directory not look like a noun.
+ */
+export function findCommand(argv: string[]): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]
+    if (!token.startsWith('-')) return token
+    if (token.startsWith('--') && !token.includes('=') && TAKES_VALUE.has(token.slice(2))) i++
+  }
+  return undefined
+}
+
+/** The same argv with the command itself taken out, options left where they were. */
+function withoutCommand(argv: string[], command: string): string[] {
+  const at = argv.indexOf(command)
+  return [...argv.slice(0, at), ...argv.slice(at + 1)]
+}
+
 /**
  * Run one command. Returns the process exit code; `serve` returns 0 while
  * leaving the server listening, so the caller must not exit on success.
  */
 export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
-  const command = argv[0] && !argv[0].startsWith('-') ? argv[0] : undefined
+  const command = findCommand(argv)
 
   if (!command) {
     if (argv.includes('--version')) {
@@ -255,7 +284,7 @@ export async function runCli(argv: string[], deps: CliDeps): Promise<number> {
       deps.write(USAGE)
       return EXIT_OK
     case 'server':
-      return runServerCommand(argv.slice(1), deps)
+      return runServerCommand(withoutCommand(argv, command), deps)
     // `vorn-server` was called this way for as long as it existed, and scripts
     // that still do keep working.
     case 'serve':

--- a/packages/server/src/cli/autostart.ts
+++ b/packages/server/src/cli/autostart.ts
@@ -1,0 +1,71 @@
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { dataDir } from '../rpc-client'
+import type { RpcTransport } from './transport'
+
+/** The name the desktop app already writes its server output to. */
+const SERVER_LOG_FILENAME = 'server.log'
+
+const READY_TIMEOUT_MS = 20_000
+const POLL_MS = 150
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** How this binary re-invokes itself. Dev runs from TypeScript, which needs a loader. */
+function serveCommand(dataDirFlag?: string): { command: string; args: string[] } {
+  const entry = process.argv[1] ?? ''
+  const serve = ['server', 'serve', ...(dataDirFlag ? ['--data-dir', dataDirFlag] : [])]
+  return entry.endsWith('.ts')
+    ? { command: 'npx', args: ['tsx', entry, ...serve] }
+    : { command: process.execPath, args: [entry, ...serve] }
+}
+
+/**
+ * A server to talk to, started if there is not one already.
+ *
+ * Detached, so it outlives the command that needed it — the same bargain the
+ * desktop app makes, and the reason `serve` refuses to idle-shutdown. A rival
+ * started by a second `vorn` at the same moment stands down by itself with
+ * `EXIT_ENDPOINT_TAKEN`, so no lock is held here.
+ */
+export async function ensureServer(
+  rpc: RpcTransport,
+  writeErr: (text: string) => void,
+  dataDirFlag?: string
+): Promise<boolean> {
+  if (rpc.isRunning()) return true
+
+  writeErr('No server running, starting one.\n')
+
+  const dir = dataDir()
+  fs.mkdirSync(dir, { recursive: true })
+  // A file descriptor rather than a pipe: the parent exits in a moment, and a
+  // pipe dying under the server takes the server with it on its next log line.
+  const logFd = fs.openSync(path.join(dir, SERVER_LOG_FILENAME), 'a')
+
+  try {
+    const { command, args } = serveCommand(dataDirFlag)
+    const child = spawn(command, args, {
+      stdio: ['ignore', logFd, logFd],
+      detached: true,
+      cwd: dir,
+      env: process.env
+    })
+    child.unref()
+  } finally {
+    fs.closeSync(logFd)
+  }
+
+  const deadline = Date.now() + READY_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    await sleep(POLL_MS)
+    if (rpc.isRunning()) return true
+  }
+
+  writeErr(
+    `The server did not come up within ${Math.round(READY_TIMEOUT_MS / 1000)}s. ` +
+      `Its output is in ${path.join(dir, SERVER_LOG_FILENAME)}.\n`
+  )
+  return false
+}

--- a/packages/server/src/cli/autostart.ts
+++ b/packages/server/src/cli/autostart.ts
@@ -38,7 +38,9 @@ export async function ensureServer(
 
   writeErr('No server running, starting one.\n')
 
-  const dir = dataDir()
+  // The flag wins over what discovery resolved, so the log this names and the
+  // directory the server is told to use cannot disagree with each other.
+  const dir = dataDirFlag ?? dataDir()
   fs.mkdirSync(dir, { recursive: true })
   // A file descriptor rather than a pipe: the parent exits in a moment, and a
   // pipe dying under the server takes the server with it on its next log line.

--- a/packages/server/src/cli/deps.ts
+++ b/packages/server/src/cli/deps.ts
@@ -1,0 +1,56 @@
+import type { ClientArgs } from '../client-args'
+import { ensureServer } from './autostart'
+import { isPlain } from './output'
+import { socketTransport, type RpcTransport } from './transport'
+
+export interface CliDeps {
+  /** Normal output. Log lines go to stderr (see `logger.ts`), so this is safe to pipe. */
+  write(text: string): void
+  /** Errors, notices and confirmations. Never data. */
+  writeErr(text: string): void
+  /** Defaults to the socket client. A test passes a fake and needs no server. */
+  rpc?: RpcTransport
+  /** Defaults to starting a server. A test passes a stub and spawns nothing. */
+  ensureServer?: typeof ensureServer
+  /** Defaults to whether stdout is a terminal. */
+  isTty?: boolean
+}
+
+/** Everything a client command needs, with the production wiring already chosen. */
+export interface ClientContext {
+  write(text: string): void
+  writeErr(text: string): void
+  rpc: RpcTransport
+  args: ClientArgs
+  /** No colour: piped, redirected, or asked to go without. */
+  plain: boolean
+  /** A server to talk to, started if there is not one. False when it could not be. */
+  server(): Promise<boolean>
+}
+
+/** `--timeout` applies to every call a command makes, so it is applied once, here. */
+function withTimeout(rpc: RpcTransport, timeoutMs: number | undefined): RpcTransport {
+  if (timeoutMs === undefined) return rpc
+  return {
+    call(method, params) {
+      return rpc.call(method, params, timeoutMs)
+    },
+    notify(method, params) {
+      return rpc.notify(method, params)
+    },
+    isRunning: () => rpc.isRunning()
+  }
+}
+
+export function clientContext(deps: CliDeps, args: ClientArgs): ClientContext {
+  const rpc = withTimeout(deps.rpc ?? socketTransport, args.timeoutMs)
+  const start = deps.ensureServer ?? ensureServer
+  return {
+    write: deps.write,
+    writeErr: deps.writeErr,
+    rpc,
+    args,
+    plain: isPlain(deps.isTty ?? Boolean(process.stdout.isTTY)),
+    server: () => start(rpc, deps.writeErr, args.dataDir)
+  }
+}

--- a/packages/server/src/cli/exit.ts
+++ b/packages/server/src/cli/exit.ts
@@ -1,0 +1,11 @@
+/**
+ * What the process leaves behind, so a script can branch on it.
+ *
+ * 3 is missing deliberately: the server already exits with it for
+ * `EXIT_ENDPOINT_TAKEN` (`packages/shared/src/protocol.ts`), and `vorn server
+ * serve` passes that code through.
+ */
+export const EXIT_OK = 0
+export const EXIT_FAILURE = 1
+export const EXIT_USAGE = 2
+export const EXIT_UNREACHABLE = 4

--- a/packages/server/src/cli/output.ts
+++ b/packages/server/src/cli/output.ts
@@ -1,0 +1,91 @@
+/**
+ * How the client commands write.
+ *
+ * One rule underneath all of it: stdout carries data and nothing else, so a
+ * command can be piped without anything having to be stripped out of it.
+ * Notices and errors go to stderr, which is where the logger already writes.
+ */
+
+// Built rather than typed, so no escape byte sits in the source.
+const CSI = `${String.fromCharCode(27)}[`
+const RESET = `${CSI}0m`
+
+/**
+ * Whether output must stay plain: piped, redirected, or asked to be.
+ *
+ * `NO_COLOR` is honoured by presence, not value — that is what the convention
+ * says, and an empty string is how most shells set it.
+ */
+export function isPlain(isTty: boolean): boolean {
+  return !isTty || process.env.NO_COLOR !== undefined || process.env.TERM === 'dumb'
+}
+
+/** The one place data becomes JSON, so every command emits the same shape. */
+export function asJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`
+}
+
+const UUID_HEAD = /^[0-9a-f]{8}-[0-9a-f]{4}-/i
+
+/**
+ * Eight characters of a uuid still identify it, and a row stays readable.
+ *
+ * Only of a uuid: seeded and imported workflows carry names as ids, and cutting
+ * `system:default-task-workflow` down to `system:d` identifies nothing — two of
+ * them would print the same string.
+ */
+export function shortId(id: string): string {
+  return UUID_HEAD.test(id) ? id.slice(0, 8) : id
+}
+
+/**
+ * Columns padded to their widest cell, never truncated.
+ *
+ * Padding happens before `paint` runs, so colour codes cannot widen a cell and
+ * push the columns out of line.
+ */
+export function table(
+  headers: string[],
+  rows: string[][],
+  paint?: (cell: string, column: number) => string
+): string {
+  const widths = headers.map((header, i) =>
+    Math.max(header.length, ...rows.map((row) => (row[i] ?? '').length))
+  )
+  const line = (cells: string[], colour: boolean): string =>
+    cells
+      .map((cell, i) => {
+        const padded = i === cells.length - 1 ? cell : cell.padEnd(widths[i])
+        return colour && paint ? paint(padded, i) : padded
+      })
+      .join('  ')
+      .trimEnd()
+
+  return [line(headers, false), ...rows.map((row) => line(row, true))].join('\n') + '\n'
+}
+
+/** Colour carries status and nothing else, and only when a terminal is watching. */
+export function paintStatus(text: string, plain: boolean): string {
+  if (plain) return text
+  const key = text.trim()
+  if (key === 'waiting') return `${CSI}33m${text}${RESET}`
+  if (key === 'error' || key === 'cancelled') return `${CSI}31m${text}${RESET}`
+  if (key === 'running' || key === 'success') return `${CSI}32m${text}${RESET}`
+  if (key === 'idle' || key === 'exited') return `${CSI}2m${text}${RESET}`
+  return text
+}
+
+/** How long ago, in the coarsest unit that still says something. */
+export function timeAgo(when: number | string | undefined): string {
+  if (when === undefined) return '-'
+  const then = typeof when === 'number' ? when : Date.parse(when)
+  if (!Number.isFinite(then)) return '-'
+
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000))
+  if (seconds < 60) return 'just now'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 48) return `${hours}h ago`
+  return `${Math.round(hours / 24)}d ago`
+}

--- a/packages/server/src/cli/session.ts
+++ b/packages/server/src/cli/session.ts
@@ -1,0 +1,323 @@
+import path from 'node:path'
+import type {
+  AiAgentType,
+  AppConfig,
+  CreateTerminalPayload,
+  HeadlessSession,
+  ProjectConfig,
+  TerminalSession
+} from '@vornrun/shared/types'
+import { getRepoRoot } from '../git-utils'
+import { normalizePath } from '../process-utils'
+import type { ClientContext } from './deps'
+import { EXIT_FAILURE, EXIT_OK, EXIT_UNREACHABLE, EXIT_USAGE } from './exit'
+import { asJson, paintStatus, shortId, table, timeAgo } from './output'
+
+const AGENTS: AiAgentType[] = ['claude', 'copilot', 'codex', 'opencode', 'gemini']
+
+export const SESSION_USAGE = `Usage
+  vorn session start --agent <agent> [--prompt <text>] [options]
+  vorn session list [--recent] [--project <name>] [--json]
+  vorn session logs <id> [--lines <n>] [--json]
+  vorn session send <id> <text> [--raw]
+  vorn session kill <id>
+
+Agents
+  ${AGENTS.join(', ')}
+
+Options for start
+  --prompt <text>     First thing the agent is told
+  --project <name>    A project Vorn knows, or a name for this one
+  --path <dir>        Project directory (default: the git root of this one)
+  --branch <branch>   Branch to check out
+  --worktree          Run in a new git worktree
+  --headless          No terminal pane; the agent runs to completion
+  --name <label>      Display name for the session
+`
+
+function usage(ctx: ClientContext, message: string): number {
+  ctx.writeErr(`vorn: ${message}\n\n${SESSION_USAGE}`)
+  return EXIT_USAGE
+}
+
+/** Turn what the server threw into one line a person can act on. */
+function failed(ctx: ClientContext, what: string, err: unknown): number {
+  ctx.writeErr(`vorn: ${what}: ${err instanceof Error ? err.message : String(err)}\n`)
+  return EXIT_FAILURE
+}
+
+/**
+ * The project a session belongs to, registered if Vorn has not seen it.
+ *
+ * A directory is identified by its path, never its name: two checkouts of one
+ * repository are two projects, and renaming a directory does not create a third.
+ */
+async function resolveProject(
+  ctx: ClientContext,
+  agentType: AiAgentType
+): Promise<{ projectName: string; projectPath: string }> {
+  const config = await ctx.rpc.call('config:load')
+  const projects: ProjectConfig[] = config.projects ?? []
+
+  // A project named with no directory beside it is one Vorn already knows, so
+  // this works from anywhere rather than only from inside that checkout.
+  if (ctx.args.project && !ctx.args.path) {
+    const named = projects.find((p) => p.name === ctx.args.project)
+    if (named) return { projectName: named.name, projectPath: named.path }
+  }
+
+  const cwd = process.cwd()
+  const projectPath = ctx.args.path ? path.resolve(ctx.args.path) : (getRepoRoot(cwd) ?? cwd)
+  const known = projects.find((p) => normalizePath(p.path) === normalizePath(projectPath))
+  if (known) return { projectName: known.name, projectPath }
+
+  const projectName = ctx.args.project ?? path.basename(projectPath)
+  const registered: ProjectConfig = {
+    name: projectName,
+    path: projectPath,
+    preferredAgents: [agentType]
+  }
+  const next: AppConfig = { ...config, projects: [...projects, registered] }
+  await ctx.rpc.call('config:save', next)
+  return { projectName, projectPath }
+}
+
+/** A session and which half of the server owns it, because they are killed differently. */
+interface Addressed {
+  id: string
+  kind: 'terminal' | 'headless'
+}
+
+/**
+ * The session an id names, accepting any prefix that names only one.
+ *
+ * Every list prints eight characters, so those eight have to be enough to act
+ * on afterwards -- and the list shows headless sessions too, so this has to
+ * look in both places or it would print ids nothing here could address.
+ */
+async function resolveSession(ctx: ClientContext, given: string): Promise<Addressed> {
+  const [terminals, headless] = await Promise.all([
+    ctx.rpc.call('terminal:listActive'),
+    ctx.rpc.call('headless:list')
+  ])
+  const candidates: Addressed[] = [
+    ...terminals.map((s) => ({ id: s.id, kind: 'terminal' as const })),
+    ...headless.map((s) => ({ id: s.id, kind: 'headless' as const }))
+  ]
+
+  const exact = candidates.find((c) => c.id === given)
+  if (exact) return exact
+
+  const matches = candidates.filter((c) => c.id.startsWith(given))
+  if (matches.length === 1) return matches[0]
+  if (matches.length === 0) throw new Error(`no session matches "${given}"`)
+  throw new Error(
+    `"${given}" matches ${matches.length} sessions: ${matches.map((c) => shortId(c.id)).join(', ')}`
+  )
+}
+
+/** A headless run has no terminal behind it, so two of the verbs cannot reach one. */
+function noTerminal(ctx: ClientContext, id: string, verb: string): number {
+  ctx.writeErr(
+    `vorn: ${shortId(id)} is a headless session, which has no terminal to ${verb}. ` +
+      `Its output streams to Vorn while it runs; kill it with: vorn session kill ${shortId(id)}\n`
+  )
+  return EXIT_FAILURE
+}
+
+async function startSession(ctx: ClientContext): Promise<number> {
+  const agent = ctx.args.agent
+  if (!agent) return usage(ctx, 'session start needs --agent')
+  if (!AGENTS.includes(agent as AiAgentType)) {
+    return usage(ctx, `unknown agent "${agent}". Try: ${AGENTS.join(', ')}`)
+  }
+  const agentType = agent as AiAgentType
+
+  try {
+    const { projectName, projectPath } = await resolveProject(ctx, agentType)
+    const payload: CreateTerminalPayload = {
+      agentType,
+      projectName,
+      projectPath,
+      ...(ctx.args.prompt ? { initialPrompt: ctx.args.prompt } : {}),
+      ...(ctx.args.branch ? { branch: ctx.args.branch } : {}),
+      ...(ctx.args.worktree ? { useWorktree: true } : {}),
+      ...(ctx.args.name ? { displayName: ctx.args.name } : {})
+    }
+
+    const session: TerminalSession | HeadlessSession = ctx.args.headless
+      ? await ctx.rpc.call('headless:create', payload)
+      : await ctx.rpc.call('terminal:create', payload)
+
+    if (ctx.args.json) {
+      ctx.write(asJson(session))
+      return EXIT_OK
+    }
+
+    const branch = 'branch' in session ? session.branch : undefined
+    ctx.write(
+      [
+        `session  ${session.id}`,
+        `agent    ${session.agentType}`,
+        `project  ${session.projectName}`,
+        `path     ${'worktreePath' in session && session.worktreePath ? session.worktreePath : session.projectPath}`,
+        ...(branch ? [`branch   ${branch}`] : []),
+        ''
+      ].join('\n')
+    )
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not start the session', err)
+  }
+}
+
+/** Headless sessions are sessions; a list that hid them would hide `--headless`. */
+async function listSessions(ctx: ClientContext): Promise<number> {
+  try {
+    if (ctx.args.recent) {
+      const recent = await ctx.rpc.call(
+        'sessions:getRecent',
+        ctx.args.path ? path.resolve(ctx.args.path) : undefined
+      )
+      if (ctx.args.json) {
+        ctx.write(asJson(recent))
+        return EXIT_OK
+      }
+      if (recent.length === 0) {
+        ctx.writeErr('No recent sessions.\n')
+        return EXIT_OK
+      }
+      ctx.write(
+        table(
+          ['ID', 'AGENT', 'PROJECT', 'WHEN', 'ACTIVITY'],
+          recent.map((s) => [
+            shortId(s.sessionId),
+            s.agentType,
+            path.basename(s.projectPath),
+            timeAgo(s.timestamp),
+            s.activityLabel
+          ])
+        )
+      )
+      return EXIT_OK
+    }
+
+    const [terminals, headless] = await Promise.all([
+      ctx.rpc.call('terminal:listActive'),
+      ctx.rpc.call('headless:list')
+    ])
+    const running = headless.filter((s) => s.status === 'running')
+    const wanted = ctx.args.project
+    const sessions = [...terminals, ...running].filter((s) => !wanted || s.projectName === wanted)
+
+    if (ctx.args.json) {
+      ctx.write(asJson(sessions))
+      return EXIT_OK
+    }
+    if (sessions.length === 0) {
+      ctx.writeErr('No sessions running.\n')
+      return EXIT_OK
+    }
+
+    const statusColumn = 4
+    ctx.write(
+      table(
+        ['ID', 'AGENT', 'PROJECT', 'BRANCH', 'STATUS'],
+        sessions.map((s) => [shortId(s.id), s.agentType, s.projectName, s.branch ?? '-', s.status]),
+        (cell, column) => (column === statusColumn ? paintStatus(cell, ctx.plain) : cell)
+      )
+    )
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not list sessions', err)
+  }
+}
+
+async function readLogs(ctx: ClientContext, given: string | undefined): Promise<number> {
+  if (!given) return usage(ctx, 'session logs needs a session id')
+  try {
+    const target = await resolveSession(ctx, given)
+    if (target.kind === 'headless') return noTerminal(ctx, target.id, 'read')
+
+    const lines = await ctx.rpc.call('terminal:readOutput', {
+      id: target.id,
+      lines: ctx.args.lines
+    })
+    if (ctx.args.json) {
+      ctx.write(asJson(lines))
+      return EXIT_OK
+    }
+    // Empty is an answer, and silence reads as a broken command.
+    if (lines.length === 0) {
+      ctx.writeErr(`Nothing kept for ${shortId(target.id)} yet.\n`)
+      return EXIT_OK
+    }
+    ctx.write(`${lines.join('\n')}\n`)
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not read the session', err)
+  }
+}
+
+async function sendInput(
+  ctx: ClientContext,
+  given: string | undefined,
+  text: string | undefined
+): Promise<number> {
+  if (!given || text === undefined) return usage(ctx, 'session send needs a session id and text')
+  try {
+    const target = await resolveSession(ctx, given)
+    if (target.kind === 'headless') return noTerminal(ctx, target.id, 'send to')
+
+    // Enter is what submits a prompt; --raw is for sending control sequences instead.
+    const data = ctx.args.raw ? text : `${text.replace(/[\r\n]+$/, '')}\r`
+    await ctx.rpc.notify('terminal:write', { id: target.id, data })
+    ctx.writeErr(`Sent to ${shortId(target.id)}.\n`)
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not send to the session', err)
+  }
+}
+
+async function killSession(ctx: ClientContext, given: string | undefined): Promise<number> {
+  if (!given) return usage(ctx, 'session kill needs a session id')
+  try {
+    const target = await resolveSession(ctx, given)
+    // Two registries, two kill methods: a headless run is not a pty.
+    await ctx.rpc.call(target.kind === 'headless' ? 'headless:kill' : 'terminal:kill', target.id)
+    ctx.writeErr(`Killed ${shortId(target.id)}.\n`)
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not kill the session', err)
+  }
+}
+
+export async function runSessionCommand(ctx: ClientContext): Promise<number> {
+  const [, verb, ...rest] = ctx.args.positionals
+
+  if (ctx.args.help) {
+    ctx.write(SESSION_USAGE)
+    return EXIT_OK
+  }
+  if (!verb) {
+    ctx.writeErr(SESSION_USAGE)
+    return EXIT_USAGE
+  }
+  if (!['start', 'list', 'logs', 'send', 'kill'].includes(verb)) {
+    return usage(ctx, `unknown session command "${verb}"`)
+  }
+  if (!(await ctx.server())) return EXIT_UNREACHABLE
+
+  switch (verb) {
+    case 'start':
+      return startSession(ctx)
+    case 'list':
+      return listSessions(ctx)
+    case 'logs':
+      return readLogs(ctx, rest[0])
+    case 'send':
+      return sendInput(ctx, rest[0], rest.slice(1).join(' ') || undefined)
+    default:
+      return killSession(ctx, rest[0])
+  }
+}

--- a/packages/server/src/cli/session.ts
+++ b/packages/server/src/cli/session.ts
@@ -171,14 +171,27 @@ async function startSession(ctx: ClientContext): Promise<number> {
   }
 }
 
+/** Where a project by that name lives, so `--project` means the same thing everywhere. */
+async function pathForProject(ctx: ClientContext, name: string): Promise<string> {
+  const config = await ctx.rpc.call('config:load')
+  const project = (config.projects ?? []).find((p) => p.name === name)
+  if (!project) throw new Error(`no project named "${name}"`)
+  return project.path
+}
+
 /** Headless sessions are sessions; a list that hid them would hide `--headless`. */
 async function listSessions(ctx: ClientContext): Promise<number> {
   try {
     if (ctx.args.recent) {
-      const recent = await ctx.rpc.call(
-        'sessions:getRecent',
-        ctx.args.path ? path.resolve(ctx.args.path) : undefined
-      )
+      // Recent sessions are filtered by where they ran, so a project name has
+      // to become a path -- rather than being quietly dropped, as it was.
+      const within = ctx.args.project
+        ? await pathForProject(ctx, ctx.args.project)
+        : ctx.args.path
+          ? path.resolve(ctx.args.path)
+          : undefined
+
+      const recent = await ctx.rpc.call('sessions:getRecent', within)
       if (ctx.args.json) {
         ctx.write(asJson(recent))
         return EXIT_OK

--- a/packages/server/src/cli/transport.ts
+++ b/packages/server/src/cli/transport.ts
@@ -1,0 +1,30 @@
+import type { RequestMethods } from '@vornrun/shared/protocol'
+import { rpcCall, rpcNotify, isServerRunning } from '../rpc-client'
+
+/**
+ * How a client command reaches the server.
+ *
+ * An interface rather than the module itself, so a test drives every command
+ * without a socket, a port file or a credential — the same reason `runCli`
+ * takes its output sinks as arguments.
+ */
+export interface RpcTransport {
+  call<M extends keyof RequestMethods>(
+    method: M,
+    params?: RequestMethods[M]['params'],
+    timeoutMs?: number
+  ): Promise<RequestMethods[M]['result']>
+  notify(method: string, params?: unknown): Promise<void>
+  /** Whether a server is reachable right now, without opening a socket. */
+  isRunning(): boolean
+}
+
+export const socketTransport: RpcTransport = {
+  call(method, params, timeoutMs) {
+    return rpcCall(method, params, timeoutMs)
+  },
+  notify(method, params) {
+    return rpcNotify(method, params)
+  },
+  isRunning: isServerRunning
+}

--- a/packages/server/src/cli/workflow.ts
+++ b/packages/server/src/cli/workflow.ts
@@ -1,0 +1,133 @@
+import type { WorkflowDefinition } from '@vornrun/shared/types'
+import type { ClientContext } from './deps'
+import { EXIT_FAILURE, EXIT_OK, EXIT_UNREACHABLE, EXIT_USAGE } from './exit'
+import { asJson, paintStatus, shortId, table, timeAgo } from './output'
+
+export const WORKFLOW_USAGE = `Usage
+  vorn workflow list [--json]
+  vorn workflow runs [--workflow <name or id>] [--limit <n>] [--json]
+
+Running a workflow from here waits on the engine moving into the server; until
+then a run is started from the app.
+`
+
+function usage(ctx: ClientContext, message: string): number {
+  ctx.writeErr(`vorn: ${message}\n\n${WORKFLOW_USAGE}`)
+  return EXIT_USAGE
+}
+
+function failed(ctx: ClientContext, what: string, err: unknown): number {
+  ctx.writeErr(`vorn: ${what}: ${err instanceof Error ? err.message : String(err)}\n`)
+  return EXIT_FAILURE
+}
+
+/** What starts a workflow, read off its trigger node. */
+function triggerKind(workflow: WorkflowDefinition): string {
+  const trigger = workflow.nodes.find((node) => node.type === 'trigger')
+  if (!trigger) return 'none'
+  const kind = (trigger.config as { triggerType?: string }).triggerType
+  return kind ?? 'manual'
+}
+
+/** A workflow by id, or by name when that names exactly one. */
+function findWorkflow(workflows: WorkflowDefinition[], given: string): WorkflowDefinition {
+  const byId = workflows.find((w) => w.id === given || w.id.startsWith(given))
+  if (byId) return byId
+  const byName = workflows.filter((w) => w.name.toLowerCase() === given.toLowerCase())
+  if (byName.length === 1) return byName[0]
+  if (byName.length === 0) throw new Error(`no workflow matches "${given}"`)
+  throw new Error(`"${given}" matches ${byName.length} workflows; use an id`)
+}
+
+async function listWorkflows(ctx: ClientContext): Promise<number> {
+  try {
+    const workflows = await ctx.rpc.call('workflow:list')
+    if (ctx.args.json) {
+      ctx.write(asJson(workflows))
+      return EXIT_OK
+    }
+    if (workflows.length === 0) {
+      ctx.writeErr('No workflows.\n')
+      return EXIT_OK
+    }
+    // How it went and when are two columns, not one: colour belongs on the
+    // status word alone, and it cannot be picked out of "success 2h ago".
+    const statusColumn = 4
+    ctx.write(
+      table(
+        ['ID', 'NAME', 'TRIGGER', 'ENABLED', 'LAST RUN', 'WHEN'],
+        workflows.map((w) => [
+          shortId(w.id),
+          w.name,
+          triggerKind(w),
+          w.enabled ? 'yes' : 'no',
+          w.lastRunAt ? (w.lastRunStatus ?? 'ran') : '-',
+          w.lastRunAt ? timeAgo(w.lastRunAt) : '-'
+        ]),
+        (cell, column) => (column === statusColumn ? paintStatus(cell, ctx.plain) : cell)
+      )
+    )
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not list workflows', err)
+  }
+}
+
+async function listRuns(ctx: ClientContext): Promise<number> {
+  try {
+    const workflows = await ctx.rpc.call('workflow:list')
+    const names = new Map(workflows.map((w) => [w.id, w.name]))
+
+    const runs = ctx.args.workflow
+      ? await ctx.rpc.call('workflowRun:list', {
+          workflowId: findWorkflow(workflows, ctx.args.workflow).id,
+          limit: ctx.args.limit
+        })
+      : await ctx.rpc.call('workflowRun:listAll', { limit: ctx.args.limit })
+
+    if (ctx.args.json) {
+      ctx.write(asJson(runs))
+      return EXIT_OK
+    }
+    if (runs.length === 0) {
+      ctx.writeErr('No runs.\n')
+      return EXIT_OK
+    }
+
+    const statusColumn = 2
+    ctx.write(
+      table(
+        ['RUN', 'WORKFLOW', 'STATUS', 'STARTED'],
+        runs.map((run) => [
+          shortId(run.runId),
+          names.get(run.workflowId) ?? shortId(run.workflowId),
+          run.status,
+          timeAgo(run.startedAt)
+        ]),
+        (cell, column) => (column === statusColumn ? paintStatus(cell, ctx.plain) : cell)
+      )
+    )
+    return EXIT_OK
+  } catch (err) {
+    return failed(ctx, 'could not list runs', err)
+  }
+}
+
+export async function runWorkflowCommand(ctx: ClientContext): Promise<number> {
+  const [, verb] = ctx.args.positionals
+
+  if (ctx.args.help) {
+    ctx.write(WORKFLOW_USAGE)
+    return EXIT_OK
+  }
+  if (!verb) {
+    ctx.writeErr(WORKFLOW_USAGE)
+    return EXIT_USAGE
+  }
+  if (!['list', 'runs'].includes(verb)) {
+    return usage(ctx, `unknown workflow command "${verb}"`)
+  }
+  if (!(await ctx.server())) return EXIT_UNREACHABLE
+
+  return verb === 'list' ? listWorkflows(ctx) : listRuns(ctx)
+}

--- a/packages/server/src/cli/workflow.ts
+++ b/packages/server/src/cli/workflow.ts
@@ -29,10 +29,26 @@ function triggerKind(workflow: WorkflowDefinition): string {
   return kind ?? 'manual'
 }
 
-/** A workflow by id, or by name when that names exactly one. */
+/**
+ * A workflow by id, by a prefix of one, or by name -- and only when that names
+ * exactly one of them.
+ *
+ * A prefix that matches several is refused rather than resolved to the first:
+ * seeded and imported workflows carry ids like `import:foo`, so shared prefixes
+ * are ordinary here, and acting on the wrong workflow is not a small mistake.
+ */
 function findWorkflow(workflows: WorkflowDefinition[], given: string): WorkflowDefinition {
-  const byId = workflows.find((w) => w.id === given || w.id.startsWith(given))
-  if (byId) return byId
+  const exact = workflows.find((w) => w.id === given)
+  if (exact) return exact
+
+  const byPrefix = workflows.filter((w) => w.id.startsWith(given))
+  if (byPrefix.length === 1) return byPrefix[0]
+  if (byPrefix.length > 1) {
+    throw new Error(
+      `"${given}" matches ${byPrefix.length} workflows: ${byPrefix.map((w) => w.name).join(', ')}`
+    )
+  }
+
   const byName = workflows.filter((w) => w.name.toLowerCase() === given.toLowerCase())
   if (byName.length === 1) return byName[0]
   if (byName.length === 0) throw new Error(`no workflow matches "${given}"`)

--- a/packages/server/src/client-args.ts
+++ b/packages/server/src/client-args.ts
@@ -37,6 +37,33 @@ export interface ClientArgs {
 
 export class ClientArgsError extends Error {}
 
+/**
+ * The options this grammar accepts.
+ *
+ * Exported because the dispatcher has to know which of them take a value, to
+ * find the command in `vorn --data-dir /tmp session list` without mistaking the
+ * directory for it.
+ */
+export const CLIENT_OPTIONS = {
+  agent: { type: 'string' },
+  prompt: { type: 'string' },
+  project: { type: 'string' },
+  path: { type: 'string' },
+  name: { type: 'string' },
+  branch: { type: 'string' },
+  workflow: { type: 'string' },
+  'data-dir': { type: 'string' },
+  lines: { type: 'string' },
+  limit: { type: 'string' },
+  timeout: { type: 'string' },
+  headless: { type: 'boolean' },
+  worktree: { type: 'boolean' },
+  recent: { type: 'boolean' },
+  raw: { type: 'boolean' },
+  json: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' }
+} as const
+
 /** A count, a line budget, a millisecond ceiling: all of them positive integers. */
 function positiveInt(raw: string | undefined, flag: string): number | undefined {
   if (raw === undefined) return undefined
@@ -60,25 +87,7 @@ export function parseClientArgs(argv: string[]): ClientArgs {
   try {
     const parsed = parseArgs({
       args: argv,
-      options: {
-        agent: { type: 'string' },
-        prompt: { type: 'string' },
-        project: { type: 'string' },
-        path: { type: 'string' },
-        name: { type: 'string' },
-        branch: { type: 'string' },
-        workflow: { type: 'string' },
-        'data-dir': { type: 'string' },
-        lines: { type: 'string' },
-        limit: { type: 'string' },
-        timeout: { type: 'string' },
-        headless: { type: 'boolean' },
-        worktree: { type: 'boolean' },
-        recent: { type: 'boolean' },
-        raw: { type: 'boolean' },
-        json: { type: 'boolean' },
-        help: { type: 'boolean', short: 'h' }
-      },
+      options: CLIENT_OPTIONS,
       allowPositionals: true,
       strict: true
     })

--- a/packages/server/src/client-args.ts
+++ b/packages/server/src/client-args.ts
@@ -1,0 +1,116 @@
+import { parseArgs } from 'node:util'
+
+/**
+ * The grammar for the commands that talk to a running server.
+ *
+ * Kept apart from `server-args.ts` on purpose: that grammar is shared with the
+ * entry point Electron forks, so a flag only a person types has no business in
+ * it. Both are built on `node:util`'s `parseArgs`, which costs no dependency at
+ * the node22 target.
+ */
+export interface ClientArgs {
+  /** The noun, its verb, and their operands: `session`, `start`, an id. */
+  positionals: string[]
+  agent?: string
+  prompt?: string
+  /** Project name. Defaults to the basename of the resolved path. */
+  project?: string
+  /** Project directory. Defaults to the git root of the working directory. */
+  path?: string
+  /** Display name for a session. */
+  name?: string
+  branch?: string
+  /** Workflow id or name, for the commands that filter by one. */
+  workflow?: string
+  dataDir?: string
+  lines?: number
+  limit?: number
+  timeoutMs?: number
+  headless: boolean
+  worktree: boolean
+  recent: boolean
+  /** Send input exactly as given, without the Enter that submits it. */
+  raw: boolean
+  json: boolean
+  help: boolean
+}
+
+export class ClientArgsError extends Error {}
+
+/** A count, a line budget, a millisecond ceiling: all of them positive integers. */
+function positiveInt(raw: string | undefined, flag: string): number | undefined {
+  if (raw === undefined) return undefined
+  const value = Number.parseInt(raw, 10)
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new ClientArgsError(`${flag} must be a positive number, got "${raw}"`)
+  }
+  return value
+}
+
+/**
+ * Parse a client command line, accepting both `--lines=200` and `--lines 200`.
+ *
+ * Throws `ClientArgsError` rather than exiting, so the caller decides between
+ * printing usage and failing — the same contract `parseServerArgs` has.
+ */
+export function parseClientArgs(argv: string[]): ClientArgs {
+  let values: Record<string, string | boolean | undefined>
+  let positionals: string[]
+
+  try {
+    const parsed = parseArgs({
+      args: argv,
+      options: {
+        agent: { type: 'string' },
+        prompt: { type: 'string' },
+        project: { type: 'string' },
+        path: { type: 'string' },
+        name: { type: 'string' },
+        branch: { type: 'string' },
+        workflow: { type: 'string' },
+        'data-dir': { type: 'string' },
+        lines: { type: 'string' },
+        limit: { type: 'string' },
+        timeout: { type: 'string' },
+        headless: { type: 'boolean' },
+        worktree: { type: 'boolean' },
+        recent: { type: 'boolean' },
+        raw: { type: 'boolean' },
+        json: { type: 'boolean' },
+        help: { type: 'boolean', short: 'h' }
+      },
+      allowPositionals: true,
+      strict: true
+    })
+    values = parsed.values
+    positionals = parsed.positionals
+  } catch (err) {
+    throw new ClientArgsError(err instanceof Error ? err.message : String(err))
+  }
+
+  const str = (name: string): string | undefined => {
+    const value = values[name]
+    return typeof value === 'string' ? value : undefined
+  }
+
+  return {
+    positionals,
+    agent: str('agent'),
+    prompt: str('prompt'),
+    project: str('project'),
+    path: str('path'),
+    name: str('name'),
+    branch: str('branch'),
+    workflow: str('workflow'),
+    dataDir: str('data-dir'),
+    lines: positiveInt(str('lines'), '--lines'),
+    limit: positiveInt(str('limit'), '--limit'),
+    timeoutMs: positiveInt(str('timeout'), '--timeout'),
+    headless: values.headless === true,
+    worktree: values.worktree === true,
+    recent: values.recent === true,
+    raw: values.raw === true,
+    json: values.json === true,
+    help: values.help === true
+  }
+}

--- a/packages/server/src/client-args.ts
+++ b/packages/server/src/client-args.ts
@@ -93,6 +93,13 @@ export function parseClientArgs(argv: string[]): ClientArgs {
     return typeof value === 'string' ? value : undefined
   }
 
+  // An empty path is not a path. Left to run, `--data-dir=` would resolve to
+  // wherever the command was typed and look for a server nobody started there.
+  const dataDir = str('data-dir')
+  if (dataDir !== undefined && dataDir.trim() === '') {
+    throw new ClientArgsError('--data-dir needs a directory')
+  }
+
   return {
     positionals,
     agent: str('agent'),
@@ -102,7 +109,7 @@ export function parseClientArgs(argv: string[]): ClientArgs {
     name: str('name'),
     branch: str('branch'),
     workflow: str('workflow'),
-    dataDir: str('data-dir'),
+    dataDir,
     lines: positiveInt(str('lines'), '--lines'),
     limit: positiveInt(str('limit'), '--limit'),
     timeoutMs: positiveInt(str('timeout'), '--timeout'),

--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -59,6 +59,15 @@ export function isGitRepo(projectPath: string): boolean {
   }
 }
 
+/** The repository a path sits in, or null when it sits in none. */
+export function getRepoRoot(cwd: string): string | null {
+  try {
+    return gitExec(['rev-parse', '--show-toplevel'], cwd, { timeout: 3000 }) || null
+  } catch {
+    return null
+  }
+}
+
 export function getGitBranch(projectPath: string, remote?: RemoteHost): string | null {
   try {
     const branch = gitExec(['rev-parse', '--abbrev-ref', 'HEAD'], projectPath, {

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -50,7 +50,9 @@ function tokenFileMissingMessage(): string {
   return `Vorn local credential not found (${localTokenFile()}).
 The server writes it on startup and removes it on shutdown, so this usually means
 Vorn is not running. Start Vorn (or \`vorn server serve\`) and try again.
-If the server runs with --data-dir, pass the same --data-dir here.`
+If the server runs with --data-dir, pass the same --data-dir here, or set
+VORN_DATA_DIR to that directory -- which is how anything that is not the CLI,
+MCP included, reaches a server that moved.`
 }
 
 /**

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -22,14 +22,19 @@ import {
  */
 let dataDirOverride: string | undefined
 
-/** Point discovery at a server started with `--data-dir`, before any call. */
+/**
+ * Point discovery at a server started with `--data-dir`, before any call.
+ *
+ * An empty override is no override: it would otherwise resolve to the process's
+ * working directory and quietly look for a server that is not there.
+ */
 export function useDataDir(dir: string | undefined): void {
-  dataDirOverride = dir
+  dataDirOverride = dir?.trim() ? dir : undefined
 }
 
 /** Where the server this client talks to keeps its port and credential files. */
 export function dataDir(): string {
-  return dataDirOverride || process.env.VORN_DATA_DIR || path.join(os.homedir(), '.vorn')
+  return dataDirOverride ?? process.env.VORN_DATA_DIR ?? path.join(os.homedir(), '.vorn')
 }
 
 // Resolved per call rather than at import: `--data-dir` is parsed after this module loads.
@@ -329,12 +334,15 @@ export async function rpcCall<T = unknown>(
         const msg: RpcResponse = JSON.parse(raw.toString())
         if (msg.id !== id) return // ignore broadcasts / notifications
         clearTimeout(timer)
-        ws.close()
+        // Settled before the socket is closed, because closing it is what runs
+        // the close handler below -- which would otherwise reject the answer
+        // this line already has.
         if (msg.error) {
           reject(new Error(msg.error.message))
         } else {
           resolve(msg.result as T)
         }
+        ws.close()
       } catch {
         // ignore non-JSON messages
       }

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -3,24 +3,48 @@ import path from 'node:path'
 import os from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { WebSocket } from 'ws'
-import { LOCAL_TOKEN_FILENAME, type RpcResponse } from '@vornrun/shared/protocol'
+import {
+  LOCAL_TOKEN_FILENAME,
+  WS_PORT_FILENAME,
+  type RequestMethods,
+  type RpcResponse
+} from '@vornrun/shared/protocol'
 
 /**
  * Where the running server keeps its port and credential files.
  *
- * Both live in the server's data directory, which `vorn-server serve --data-dir`
+ * Both live in the server's data directory, which `vorn server serve --data-dir`
  * can move. Hard-coding `~/.vorn` meant that a server started anywhere else was
  * invisible here: not just unauthenticated, but undiscoverable, since the port file
  * moves with it. `VORN_DATA_DIR` is how that server tells us where it went.
  */
-const DATA_DIR = process.env.VORN_DATA_DIR || path.join(os.homedir(), '.vorn')
-const PORT_FILE = path.join(DATA_DIR, 'ws-port')
-const LOCAL_TOKEN_FILE = path.join(DATA_DIR, LOCAL_TOKEN_FILENAME)
+let dataDirOverride: string | undefined
 
-const TOKEN_FILE_MISSING_MSG = `Vorn local credential not found (${LOCAL_TOKEN_FILE}).
+/** Point discovery at a server started with `--data-dir`, before any call. */
+export function useDataDir(dir: string | undefined): void {
+  dataDirOverride = dir
+}
+
+/** Where the server this client talks to keeps its port and credential files. */
+export function dataDir(): string {
+  return dataDirOverride || process.env.VORN_DATA_DIR || path.join(os.homedir(), '.vorn')
+}
+
+// Resolved per call rather than at import: `--data-dir` is parsed after this module loads.
+function portFile(): string {
+  return path.join(dataDir(), WS_PORT_FILENAME)
+}
+
+function localTokenFile(): string {
+  return path.join(dataDir(), LOCAL_TOKEN_FILENAME)
+}
+
+function tokenFileMissingMessage(): string {
+  return `Vorn local credential not found (${localTokenFile()}).
 The server writes it on startup and removes it on shutdown, so this usually means
-Vorn is not running. Start Vorn (or \`vorn-server serve\`) and try again.
-If the server runs with --data-dir, set VORN_DATA_DIR to the same directory.`
+Vorn is not running. Start Vorn (or \`vorn server serve\`) and try again.
+If the server runs with --data-dir, pass the same --data-dir here.`
+}
 
 /**
  * The running server's local credential.
@@ -31,11 +55,11 @@ If the server runs with --data-dir, set VORN_DATA_DIR to the same directory.`
  */
 function readLocalToken(): string {
   try {
-    const token = fs.readFileSync(LOCAL_TOKEN_FILE, 'utf-8').trim()
+    const token = fs.readFileSync(localTokenFile(), 'utf-8').trim()
     if (!token) throw new Error('empty')
     return token
   } catch {
-    throw new Error(TOKEN_FILE_MISSING_MSG)
+    throw new Error(tokenFileMissingMessage())
   }
 }
 
@@ -149,8 +173,24 @@ function discoverPort(): number | null {
   return null
 }
 
+/**
+ * Whether looking for a Vorn process is a fair answer to "where is the server".
+ *
+ * Only when nobody named a data directory. `discoverPort` finds any Vorn
+ * listening on this machine, which is the right guess for the default directory
+ * and the wrong one for a named directory: it would report a server that is not
+ * the one asked for, and heal a port file with a port belonging to somebody
+ * else -- which is exactly what happened the first time `--data-dir` met an
+ * empty directory with the desktop app running.
+ */
+function discoveryAllowed(): boolean {
+  return dataDirOverride === undefined && !process.env.VORN_DATA_DIR
+}
+
 /** Try OS-level discovery, cache result, and heal the port file. */
 function discoverAndHeal(): { port: number } | { port: null; reason: 'missing' } {
+  if (!discoveryAllowed()) return { port: null, reason: 'missing' }
+
   const now = Date.now()
   if (cachedPort && now - cacheTimestamp < CACHE_TTL_MS) return { port: cachedPort }
 
@@ -159,8 +199,8 @@ function discoverAndHeal(): { port: number } | { port: null; reason: 'missing' }
   cacheTimestamp = now
   if (discovered) {
     try {
-      fs.mkdirSync(path.dirname(PORT_FILE), { recursive: true })
-      fs.writeFileSync(PORT_FILE, JSON.stringify({ port: discovered }), 'utf-8')
+      fs.mkdirSync(dataDir(), { recursive: true })
+      fs.writeFileSync(portFile(), JSON.stringify({ port: discovered }), 'utf-8')
     } catch {
       // best-effort
     }
@@ -175,7 +215,7 @@ function discoverAndHeal(): { port: number } | { port: null; reason: 'missing' }
  */
 function readPort(): { port: number } | { port: null; reason: 'missing' | 'invalid' } {
   try {
-    const raw = fs.readFileSync(PORT_FILE, 'utf-8').trim()
+    const raw = fs.readFileSync(portFile(), 'utf-8').trim()
     if (!raw) return { port: null, reason: 'invalid' }
 
     // JSON format: { "port": 53829, "pid": 1234 }
@@ -213,7 +253,19 @@ function readPort(): { port: number } | { port: null; reason: 'missing' | 'inval
  * Send a single JSON-RPC request to the running Vorn server over WebSocket.
  * Opens a connection, sends, waits for the response, then closes.
  */
-export async function rpcCall<T = unknown>(
+// Two shapes, one implementation. A method named in `RequestMethods` types its own
+// params and result; anything else falls to the loose form callers annotate by hand.
+export function rpcCall<M extends keyof RequestMethods>(
+  method: M,
+  params?: RequestMethods[M]['params'],
+  timeoutMs?: number
+): Promise<RequestMethods[M]['result']>
+export function rpcCall<T = unknown>(
+  method: string,
+  params?: unknown,
+  timeoutMs?: number
+): Promise<T>
+export function rpcCall<T = unknown>(
   method: string,
   params?: unknown,
   /**

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -79,7 +79,7 @@ function connection(): { url: string; options: { headers: Record<string, string>
     // Narrowed through the union rather than reaching for `.reason` directly,
     // which only exists on the failure arm.
     const reason = 'reason' in result ? result.reason : 'missing'
-    throw new Error(reason === 'invalid' ? PORT_FILE_INVALID_MSG : PORT_FILE_MISSING_MSG)
+    throw new Error(reason === 'invalid' ? portFileInvalidMessage() : portFileMissingMessage())
   }
   return {
     url: `ws://127.0.0.1:${result.port}/ws`,
@@ -90,24 +90,32 @@ const TIMEOUT_MS = 10_000
 
 const IS_WIN = process.platform === 'win32'
 
-const PORT_FILE_MISSING_MSG = IS_WIN
-  ? `Vorn port file not found (~/.vorn/ws-port).
+// Both name the file that was actually read: with --data-dir it is not the one
+// under ~/.vorn, and a fix-it line pointing at the wrong path is worse than none.
+function portFileMissingMessage(): string {
+  const file = portFile()
+  return IS_WIN
+    ? `Vorn port file not found (${file}).
 The app may be running but the port file was deleted (e.g. by another instance shutting down).
 To fix, find the Vorn process and its listening port:
   powershell -c "Get-NetTCPConnection -State Listen -OwningProcess (Get-Process Vorn).Id | Select LocalPort"
 Then write the WS port to the file:
-  echo {"port":<PORT>,"pid":<PID>} > %USERPROFILE%\\.vorn\\ws-port
+  echo {"port":<PORT>,"pid":<PID>} > ${file}
 Or restart Vorn to regenerate it.`
-  : `Vorn port file not found (~/.vorn/ws-port).
+    : `Vorn port file not found (${file}).
 The app may be running but the port file was deleted (e.g. by another instance shutting down).
 To fix, run:  lsof -iTCP -sTCP:LISTEN -P | grep Vorn
 Then write the WS port (the one on *:<port>) to the file:
-  echo '{"port":<PORT>,"pid":<PID>}' > ~/.vorn/ws-port
+  echo '{"port":<PORT>,"pid":<PID>}' > ${file}
 Or restart Vorn to regenerate it.`
+}
 
-const PORT_FILE_INVALID_MSG = `Vorn port file exists but contains invalid data (~/.vorn/ws-port).
+function portFileInvalidMessage(): string {
+  const file = portFile()
+  return `Vorn port file exists but contains invalid data (${file}).
 Delete it and restart Vorn, or overwrite it with the correct port:
-  ${IS_WIN ? 'del %USERPROFILE%\\.vorn\\ws-port' : 'rm ~/.vorn/ws-port'}`
+  ${IS_WIN ? `del ${file}` : `rm ${file}`}`
+}
 
 /**
  * A socket that closed before the call was answered.
@@ -286,7 +294,10 @@ export function rpcCall<T = unknown>(
   params?: unknown,
   timeoutMs?: number
 ): Promise<T>
-export function rpcCall<T = unknown>(
+// `async` on the implementation, so a failure before the socket opens -- no port
+// file, no credential -- arrives as a rejection like every other failure, rather
+// than as a synchronous throw past a caller's `.catch`.
+export async function rpcCall<T = unknown>(
   method: string,
   params?: unknown,
   /**

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -4,6 +4,8 @@ import os from 'node:os'
 import { execFileSync } from 'node:child_process'
 import { WebSocket } from 'ws'
 import {
+  CLOSE_CREDENTIAL_REJECTED,
+  CLOSE_UNAUTHENTICATED,
   LOCAL_TOKEN_FILENAME,
   WS_PORT_FILENAME,
   type RequestMethods,
@@ -106,6 +108,25 @@ Or restart Vorn to regenerate it.`
 const PORT_FILE_INVALID_MSG = `Vorn port file exists but contains invalid data (~/.vorn/ws-port).
 Delete it and restart Vorn, or overwrite it with the correct port:
   ${IS_WIN ? 'del %USERPROFILE%\\.vorn\\ws-port' : 'rm ~/.vorn/ws-port'}`
+
+/**
+ * A socket that closed before the call was answered.
+ *
+ * Worth its own message, because the honest reading of a refused credential is
+ * not "the server is slow". A second Vorn server on the same port -- a dev build
+ * bound to loopback while the app holds the wildcard address -- takes the
+ * connection and rejects a credential minted for the other one's data directory.
+ * Without this the call sat until the timeout and blamed the wrong thing.
+ */
+function closedBeforeAnswering(code: number): string {
+  if (code === CLOSE_UNAUTHENTICATED || code === CLOSE_CREDENTIAL_REJECTED) {
+    return `A Vorn server on this port refused the credential in ${localTokenFile()}.
+Another server is listening on it with its own data directory, which a dev build
+running beside the app does. Point at that one with --data-dir (or VORN_DATA_DIR),
+or stop it.`
+  }
+  return `The server closed the connection before answering (code ${code}).`
+}
 
 let rpcId = 0
 
@@ -304,6 +325,13 @@ export function rpcCall<T = unknown>(
       } catch {
         // ignore non-JSON messages
       }
+    })
+
+    // A close is an answer too. Settling here is safe on the happy path: the
+    // response resolves first and this fires on the close that follows it.
+    ws.on('close', (code: number) => {
+      clearTimeout(timer)
+      reject(new Error(closedBeforeAnswering(code)))
     })
 
     ws.on('error', (err) => {

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -23,18 +23,24 @@ import {
 let dataDirOverride: string | undefined
 
 /**
- * Point discovery at a server started with `--data-dir`, before any call.
+ * A blank value names no directory, wherever it came from.
  *
- * An empty override is no override: it would otherwise resolve to the process's
- * working directory and quietly look for a server that is not there.
+ * Both sources need this: an empty override or an empty `VORN_DATA_DIR` would
+ * otherwise resolve to the process's working directory, and the client would
+ * look for `ws-port` wherever the command happened to be typed.
  */
+function named(value: string | undefined): string | undefined {
+  return value?.trim() ? value : undefined
+}
+
+/** Point discovery at a server started with `--data-dir`, before any call. */
 export function useDataDir(dir: string | undefined): void {
-  dataDirOverride = dir?.trim() ? dir : undefined
+  dataDirOverride = named(dir)
 }
 
 /** Where the server this client talks to keeps its port and credential files. */
 export function dataDir(): string {
-  return dataDirOverride ?? process.env.VORN_DATA_DIR ?? path.join(os.homedir(), '.vorn')
+  return dataDirOverride ?? named(process.env.VORN_DATA_DIR) ?? path.join(os.homedir(), '.vorn')
 }
 
 // Resolved per call rather than at import: `--data-dir` is parsed after this module loads.
@@ -222,7 +228,7 @@ function discoverPort(): number | null {
  * empty directory with the desktop app running.
  */
 function discoveryAllowed(): boolean {
-  return dataDirOverride === undefined && !process.env.VORN_DATA_DIR
+  return dataDirOverride === undefined && named(process.env.VORN_DATA_DIR) === undefined
 }
 
 /** Try OS-level discovery, cache result, and heal the port file. */

--- a/packages/server/src/rpc-client.ts
+++ b/packages/server/src/rpc-client.ts
@@ -94,19 +94,21 @@ const IS_WIN = process.platform === 'win32'
 // under ~/.vorn, and a fix-it line pointing at the wrong path is worse than none.
 function portFileMissingMessage(): string {
   const file = portFile()
+  // Quoted paths and, on Windows, PowerShell -- the line above it already sends
+  // you there, and `echo {...} > file` is not a thing PowerShell will do for you.
   return IS_WIN
     ? `Vorn port file not found (${file}).
 The app may be running but the port file was deleted (e.g. by another instance shutting down).
-To fix, find the Vorn process and its listening port:
-  powershell -c "Get-NetTCPConnection -State Listen -OwningProcess (Get-Process Vorn).Id | Select LocalPort"
+To fix, in PowerShell, find the Vorn process and its listening port:
+  Get-NetTCPConnection -State Listen -OwningProcess (Get-Process Vorn).Id | Select LocalPort
 Then write the WS port to the file:
-  echo {"port":<PORT>,"pid":<PID>} > ${file}
+  '{"port":<PORT>,"pid":<PID>}' | Set-Content -Path "${file}"
 Or restart Vorn to regenerate it.`
     : `Vorn port file not found (${file}).
 The app may be running but the port file was deleted (e.g. by another instance shutting down).
 To fix, run:  lsof -iTCP -sTCP:LISTEN -P | grep Vorn
 Then write the WS port (the one on *:<port>) to the file:
-  echo '{"port":<PORT>,"pid":<PID>}' > ${file}
+  echo '{"port":<PORT>,"pid":<PID>}' > "${file}"
 Or restart Vorn to regenerate it.`
 }
 
@@ -114,7 +116,7 @@ function portFileInvalidMessage(): string {
   const file = portFile()
   return `Vorn port file exists but contains invalid data (${file}).
 Delete it and restart Vorn, or overwrite it with the correct port:
-  ${IS_WIN ? `del ${file}` : `rm ${file}`}`
+  ${IS_WIN ? `Remove-Item "${file}"` : `rm "${file}"`}`
 }
 
 /**

--- a/packages/server/src/server-args.ts
+++ b/packages/server/src/server-args.ts
@@ -25,6 +25,15 @@ export interface ServerArgs {
 
 export class ServerArgsError extends Error {}
 
+/** The options this grammar accepts, exported for the reason `CLIENT_OPTIONS` is. */
+export const SERVER_OPTIONS = {
+  host: { type: 'string' },
+  port: { type: 'string' },
+  'data-dir': { type: 'string' },
+  name: { type: 'string' },
+  help: { type: 'boolean', short: 'h' }
+} as const
+
 /**
  * Parse server arguments, accepting both `--port=3000` and `--port 3000`.
  *
@@ -44,13 +53,7 @@ export function parseServerArgs(argv: string[]): ServerArgs {
   try {
     const parsed = parseArgs({
       args: argv,
-      options: {
-        host: { type: 'string' },
-        port: { type: 'string' },
-        'data-dir': { type: 'string' },
-        name: { type: 'string' },
-        help: { type: 'boolean', short: 'h' }
-      },
+      options: SERVER_OPTIONS,
       allowPositionals: true,
       // Unknown options are reported by us, with the option name in the message,
       // rather than surfacing parseArgs' internal phrasing.

--- a/packages/server/src/ws-auth.ts
+++ b/packages/server/src/ws-auth.ts
@@ -14,7 +14,7 @@ import log from './logger'
  * upgrade, and they let a page on any origin open a socket to `localhost`. So
  * binding 127.0.0.1 is no protection at all: before this module, any website the
  * user visited could open `ws://127.0.0.1:<port>/ws` and send `terminal:create`.
- * The ephemeral port is obscurity, not a control — `packages/mcp/src/ws-client.ts`
+ * The ephemeral port is obscurity, not a control — `packages/server/src/rpc-client.ts`
  * finds it with `lsof` when the port file is missing.
  *
  * Two independent controls, because each covers what the other cannot:

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from 'node:fs'
 import { defineConfig } from 'tsup'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // Prepended to both entries. `cli.cjs` is the `vorn-server` binary, and Yarn
 // links a bin as a plain symlink — without this the shell runs it as sh and it
@@ -41,15 +44,19 @@ const NATIVE_MODULE_PATCH = `
 
 export default defineConfig({
   // Two entries: `index` is what Electron's utilityProcess spawns, `cli` is the
-  // standalone `vorn-server` binary. They are bundled independently rather than
-  // code-split, because each runs as its own process and a shared chunk would
-  // only add a require() hop.
+  // `vorn` binary the installers put on PATH. They are bundled independently
+  // rather than code-split, because each runs as its own process and a shared
+  // chunk would only add a require() hop.
   entry: ['src/index.ts', 'src/cli.ts'],
   format: ['cjs'],
   target: 'node22',
   clean: true,
   banner: {
     js: `${SHEBANG}\n${NATIVE_MODULE_PATCH}`
+  },
+  // What `vorn --version` answers. The bundle has no package.json to read.
+  define: {
+    __CLI_VERSION__: JSON.stringify(version)
   },
   // Bundle ALL JS dependencies so the server runs standalone in Electron's
   // utilityProcess (which cannot access modules inside the asar archive).

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -3,9 +3,10 @@ import { defineConfig } from 'tsup'
 
 const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
-// Prepended to both entries. `cli.cjs` is the `vorn-server` binary, and Yarn
-// links a bin as a plain symlink — without this the shell runs it as sh and it
-// dies with a syntax error partway through the bundle. It has to live in the
+// Prepended to both entries. `cli.cjs` is what both bins point at -- `vorn` and
+// the `vorn-server` alias -- and Yarn links a bin as a plain symlink: without
+// this the shell runs it as sh and it dies partway through the bundle with a
+// syntax error. It has to live in the
 // banner rather than at the top of `src/cli.ts`, because the banner is emitted
 // first and a shebang is only honoured on line 1. Node ignores it in
 // `index.cjs`, which is required rather than executed.

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1815,6 +1815,8 @@ export const IPC = {
   FILE_READ_CONTENT: 'file:readContent',
   FILE_STAMP: 'file:stamp',
   FILE_WRITE_CONTENT: 'file:writeContent',
+  CLI_STATUS: 'cli:status',
+  CLI_INSTALL: 'cli:install',
   SHELL_LIST_EXECUTABLES: 'shell:listExecutables',
   SHELL_LIST_INSTALLED: 'shell:listInstalled',
   CONNECTOR_LIST: 'connector:list',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -706,6 +706,11 @@ export function createApiShim(wsUrl: string) {
     writeFileContent: (filePath: string, content: string, remoteHostId?: string) =>
       rpc.invoke('file:writeContent', { filePath, content, remoteHostId }),
 
+    // ── The vorn command ──
+    // A browser has no PATH to put it on, and says so rather than pretending.
+    cliCommandStatus: () => Promise.resolve({ available: false, installed: false, path: '' }),
+    installCliCommand: unsupportedInWeb('Installing the command line tool'),
+
     // ── Shells ──
     listShellExecutables: () => rpc.invoke('shell:listExecutables'),
     listInstalledShells: () => rpc.invoke('shell:listInstalled'),

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -708,7 +708,8 @@ export function createApiShim(wsUrl: string) {
 
     // ── The vorn command ──
     // A browser has no PATH to put it on, and says so rather than pretending.
-    cliCommandStatus: () => Promise.resolve({ available: false, installed: false, path: '' }),
+    cliCommandStatus: () =>
+      Promise.resolve({ available: false, installed: false, path: '', onPath: false }),
     installCliCommand: unsupportedInWeb('Installing the command line tool'),
 
     // ── Shells ──

--- a/src/main/cli-shim.ts
+++ b/src/main/cli-shim.ts
@@ -79,6 +79,10 @@ export interface ShimPaths {
  */
 export function shimScript(paths: ShimPaths, platform: NodeJS.Platform = process.platform): string {
   if (platform === 'win32') {
+    // `path.win32`, not `path` -- this script may be written from a machine that
+    // is not Windows, and a batch file with forward slashes in it is a bug.
+    const inResources = (...parts: string[]): string => path.win32.join(paths.resources, ...parts)
+
     return [
       '@echo off',
       'setlocal',
@@ -87,9 +91,9 @@ export function shimScript(paths: ShimPaths, platform: NodeJS.Platform = process
       '  exit /b',
       ')',
       'set "ELECTRON_RUN_AS_NODE=1"',
-      `set "VORN_NATIVE_MODULES_PATH=${path.join(paths.resources, 'app.asar.unpacked', 'node_modules')}"`,
-      `set "NODE_PATH=${path.join(paths.resources, 'app.asar', 'node_modules')};%VORN_NATIVE_MODULES_PATH%"`,
-      `"${paths.exe}" "${path.join(paths.resources, 'server', 'cli.cjs')}" %*`,
+      `set "VORN_NATIVE_MODULES_PATH=${inResources('app.asar.unpacked', 'node_modules')}"`,
+      `set "NODE_PATH=${inResources('app.asar', 'node_modules')};%VORN_NATIVE_MODULES_PATH%"`,
+      `"${paths.exe}" "${inResources('server', 'cli.cjs')}" %*`,
       ''
     ].join('\r\n')
   }

--- a/src/main/cli-shim.ts
+++ b/src/main/cli-shim.ts
@@ -13,18 +13,36 @@ import log from './logger'
  * that is actually running, so it points at wherever this copy lives.
  */
 
-/** Where the command can go: a directory already on PATH, or the per-user one. */
+function isWritable(dir: string): boolean {
+  try {
+    fs.accessSync(dir, fs.constants.W_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Whether a shell would find a command in this directory. */
+export function onPath(dir: string): boolean {
+  return (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .some((entry) => entry !== '' && path.resolve(entry) === path.resolve(dir))
+}
+
+/**
+ * Where the command can go.
+ *
+ * A writable directory the shell already searches, first -- a command installed
+ * anywhere else is a file, not a command. `~/.local/bin` is the fallback even
+ * when it is neither: it is the one place this process may always create, and
+ * the caller says so rather than claiming the command is ready to run.
+ */
 export function shimDirectory(): string {
   if (process.platform === 'win32') return path.dirname(app.getPath('exe'))
-  for (const dir of ['/usr/local/bin', path.join(os.homedir(), '.local', 'bin')]) {
-    try {
-      fs.accessSync(dir, fs.constants.W_OK)
-      return dir
-    } catch {
-      // Not writable, or not there. The per-user directory is created below.
-    }
-  }
-  return path.join(os.homedir(), '.local', 'bin')
+
+  const userBin = path.join(os.homedir(), '.local', 'bin')
+  const candidates = ['/usr/local/bin', userBin].filter(isWritable)
+  return candidates.find(onPath) ?? candidates[0] ?? userBin
 }
 
 export function shimPath(): string {
@@ -109,11 +127,18 @@ export interface ShimStatus {
   available: boolean
   installed: boolean
   path: string
+  /** Whether a shell would find it there, which decides what the UI can promise. */
+  onPath: boolean
 }
 
 export function cliShimStatus(): ShimStatus {
   const target = shimPath()
-  return { available: app.isPackaged, installed: fs.existsSync(target), path: target }
+  return {
+    available: app.isPackaged,
+    installed: fs.existsSync(target),
+    path: target,
+    onPath: onPath(path.dirname(target))
+  }
 }
 
 export function installCliShim(): { ok: true; path: string } | { ok: false; error: string } {

--- a/src/main/cli-shim.ts
+++ b/src/main/cli-shim.ts
@@ -1,0 +1,142 @@
+import { app } from 'electron'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import log from './logger'
+
+/**
+ * The `vorn` command, installed by the app rather than by `install.sh`.
+ *
+ * Somebody who dragged Vorn out of the DMG, or installed the cask, never ran
+ * that script — and the command it writes is the only way the CLI reaches PATH.
+ * The shim written here is the same one, generated from the paths of the app
+ * that is actually running, so it points at wherever this copy lives.
+ */
+
+/** Where the command can go: a directory already on PATH, or the per-user one. */
+export function shimDirectory(): string {
+  if (process.platform === 'win32') return path.dirname(app.getPath('exe'))
+  for (const dir of ['/usr/local/bin', path.join(os.homedir(), '.local', 'bin')]) {
+    try {
+      fs.accessSync(dir, fs.constants.W_OK)
+      return dir
+    } catch {
+      // Not writable, or not there. The per-user directory is created below.
+    }
+  }
+  return path.join(os.homedir(), '.local', 'bin')
+}
+
+export function shimPath(): string {
+  return path.join(shimDirectory(), process.platform === 'win32' ? 'vorn.cmd' : 'vorn')
+}
+
+export interface ShimPaths {
+  /** The app binary, which doubles as this bundle's Node. */
+  exe: string
+  /** Where `server/cli.cjs` and the unpacked native modules sit. */
+  resources: string
+  /** The AppImage this app was started from, when it was. */
+  appImage?: string
+}
+
+/**
+ * The script itself.
+ *
+ * Pure, and told which platform it is writing for, so a test can read all three
+ * shapes rather than only the one it happens to run on. An AppImage cannot be
+ * referenced from outside its own mount, which is why that shape resolves its
+ * entry point from `APPDIR` on the inside.
+ */
+export function shimScript(paths: ShimPaths, platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'win32') {
+    return [
+      '@echo off',
+      'setlocal',
+      'if "%~1"=="" (',
+      `  start "" "${paths.exe}"`,
+      '  exit /b',
+      ')',
+      'set "ELECTRON_RUN_AS_NODE=1"',
+      `set "VORN_NATIVE_MODULES_PATH=${path.join(paths.resources, 'app.asar.unpacked', 'node_modules')}"`,
+      `set "NODE_PATH=${path.join(paths.resources, 'app.asar', 'node_modules')};%VORN_NATIVE_MODULES_PATH%"`,
+      `"${paths.exe}" "${path.join(paths.resources, 'server', 'cli.cjs')}" %*`,
+      ''
+    ].join('\r\n')
+  }
+
+  if (paths.appImage) {
+    return `#!/bin/sh
+APPIMAGE="${paths.appImage}"
+
+if [ "$#" -eq 0 ]; then
+  exec "$APPIMAGE"
+fi
+
+BOOTSTRAP='var entry = process.env.APPDIR + "/resources/server/cli.cjs"; process.argv.splice(1, 0, entry); require(entry)'
+
+ELECTRON_RUN_AS_NODE=1 exec "$APPIMAGE" -e "$BOOTSTRAP" "$@"
+`
+  }
+
+  // On macOS the app is opened by its bundle, not by the binary inside it, so
+  // it arrives as a normal launch rather than a child of this shell.
+  const launch =
+    platform === 'darwin'
+      ? `exec open -a "${paths.exe.replace(/\/Contents\/MacOS\/.*$/, '')}"`
+      : `exec "${paths.exe}"`
+
+  return `#!/bin/sh
+APP_EXE="${paths.exe}"
+RESOURCES="${paths.resources}"
+
+# No command: open the app, which is what typing \`vorn\` should mean.
+if [ "$#" -eq 0 ]; then
+  ${launch}
+fi
+
+ELECTRON_RUN_AS_NODE=1
+VORN_NATIVE_MODULES_PATH="\${RESOURCES}/app.asar.unpacked/node_modules"
+NODE_PATH="\${RESOURCES}/app.asar/node_modules:\${VORN_NATIVE_MODULES_PATH}"
+export ELECTRON_RUN_AS_NODE VORN_NATIVE_MODULES_PATH NODE_PATH
+
+exec "$APP_EXE" "\${RESOURCES}/server/cli.cjs" "$@"
+`
+}
+
+export interface ShimStatus {
+  /** False while running from source: the paths would point into a dev tree. */
+  available: boolean
+  installed: boolean
+  path: string
+}
+
+export function cliShimStatus(): ShimStatus {
+  const target = shimPath()
+  return { available: app.isPackaged, installed: fs.existsSync(target), path: target }
+}
+
+export function installCliShim(): { ok: true; path: string } | { ok: false; error: string } {
+  if (!app.isPackaged) {
+    return { ok: false, error: 'Only a packaged Vorn can install the command.' }
+  }
+
+  const target = shimPath()
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(
+      target,
+      shimScript({
+        exe: app.getPath('exe'),
+        resources: process.resourcesPath,
+        appImage: process.env.APPIMAGE
+      }),
+      'utf-8'
+    )
+    if (process.platform !== 'win32') fs.chmodSync(target, 0o755)
+    return { ok: true, path: target }
+  } catch (err) {
+    log.warn({ err, target }, '[cli] could not install the vorn command')
+    return { ok: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}

--- a/src/main/cli-shim.ts
+++ b/src/main/cli-shim.ts
@@ -22,11 +22,22 @@ function isWritable(dir: string): boolean {
   }
 }
 
-/** Whether a shell would find a command in this directory. */
-export function onPath(dir: string): boolean {
+/**
+ * Whether a shell would find a command in this directory.
+ *
+ * Case-folded on Windows, where `%PATH%` names the same directory in whatever
+ * case it was written in and a literal comparison would call it absent.
+ */
+export function onPath(dir: string, platform: NodeJS.Platform = process.platform): boolean {
+  // The platform's own rules, taken explicitly: separator, delimiter and case.
+  const rules = platform === 'win32' ? path.win32 : path.posix
+  const fold = (value: string): string =>
+    platform === 'win32' ? rules.resolve(value).toLowerCase() : rules.resolve(value)
+
+  const wanted = fold(dir)
   return (process.env.PATH ?? '')
-    .split(path.delimiter)
-    .some((entry) => entry !== '' && path.resolve(entry) === path.resolve(dir))
+    .split(rules.delimiter)
+    .some((entry) => entry !== '' && fold(entry) === wanted)
 }
 
 /**
@@ -42,7 +53,7 @@ export function shimDirectory(): string {
 
   const userBin = path.join(os.homedir(), '.local', 'bin')
   const candidates = ['/usr/local/bin', userBin].filter(isWritable)
-  return candidates.find(onPath) ?? candidates[0] ?? userBin
+  return candidates.find((dir) => onPath(dir)) ?? candidates[0] ?? userBin
 }
 
 export function shimPath(): string {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -6,6 +6,7 @@ import { IPC, ResizePayload, browserPartition } from '../shared/types'
 import type { ServerBridge } from './server/server-bridge'
 import type { RequestMethods } from '@vornrun/shared/protocol'
 import * as browserRegistry from './browser-registry'
+import { cliShimStatus, installCliShim } from './cli-shim'
 import { setFileRoot, allowsFileUrl } from './browser-file-scope'
 import { watchArtifact, stopWatching } from './artifact-watcher'
 import * as deviceRegistry from './device-registry'
@@ -286,6 +287,10 @@ export function registerIpcHandlers(): void {
 
   // File explorer
   safeHandle(IPC.FILE_LIST_DIR, (_, dirPath) => requireBridge().request(IPC.FILE_LIST_DIR, dirPath))
+  // The `vorn` command, for people who never ran the installer script.
+  safeHandle(IPC.CLI_STATUS, () => cliShimStatus())
+  safeHandle(IPC.CLI_INSTALL, () => installCliShim())
+
   safeHandle(IPC.SHELL_LIST_EXECUTABLES, () => requireBridge().request(IPC.SHELL_LIST_EXECUTABLES))
   safeHandle(IPC.SHELL_LIST_INSTALLED, () => requireBridge().request(IPC.SHELL_LIST_INSTALLED))
   safeHandle(IPC.FILE_READ_CONTENT, (_, params) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -329,6 +329,12 @@ const api = {
   listShellExecutables: (): Promise<string[]> => ipcRenderer.invoke(IPC.SHELL_LIST_EXECUTABLES),
   listInstalledShells: (): Promise<InstalledShell[]> =>
     ipcRenderer.invoke(IPC.SHELL_LIST_INSTALLED),
+
+  /** Whether the `vorn` command is on PATH, and where it would go. */
+  cliCommandStatus: (): Promise<{ available: boolean; installed: boolean; path: string }> =>
+    ipcRenderer.invoke(IPC.CLI_STATUS),
+  installCliCommand: (): Promise<{ ok: true; path: string } | { ok: false; error: string }> =>
+    ipcRenderer.invoke(IPC.CLI_INSTALL),
   readFileContent: (
     filePath: string,
     maxBytes?: number,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -331,8 +331,12 @@ const api = {
     ipcRenderer.invoke(IPC.SHELL_LIST_INSTALLED),
 
   /** Whether the `vorn` command is on PATH, and where it would go. */
-  cliCommandStatus: (): Promise<{ available: boolean; installed: boolean; path: string }> =>
-    ipcRenderer.invoke(IPC.CLI_STATUS),
+  cliCommandStatus: (): Promise<{
+    available: boolean
+    installed: boolean
+    path: string
+    onPath: boolean
+  }> => ipcRenderer.invoke(IPC.CLI_STATUS),
   installCliCommand: (): Promise<{ ok: true; path: string } | { ok: false; error: string }> =>
     ipcRenderer.invoke(IPC.CLI_INSTALL),
   readFileContent: (

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -55,8 +55,10 @@ function CliCommandRow() {
     window.api
       .installCliCommand()
       .then((result) => {
-        if (result.ok) setState({ ...state, installed: true, path: result.path })
-        else setError(result.error)
+        // Functional form: the status can change between the click and this.
+        if (result.ok) {
+          setState((prev) => (prev ? { ...prev, installed: true, path: result.path } : prev))
+        } else setError(result.error)
       })
       .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setBusy(false))

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -55,10 +55,15 @@ function CliCommandRow() {
     window.api
       .installCliCommand()
       .then((result) => {
-        // Functional form: the status can change between the click and this.
-        if (result.ok) {
-          setState((prev) => (prev ? { ...prev, installed: true, path: result.path } : prev))
-        } else setError(result.error)
+        if (!result.ok) {
+          setError(result.error)
+          return undefined
+        }
+        // Asked again rather than patched: where it went decides whether the
+        // shell will find it, and only the main process knows both.
+        return window.api.cliCommandStatus?.().then((next) => {
+          if (next) setState(next)
+        })
       })
       .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setBusy(false))

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useAppStore } from '../../stores'
 import { ShellPicker } from './ShellPicker'
 import { AGENT_LIST } from '../../lib/agent-definitions'
@@ -9,6 +10,72 @@ import { SettingsPageHeader } from './SettingsPageHeader'
 import { SettingRow } from './SettingRow'
 import { ToggleSwitch } from './ToggleSwitch'
 import { DEFAULT_STEP_TIMEOUT_MINUTES } from '../../lib/workflow-execution'
+
+interface CliCommandState {
+  available: boolean
+  installed: boolean
+  path: string
+}
+
+/**
+ * The `vorn` command, and whether this copy of Vorn has put it on PATH.
+ *
+ * Asked of the main process rather than remembered in the config: the file can
+ * be removed, and an install that happened on another machine sharing this
+ * configuration says nothing about this one.
+ */
+function CliCommandRow() {
+  const [state, setState] = useState<CliCommandState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.cliCommandStatus?.().then((next) => {
+      if (!cancelled) setState(next)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (!state) return null
+
+  const install = (): void => {
+    setBusy(true)
+    setError(null)
+    window.api
+      .installCliCommand()
+      .then((result) => {
+        if (result.ok) setState({ ...state, installed: true, path: result.path })
+        else setError(result.error)
+      })
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <SettingRow
+      label="Command Line Tool"
+      description={
+        state.installed
+          ? `Installed. Run \`vorn --help\` in a terminal.`
+          : 'Put the vorn command on your PATH, for starting sessions and reading them from a terminal.'
+      }
+      note={error ?? state.path}
+      disabled={!state.available}
+    >
+      <button
+        onClick={install}
+        disabled={busy || !state.available}
+        className="text-xs px-2 py-1 rounded bg-white/[0.04] hover:bg-white/[0.08]
+                   text-gray-400 hover:text-gray-200 transition-colors shrink-0
+                   disabled:opacity-40"
+      >
+        {state.installed ? 'Reinstall' : 'Install'}
+      </button>
+    </SettingRow>
+  )
+}
 
 export function GeneralSettings() {
   const config = useAppStore((s) => s.config)
@@ -171,6 +238,8 @@ export function GeneralSettings() {
             onChange={(enableHoverPreview) => updateDefaults({ enableHoverPreview })}
           />
         </SettingRow>
+
+        {isElectron && <CliCommandRow />}
 
         {/* Floating Widget — Electron only */}
         {isElectron && (

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -15,6 +15,7 @@ interface CliCommandState {
   available: boolean
   installed: boolean
   path: string
+  onPath: boolean
 }
 
 /**
@@ -31,9 +32,16 @@ function CliCommandRow() {
 
   useEffect(() => {
     let cancelled = false
-    void window.api.cliCommandStatus?.().then((next) => {
-      if (!cancelled) setState(next)
-    })
+    // Optional chaining short-circuits the whole chain, so a build without the
+    // method never reaches `then`; the catch is for an IPC call that rejects.
+    void window.api
+      .cliCommandStatus?.()
+      .then((next) => {
+        if (!cancelled) setState(next)
+      })
+      .catch(() => {
+        if (!cancelled) setState(null)
+      })
     return () => {
       cancelled = true
     }
@@ -50,8 +58,13 @@ function CliCommandRow() {
         if (result.ok) setState({ ...state, installed: true, path: result.path })
         else setError(result.error)
       })
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
       .finally(() => setBusy(false))
   }
+
+  // Installed somewhere the shell does not look is a file, not a command.
+  const note =
+    error ?? (state.onPath ? state.path : `${state.path} — add its directory to your PATH`)
 
   return (
     <SettingRow
@@ -61,7 +74,7 @@ function CliCommandRow() {
           ? `Installed. Run \`vorn --help\` in a terminal.`
           : 'Put the vorn command on your PATH, for starting sessions and reading them from a terminal.'
       }
-      note={error ?? state.path}
+      note={note}
       disabled={!state.available}
     >
       <button

--- a/tests/cli-autostart.test.ts
+++ b/tests/cli-autostart.test.ts
@@ -52,8 +52,10 @@ describe('starting a server when there is none', () => {
     const err = sink()
     await ensureServer(transportUpAfter(1), err.write, '/tmp/elsewhere')
 
-    const [, args] = spawn.mock.calls[0] as unknown as [string, string[]]
+    const [, args, options] = spawn.mock.calls[0] as unknown as [string, string[], { cwd: string }]
     expect(args.slice(-2)).toEqual(['--data-dir', '/tmp/elsewhere'])
+    // The log and the working directory follow the flag, not what discovery found.
+    expect(options.cwd).toBe('/tmp/elsewhere')
   })
 
   it('gives up on a deadline rather than hanging, and says where to look', async () => {

--- a/tests/cli-autostart.test.ts
+++ b/tests/cli-autostart.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const spawn = vi.hoisted(() => vi.fn(() => ({ unref: vi.fn() })))
+vi.mock('node:child_process', () => ({ spawn }))
+vi.mock('node:fs', () => ({
+  default: { mkdirSync: vi.fn(), openSync: vi.fn(() => 7), closeSync: vi.fn() }
+}))
+
+import { ensureServer } from '../packages/server/src/cli/autostart'
+import type { RpcTransport } from '../packages/server/src/cli/transport'
+
+/** A transport that is down until the nth question, then up. */
+function transportUpAfter(answers: number): RpcTransport {
+  let asked = 0
+  return { isRunning: () => ++asked > answers } as unknown as RpcTransport
+}
+
+const sink = (): { write: (t: string) => void; text: () => string } => {
+  const parts: string[] = []
+  return { write: (t) => parts.push(t), text: () => parts.join('') }
+}
+
+beforeEach(() => spawn.mockClear())
+afterEach(() => vi.useRealTimers())
+
+describe('starting a server when there is none', () => {
+  it('spawns nothing when one is already listening', async () => {
+    const err = sink()
+    const rpc = { isRunning: () => true } as unknown as RpcTransport
+
+    expect(await ensureServer(rpc, err.write)).toBe(true)
+    expect(spawn).not.toHaveBeenCalled()
+    expect(err.text()).toBe('')
+  })
+
+  it('starts one detached, says so on stderr, and waits for it', async () => {
+    const err = sink()
+
+    expect(await ensureServer(transportUpAfter(2), err.write)).toBe(true)
+    expect(err.text()).toContain('starting one')
+
+    const [, args, options] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      { detached: boolean }
+    ]
+    expect(args.slice(-2)).toEqual(['server', 'serve'])
+    expect(options.detached).toBe(true)
+  })
+
+  it('passes a data directory on, so both halves agree where the server is', async () => {
+    const err = sink()
+    await ensureServer(transportUpAfter(1), err.write, '/tmp/elsewhere')
+
+    const [, args] = spawn.mock.calls[0] as unknown as [string, string[]]
+    expect(args.slice(-2)).toEqual(['--data-dir', '/tmp/elsewhere'])
+  })
+
+  it('gives up on a deadline rather than hanging, and says where to look', async () => {
+    vi.useFakeTimers()
+    const err = sink()
+    const rpc = { isRunning: () => false } as unknown as RpcTransport
+
+    const result = ensureServer(rpc, err.write)
+    await vi.advanceTimersByTimeAsync(21_000)
+
+    expect(await result).toBe(false)
+    expect(err.text()).toContain('server.log')
+  })
+})

--- a/tests/cli-session.test.ts
+++ b/tests/cli-session.test.ts
@@ -153,6 +153,31 @@ describe('session list', () => {
     expect(io.out()).toContain('12 turns')
   })
 
+  it('turns a project name into the directory recent sessions are filtered by', async () => {
+    const { transport, calls } = fakeRpc({
+      'config:load': () => ({
+        projects: [{ name: 'website', path: '/repo/website', preferredAgents: [] }]
+      }),
+      'sessions:getRecent': () => []
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list', '--recent', '--project', 'website'], io)).toBe(0)
+    expect(calls.at(-1)).toEqual({
+      method: 'sessions:getRecent',
+      params: '/repo/website',
+      timeoutMs: undefined
+    })
+  })
+
+  it('says which project it does not know rather than listing everything', async () => {
+    const { transport } = fakeRpc({ 'config:load': () => ({ projects: [] }) })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list', '--recent', '--project', 'nope'], io)).toBe(1)
+    expect(io.err()).toContain('no project named "nope"')
+  })
+
   it('says so when nothing recent is kept either', async () => {
     const { transport } = fakeRpc({ 'sessions:getRecent': () => [] })
     const io = capture(transport)

--- a/tests/cli-session.test.ts
+++ b/tests/cli-session.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { HeadlessSession, TerminalSession } from '../packages/shared/src/types'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+// `serve` is the only command that needs one, and no test here runs it.
+vi.mock('../packages/server/src/index', () => ({ startServer: vi.fn() }))
+
+import { runCli, type CliDeps } from '../packages/server/src/cli'
+import type { RpcTransport } from '../packages/server/src/cli/transport'
+
+type Handlers = Record<string, (params: unknown) => unknown>
+
+/**
+ * A server that answers from a script.
+ *
+ * Every command is driven through this rather than a socket, which is why the
+ * transport is injected in the first place.
+ */
+function fakeRpc(handlers: Handlers): {
+  transport: RpcTransport
+  calls: { method: string; params: unknown; timeoutMs?: number }[]
+} {
+  const calls: { method: string; params: unknown; timeoutMs?: number }[] = []
+  const transport = {
+    async call(method: string, params: unknown, timeoutMs?: number) {
+      calls.push({ method, params, timeoutMs })
+      const handler = handlers[method]
+      if (!handler) throw new Error(`unexpected call ${method}`)
+      return handler(params)
+    },
+    async notify(method: string, params: unknown) {
+      calls.push({ method, params })
+    },
+    isRunning: () => true
+  } as unknown as RpcTransport
+  return { transport, calls }
+}
+
+function capture(rpc: RpcTransport, isTty = false) {
+  const out: string[] = []
+  const err: string[] = []
+  const deps: CliDeps & { out: () => string; err: () => string } = {
+    write: (t) => out.push(t),
+    writeErr: (t) => err.push(t),
+    rpc,
+    ensureServer: async () => true,
+    isTty,
+    out: () => out.join(''),
+    err: () => err.join('')
+  }
+  return deps
+}
+
+const terminal = (over: Partial<TerminalSession> = {}): TerminalSession =>
+  ({
+    id: 'c3f1a2e8-1111-2222-3333-444455556666',
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/repo/vorn',
+    status: 'running',
+    createdAt: Date.now(),
+    pid: 1234,
+    branch: 'main',
+    ...over
+  }) as TerminalSession
+
+const headless = (over: Partial<HeadlessSession> = {}): HeadlessSession =>
+  ({
+    id: '9b4d0117-aaaa-bbbb-cccc-ddddeeeeffff',
+    pid: 4321,
+    agentType: 'codex',
+    projectName: 'vorn',
+    projectPath: '/repo/vorn',
+    status: 'running',
+    startedAt: Date.now(),
+    ...over
+  }) as HeadlessSession
+
+describe('session dispatch', () => {
+  it('treats a bare noun as a usage error, on stderr', async () => {
+    const io = capture(fakeRpc({}).transport)
+    expect(await runCli(['session'], io)).toBe(2)
+    expect(io.err()).toContain('vorn session start')
+    expect(io.out()).toBe('')
+  })
+
+  it('reports an unknown verb', async () => {
+    const io = capture(fakeRpc({}).transport)
+    expect(await runCli(['session', 'dance'], io)).toBe(2)
+    expect(io.err()).toContain('unknown session command "dance"')
+  })
+
+  it('gives up with its own code when no server could be reached', async () => {
+    const io = capture(fakeRpc({}).transport)
+    io.ensureServer = async () => false
+    expect(await runCli(['session', 'list'], io)).toBe(4)
+  })
+})
+
+describe('session list', () => {
+  it('shows running sessions of both kinds, short ids, no colour when piped', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [terminal()],
+      'headless:list': () => [headless(), headless({ id: 'gone', status: 'exited' })]
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list'], io)).toBe(0)
+    const out = io.out()
+    expect(out).toContain('ID        AGENT')
+    expect(out).toContain('c3f1a2e8')
+    expect(out).toContain('9b4d0117')
+    expect(out).not.toContain('gone')
+    expect(out).not.toContain(String.fromCharCode(27))
+  })
+
+  it('prints what the server said when asked for json', async () => {
+    const sessions = [terminal()]
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => sessions,
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list', '--json'], io)).toBe(0)
+    expect(JSON.parse(io.out())).toEqual(sessions)
+  })
+
+  it('lists past sessions with --recent, from the server that keeps them', async () => {
+    const { transport, calls } = fakeRpc({
+      'sessions:getRecent': () => [
+        {
+          sessionId: 'aa11bb22-cccc-dddd-eeee-ffff00001111',
+          agentType: 'claude',
+          display: 'fix the failing test',
+          projectPath: '/repo/vorn',
+          timestamp: Date.now() - 3_600_000,
+          activityCount: 12,
+          activityLabel: '12 turns',
+          canResumeExact: true
+        }
+      ]
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list', '--recent'], io)).toBe(0)
+    expect(calls.at(-1)?.method).toBe('sessions:getRecent')
+    expect(io.out()).toContain('aa11bb22')
+    expect(io.out()).toContain('vorn')
+    expect(io.out()).toContain('1h ago')
+    expect(io.out()).toContain('12 turns')
+  })
+
+  it('says so when nothing recent is kept either', async () => {
+    const { transport } = fakeRpc({ 'sessions:getRecent': () => [] })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list', '--recent'], io)).toBe(0)
+    expect(io.out()).toBe('')
+    expect(io.err()).toContain('No recent sessions.')
+  })
+
+  it('filters by project', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [terminal(), terminal({ id: 'other', projectName: 'website' })],
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    await runCli(['session', 'list', '--project', 'website'], io)
+    expect(io.out()).toContain('website')
+    expect(io.out()).not.toContain('c3f1a2e8')
+  })
+
+  it('gives every call the ceiling --timeout named', async () => {
+    const { transport, calls } = fakeRpc({
+      'terminal:listActive': () => [],
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    await runCli(['session', 'list', '--timeout', '500'], io)
+    expect(calls.every((c) => c.timeoutMs === 500)).toBe(true)
+  })
+
+  it('says nothing on stdout when there is nothing running', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [],
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'list'], io)).toBe(0)
+    expect(io.out()).toBe('')
+    expect(io.err()).toContain('No sessions running.')
+  })
+})
+
+describe('session start', () => {
+  it('registers a project Vorn has not seen, then launches in it', async () => {
+    const saved: unknown[] = []
+    const { transport, calls } = fakeRpc({
+      'config:load': () => ({ projects: [] }),
+      'config:save': (params) => {
+        saved.push(params)
+      },
+      'terminal:create': () => terminal()
+    })
+    const io = capture(transport)
+
+    const code = await runCli(
+      ['session', 'start', '--agent', 'claude', '--path', '/repo/vorn', '--prompt', 'xsts'],
+      io
+    )
+
+    expect(code).toBe(0)
+    expect(saved).toEqual([
+      { projects: [{ name: 'vorn', path: '/repo/vorn', preferredAgents: ['claude'] }] }
+    ])
+    expect(calls.at(-1)).toEqual({
+      method: 'terminal:create',
+      params: {
+        agentType: 'claude',
+        projectName: 'vorn',
+        projectPath: '/repo/vorn',
+        initialPrompt: 'xsts'
+      }
+    })
+    expect(io.out()).toContain('session  c3f1a2e8-1111-2222-3333-444455556666')
+  })
+
+  it('uses the project a known path already belongs to, and saves nothing', async () => {
+    const { transport, calls } = fakeRpc({
+      'config:load': () => ({
+        projects: [{ name: 'Vorn', path: '/repo/vorn', preferredAgents: ['claude'] }]
+      }),
+      'terminal:create': () => terminal()
+    })
+    const io = capture(transport)
+
+    await runCli(['session', 'start', '--agent', 'codex', '--path', '/repo/vorn'], io)
+    expect(calls.some((c) => c.method === 'config:save')).toBe(false)
+    expect(calls.at(-1)?.params).toMatchObject({ projectName: 'Vorn', agentType: 'codex' })
+  })
+
+  it('finds a project by name, from anywhere', async () => {
+    const { transport, calls } = fakeRpc({
+      'config:load': () => ({
+        projects: [{ name: 'website', path: '/repo/website', preferredAgents: [] }]
+      }),
+      'terminal:create': () => terminal()
+    })
+    const io = capture(transport)
+
+    await runCli(['session', 'start', '--agent', 'claude', '--project', 'website'], io)
+    expect(calls.at(-1)?.params).toMatchObject({
+      projectName: 'website',
+      projectPath: '/repo/website'
+    })
+    expect(calls.some((c) => c.method === 'config:save')).toBe(false)
+  })
+
+  it('sends a headless launch to the other method', async () => {
+    const { transport, calls } = fakeRpc({
+      'config:load': () => ({
+        projects: [{ name: 'vorn', path: '/repo/vorn', preferredAgents: [] }]
+      }),
+      'headless:create': () => headless()
+    })
+    const io = capture(transport)
+
+    await runCli(
+      ['session', 'start', '--agent', 'claude', '--path', '/repo/vorn', '--headless'],
+      io
+    )
+    expect(calls.at(-1)?.method).toBe('headless:create')
+  })
+
+  it('needs an agent, and refuses one it does not have', async () => {
+    const io = capture(fakeRpc({}).transport)
+    expect(await runCli(['session', 'start'], io)).toBe(2)
+    expect(io.err()).toContain('needs --agent')
+
+    const io2 = capture(fakeRpc({}).transport)
+    expect(await runCli(['session', 'start', '--agent', 'hal'], io2)).toBe(2)
+    expect(io2.err()).toContain('unknown agent "hal"')
+  })
+})
+
+describe('addressing a session', () => {
+  it('accepts the eight characters a list prints', async () => {
+    const { transport, calls } = fakeRpc({
+      'terminal:listActive': () => [terminal()],
+      'headless:list': () => [],
+      'terminal:readOutput': () => ['first line', 'second line']
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'logs', 'c3f1a2e8'], io)).toBe(0)
+    expect(calls.at(-1)?.params).toEqual({
+      id: 'c3f1a2e8-1111-2222-3333-444455556666',
+      lines: undefined
+    })
+    expect(io.out()).toBe('first line\nsecond line\n')
+  })
+
+  it('says so on stderr when a session has kept nothing, leaving stdout empty', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [terminal()],
+      'headless:list': () => [],
+      'terminal:readOutput': () => []
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'logs', 'c3f1a2e8'], io)).toBe(0)
+    expect(io.out()).toBe('')
+    expect(io.err()).toContain('Nothing kept for c3f1a2e8')
+  })
+
+  it('refuses a prefix that names more than one', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [terminal({ id: 'aa-1' })],
+      'headless:list': () => [headless({ id: 'aa-2' })]
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'kill', 'aa'], io)).toBe(1)
+    expect(io.err()).toContain('matches 2 sessions')
+  })
+
+  it('addresses a headless session too, and kills it as one', async () => {
+    const { transport, calls } = fakeRpc({
+      'terminal:listActive': () => [],
+      'headless:list': () => [headless()],
+      'headless:kill': () => undefined
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'kill', '9b4d0117'], io)).toBe(0)
+    expect(calls.at(-1)).toEqual({
+      method: 'headless:kill',
+      params: '9b4d0117-aaaa-bbbb-cccc-ddddeeeeffff',
+      timeoutMs: undefined
+    })
+  })
+
+  it('explains that a headless session has no terminal to read or steer', async () => {
+    const handlers = { 'terminal:listActive': () => [], 'headless:list': () => [headless()] }
+
+    const io = capture(fakeRpc(handlers).transport)
+    expect(await runCli(['session', 'logs', '9b4d0117'], io)).toBe(1)
+    expect(io.err()).toContain('headless session')
+    expect(io.err()).toContain('vorn session kill 9b4d0117')
+
+    const io2 = capture(fakeRpc(handlers).transport)
+    expect(await runCli(['session', 'send', '9b4d0117', 'hi'], io2)).toBe(1)
+    expect(io2.err()).toContain('no terminal to send to')
+  })
+
+  it('says which id it could not find', async () => {
+    const { transport } = fakeRpc({ 'terminal:listActive': () => [], 'headless:list': () => [] })
+    const io = capture(transport)
+
+    expect(await runCli(['session', 'logs', 'nope'], io)).toBe(1)
+    expect(io.err()).toContain('no session matches "nope"')
+  })
+})
+
+describe('session send', () => {
+  it('submits the text, and leaves it alone with --raw', async () => {
+    const { transport, calls } = fakeRpc({
+      'terminal:listActive': () => [terminal()],
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    await runCli(['session', 'send', 'c3f1a2e8', 'run the tests'], io)
+    expect(calls.at(-1)?.params).toEqual({
+      id: 'c3f1a2e8-1111-2222-3333-444455556666',
+      data: 'run the tests\r'
+    })
+
+    const io2 = capture(transport)
+    await runCli(['session', 'send', 'c3f1a2e8', 'q', '--raw'], io2)
+    expect(calls.at(-1)?.params).toMatchObject({ data: 'q' })
+  })
+
+  it('confirms on stderr, so stdout stays empty', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [terminal()],
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    await runCli(['session', 'send', 'c3f1a2e8', 'hello'], io)
+    expect(io.out()).toBe('')
+    expect(io.err()).toContain('Sent to c3f1a2e8')
+  })
+})

--- a/tests/cli-session.test.ts
+++ b/tests/cli-session.test.ts
@@ -86,6 +86,17 @@ describe('session dispatch', () => {
     expect(io.out()).toBe('')
   })
 
+  it('takes options written before the noun', async () => {
+    const { transport } = fakeRpc({
+      'terminal:listActive': () => [terminal()],
+      'headless:list': () => []
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['--json', 'session', 'list'], io)).toBe(0)
+    expect(JSON.parse(io.out())).toHaveLength(1)
+  })
+
   it('reports an unknown verb', async () => {
     const io = capture(fakeRpc({}).transport)
     expect(await runCli(['session', 'dance'], io)).toBe(2)

--- a/tests/cli-shim.test.ts
+++ b/tests/cli-shim.test.ts
@@ -22,7 +22,7 @@ vi.mock('../src/main/logger', () => ({ default: { warn: () => {}, error: () => {
 
 import os from 'node:os'
 import path from 'node:path'
-import { shimDirectory, shimScript } from '../src/main/cli-shim'
+import { onPath, shimDirectory, shimScript } from '../src/main/cli-shim'
 
 const MAC = {
   exe: '/Applications/Vorn.app/Contents/MacOS/Vorn',
@@ -98,6 +98,13 @@ describe('where the command goes', () => {
     process.env.PATH = '/usr/bin'
 
     expect(shimDirectory()).toBe('/usr/local/bin')
+  })
+
+  it('reads a Windows PATH entry whatever case it was written in', () => {
+    process.env.PATH = 'C:\\Users\\J\\AppData\\Local\\Programs\\Vorn'
+
+    expect(onPath('C:\\users\\j\\appdata\\local\\programs\\vorn', 'win32')).toBe(true)
+    expect(onPath('C:\\users\\j\\appdata\\local\\programs\\vorn', 'linux')).toBe(false)
   })
 
   it('falls back to the one directory it may always create', () => {

--- a/tests/cli-shim.test.ts
+++ b/tests/cli-shim.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/Applications/Vorn.app/Contents/MacOS/Vorn' }
+}))
+vi.mock('../src/main/logger', () => ({ default: { warn: () => {}, error: () => {} } }))
+
+import { shimScript } from '../src/main/cli-shim'
+
+const MAC = {
+  exe: '/Applications/Vorn.app/Contents/MacOS/Vorn',
+  resources: '/Applications/Vorn.app/Contents/Resources'
+}
+
+describe('the vorn command the app writes', () => {
+  it('runs the CLI inside the app on macOS, and opens the app when given nothing', () => {
+    const script = shimScript(MAC, 'darwin')
+
+    expect(script.startsWith('#!/bin/sh')).toBe(true)
+    expect(script).toContain('exec open -a "/Applications/Vorn.app"')
+    expect(script).toContain('ELECTRON_RUN_AS_NODE=1')
+    expect(script).toContain('RESOURCES="/Applications/Vorn.app/Contents/Resources"')
+    expect(script).toContain('${RESOURCES}/server/cli.cjs')
+    expect(script).toContain('app.asar.unpacked/node_modules')
+  })
+
+  it('names the AppImage rather than the mount it is unpacked into', () => {
+    const script = shimScript(
+      {
+        exe: '/tmp/.mount_Vorn12/vorn',
+        resources: '/tmp/.mount_Vorn12/resources',
+        appImage: '/home/j/.local/lib/vorn/Vorn.AppImage'
+      },
+      'linux'
+    )
+
+    expect(script).toContain('/home/j/.local/lib/vorn/Vorn.AppImage')
+    expect(script).not.toContain('.mount_Vorn12')
+    // The entry point is only knowable from inside, so it is resolved there.
+    expect(script).toContain('process.env.APPDIR')
+  })
+
+  it('writes a batch file on Windows, starting the app when given nothing', () => {
+    const script = shimScript(
+      {
+        exe: 'C:\\Users\\j\\AppData\\Local\\Programs\\Vorn\\Vorn.exe',
+        resources: 'C:\\Users\\j\\AppData\\Local\\Programs\\Vorn\\resources'
+      },
+      'win32'
+    )
+
+    expect(script.startsWith('@echo off')).toBe(true)
+    expect(script).toContain('if "%~1"=="" (')
+    expect(script).toContain('set "ELECTRON_RUN_AS_NODE=1"')
+    expect(script).toContain('%*')
+  })
+})

--- a/tests/cli-shim.test.ts
+++ b/tests/cli-shim.test.ts
@@ -70,6 +70,10 @@ describe('the vorn command the app writes', () => {
     expect(script).toContain('if "%~1"=="" (')
     expect(script).toContain('set "ELECTRON_RUN_AS_NODE=1"')
     expect(script).toContain('%*')
+    // Written from a Mac in this test, and still a Windows path.
+    expect(script).toContain('\\resources\\server\\cli.cjs')
+    expect(script).not.toContain('/resources/')
+    expect(script.split('\n').every((line) => line === '' || line.endsWith('\r'))).toBe(true)
   })
 })
 

--- a/tests/cli-shim.test.ts
+++ b/tests/cli-shim.test.ts
@@ -1,11 +1,28 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/Applications/Vorn.app/Contents/MacOS/Vorn' }
 }))
+
+// Which directories exist and are writable is the machine's business, not the test's.
+const writable = vi.hoisted(() => new Set<string>())
+vi.mock('node:fs', () => ({
+  default: {
+    accessSync: (dir: string) => {
+      if (!writable.has(dir)) throw new Error('not writable')
+    },
+    constants: { W_OK: 2 },
+    existsSync: () => false,
+    mkdirSync: () => undefined,
+    writeFileSync: () => undefined,
+    chmodSync: () => undefined
+  }
+}))
 vi.mock('../src/main/logger', () => ({ default: { warn: () => {}, error: () => {} } }))
 
-import { shimScript } from '../src/main/cli-shim'
+import os from 'node:os'
+import path from 'node:path'
+import { shimDirectory, shimScript } from '../src/main/cli-shim'
 
 const MAC = {
   exe: '/Applications/Vorn.app/Contents/MacOS/Vorn',
@@ -53,5 +70,39 @@ describe('the vorn command the app writes', () => {
     expect(script).toContain('if "%~1"=="" (')
     expect(script).toContain('set "ELECTRON_RUN_AS_NODE=1"')
     expect(script).toContain('%*')
+  })
+})
+
+describe('where the command goes', () => {
+  const userBin = path.join(os.homedir(), '.local', 'bin')
+  const originalPath = process.env.PATH
+
+  beforeEach(() => {
+    writable.clear()
+  })
+
+  afterEach(() => {
+    process.env.PATH = originalPath
+  })
+
+  it('prefers a writable directory the shell already searches', () => {
+    writable.add('/usr/local/bin')
+    writable.add(userBin)
+    process.env.PATH = `${userBin}:/usr/bin`
+
+    expect(shimDirectory()).toBe(userBin)
+  })
+
+  it('takes a writable directory over none when the shell searches neither', () => {
+    writable.add('/usr/local/bin')
+    process.env.PATH = '/usr/bin'
+
+    expect(shimDirectory()).toBe('/usr/local/bin')
+  })
+
+  it('falls back to the one directory it may always create', () => {
+    process.env.PATH = '/usr/bin'
+
+    expect(shimDirectory()).toBe(userBin)
   })
 })

--- a/tests/cli-transport.test.ts
+++ b/tests/cli-transport.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const rpcCall = vi.hoisted(() => vi.fn(async () => 'called'))
+const rpcNotify = vi.hoisted(() => vi.fn(async () => undefined))
+const isServerRunning = vi.hoisted(() => vi.fn(() => true))
+vi.mock('../packages/server/src/rpc-client', () => ({
+  rpcCall,
+  rpcNotify,
+  isServerRunning,
+  useDataDir: vi.fn(),
+  dataDir: () => '/tmp/vorn'
+}))
+
+import { socketTransport } from '../packages/server/src/cli/transport'
+import { clientContext } from '../packages/server/src/cli/deps'
+import { parseClientArgs } from '../packages/server/src/client-args'
+
+beforeEach(() => {
+  rpcCall.mockClear()
+  rpcNotify.mockClear()
+  isServerRunning.mockClear()
+})
+
+const sink = { write: () => {}, writeErr: () => {} }
+
+describe('the socket transport', () => {
+  it('is what a command reaches the server through by default', async () => {
+    const ctx = clientContext(sink, parseClientArgs(['session', 'list']))
+
+    await ctx.rpc.call('terminal:listActive')
+    await ctx.rpc.notify('terminal:write', { id: 'a', data: 'b' })
+    ctx.rpc.isRunning()
+
+    expect(rpcCall).toHaveBeenCalledWith('terminal:listActive', undefined, undefined)
+    expect(rpcNotify).toHaveBeenCalledWith('terminal:write', { id: 'a', data: 'b' })
+    expect(isServerRunning).toHaveBeenCalled()
+  })
+
+  it('carries --timeout into every call without touching the rest', async () => {
+    const ctx = clientContext(sink, parseClientArgs(['session', 'list', '--timeout', '250']))
+
+    await ctx.rpc.call('terminal:listActive')
+    await ctx.rpc.notify('terminal:write', { id: 'a', data: 'b' })
+    expect(ctx.rpc.isRunning()).toBe(true)
+
+    expect(rpcCall).toHaveBeenCalledWith('terminal:listActive', undefined, 250)
+    expect(rpcNotify).toHaveBeenCalledWith('terminal:write', { id: 'a', data: 'b' })
+  })
+
+  it('passes calls straight through when no ceiling was named', async () => {
+    await socketTransport.call('workflow:list')
+    expect(rpcCall).toHaveBeenCalledWith('workflow:list', undefined, undefined)
+  })
+})

--- a/tests/cli-workflow.test.ts
+++ b/tests/cli-workflow.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { WorkflowDefinition, WorkflowExecution } from '../packages/shared/src/types'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('../packages/server/src/index', () => ({ startServer: vi.fn() }))
+
+import { runCli, type CliDeps } from '../packages/server/src/cli'
+import type { RpcTransport } from '../packages/server/src/cli/transport'
+
+type Handlers = Record<string, (params: unknown) => unknown>
+
+function fakeRpc(handlers: Handlers): {
+  transport: RpcTransport
+  calls: { method: string; params: unknown }[]
+} {
+  const calls: { method: string; params: unknown }[] = []
+  const transport = {
+    async call(method: string, params: unknown) {
+      calls.push({ method, params })
+      const handler = handlers[method]
+      if (!handler) throw new Error(`unexpected call ${method}`)
+      return handler(params)
+    },
+    async notify(method: string, params: unknown) {
+      calls.push({ method, params })
+    },
+    isRunning: () => true
+  } as unknown as RpcTransport
+  return { transport, calls }
+}
+
+function capture(rpc: RpcTransport, isTty = false) {
+  const out: string[] = []
+  const err: string[] = []
+  const deps: CliDeps & { out: () => string; err: () => string } = {
+    write: (t) => out.push(t),
+    writeErr: (t) => err.push(t),
+    rpc,
+    ensureServer: async () => true,
+    isTty,
+    out: () => out.join(''),
+    err: () => err.join('')
+  }
+  return deps
+}
+
+const workflow = (over: Partial<WorkflowDefinition> = {}): WorkflowDefinition =>
+  ({
+    id: '7c2e11a0-1111-2222-3333-444455556666',
+    name: 'Nightly review',
+    icon: 'Zap',
+    iconColor: '#6366f1',
+    enabled: true,
+    nodes: [{ id: 'n1', type: 'trigger', label: 'Trigger', config: { triggerType: 'recurring' } }],
+    edges: [],
+    ...over
+  }) as WorkflowDefinition
+
+const run = (over: Partial<WorkflowExecution> = {}): WorkflowExecution =>
+  ({
+    runId: 'r8813f01-aaaa-bbbb-cccc-ddddeeeeffff',
+    workflowId: '7c2e11a0-1111-2222-3333-444455556666',
+    startedAt: new Date().toISOString(),
+    status: 'success',
+    nodeStates: [],
+    ...over
+  }) as WorkflowExecution
+
+describe('workflow list', () => {
+  it('names what starts each one and whether it is on', async () => {
+    const { transport } = fakeRpc({ 'workflow:list': () => [workflow()] })
+    const io = capture(transport)
+
+    expect(await runCli(['workflow', 'list'], io)).toBe(0)
+    expect(io.out()).toContain('Nightly review')
+    expect(io.out()).toContain('recurring')
+    expect(io.out()).toContain('yes')
+  })
+
+  it('calls a workflow with no trigger node what it is', async () => {
+    const { transport } = fakeRpc({ 'workflow:list': () => [workflow({ nodes: [] })] })
+    const io = capture(transport)
+
+    await runCli(['workflow', 'list'], io)
+    expect(io.out()).toContain('none')
+  })
+
+  it('colours the status word for a terminal, and only that word', async () => {
+    delete process.env.NO_COLOR
+    const { transport } = fakeRpc({
+      'workflow:list': () => [
+        workflow({ lastRunAt: new Date().toISOString(), lastRunStatus: 'success' })
+      ]
+    })
+    const io = capture(transport, true)
+
+    await runCli(['workflow', 'list'], io)
+    const escape = String.fromCharCode(27)
+    expect(io.out()).toContain(`${escape}[32msuccess`)
+    expect(io.out()).toContain('just now')
+  })
+
+  it('hands the definitions through untouched as json', async () => {
+    const workflows = [workflow()]
+    const { transport } = fakeRpc({ 'workflow:list': () => workflows })
+    const io = capture(transport)
+
+    await runCli(['workflow', 'list', '--json'], io)
+    expect(JSON.parse(io.out())).toEqual(workflows)
+  })
+})
+
+describe('workflow runs', () => {
+  it('reads every workflow when none is named', async () => {
+    const { transport, calls } = fakeRpc({
+      'workflow:list': () => [workflow()],
+      'workflowRun:listAll': () => [run()]
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['workflow', 'runs', '--limit', '5'], io)).toBe(0)
+    expect(calls.at(-1)).toEqual({ method: 'workflowRun:listAll', params: { limit: 5 } })
+    expect(io.out()).toContain('Nightly review')
+  })
+
+  it('takes a workflow by name and asks for that one', async () => {
+    const { transport, calls } = fakeRpc({
+      'workflow:list': () => [workflow()],
+      'workflowRun:list': () => [run()]
+    })
+    const io = capture(transport)
+
+    await runCli(['workflow', 'runs', '--workflow', 'nightly review'], io)
+    expect(calls.at(-1)).toEqual({
+      method: 'workflowRun:list',
+      params: { workflowId: '7c2e11a0-1111-2222-3333-444455556666', limit: undefined }
+    })
+  })
+
+  it('says so when the name matches nothing', async () => {
+    const { transport } = fakeRpc({ 'workflow:list': () => [workflow()] })
+    const io = capture(transport)
+
+    expect(await runCli(['workflow', 'runs', '--workflow', 'weekly'], io)).toBe(1)
+    expect(io.err()).toContain('no workflow matches "weekly"')
+  })
+})
+
+describe('workflow dispatch', () => {
+  it('treats a bare noun as a usage error, on stderr', async () => {
+    const io = capture(fakeRpc({}).transport)
+    expect(await runCli(['workflow'], io)).toBe(2)
+    expect(io.out()).toBe('')
+    expect(io.err()).toContain('vorn workflow list')
+  })
+
+  it('says running one is not here yet rather than pretending', async () => {
+    const io = capture(fakeRpc({}).transport)
+    expect(await runCli(['workflow', 'run', 'Nightly review'], io)).toBe(2)
+    expect(io.err()).toContain('unknown workflow command "run"')
+    expect(io.err()).toContain('a run is started from the app')
+  })
+})

--- a/tests/cli-workflow.test.ts
+++ b/tests/cli-workflow.test.ts
@@ -139,6 +139,34 @@ describe('workflow runs', () => {
     })
   })
 
+  it('refuses an id prefix that names more than one, rather than picking one', async () => {
+    const { transport } = fakeRpc({
+      'workflow:list': () => [
+        workflow({ id: 'import:first', name: 'Build connector' }),
+        workflow({ id: 'import:second', name: 'Build connector twice' })
+      ]
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['workflow', 'runs', '--workflow', 'import:'], io)).toBe(1)
+    expect(io.err()).toContain('matches 2 workflows')
+    expect(io.err()).toContain('Build connector')
+  })
+
+  it('takes a full id even when it is a prefix of another', async () => {
+    const { transport, calls } = fakeRpc({
+      'workflow:list': () => [
+        workflow({ id: 'import:first', name: 'Build connector' }),
+        workflow({ id: 'import:first-again', name: 'Build connector again' })
+      ],
+      'workflowRun:list': () => []
+    })
+    const io = capture(transport)
+
+    expect(await runCli(['workflow', 'runs', '--workflow', 'import:first'], io)).toBe(0)
+    expect(calls.at(-1)?.params).toMatchObject({ workflowId: 'import:first' })
+  })
+
   it('says so when the name matches nothing', async () => {
     const { transport } = fakeRpc({ 'workflow:list': () => [workflow()] })
     const io = capture(transport)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -20,12 +20,13 @@ import { mintOwnerToken } from '../packages/server/src/token-manager'
 let dataDir: string
 
 /** Collects what the CLI wrote, so assertions read against real output. */
-function capture(): CliDeps & { out: () => string; err: () => string } {
+function capture(isTty = false): CliDeps & { out: () => string; err: () => string } {
   const outParts: string[] = []
   const errParts: string[] = []
   return {
     write: (t) => outParts.push(t),
     writeErr: (t) => errParts.push(t),
+    isTty,
     out: () => outParts.join(''),
     err: () => errParts.join('')
   }
@@ -64,7 +65,7 @@ describe('usage and dispatch', () => {
   it('prints usage to stdout and succeeds for --help', async () => {
     const io = capture()
     expect(await runCli(['--help'], io)).toBe(0)
-    expect(io.out()).toContain('vorn-server: run a Vorn server')
+    expect(io.out()).toContain('vorn: Vorn from the command line')
     expect(io.err()).toBe('')
   })
 
@@ -72,6 +73,18 @@ describe('usage and dispatch', () => {
     const io = capture()
     expect(await runCli(['help'], io)).toBe(0)
     expect(io.out()).toContain('Usage')
+  })
+
+  it('describes the server commands under their own noun', async () => {
+    const io = capture()
+    expect(await runCli(['server', '--help'], io)).toBe(0)
+    expect(io.out()).toContain('vorn server: run a Vorn server')
+  })
+
+  it('still takes the bare serve and token commands vorn-server was called with', async () => {
+    const io = capture()
+    expect(await runCli(['server'], io)).toBe(2)
+    expect(io.err()).toContain('vorn server serve')
   })
 
   it('treats a bare invocation as a usage error, on stderr', async () => {
@@ -97,7 +110,7 @@ describe('usage and dispatch', () => {
   it('reports an unknown option', async () => {
     const io = capture()
     expect(await runCli(['serve', '--nope'], io)).toBe(2)
-    expect(io.err()).toContain('vorn-server:')
+    expect(io.err()).toContain('vorn:')
   })
 })
 
@@ -178,8 +191,17 @@ describe('token revoke', () => {
 })
 
 describe('serve', () => {
+  it('keeps the first-run token out of a stream nobody is watching', async () => {
+    const io = capture(false)
+    const code = await runCli(['serve', '--data-dir', dataDir], io)
+
+    expect(code).toBe(0)
+    expect(io.out()).not.toContain('vorn_')
+    expect(io.out()).toContain('vorn server token create')
+  })
+
   it('reports the port and mints a first-run token on an empty data dir', async () => {
-    const io = capture()
+    const io = capture(true)
     const code = await runCli(['serve', '--data-dir', dataDir], io)
 
     expect(code).toBe(0)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -94,6 +94,18 @@ describe('usage and dispatch', () => {
     expect(io.out()).toBe('')
   })
 
+  it("finds the command after a global option, not the option's value", async () => {
+    const io = capture()
+    expect(await runCli(['--data-dir', dataDir, 'token', 'list'], io)).toBe(0)
+    expect(io.out()).toBe('No device tokens.\n')
+  })
+
+  it('finds it after the noun the server commands live under too', async () => {
+    const io = capture()
+    expect(await runCli(['--data-dir', dataDir, 'server', 'token', 'list'], io)).toBe(0)
+    expect(io.out()).toBe('No device tokens.\n')
+  })
+
   it('reports an unknown command', async () => {
     const io = capture()
     expect(await runCli(['bogus'], io)).toBe(2)

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -106,6 +106,16 @@ describe('usage and dispatch', () => {
     expect(io.out()).toBe('No device tokens.\n')
   })
 
+  it('names the option that swallowed the command, not the leftovers', async () => {
+    const io = capture()
+    expect(await runCli(['--data-dir', 'session', 'list'], io)).toBe(2)
+    expect(io.err()).toContain('--data-dir needs a value; it took "session" as one')
+
+    const io2 = capture()
+    expect(await runCli(['--data-dir', 'session'], io2)).toBe(2)
+    expect(io2.err()).toContain('--data-dir needs a value')
+  })
+
   it('reports an unknown command', async () => {
     const io = capture()
     expect(await runCli(['bogus'], io)).toBe(2)

--- a/tests/client-args.test.ts
+++ b/tests/client-args.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { parseClientArgs, ClientArgsError } from '../packages/server/src/client-args'
+
+describe('client argument grammar', () => {
+  it('keeps the command and its operands in order', () => {
+    const args = parseClientArgs(['session', 'logs', 'c3f1a2e8'])
+    expect(args.positionals).toEqual(['session', 'logs', 'c3f1a2e8'])
+  })
+
+  it('accepts a value attached or separate', () => {
+    expect(parseClientArgs(['session', 'logs', 'x', '--lines=200']).lines).toBe(200)
+    expect(parseClientArgs(['session', 'logs', 'x', '--lines', '200']).lines).toBe(200)
+  })
+
+  it('refuses a count that is not one', () => {
+    expect(() => parseClientArgs(['session', 'logs', 'x', '--lines', 'abc'])).toThrow(
+      ClientArgsError
+    )
+    expect(() => parseClientArgs(['session', 'logs', 'x', '--limit', '0'])).toThrow(
+      /--limit must be a positive number/
+    )
+  })
+
+  it('reports an unknown option rather than ignoring it', () => {
+    expect(() => parseClientArgs(['session', 'list', '--nope'])).toThrow(ClientArgsError)
+  })
+
+  it('leaves every flag off until it is given', () => {
+    const args = parseClientArgs(['session', 'list'])
+    expect(args.json).toBe(false)
+    expect(args.headless).toBe(false)
+    expect(args.worktree).toBe(false)
+    expect(args.recent).toBe(false)
+    expect(args.raw).toBe(false)
+    expect(args.help).toBe(false)
+    expect(args.dataDir).toBeUndefined()
+  })
+})

--- a/tests/client-args.test.ts
+++ b/tests/client-args.test.ts
@@ -21,6 +21,13 @@ describe('client argument grammar', () => {
     )
   })
 
+  it('refuses an empty data directory, which would mean the working one', () => {
+    expect(() => parseClientArgs(['session', 'list', '--data-dir='])).toThrow(
+      /--data-dir needs a directory/
+    )
+    expect(() => parseClientArgs(['session', 'list', '--data-dir', '  '])).toThrow(ClientArgsError)
+  })
+
   it('reports an unknown option rather than ignoring it', () => {
     expect(() => parseClientArgs(['session', 'list', '--nope'])).toThrow(ClientArgsError)
   })

--- a/tests/connector-pack-install-paths.test.tsx
+++ b/tests/connector-pack-install-paths.test.tsx
@@ -16,7 +16,9 @@ vi.mock('../src/renderer/stores', () => ({
 }))
 
 const rpcCall = vi.fn()
-vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
+vi.mock('../packages/server/src/rpc-client', () => ({
+  rpcCall: (...a: unknown[]) => rpcCall(...a)
+}))
 
 const { registerConnectorTools } = await import('../packages/mcp/src/tools/connectors')
 

--- a/tests/git-repo-root.test.ts
+++ b/tests/git-repo-root.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { getRepoRoot } from '../packages/server/src/git-utils'
+
+let repo: string
+let outside: string
+
+beforeAll(() => {
+  // realpath: /tmp is a symlink on macOS, and git answers with the resolved path.
+  repo = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-repo-')))
+  outside = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-plain-')))
+  execFileSync('git', ['init', '-q'], { cwd: repo })
+  fs.mkdirSync(path.join(repo, 'packages', 'server'), { recursive: true })
+})
+
+afterAll(() => {
+  fs.rmSync(repo, { recursive: true, force: true })
+  fs.rmSync(outside, { recursive: true, force: true })
+})
+
+describe('the repository a directory sits in', () => {
+  it('is the root, asked from anywhere inside it', () => {
+    expect(getRepoRoot(repo)).toBe(repo)
+    expect(getRepoRoot(path.join(repo, 'packages', 'server'))).toBe(repo)
+  })
+
+  it('is nothing at all outside one, rather than an error', () => {
+    expect(getRepoRoot(outside)).toBeNull()
+  })
+})

--- a/tests/mcp-connector-tools.test.ts
+++ b/tests/mcp-connector-tools.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
 const rpcCall = vi.fn()
-vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
+vi.mock('../packages/server/src/rpc-client', () => ({
+  rpcCall: (...a: unknown[]) => rpcCall(...a)
+}))
 
 const { registerConnectorTools } = await import('../packages/mcp/src/tools/connectors')
 

--- a/tests/mcp-data-access.test.ts
+++ b/tests/mcp-data-access.test.ts
@@ -14,7 +14,7 @@ import type { AppConfig } from '../packages/shared/src/types'
 const calls: Array<{ method: string; params?: unknown }> = []
 let stored: AppConfig
 
-vi.mock('../packages/mcp/src/ws-client', () => ({
+vi.mock('../packages/server/src/rpc-client', () => ({
   rpcCall: async (method: string, params?: unknown) => {
     calls.push({ method, params })
     if (method === 'config:load') return stored

--- a/tests/mcp-device.test.ts
+++ b/tests/mcp-device.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const rpc = vi.fn()
-vi.mock('../packages/mcp/src/ws-client', () => ({
+vi.mock('../packages/server/src/rpc-client', () => ({
   rpcCall: (method: string, params: unknown) => rpc(method, params),
   rpcNotify: async () => {}
 }))

--- a/tests/mcp-resolve-gate.test.ts
+++ b/tests/mcp-resolve-gate.test.ts
@@ -16,7 +16,9 @@ const { rpcCall, listAllWorkflowRuns, listRunsWithWaitingGates, dbListWorkflows 
   })
 )
 
-vi.mock('../packages/mcp/src/ws-client', () => ({ rpcCall: (...a: unknown[]) => rpcCall(...a) }))
+vi.mock('../packages/server/src/rpc-client', () => ({
+  rpcCall: (...a: unknown[]) => rpcCall(...a)
+}))
 vi.mock('../packages/mcp/src/data-access', () => ({
   listAllWorkflowRuns: (...a: unknown[]) => listAllWorkflowRuns(...a),
   listRunsWithWaitingGates: (...a: unknown[]) => listRunsWithWaitingGates(...a),

--- a/tests/rpc-client-close.test.ts
+++ b/tests/rpc-client-close.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+interface Fake {
+  sent: string[]
+  emit(event: string, ...args: unknown[]): void
+}
+
+/** Every socket the client opened, so a test can answer or close it by hand. */
+const sockets = vi.hoisted(() => [] as Fake[])
+
+vi.mock('ws', () => {
+  class FakeSocket implements Fake {
+    private handlers: Record<string, ((...args: unknown[]) => void)[]> = {}
+    sent: string[] = []
+
+    constructor() {
+      sockets.push(this)
+      setTimeout(() => this.emit('open'), 0)
+    }
+
+    on(event: string, handler: (...args: unknown[]) => void): this {
+      ;(this.handlers[event] ??= []).push(handler)
+      return this
+    }
+
+    emit(event: string, ...args: unknown[]): void {
+      for (const handler of this.handlers[event] ?? []) handler(...args)
+    }
+
+    send(data: string): void {
+      this.sent.push(data)
+    }
+
+    close(): void {}
+  }
+  return { WebSocket: FakeSocket }
+})
+
+vi.mock('node:fs', () => {
+  const fs = {
+    readFileSync: (file: string) =>
+      String(file).endsWith('ws-port')
+        ? JSON.stringify({ port: 50091, pid: process.pid })
+        : 'vorn_token',
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+    writeFileSync: () => undefined
+  }
+  return { default: fs, ...fs }
+})
+
+import { rpcCall } from '../packages/server/src/rpc-client'
+
+/** The socket for the call just made, once it has sent its request. */
+async function sent(): Promise<Fake> {
+  await vi.waitFor(() => expect(sockets.at(-1)?.sent.length).toBe(1))
+  return sockets.at(-1)!
+}
+
+beforeEach(() => {
+  sockets.length = 0
+})
+
+describe('a call the server never answers', () => {
+  it('names a refused credential rather than blaming the clock', async () => {
+    const call = rpcCall('terminal:listActive')
+    // 4002 is CLOSE_CREDENTIAL_REJECTED: another server holds this port.
+    ;(await sent()).emit('close', 4002)
+
+    await expect(call).rejects.toThrow(/refused the credential/)
+  })
+
+  it('says the connection closed when the code means nothing in particular', async () => {
+    const call = rpcCall('terminal:listActive')
+    ;(await sent()).emit('close', 1006)
+
+    await expect(call).rejects.toThrow(/closed the connection before answering \(code 1006\)/)
+  })
+
+  it('still resolves when the answer arrives before the close', async () => {
+    const call = rpcCall('terminal:listActive')
+    const socket = await sent()
+    const { id } = JSON.parse(socket.sent[0]) as { id: number }
+
+    socket.emit('message', Buffer.from(JSON.stringify({ id, result: [] })))
+    socket.emit('close', 1000)
+
+    await expect(call).resolves.toEqual([])
+  })
+})

--- a/tests/rpc-client-close.test.ts
+++ b/tests/rpc-client-close.test.ts
@@ -31,7 +31,11 @@ vi.mock('ws', () => {
       this.sent.push(data)
     }
 
-    close(): void {}
+    // Hostile on purpose: a socket that reports the close synchronously is what
+    // would let the close handler settle the call before its own answer did.
+    close(): void {
+      this.emit('close', 1000)
+    }
   }
   return { WebSocket: FakeSocket }
 })

--- a/tests/rpc-client-discovery.test.ts
+++ b/tests/rpc-client-discovery.test.ts
@@ -92,6 +92,15 @@ describe('finding the server', () => {
     )
   })
 
+  it('treats an empty override as no override at all', async () => {
+    readFileSync.mockReturnValue(JSON.stringify({ port: 4321, pid: process.pid }))
+    process.env.VORN_DATA_DIR = '/tmp/env-dir'
+    const { useDataDir, dataDir } = await load()
+
+    useDataDir('   ')
+    expect(dataDir()).toBe('/tmp/env-dir')
+  })
+
   it('treats VORN_DATA_DIR the same way', async () => {
     noPortFile()
     process.env.VORN_DATA_DIR = '/tmp/env-dir'

--- a/tests/rpc-client-discovery.test.ts
+++ b/tests/rpc-client-discovery.test.ts
@@ -82,6 +82,16 @@ describe('finding the server', () => {
     expect(writeFileSync).not.toHaveBeenCalled()
   })
 
+  it('points at the port file it actually looked for, not the default one', async () => {
+    noPortFile()
+    const { useDataDir, rpcCall } = await load()
+
+    useDataDir('/tmp/elsewhere')
+    await expect(rpcCall('terminal:listActive')).rejects.toThrow(
+      path.join('/tmp/elsewhere', 'ws-port')
+    )
+  })
+
   it('treats VORN_DATA_DIR the same way', async () => {
     noPortFile()
     process.env.VORN_DATA_DIR = '/tmp/env-dir'

--- a/tests/rpc-client-discovery.test.ts
+++ b/tests/rpc-client-discovery.test.ts
@@ -101,6 +101,17 @@ describe('finding the server', () => {
     expect(dataDir()).toBe('/tmp/env-dir')
   })
 
+  it('ignores a VORN_DATA_DIR that names nothing, for both questions it answers', async () => {
+    noPortFile()
+    process.env.VORN_DATA_DIR = '   '
+    const { dataDir, isServerRunning } = await load()
+
+    expect(dataDir()).toBe(path.join(os.homedir(), '.vorn'))
+    // And discovery is allowed again: a blank value did not name another server.
+    expect(isServerRunning()).toBe(true)
+    expect(execFileSync).toHaveBeenCalled()
+  })
+
   it('treats VORN_DATA_DIR the same way', async () => {
     noPortFile()
     process.env.VORN_DATA_DIR = '/tmp/env-dir'

--- a/tests/rpc-client-discovery.test.ts
+++ b/tests/rpc-client-discovery.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import path from 'node:path'
+import os from 'node:os'
+
+vi.mock('ws', () => ({ WebSocket: vi.fn() }))
+
+const readFileSync = vi.fn()
+const writeFileSync = vi.fn()
+vi.mock('node:fs', () => {
+  const fs = {
+    readFileSync: (...args: unknown[]) => readFileSync(...args),
+    existsSync: () => true,
+    mkdirSync: () => undefined,
+    writeFileSync: (...args: unknown[]) => writeFileSync(...args)
+  }
+  return { default: fs, ...fs }
+})
+
+// One Vorn listening on this machine, which is what discovery goes looking for.
+const execFileSync = vi.fn(
+  (..._args: unknown[]) => 'Vorn  71718 someone  26u  IPv4  0t0  TCP *:50091 (LISTEN)\n'
+)
+vi.mock('node:child_process', () => ({ execFileSync }))
+
+/**
+ * A port file that is not there.
+ *
+ * The interesting case: with nothing to read, the client either goes looking for
+ * a Vorn process or does not, and which it does depends on whether a data
+ * directory was named.
+ */
+function noPortFile(): void {
+  readFileSync.mockImplementation(() => {
+    throw new Error('ENOENT')
+  })
+}
+
+async function load() {
+  return import('../packages/server/src/rpc-client')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  readFileSync.mockReset()
+  writeFileSync.mockReset()
+  execFileSync.mockClear()
+  delete process.env.VORN_DATA_DIR
+})
+
+describe('finding the server', () => {
+  it('reads the port file inside a named data directory', async () => {
+    readFileSync.mockReturnValue(JSON.stringify({ port: 4321, pid: process.pid }))
+    const { useDataDir, isServerRunning, dataDir } = await load()
+
+    useDataDir('/tmp/elsewhere')
+    expect(isServerRunning()).toBe(true)
+    expect(dataDir()).toBe('/tmp/elsewhere')
+    expect(readFileSync).toHaveBeenCalledWith(path.join('/tmp/elsewhere', 'ws-port'), 'utf-8')
+  })
+
+  it('looks for a running Vorn when nothing named a directory', async () => {
+    noPortFile()
+    const { isServerRunning } = await load()
+
+    expect(isServerRunning()).toBe(true)
+    expect(execFileSync).toHaveBeenCalled()
+    expect(writeFileSync).toHaveBeenCalledWith(
+      path.join(os.homedir(), '.vorn', 'ws-port'),
+      JSON.stringify({ port: 50091 }),
+      'utf-8'
+    )
+  })
+
+  it('does not answer with somebody else’s server when a directory was named', async () => {
+    noPortFile()
+    const { useDataDir, isServerRunning } = await load()
+
+    useDataDir('/tmp/elsewhere')
+    expect(isServerRunning()).toBe(false)
+    expect(execFileSync).not.toHaveBeenCalled()
+    // Nor heal that directory with a port belonging to another server.
+    expect(writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('treats VORN_DATA_DIR the same way', async () => {
+    noPortFile()
+    process.env.VORN_DATA_DIR = '/tmp/env-dir'
+    const { isServerRunning } = await load()
+
+    expect(isServerRunning()).toBe(false)
+    expect(execFileSync).not.toHaveBeenCalled()
+  })
+})

--- a/tests/settings-cli-command.test.tsx
+++ b/tests/settings-cli-command.test.tsx
@@ -48,7 +48,7 @@ beforeEach(() => {
 
 describe('the command line tool row', () => {
   it('offers to install the command, and says where it went', async () => {
-    cliCommandStatus.mockResolvedValue({
+    cliCommandStatus.mockResolvedValueOnce({
       available: true,
       installed: false,
       path: '/usr/local/bin/vorn',
@@ -60,9 +60,19 @@ describe('the command line tool row', () => {
     const button = await screen.findByRole('button', { name: 'Install' })
     expect(screen.getByText('/usr/local/bin/vorn')).toBeInTheDocument()
 
+    // What the install actually did is read back, not assumed: it landed
+    // somewhere the shell does not search, and the row says so.
+    cliCommandStatus.mockResolvedValueOnce({
+      available: true,
+      installed: true,
+      path: '/Users/j/.local/bin/vorn',
+      onPath: false
+    })
+
     fireEvent.click(button)
     await waitFor(() => expect(installCliCommand).toHaveBeenCalled())
     expect(await screen.findByRole('button', { name: 'Reinstall' })).toBeInTheDocument()
+    expect(await screen.findByText(/add its directory to your PATH/)).toBeInTheDocument()
   })
 
   it('shows why it could not, instead of claiming it did', async () => {

--- a/tests/settings-cli-command.test.tsx
+++ b/tests/settings-cli-command.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { AppConfig } from '../src/shared/types'
+
+const config = (): AppConfig =>
+  ({
+    version: 1,
+    defaults: { shell: '/bin/zsh', fontSize: 13, theme: 'dark' },
+    workflows: []
+  }) as unknown as AppConfig
+
+const mockStore = { config: config(), setConfig: vi.fn() }
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockStore) : mockStore
+}))
+
+vi.mock('../src/renderer/lib/platform', () => ({
+  isElectron: true,
+  isMac: true,
+  isWeb: false,
+  MOD: 'Cmd'
+}))
+vi.mock('../src/renderer/hooks/useAgentInstallStatus', () => ({
+  useAgentInstallStatus: () => ({ status: {} })
+}))
+vi.mock('../src/renderer/components/settings/ShellPicker', () => ({
+  ShellPicker: () => <div />
+}))
+
+import { GeneralSettings } from '../src/renderer/components/settings/GeneralSettings'
+
+const cliCommandStatus = vi.fn()
+const installCliCommand = vi.fn()
+
+beforeEach(() => {
+  mockStore.config = config()
+  cliCommandStatus.mockReset()
+  installCliCommand.mockReset()
+  ;(window as unknown as { api: unknown }).api = {
+    saveConfig: vi.fn(),
+    cliCommandStatus,
+    installCliCommand
+  }
+})
+
+describe('the command line tool row', () => {
+  it('offers to install the command, and says where it went', async () => {
+    cliCommandStatus.mockResolvedValue({
+      available: true,
+      installed: false,
+      path: '/usr/local/bin/vorn'
+    })
+    installCliCommand.mockResolvedValue({ ok: true, path: '/usr/local/bin/vorn' })
+
+    render(<GeneralSettings />)
+    const button = await screen.findByRole('button', { name: 'Install' })
+    expect(screen.getByText('/usr/local/bin/vorn')).toBeInTheDocument()
+
+    fireEvent.click(button)
+    await waitFor(() => expect(installCliCommand).toHaveBeenCalled())
+    expect(await screen.findByRole('button', { name: 'Reinstall' })).toBeInTheDocument()
+  })
+
+  it('shows why it could not, instead of claiming it did', async () => {
+    cliCommandStatus.mockResolvedValue({
+      available: true,
+      installed: false,
+      path: '/usr/local/bin/vorn'
+    })
+    installCliCommand.mockResolvedValue({ ok: false, error: 'EACCES: permission denied' })
+
+    render(<GeneralSettings />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+
+    expect(await screen.findByText('EACCES: permission denied')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument()
+  })
+
+  it('stays out of the way while running from source', async () => {
+    cliCommandStatus.mockResolvedValue({ available: false, installed: false, path: '' })
+
+    render(<GeneralSettings />)
+    expect(await screen.findByRole('button', { name: 'Install' })).toBeDisabled()
+  })
+})

--- a/tests/settings-cli-command.test.tsx
+++ b/tests/settings-cli-command.test.tsx
@@ -51,7 +51,8 @@ describe('the command line tool row', () => {
     cliCommandStatus.mockResolvedValue({
       available: true,
       installed: false,
-      path: '/usr/local/bin/vorn'
+      path: '/usr/local/bin/vorn',
+      onPath: true
     })
     installCliCommand.mockResolvedValue({ ok: true, path: '/usr/local/bin/vorn' })
 
@@ -68,7 +69,8 @@ describe('the command line tool row', () => {
     cliCommandStatus.mockResolvedValue({
       available: true,
       installed: false,
-      path: '/usr/local/bin/vorn'
+      path: '/usr/local/bin/vorn',
+      onPath: true
     })
     installCliCommand.mockResolvedValue({ ok: false, error: 'EACCES: permission denied' })
 
@@ -79,8 +81,25 @@ describe('the command line tool row', () => {
     expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument()
   })
 
+  it('says when the command would land somewhere the shell does not look', async () => {
+    cliCommandStatus.mockResolvedValue({
+      available: true,
+      installed: false,
+      path: '/Users/j/.local/bin/vorn',
+      onPath: false
+    })
+
+    render(<GeneralSettings />)
+    expect(await screen.findByText(/add its directory to your PATH/)).toBeInTheDocument()
+  })
+
   it('stays out of the way while running from source', async () => {
-    cliCommandStatus.mockResolvedValue({ available: false, installed: false, path: '' })
+    cliCommandStatus.mockResolvedValue({
+      available: false,
+      installed: false,
+      path: '',
+      onPath: false
+    })
 
     render(<GeneralSettings />)
     expect(await screen.findByRole('button', { name: 'Install' })).toBeDisabled()

--- a/tests/ws-port-file.test.ts
+++ b/tests/ws-port-file.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import path from 'node:path'
 import os from 'node:os'
 
-// Mock ws so importing ws-client doesn't pull in the real WebSocket
+// Mock ws so importing the rpc client doesn't pull in the real WebSocket
 vi.mock('ws', () => ({ WebSocket: vi.fn() }))
 
 // Mock node:fs so readPort() sees our controlled data
@@ -36,7 +36,7 @@ describe('ws-port file parsing (readPort via isServerRunning)', () => {
   })
 
   async function loadIsServerRunning() {
-    const mod = await import('../packages/mcp/src/ws-client')
+    const mod = await import('../packages/server/src/rpc-client')
     return mod.isServerRunning
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4725,6 +4725,7 @@ __metadata:
     ws: "npm:^8.21.1"
     zod: "npm:^4.4.3"
   bin:
+    vorn: ./dist/cli.cjs
     vorn-server: ./dist/cli.cjs
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
The installers put the app in place and nothing else, so anyone who ran `install.sh` had no way to reach Vorn from a shell. `vorn-server` existed as an npm bin and was deliberately kept out of the packaged app.

One `vorn` command now covers both halves:

```
vorn                                                   opens the app
vorn session start --agent claude --prompt "…"         [--headless] [--worktree] [--branch b]
vorn session list [--recent] [--project p] [--json]
vorn session logs | send | kill <id>
vorn workflow list | runs
vorn server serve | token                              what vorn-server always did, kept as an alias
```

Every verb was already a server RPC, so this adds a front end rather than capability. Running a workflow is deliberately absent: runs execute in the renderer today, so `vorn workflow run` would trigger something nothing picks up with no window open. It arrives when the engine can execute one on its own.

## The rules it holds itself to

These are what the tests assert, not aspirations.

- **stdout carries data and nothing else.** Notices, confirmations and errors go to stderr, so `vorn session list --json | jq` is clean and `vorn session send` prints nothing to stdout at all.
- **`--json` prints the server's own shapes**, not a per-command reshape that would be a second schema to keep in sync.
- **Colour is for status, and only for a terminal.** Piped, redirected, `NO_COLOR` or `TERM=dumb` all mean plain.
- **Exit codes are part of the contract**: 0 success, 1 failure, 2 usage, 4 no server reachable. 3 stays reserved for the server's own `EXIT_ENDPOINT_TAKEN`.
- **Errors say what to do next**, and never hang: the 10s call ceiling is overridable with `--timeout`, and auto-start waits on a deadline.
- **No secret to a stream nobody is watching.** `serve` used to print a first-run token's plaintext unconditionally; under auto-start that stream is a log file, so it now prints how to mint one instead.
- **No new dependency**: the grammar is `node:util`'s `parseArgs`, beside the one the server already uses.
- **Every command is assertable without a server**: `runCli(argv, deps)` keeps returning an exit code through injected sinks, and the RPC transport is injected the same way.

A session is addressed by any prefix of its id that names exactly one, across both registries — the list shows headless runs beside terminals, so the ids it prints have to be ids the other verbs accept. Killing one goes to whichever half owns it, and the two verbs that need a terminal explain why a headless run has none.

## Under it

- The WebSocket client moves from the MCP package to the server, beside `published-files.ts`, which writes the very `ws-port` and `local-token` it reads. New callers are typed against `RequestMethods`; the ~60 existing MCP call sites keep the loose form.
- That client no longer goes looking for any Vorn on the machine when a data directory was named. It used to heal a scratch directory with the desktop app's port, and the CLI then failed on a credential that was never there.
- Auto-start spawns a detached server the way the app does. A rival started by a second `vorn` at the same moment stands down by itself with `EXIT_ENDPOINT_TAKEN`, so nothing here holds a lock.

## Packaging

- `build:server` now builds both entries through the tsup config, and the CLI bundle ships in the app — about 3MB beside the server it needs to start.
- `install.sh` writes a shim that runs the CLI through the app's own Node, so nothing else has to be installed and the native modules inside the bundle resolve. On Linux the AppImage moves to `~/.local/lib/vorn/` to give the command its name; `install.ps1` writes a `vorn.cmd` in the directory it already puts on PATH.
- Settings → General → Command Line Tool writes the same shim, for anyone who dragged the app across or installed the cask.

## Testing

- Full suite green; the CLI has its own tests for dispatch, exit codes, project resolution, id prefixes across both registries, table vs `--json`, the non-TTY rules, auto-start with spawn stubbed, and the three shim shapes.
- Run against a real server: `session list`, `logs`, `workflow list`, `workflow runs`, `--json` through a parser, and auto-start into a scratch data directory.
- Run through the packaged app: `yarn run pack`, then the shim `install.sh` writes, driving the CLI from `Vorn.app` — including an auto-start that came up with the seeded workflows.

Not exercised here: `install.sh` end to end (it needs a published release to download), and Linux and Windows beyond the generated scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9xDZGyS3vzszATiHWYF8F
