### PR TITLE
Let a group hold sessions from any repo or worktree

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -23,6 +23,7 @@ import {
   AgentType,
   AiAgentType,
   WorkspaceConfig,
+  SessionGroupConfig,
   DEFAULT_WORKSPACE,
   SessionEvent,
   SessionEventType,
@@ -416,6 +417,16 @@ function createSchema(): void {
       icon TEXT,
       icon_color TEXT,
       "order" INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS session_groups (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      icon TEXT,
+      icon_color TEXT,
+      "order" INTEGER NOT NULL DEFAULT 0,
+      workspace_id TEXT NOT NULL DEFAULT 'personal',
+      row_revision INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS workflow_runs (
@@ -1041,6 +1052,20 @@ function migrateSchema(d: Database.Database): void {
     })()
     log.info('[database] migrated schema to version 17 (packaged connector task ids)')
   }
+
+  if (version < 18) {
+    d.transaction(() => {
+      const sessionCols = d.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>
+      if (!sessionCols.some((c) => c.name === 'group_id')) {
+        d.exec('ALTER TABLE sessions ADD COLUMN group_id TEXT')
+      }
+
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '18')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 18 (session groups)')
+  }
 }
 
 /** The config-blob tables `saveConfig` rewrites, and so the ones that need stamping. */
@@ -1048,6 +1073,7 @@ const REVISIONED_TABLES = [
   'projects',
   'tasks',
   'workspaces',
+  'session_groups',
   'remote_hosts',
   'agent_commands'
 ] as const
@@ -1097,6 +1123,7 @@ function verifySchema(d: Database.Database): void {
         column: 'sort_order',
         ddl: 'ALTER TABLE sessions ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0'
       },
+      { column: 'group_id', ddl: 'ALTER TABLE sessions ADD COLUMN group_id TEXT' },
       { column: 'worktree_name', ddl: 'ALTER TABLE sessions ADD COLUMN worktree_name TEXT' },
       { column: 'agent_session_id', ddl: 'ALTER TABLE sessions ADD COLUMN agent_session_id TEXT' },
       { column: 'shell_cwd', ddl: 'ALTER TABLE sessions ADD COLUMN shell_cwd TEXT' },
@@ -1229,6 +1256,7 @@ export function loadConfig(): AppConfig {
   const remoteHosts = loadRemoteHosts(d)
   const tasks = loadTasks(d)
   const workspaces = loadWorkspaces(d)
+  const sessionGroups = loadSessionGroups(d)
 
   return {
     version: 1,
@@ -1240,7 +1268,8 @@ export function loadConfig(): AppConfig {
     workflows,
     remoteHosts,
     tasks,
-    workspaces
+    workspaces,
+    sessionGroups
   }
 }
 
@@ -1455,6 +1484,18 @@ function loadTasks(d: Database.Database): TaskConfig[] {
     archived_at: string | null
   }>
   return rows.map(rowToTask)
+}
+
+function loadSessionGroups(d: Database.Database): SessionGroupConfig[] {
+  const rows = d.prepare('SELECT * FROM session_groups ORDER BY "order"').all() as Array<{
+    id: string
+    name: string
+    icon: string | null
+    icon_color: string | null
+    order: number
+    workspace_id: string | null
+  }>
+  return rows.map(rowToSessionGroup)
 }
 
 function loadWorkspaces(d: Database.Database): WorkspaceConfig[] {
@@ -1770,6 +1811,38 @@ export function saveConfig(config: AppConfig): void {
     )
     for (const ws of workspaces) {
       insertWorkspace.run(ws.id, ws.name, ws.icon ?? null, ws.iconColor ?? null, ws.order, revision)
+    }
+
+    // Session groups
+    const sessionGroups = config.sessionGroups ?? []
+    pruneMissing(
+      d,
+      'session_groups',
+      'id',
+      sessionGroups.map((g) => g.id),
+      baseRevision
+    )
+    const insertSessionGroup = d.prepare(
+      `INSERT INTO session_groups (id, name, icon, icon_color, "order", workspace_id, row_revision)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         row_revision = excluded.row_revision,
+         name = excluded.name,
+         icon = excluded.icon,
+         icon_color = excluded.icon_color,
+         "order" = excluded."order",
+         workspace_id = excluded.workspace_id`
+    )
+    for (const g of sessionGroups) {
+      insertSessionGroup.run(
+        g.id,
+        g.name,
+        g.icon ?? null,
+        g.iconColor ?? null,
+        g.order,
+        g.workspaceId,
+        revision
+      )
     }
 
     d.prepare('INSERT OR REPLACE INTO schema_meta (key, value) VALUES (?, ?)').run(
@@ -2937,10 +3010,85 @@ export function dbUpdateWorkspace(id: string, updates: Partial<WorkspaceConfig>)
 export function dbDeleteWorkspace(id: string): void {
   const d = getDb()
   d.transaction(() => {
-    // Move projects and workflows to 'personal' before deleting
+    // Move projects and workflows to 'personal' before deleting. A group belongs
+    // to one workspace, so it dies with it and its sessions come back ungrouped.
+    d.prepare(
+      'UPDATE sessions SET group_id = NULL WHERE group_id IN (SELECT id FROM session_groups WHERE workspace_id = ?)'
+    ).run(id)
+    d.prepare('DELETE FROM session_groups WHERE workspace_id = ?').run(id)
     d.prepare("UPDATE projects SET workspace_id = 'personal' WHERE workspace_id = ?").run(id)
     d.prepare("UPDATE workflows SET workspace_id = 'personal' WHERE workspace_id = ?").run(id)
     d.prepare('DELETE FROM workspaces WHERE id = ?').run(id)
+  })()
+}
+
+// ---------------------------------------------------------------------------
+// Targeted CRUD: Session groups
+// ---------------------------------------------------------------------------
+
+export function dbListSessionGroups(): SessionGroupConfig[] {
+  const rows = getDb().prepare('SELECT * FROM session_groups ORDER BY "order"').all() as Array<{
+    id: string
+    name: string
+    icon: string | null
+    icon_color: string | null
+    order: number
+    workspace_id: string | null
+  }>
+  return rows.map(rowToSessionGroup)
+}
+
+export function dbInsertSessionGroup(group: SessionGroupConfig): void {
+  getDb()
+    .prepare(
+      `INSERT INTO session_groups (id, name, icon, icon_color, "order", workspace_id) VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      group.id,
+      group.name,
+      group.icon ?? null,
+      group.iconColor ?? null,
+      group.order,
+      group.workspaceId
+    )
+}
+
+export function dbUpdateSessionGroup(id: string, updates: Partial<SessionGroupConfig>): void {
+  const sets: string[] = []
+  const params: unknown[] = []
+  if (updates.name !== undefined) {
+    sets.push('name = ?')
+    params.push(updates.name)
+  }
+  if (updates.icon !== undefined) {
+    sets.push('icon = ?')
+    params.push(updates.icon)
+  }
+  if (updates.iconColor !== undefined) {
+    sets.push('icon_color = ?')
+    params.push(updates.iconColor)
+  }
+  if (updates.order !== undefined) {
+    sets.push('"order" = ?')
+    params.push(updates.order)
+  }
+  if (updates.workspaceId !== undefined) {
+    sets.push('workspace_id = ?')
+    params.push(updates.workspaceId)
+  }
+  if (sets.length === 0) return
+  params.push(id)
+  getDb()
+    .prepare(`UPDATE session_groups SET ${sets.join(', ')} WHERE id = ?`)
+    .run(...params)
+}
+
+export function dbDeleteSessionGroup(id: string): void {
+  const d = getDb()
+  d.transaction(() => {
+    // Let the sessions go first; deleting a group never kills one.
+    d.prepare('UPDATE sessions SET group_id = NULL WHERE group_id = ?').run(id)
+    d.prepare('DELETE FROM session_groups WHERE id = ?').run(id)
   })()
 }
 
@@ -3107,6 +3255,24 @@ function rowToWorkflow(r: {
   }
 }
 
+function rowToSessionGroup(r: {
+  id: string
+  name: string
+  icon: string | null
+  icon_color: string | null
+  order: number
+  workspace_id?: string | null
+}): SessionGroupConfig {
+  return {
+    id: r.id,
+    name: r.name,
+    ...(r.icon != null && { icon: r.icon }),
+    ...(r.icon_color != null && { iconColor: r.icon_color }),
+    order: r.order,
+    workspaceId: r.workspace_id ?? 'personal'
+  }
+}
+
 function rowToWorkspace(r: {
   id: string
   name: string
@@ -3148,8 +3314,8 @@ export function saveSessions(sessions: TerminalSession[]): void {
   const run = d.transaction(() => {
     d.prepare('DELETE FROM sessions').run()
     const insert = d.prepare(
-      `INSERT INTO sessions (id, agent_type, project_name, project_path, status, created_at, pid, display_name, branch, worktree_path, is_worktree, remote_host_id, remote_host_label, hook_session_id, status_source, saved_at, sort_order, worktree_name, agent_session_id, shell_cwd, head_commit, renamed_by_person)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO sessions (id, agent_type, project_name, project_path, status, created_at, pid, display_name, branch, worktree_path, is_worktree, remote_host_id, remote_host_label, hook_session_id, status_source, saved_at, sort_order, worktree_name, agent_session_id, shell_cwd, head_commit, renamed_by_person, group_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (let i = 0; i < sessions.length; i++) {
       const s = sessions[i]
@@ -3180,7 +3346,8 @@ export function saveSessions(sessions: TerminalSession[]): void {
         s.agentSessionId ?? null,
         s.shellCwd ?? null,
         s.headCommit ?? null,
-        s.renamedByPerson ? 1 : 0
+        s.renamedByPerson ? 1 : 0,
+        s.groupId ?? null
       )
     }
   })
@@ -3208,6 +3375,7 @@ export function getPreviousSessions(): TerminalSession[] {
     saved_at: number | null
     shell_cwd: string | null
     head_commit: string | null
+    group_id: string | null
     worktree_name: string | null
     agent_session_id: string | null
     renamed_by_person: number | null
@@ -3237,7 +3405,8 @@ export function getPreviousSessions(): TerminalSession[] {
     ...(r.saved_at != null && { savedAt: r.saved_at }),
     ...(r.shell_cwd != null && { shellCwd: r.shell_cwd }),
     ...(r.head_commit != null && { headCommit: r.head_commit }),
-    ...(r.renamed_by_person != null && r.renamed_by_person !== 0 && { renamedByPerson: true })
+    ...(r.renamed_by_person != null && r.renamed_by_person !== 0 && { renamedByPerson: true }),
+    ...(r.group_id != null && { groupId: r.group_id })
   }))
 }
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -1185,6 +1185,15 @@ class PtyManager extends EventEmitter {
     this.emit('client-message', IPC.SESSION_UPDATED, session)
   }
 
+  /** Files a session under a group, or takes it out of one with null. */
+  setSessionGroup(id: string, groupId: string | null): void {
+    const session = this.sessions.get(id)
+    if (!session) throw new Error(`Session not found: ${id}`)
+    if (groupId) session.groupId = groupId
+    else delete session.groupId
+    this.emit('client-message', IPC.SESSION_UPDATED, session)
+  }
+
   reorderSessions(ids: string[]): void {
     if (new Set(ids).size !== ids.length) throw new Error('Duplicate session IDs')
     for (const id of ids) {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -729,6 +729,11 @@ export function registerAllMethods(): void {
     sessionManager.scheduleSave()
     broadcastWidgetUpdate()
   })
+  registerMethod('terminal:setGroup', ({ id, groupId }) => {
+    ptyManager.setSessionGroup(id, groupId)
+    sessionManager.scheduleSave()
+    broadcastWidgetUpdate()
+  })
   registerMethod('terminal:reorder', (ids) => {
     ptyManager.reorderSessions(ids)
     sessionManager.scheduleSave()
@@ -1085,7 +1090,10 @@ export function registerAllMethods(): void {
           ...(previous.worktreeName !== undefined && { worktreeName: previous.worktreeName }),
           ...(previous.branch !== undefined && { branch: previous.branch }),
           ...(previous.isWorktree !== undefined && { isWorktree: previous.isWorktree }),
-          ...(previous.displayName !== undefined && { displayName: previous.displayName })
+          ...(previous.displayName !== undefined && { displayName: previous.displayName }),
+          // Same reason as the rest: rebuilt from a whitelist, so anything left
+          // out is written back as null by the save below and gone for good.
+          ...(previous.groupId !== undefined && { groupId: previous.groupId })
         })
         // Synchronously, so it is in the buffer before the shell's first byte.
         ptyManager.injectOutput(session.id, BETWEEN_RUNS)
@@ -1114,6 +1122,9 @@ export function registerAllMethods(): void {
 
       // Same id, same reasons as the shell branch above.
       const session = ptyManager.createPty(buildRestorePayload(grounded, transcriptId), id)
+      // Carried on the server rather than through the payload, so membership is
+      // never something a client can set on a spawn.
+      if (grounded.groupId !== undefined) session.groupId = grounded.groupId
       // The record names the conversation now, so the claim standing in for it is
       // spent; leaving it would hold an id the session already reports.
       if (session.agentSessionId) releaseSpawningTranscriptsFor(id)

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -534,6 +534,7 @@ export interface RequestMethods {
   'terminal:listActive': { params: void; result: TerminalSession[] }
   'terminal:rename': { params: { id: string; displayName: string }; result: void }
   'terminal:reorder': { params: string[]; result: void }
+  'terminal:setGroup': { params: { id: string; groupId: string | null }; result: void }
   'terminal:readOutput': { params: { id: string; lines?: number }; result: string[] }
   /**
    * The terminal's output as it was emitted, escape sequences intact.

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -90,6 +90,8 @@ export interface TerminalSession {
   hookSessionId?: string
   agentSessionId?: string
   statusSource?: 'hooks' | 'pattern'
+  /** The group this session was filed under, if any. */
+  groupId?: string
   /**
    * The geometry the PTY is currently running at.
    *
@@ -272,6 +274,23 @@ export const DEFAULT_WORKSPACE: WorkspaceConfig = {
   icon: 'User',
   iconColor: '#6b7280',
   order: 0
+}
+
+/**
+ * A bucket of sessions inside one workspace, and a scope you can select.
+ *
+ * Membership cuts across the project tree on purpose: the sessions in a group
+ * come from whatever repos and worktrees the work spans. A session belongs to
+ * at most one, and belonging to none is the ordinary state — an ungrouped
+ * session is drawn exactly where it was before any group existed.
+ */
+export interface SessionGroupConfig {
+  id: string
+  name: string
+  icon?: string
+  iconColor?: string
+  order: number
+  workspaceId: string
 }
 
 export interface ProjectConfig {
@@ -1362,6 +1381,7 @@ export interface AppConfig {
   remoteHosts?: RemoteHost[]
   tasks?: TaskConfig[]
   workspaces?: WorkspaceConfig[]
+  sessionGroups?: SessionGroupConfig[]
 }
 
 export interface RecentSession {
@@ -1644,6 +1664,7 @@ export const IPC = {
   SESSION_REORDERED: 'session:reordered',
   TERMINAL_RENAME: 'terminal:rename-session',
   TERMINAL_REORDER: 'terminal:reorder-sessions',
+  TERMINAL_SET_GROUP: 'terminal:set-group',
   CONFIG_LOAD: 'config:load',
   CONFIG_SAVE: 'config:save',
   CONFIG_CHANGED: 'config:changed',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -455,6 +455,8 @@ export function createApiShim(wsUrl: string) {
     renameSession: (id: string, displayName: string) =>
       rpc.invoke('terminal:rename', { id, displayName }),
     reorderSessions: (ids: string[]) => rpc.invoke('terminal:reorder', ids),
+    setSessionGroup: (id: string, groupId: string | null) =>
+      rpc.invoke('terminal:setGroup', { id, groupId }),
 
     // ── Dialogs (web: use HTML5 file inputs) ──
     openDirectoryDialog: async (): Promise<string | null> => {

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -143,6 +143,9 @@ export function registerIpcHandlers(): void {
   )
   safeHandle(IPC.TERMINAL_RENAME, (_, params) => requireBridge().request('terminal:rename', params))
   safeHandle(IPC.TERMINAL_REORDER, (_, ids) => requireBridge().request('terminal:reorder', ids))
+  safeHandle(IPC.TERMINAL_SET_GROUP, (_, params) =>
+    requireBridge().request('terminal:setGroup', params)
+  )
 
   // Git
   safeHandle(IPC.GIT_IS_REPO, (_, projectPath) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -196,6 +196,8 @@ const api = {
     ipcRenderer.invoke(IPC.TERMINAL_RENAME, { id, displayName }),
 
   reorderSessions: (ids: string[]) => ipcRenderer.invoke(IPC.TERMINAL_REORDER, ids),
+  setSessionGroup: (id: string, groupId: string | null) =>
+    ipcRenderer.invoke(IPC.TERMINAL_SET_GROUP, { id, groupId }),
 
   openDirectoryDialog: (): Promise<string | null> => ipcRenderer.invoke(IPC.DIALOG_OPEN_DIRECTORY),
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -502,6 +502,11 @@ export function App() {
         if (session.displayName && existing.session.displayName !== session.displayName) {
           store.renameTerminal(session.id, session.displayName)
         }
+        // Filed from another client — without this the board keeps drawing the
+        // session under whatever group it last knew about.
+        if (session.groupId !== existing.session.groupId) {
+          store.updateSessionGroupId(session.id, session.groupId)
+        }
         const wtUpdates: { worktreePath?: string; worktreeName?: string } = {}
         if (session.worktreePath && session.worktreePath !== existing.session.worktreePath) {
           wtUpdates.worktreePath = session.worktreePath

--- a/src/renderer/components/AddProjectDialog.tsx
+++ b/src/renderer/components/AddProjectDialog.tsx
@@ -2,58 +2,9 @@ import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useAppStore } from '../stores'
 import { AiAgentType } from '../../shared/types'
-import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../lib/project-icons'
 import { toast } from './Toast'
-import {
-  Folder,
-  FolderGit2,
-  Code,
-  Globe,
-  Database,
-  Server,
-  Smartphone,
-  Package,
-  FileCode,
-  Terminal,
-  Cpu,
-  Cloud,
-  Shield,
-  Zap,
-  Gamepad2,
-  Music,
-  Image,
-  BookOpen,
-  FlaskConical,
-  Rocket,
-  FolderOpen,
-  Monitor
-} from 'lucide-react'
-
-const ICON_MAP: Record<
-  string,
-  React.FC<{ size?: number; color?: string; strokeWidth?: number }>
-> = {
-  Folder,
-  FolderGit2,
-  Code,
-  Globe,
-  Database,
-  Server,
-  Smartphone,
-  Package,
-  FileCode,
-  Terminal,
-  Cpu,
-  Cloud,
-  Shield,
-  Zap,
-  Gamepad2,
-  Music,
-  Image,
-  BookOpen,
-  FlaskConical,
-  Rocket
-}
+import { IconColorPicker } from './IconColorPicker'
+import { FolderOpen, Monitor, Server } from 'lucide-react'
 
 export function AddProjectDialog() {
   const isOpen = useAppStore((s) => s.isAddProjectDialogOpen)
@@ -136,8 +87,6 @@ export function AddProjectDialog() {
     setSelectedColor('#6b7280')
     setSelectedHostId('local')
   }
-
-  const SelectedIconComponent = ICON_MAP[selectedIcon] || Folder
 
   return (
     <AnimatePresence>
@@ -273,60 +222,12 @@ export function AddProjectDialog() {
                 />
               </div>
 
-              {/* Icon selector */}
-              <div>
-                <label className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2 block">
-                  Icon
-                </label>
-                <div className="grid grid-cols-10 gap-1.5">
-                  {PROJECT_ICON_OPTIONS.map((opt) => {
-                    const IconComp = ICON_MAP[opt.name] || Folder
-                    return (
-                      <button
-                        key={opt.name}
-                        onClick={() => setSelectedIcon(opt.name)}
-                        className={`flex items-center justify-center p-2 rounded-lg border transition-all ${
-                          selectedIcon === opt.name
-                            ? 'border-white/[0.2] bg-white/[0.08]'
-                            : 'border-transparent hover:bg-white/[0.04]'
-                        }`}
-                        title={opt.label}
-                      >
-                        <IconComp
-                          size={16}
-                          color={selectedIcon === opt.name ? selectedColor : '#9ca3af'}
-                          strokeWidth={1.5}
-                        />
-                      </button>
-                    )
-                  })}
-                </div>
-              </div>
-
-              {/* Color selector */}
-              <div>
-                <label className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2 block">
-                  Color
-                </label>
-                <div className="flex gap-2 items-center">
-                  {ICON_COLOR_PALETTE.map((color) => (
-                    <button
-                      key={color}
-                      onClick={() => setSelectedColor(color)}
-                      className={`w-7 h-7 rounded-full border-2 transition-all ${
-                        selectedColor === color
-                          ? 'border-white scale-110'
-                          : 'border-transparent hover:border-white/30'
-                      }`}
-                      style={{ backgroundColor: color }}
-                    />
-                  ))}
-                  <div className="ml-3 flex items-center gap-2">
-                    <SelectedIconComponent size={20} color={selectedColor} strokeWidth={1.5} />
-                    <span className="text-xs text-gray-500">Preview</span>
-                  </div>
-                </div>
-              </div>
+              <IconColorPicker
+                icon={selectedIcon}
+                color={selectedColor}
+                onIconChange={setSelectedIcon}
+                onColorChange={setSelectedColor}
+              />
             </div>
 
             {/* Footer */}

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -38,7 +38,8 @@ import {
   HardDrive,
   LayoutDashboard,
   Power,
-  Globe
+  Globe,
+  Group
 } from 'lucide-react'
 
 type CommandCategory =
@@ -128,6 +129,8 @@ function useCommands(
   const addTerminal = useAppStore((s) => s.addTerminal)
   const setFocusedTerminal = useAppStore((s) => s.setFocusedTerminal)
   const setActiveProject = useAppStore((s) => s.setActiveProject)
+  const setActiveGroup = useAppStore((s) => s.setActiveGroup)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
   const setNewAgentDialogOpen = useAppStore((s) => s.setNewAgentDialogOpen)
   const setAddProjectDialogOpen = useAppStore((s) => s.setAddProjectDialogOpen)
   const setWorkflowEditorOpen = useAppStore((s) => s.setWorkflowEditorOpen)
@@ -186,6 +189,23 @@ function useCommands(
       icon: <FolderPlus size={14} strokeWidth={1.5} />,
       keywords: ['new project', 'create project'],
       onExecute: () => setAddProjectDialogOpen(true)
+    })
+    commands.push({
+      id: 'action:add-group',
+      label: 'New Group',
+      category: 'actions',
+      icon: <Group size={14} strokeWidth={1.5} />,
+      keywords: ['new group', 'create group', 'sidebar'],
+      onExecute: () => {
+        const state = useAppStore.getState()
+        const groups = state.config?.sessionGroups ?? []
+        state.addSessionGroup({
+          id: crypto.randomUUID(),
+          name: 'New group',
+          order: groups.reduce((max: number, g) => Math.max(max, g.order), -1) + 1,
+          workspaceId: state.activeWorkspace
+        })
+      }
     })
     commands.push({
       id: 'action:add-workflow',
@@ -377,8 +397,23 @@ function useCommands(
       category: 'projects',
       icon: <Monitor size={14} strokeWidth={1.5} />,
       keywords: ['show all', 'clear filter'],
-      onExecute: () => setActiveProject(null)
+      onExecute: () => {
+        setActiveProject(null)
+        setActiveGroup(null)
+      }
     })
+    for (const group of (config?.sessionGroups ?? []).filter(
+      (g) => g.workspaceId === activeWorkspace
+    )) {
+      commands.push({
+        id: `group:${group.id}`,
+        label: group.name,
+        category: 'projects',
+        icon: <Group size={14} strokeWidth={1.5} />,
+        keywords: ['group'],
+        onExecute: () => setActiveGroup(group.id)
+      })
+    }
     for (const project of config?.projects ?? []) {
       commands.push({
         id: `project:${project.name}`,
@@ -535,6 +570,8 @@ function useCommands(
     addTerminal,
     setFocusedTerminal,
     setActiveProject,
+    setActiveGroup,
+    activeWorkspace,
     setNewAgentDialogOpen,
     setAddProjectDialogOpen,
     setWorkflowEditorOpen,

--- a/src/renderer/components/IconColorPicker.tsx
+++ b/src/renderer/components/IconColorPicker.tsx
@@ -1,0 +1,83 @@
+import { Folder } from 'lucide-react'
+import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../lib/project-icons'
+import { ICON_MAP } from './project-sidebar/icon-map'
+
+/** The icon grid and colour row, shared by anything that carries an icon. */
+export function IconColorPicker({
+  icon,
+  color,
+  onIconChange,
+  onColorChange,
+  showPreview = true
+}: {
+  icon: string
+  color: string
+  onIconChange: (icon: string) => void
+  onColorChange: (color: string) => void
+  showPreview?: boolean
+}) {
+  const SelectedIconComponent = ICON_MAP[icon] || Folder
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <label className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2 block">
+          Icon
+        </label>
+        <div className="grid grid-cols-8 gap-1.5">
+          {PROJECT_ICON_OPTIONS.map((opt) => {
+            const IconComp = ICON_MAP[opt.name] || Folder
+            return (
+              <button
+                key={opt.name}
+                onClick={() => onIconChange(opt.name)}
+                aria-label={opt.label}
+                aria-pressed={icon === opt.name}
+                className={`flex items-center justify-center p-2 rounded-lg border transition-all ${
+                  icon === opt.name
+                    ? 'border-white/[0.2] bg-white/[0.08]'
+                    : 'border-transparent hover:bg-white/[0.04]'
+                }`}
+                title={opt.label}
+              >
+                <IconComp
+                  size={16}
+                  color={icon === opt.name ? color : '#9ca3af'}
+                  strokeWidth={1.5}
+                />
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div>
+        <label className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2 block">
+          Color
+        </label>
+        <div className="flex gap-2 items-center flex-wrap">
+          {ICON_COLOR_PALETTE.map((swatch) => (
+            <button
+              key={swatch}
+              onClick={() => onColorChange(swatch)}
+              aria-label={`Color ${swatch}`}
+              aria-pressed={color === swatch}
+              className={`w-7 h-7 rounded-full border-2 transition-all ${
+                color === swatch
+                  ? 'border-white scale-110'
+                  : 'border-transparent hover:border-white/30'
+              }`}
+              style={{ backgroundColor: swatch }}
+            />
+          ))}
+          {showPreview && (
+            <div className="ml-3 flex items-center gap-2">
+              <SelectedIconComponent size={20} color={color} strokeWidth={1.5} />
+              <span className="text-xs text-gray-500">Preview</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/ToolbarBreadcrumb.tsx
+++ b/src/renderer/components/ToolbarBreadcrumb.tsx
@@ -10,6 +10,16 @@ const EMPTY_WORKTREES: WorktreeInfo[] = []
 
 export function ToolbarBreadcrumb() {
   const activeProject = useAppStore((s) => s.activeProject)
+  const setActiveGroup = useAppStore((s) => s.setActiveGroup)
+  // Matched on the workspace too: a stale id is no selection anywhere else, and
+  // a crumb naming it would be the only thing on screen that still believed it.
+  const activeGroup = useAppStore((s) =>
+    s.activeGroupId
+      ? s.config?.sessionGroups?.find(
+          (g) => g.id === s.activeGroupId && g.workspaceId === s.activeWorkspace
+        )
+      : undefined
+  )
   const activeWorktreePath = useAppStore((s) => s.activeWorktreePath)
   const setActiveWorktreePath = useAppStore((s) => s.setActiveWorktreePath)
   const worktreeCache = useAppStore((s) => s.worktreeCache)
@@ -37,7 +47,20 @@ export function ToolbarBreadcrumb() {
     branchName
   })
 
-  if (!activeProject) return null
+  // A group is the same selection slot as a project, so it gets the same crumb.
+  if (!activeProject) {
+    if (!activeGroup) return null
+    return (
+      <div className="flex items-center gap-0.5 text-[13px] min-w-0 max-w-[400px]">
+        <button
+          onClick={() => setActiveGroup(null)}
+          className="text-white truncate hover:text-gray-300 transition-colors"
+        >
+          {activeGroup.name}
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="flex items-center gap-0.5 text-[13px] min-w-0 max-w-[400px]">

--- a/src/renderer/components/project-sidebar/GroupContextMenu.tsx
+++ b/src/renderer/components/project-sidebar/GroupContextMenu.tsx
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from 'react'
+import { Pencil, Palette, Ungroup, Trash2 } from 'lucide-react'
+import type { SessionGroupConfig } from '../../../shared/types'
+import { toast } from '../Toast'
+
+export function GroupContextMenu({
+  group,
+  onRename,
+  onChangeIcon,
+  onUngroup,
+  onDelete,
+  onClose
+}: {
+  group: SessionGroupConfig
+  onRename: () => void
+  onChangeIcon: () => void
+  onUngroup: () => void
+  onDelete: () => void
+  onClose: () => void
+}) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('pointerdown', handleClickOutside)
+    return () => document.removeEventListener('pointerdown', handleClickOutside)
+  }, [onClose])
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute right-0 top-full mt-1 z-50 min-w-[176px] py-1
+                 bg-surface-overlay border border-white/[0.08] rounded-lg shadow-xl"
+    >
+      <button
+        onClick={() => {
+          onRename()
+          onClose()
+        }}
+        className="w-full px-3 py-2.5 text-left text-[13px] text-gray-300 hover:text-white
+                   hover:bg-white/[0.06] active:bg-white/[0.1] flex items-center gap-2 transition-colors"
+      >
+        <Pencil size={12} strokeWidth={1.5} />
+        Rename group
+      </button>
+      <button
+        onClick={() => {
+          onChangeIcon()
+          onClose()
+        }}
+        className="w-full px-3 py-2.5 text-left text-[13px] text-gray-300 hover:text-white
+                   hover:bg-white/[0.06] active:bg-white/[0.1] flex items-center gap-2 transition-colors"
+      >
+        <Palette size={12} strokeWidth={1.5} />
+        Change icon
+      </button>
+      <button
+        onClick={() => {
+          onUngroup()
+          onClose()
+          toast.success(`Sessions moved out of "${group.name}"`)
+        }}
+        className="w-full px-3 py-2.5 text-left text-[13px] text-gray-300 hover:text-white
+                   hover:bg-white/[0.06] active:bg-white/[0.1] flex items-center gap-2 transition-colors"
+      >
+        <Ungroup size={12} strokeWidth={1.5} />
+        Remove all sessions
+      </button>
+      {confirmDelete ? (
+        <button
+          onClick={() => {
+            onDelete()
+            onClose()
+            toast.success(`Group "${group.name}" deleted`)
+          }}
+          className="w-full px-3 py-2.5 text-left text-[13px] text-danger bg-danger/10
+                     hover:bg-danger/20 active:bg-danger/30 flex items-center gap-2 transition-colors"
+        >
+          <Trash2 size={12} strokeWidth={1.5} />
+          Confirm delete?
+        </button>
+      ) : (
+        <button
+          onClick={() => setConfirmDelete(true)}
+          className="w-full px-3 py-2.5 text-left text-[13px] text-danger/80 hover:text-danger
+                     hover:bg-white/[0.06] active:bg-white/[0.1] flex items-center gap-2 transition-colors"
+        >
+          <Trash2 size={12} strokeWidth={1.5} />
+          Delete group
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/project-sidebar/GroupSessionsSection.tsx
+++ b/src/renderer/components/project-sidebar/GroupSessionsSection.tsx
@@ -1,0 +1,189 @@
+import { useState, useCallback, useMemo } from 'react'
+import { useAppStore } from '../../stores'
+import { Tooltip } from '../Tooltip'
+import { SessionGroupItem } from './SessionGroupItem'
+import { SessionItem } from './SessionItem'
+import { SidebarNavItem } from './SidebarNavItem'
+import { SidebarSectionHeader } from './SidebarSectionHeader'
+import { ProjectsSectionToolbar } from './ProjectsSectionToolbar'
+import { useWorkspaceSessionGroups } from '../../hooks/useWorkspaceSessionGroups'
+import { useClaimedTerminalIds } from '../../hooks/usePanelTerminals'
+import { getDisplayName } from '../../lib/terminal-display'
+import { Group, Layers } from 'lucide-react'
+import type { SidebarSessionInfo } from './types'
+
+/**
+ * Sessions arranged by the buckets a person made, rather than by where their
+ * code lives. Groups are drawn here and nowhere else: seeing them beside the
+ * project tree as well was two organisations of the same sessions at once.
+ */
+export function GroupSessionsSection({
+  isCollapsed,
+  workspaceProjectNames,
+  workspaceTerminalCount
+}: {
+  isCollapsed: boolean
+  workspaceProjectNames: Set<string>
+  workspaceTerminalCount: number
+}) {
+  const terminals = useAppStore((s) => s.terminals)
+  const claimed = useClaimedTerminalIds()
+  const activeProject = useAppStore((s) => s.activeProject)
+  const activeGroupId = useAppStore((s) => s.activeGroupId)
+  const setActiveProject = useAppStore((s) => s.setActiveProject)
+  const setActiveGroup = useAppStore((s) => s.setActiveGroup)
+  const setFocusedTerminal = useAppStore((s) => s.setFocusedTerminal)
+  const addSessionGroup = useAppStore((s) => s.addSessionGroup)
+  const moveSessionToGroup = useAppStore((s) => s.moveSessionToGroup)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  const groups = useWorkspaceSessionGroups()
+
+  const [sectionCollapsed, setSectionCollapsed] = useState(false)
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [dropTarget, setDropTarget] = useState<string | null>(null)
+
+  const groupIds = useMemo(() => new Set(groups.map((g) => g.id)), [groups])
+
+  const { grouped, ungrouped } = useMemo(() => {
+    const all: (SidebarSessionInfo & { groupId?: string; lastActivity: number })[] = []
+    for (const [id, t] of terminals) {
+      if (claimed.has(id)) continue
+      if (!workspaceProjectNames.has(t.session.projectName)) continue
+      all.push({
+        id,
+        name: getDisplayName(t.session),
+        status: t.status,
+        agentType: t.session.agentType,
+        branch: t.session.branch,
+        isWorktree: t.session.isWorktree,
+        worktreePath: t.session.worktreePath,
+        groupId: t.session.groupId,
+        lastActivity: t.lastOutputTimestamp
+      })
+    }
+    all.sort((a, b) => b.lastActivity - a.lastActivity)
+    const byGroup = new Map<string, SidebarSessionInfo[]>()
+    const loose: SidebarSessionInfo[] = []
+    for (const s of all) {
+      // A group that has been deleted leaves its sessions loose, not lost.
+      if (s.groupId && groupIds.has(s.groupId)) {
+        byGroup.set(s.groupId, [...(byGroup.get(s.groupId) ?? []), s])
+      } else {
+        loose.push(s)
+      }
+    }
+    return { grouped: byGroup, ungrouped: loose }
+  }, [terminals, claimed, workspaceProjectNames, groupIds])
+
+  const createGroup = useCallback(() => {
+    const id = crypto.randomUUID()
+    const order = groups.reduce((max, g) => Math.max(max, g.order), -1) + 1
+    addSessionGroup({ id, name: 'New group', order, workspaceId: activeWorkspace })
+    setRenamingId(id)
+  }, [groups, addSessionGroup, activeWorkspace])
+
+  return (
+    <>
+      <SidebarSectionHeader
+        title="Groups"
+        isCollapsed={isCollapsed}
+        sectionCollapsed={sectionCollapsed}
+        onToggle={() => setSectionCollapsed(!sectionCollapsed)}
+        actions={
+          <>
+            <ProjectsSectionToolbar />
+            <Tooltip label="New group" position="bottom">
+              <button
+                onClick={createGroup}
+                aria-label="New group"
+                className="p-0.5 rounded text-gray-600 hover:text-white hover:bg-white/[0.08] transition-colors"
+              >
+                <Group size={13} strokeWidth={1.5} />
+              </button>
+            </Tooltip>
+          </>
+        }
+      />
+
+      {!sectionCollapsed && (
+        <SidebarNavItem
+          isActive={activeProject === null && activeGroupId === null}
+          isCollapsed={isCollapsed}
+          icon={<Layers size={isCollapsed ? 22 : 14} strokeWidth={1.5} />}
+          label="All Sessions"
+          badge={workspaceTerminalCount}
+          onClick={() => {
+            setActiveProject(null)
+            setActiveGroup(null)
+            setFocusedTerminal(null)
+          }}
+        />
+      )}
+
+      {!isCollapsed &&
+        !sectionCollapsed &&
+        groups.map((group) => {
+          const members = grouped.get(group.id) ?? []
+          const isExpanded = !collapsedGroups.has(group.id)
+          return (
+            <div
+              key={group.id}
+              onDragOver={(e) => {
+                if (!e.dataTransfer.types.includes('application/vorn-session')) return
+                e.preventDefault()
+                e.dataTransfer.dropEffect = 'move'
+                setDropTarget(group.id)
+              }}
+              onDragLeave={() => setDropTarget(null)}
+              onDrop={(e) => {
+                e.preventDefault()
+                const id = e.dataTransfer.getData('application/vorn-session')
+                if (id) moveSessionToGroup(id, group.id)
+                setDropTarget(null)
+              }}
+              className={dropTarget === group.id ? 'rounded-md bg-white/[0.04]' : undefined}
+            >
+              <SessionGroupItem
+                group={group}
+                sessionCount={members.length}
+                hasWaiting={members.some((m) => m.status === 'waiting')}
+                isExpanded={isExpanded}
+                onToggleExpanded={() =>
+                  setCollapsedGroups((prev) => {
+                    const next = new Set(prev)
+                    if (next.has(group.id)) next.delete(group.id)
+                    else next.add(group.id)
+                    return next
+                  })
+                }
+                startRenaming={renamingId === group.id}
+                onRenameSettled={() => setRenamingId(null)}
+              />
+              {isExpanded && (
+                <div className="ml-2">
+                  {members.length > 0 ? (
+                    members.map((m) => <SessionItem key={m.id} session={m} showBranch={true} />)
+                  ) : (
+                    <p className="text-[11px] text-gray-600 px-2 py-1">Drop a session here</p>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+
+      {/* Ungrouped sessions, drawn exactly as the flat list draws them. */}
+      {!isCollapsed && !sectionCollapsed && (
+        <div className="space-y-0.5 mt-1">
+          {ungrouped.map((s) => (
+            <SessionItem key={s.id} session={s} showBranch={true} />
+          ))}
+          {ungrouped.length === 0 && grouped.size === 0 && (
+            <p className="text-[11px] text-gray-600 px-2 py-1">No active sessions</p>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/renderer/components/project-sidebar/ProjectSidebar.tsx
+++ b/src/renderer/components/project-sidebar/ProjectSidebar.tsx
@@ -6,6 +6,7 @@ import { getDisplayName } from '../../lib/terminal-display'
 import { useSidebarResize } from './useSidebarResize'
 import { SidebarHeader } from './SidebarHeader'
 import { ProjectsSection } from './ProjectsSection'
+import { GroupSessionsSection } from './GroupSessionsSection'
 import { FlatSessionsSection } from './FlatSessionsSection'
 import { WorkflowsSection } from './WorkflowsSection'
 import { TasksProjectsSection } from './TasksProjectsSection'
@@ -136,6 +137,12 @@ export function ProjectSidebar() {
           <TasksProjectsSection isCollapsed={isCollapsed} workspaceProjects={workspaceProjects} />
         ) : sidebarViewMode === 'sessions-flat' ? (
           <FlatSessionsSection
+            isCollapsed={isCollapsed}
+            workspaceProjectNames={workspaceProjectNames}
+            workspaceTerminalCount={workspaceTerminalCount}
+          />
+        ) : sidebarViewMode === 'groups-sessions' ? (
+          <GroupSessionsSection
             isCollapsed={isCollapsed}
             workspaceProjectNames={workspaceProjectNames}
             workspaceTerminalCount={workspaceTerminalCount}

--- a/src/renderer/components/project-sidebar/ProjectsSectionToolbar.tsx
+++ b/src/renderer/components/project-sidebar/ProjectsSectionToolbar.tsx
@@ -25,6 +25,7 @@ const VIEW_MODE_OPTIONS: { value: SidebarViewMode; label: string }[] = [
   { value: 'worktrees', label: 'Projects > Worktrees' },
   { value: 'worktrees-sessions', label: 'Projects > Worktrees > Sessions' },
   { value: 'sessions', label: 'Projects > Sessions' },
+  { value: 'groups-sessions', label: 'Groups > Sessions' },
   { value: 'sessions-flat', label: 'Sessions (Flat)' }
 ]
 
@@ -88,6 +89,7 @@ export function ProjectsSectionToolbar() {
       <Tooltip label="Filter & sort" position="bottom">
         <button
           ref={buttonRef}
+          aria-label="Filter & sort"
           onClick={toggle}
           className={`relative p-0.5 rounded transition-colors ${
             open
@@ -122,7 +124,7 @@ export function ProjectsSectionToolbar() {
             ))}
           </div>
 
-          {viewMode !== 'sessions-flat' && (
+          {viewMode !== 'sessions-flat' && viewMode !== 'groups-sessions' && (
             <div className="py-1.5 border-t border-white/[0.06]">
               <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
                 Filter
@@ -138,7 +140,7 @@ export function ProjectsSectionToolbar() {
             </div>
           )}
 
-          {viewMode !== 'sessions-flat' && (
+          {viewMode !== 'sessions-flat' && viewMode !== 'groups-sessions' && (
             <div className="py-1.5 border-t border-white/[0.06]">
               <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
                 Sort projects
@@ -154,21 +156,23 @@ export function ProjectsSectionToolbar() {
             </div>
           )}
 
-          {viewMode !== 'sessions' && viewMode !== 'sessions-flat' && (
-            <div className="py-1.5 border-t border-white/[0.06]">
-              <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
-                Sort worktrees
+          {viewMode !== 'sessions' &&
+            viewMode !== 'sessions-flat' &&
+            viewMode !== 'groups-sessions' && (
+              <div className="py-1.5 border-t border-white/[0.06]">
+                <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
+                  Sort worktrees
+                </div>
+                {WORKTREE_SORT_OPTIONS.map((opt) => (
+                  <OptionRow
+                    key={opt.value}
+                    selected={worktreeSort === opt.value}
+                    label={opt.label}
+                    onClick={() => setWorktreeSort(opt.value)}
+                  />
+                ))}
               </div>
-              {WORKTREE_SORT_OPTIONS.map((opt) => (
-                <OptionRow
-                  key={opt.value}
-                  selected={worktreeSort === opt.value}
-                  label={opt.label}
-                  onClick={() => setWorktreeSort(opt.value)}
-                />
-              ))}
-            </div>
-          )}
+            )}
         </div>
       )}
     </>

--- a/src/renderer/components/project-sidebar/SessionContextMenu.tsx
+++ b/src/renderer/components/project-sidebar/SessionContextMenu.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react'
+import { Plus, Check } from 'lucide-react'
+import { useAppStore } from '../../stores'
+import { useWorkspaceSessionGroups } from '../../hooks/useWorkspaceSessionGroups'
+import { ProjectIcon } from './ProjectIcon'
+
+/**
+ * A flat section rather than a cascade: the sidebar is 256px, which a flyout
+ * cannot open into.
+ */
+export function SessionContextMenu({
+  sessionId,
+  currentGroupId,
+  onNewGroup,
+  onClose
+}: {
+  sessionId: string
+  currentGroupId?: string
+  onNewGroup: () => void
+  onClose: () => void
+}) {
+  const menuRef = useRef<HTMLDivElement>(null)
+  const groups = useWorkspaceSessionGroups()
+  const moveSessionToGroup = useAppStore((s) => s.moveSessionToGroup)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('pointerdown', handleClickOutside)
+    return () => document.removeEventListener('pointerdown', handleClickOutside)
+  }, [onClose])
+
+  return (
+    <div
+      ref={menuRef}
+      className="absolute right-0 top-full mt-1 z-50 min-w-[176px] py-1
+                 bg-surface-overlay border border-white/[0.08] rounded-lg shadow-xl"
+    >
+      <div className="px-3 py-1 text-[10px] text-gray-500 uppercase tracking-wider">
+        Move to group
+      </div>
+      {groups.map((g) => {
+        const selected = currentGroupId === g.id
+        return (
+          <button
+            key={g.id}
+            onClick={() => {
+              moveSessionToGroup(sessionId, selected ? null : g.id)
+              onClose()
+            }}
+            className={`w-full pl-5 pr-3 py-2 text-left text-[13px] flex items-center gap-2 transition-colors ${
+              selected
+                ? 'text-white bg-white/[0.06]'
+                : 'text-gray-300 hover:text-white hover:bg-white/[0.06]'
+            }`}
+          >
+            <ProjectIcon icon={g.icon} color={g.iconColor} size={12} />
+            <span className="truncate">{g.name}</span>
+            {selected && <Check size={12} strokeWidth={2.5} className="ml-auto shrink-0" />}
+          </button>
+        )
+      })}
+      <button
+        onClick={() => {
+          onNewGroup()
+          onClose()
+        }}
+        className="w-full pl-5 pr-3 py-2 text-left text-[13px] text-gray-300 hover:text-white
+                   hover:bg-white/[0.06] flex items-center gap-2 transition-colors"
+      >
+        <Plus size={12} strokeWidth={2} />
+        New group…
+      </button>
+      {currentGroupId && (
+        <button
+          onClick={() => {
+            moveSessionToGroup(sessionId, null)
+            onClose()
+          }}
+          className="w-full pl-5 pr-3 py-2 text-left text-[13px] text-gray-300 hover:text-white
+                     hover:bg-white/[0.06] flex items-center gap-2 transition-colors"
+        >
+          Remove from group
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/project-sidebar/SessionGroupItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionGroupItem.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { ChevronRight, MoreHorizontal } from 'lucide-react'
+import { useAppStore } from '../../stores'
+import { Tooltip } from '../Tooltip'
+import { InlineRename } from '../InlineRename'
+import { ProjectIcon } from './ProjectIcon'
+import { GroupContextMenu } from './GroupContextMenu'
+import { IconColorPicker } from '../IconColorPicker'
+import type { SessionGroupConfig } from '../../../shared/types'
+
+export function SessionGroupItem({
+  group,
+  sessionCount,
+  hasWaiting,
+  isExpanded,
+  onToggleExpanded,
+  startRenaming = false,
+  onRenameSettled
+}: {
+  group: SessionGroupConfig
+  sessionCount: number
+  hasWaiting: boolean
+  isExpanded: boolean
+  onToggleExpanded: () => void
+  startRenaming?: boolean
+  onRenameSettled?: () => void
+}) {
+  const activeGroupId = useAppStore((s) => s.activeGroupId)
+  const setActiveGroup = useAppStore((s) => s.setActiveGroup)
+  const setFocusedTerminal = useAppStore((s) => s.setFocusedTerminal)
+  const updateSessionGroup = useAppStore((s) => s.updateSessionGroup)
+  const removeSessionGroup = useAppStore((s) => s.removeSessionGroup)
+  const terminals = useAppStore((s) => s.terminals)
+  const moveSessionToGroup = useAppStore((s) => s.moveSessionToGroup)
+
+  const [renaming, setRenaming] = useState(startRenaming)
+  const [openMenu, setOpenMenu] = useState(false)
+  const [pickingIcon, setPickingIcon] = useState(false)
+
+  const isActive = activeGroupId === group.id
+
+  if (renaming) {
+    return (
+      <div className="flex items-center gap-2 px-2 py-1.5 min-w-0">
+        <ProjectIcon icon={group.icon} color={group.iconColor} size={14} />
+        <InlineRename
+          value={group.name}
+          onCommit={(next) => {
+            if (next !== group.name) updateSessionGroup(group.id, { name: next })
+            setRenaming(false)
+            onRenameSettled?.()
+          }}
+          onCancel={() => {
+            setRenaming(false)
+            onRenameSettled?.()
+          }}
+          className="flex-1 min-w-0 text-[13px]"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative">
+      <div className="group/grp relative flex items-center">
+        {/* A div with the button role: the row nests real buttons inside it. */}
+        <div
+          role="button"
+          tabIndex={0}
+          aria-pressed={isActive}
+          aria-label={group.name}
+          onKeyDown={(e) => {
+            // Keys bubbling from a nested control are that control's, not the row's.
+            if (e.target !== e.currentTarget) return
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              e.currentTarget.click()
+            }
+          }}
+          onClick={() => {
+            setActiveGroup(isActive ? null : group.id)
+            setFocusedTerminal(null)
+          }}
+          className={`flex-1 cursor-pointer select-none text-left px-2 py-1.5 rounded-md text-[13px] transition-colors flex items-center gap-2 min-w-0 ${
+            isActive
+              ? 'bg-white/[0.08] text-white'
+              : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
+          }`}
+        >
+          {/* The icon becomes the disclosure on hover, the way a project row
+              does it — one glyph, not two. */}
+          <div
+            role="button"
+            tabIndex={0}
+            aria-expanded={isExpanded}
+            aria-label={`Toggle ${group.name}`}
+            className="relative w-[14px] h-[14px] shrink-0"
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggleExpanded()
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation()
+                e.preventDefault()
+                onToggleExpanded()
+              }
+            }}
+          >
+            <span className="group-hover/grp:hidden flex items-center justify-center w-full h-full">
+              <ProjectIcon icon={group.icon} color={group.iconColor} size={14} />
+            </span>
+            <ChevronRight
+              size={12}
+              strokeWidth={2.5}
+              className={`hidden group-hover/grp:block text-gray-500 transition-transform absolute top-[1px] left-[1px] ${
+                isExpanded ? 'rotate-90' : ''
+              }`}
+            />
+          </div>
+          <span className="truncate">{group.name}</span>
+          {/* Shut, the group answers for the sessions it hides. */}
+          {hasWaiting && !isExpanded && (
+            <span
+              aria-label="A session in this group is waiting"
+              className="ml-auto w-[5px] h-[5px] rounded-full bg-bronzo shrink-0"
+            />
+          )}
+          {sessionCount > 0 && (
+            <span
+              className={`text-gray-500 text-xs shrink-0 group-hover/grp:hidden ${
+                hasWaiting && !isExpanded ? 'ml-1.5' : 'ml-auto'
+              }`}
+            >
+              {sessionCount}
+            </span>
+          )}
+          <div className="hidden group-hover/grp:flex items-center gap-0.5 ml-auto">
+            <Tooltip label="More" position="right">
+              <button
+                type="button"
+                aria-label={`More actions for ${group.name}`}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setOpenMenu(!openMenu)
+                }}
+                className="text-gray-500 hover:text-white p-0.5 rounded hover:bg-white/[0.08] transition-colors"
+              >
+                <MoreHorizontal size={14} strokeWidth={2} />
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+        {openMenu && (
+          <div className="relative">
+            <GroupContextMenu
+              group={group}
+              onRename={() => setRenaming(true)}
+              onChangeIcon={() => setPickingIcon(true)}
+              onUngroup={() => {
+                for (const [id, t] of terminals) {
+                  if (t.session.groupId === group.id) moveSessionToGroup(id, null)
+                }
+              }}
+              onDelete={() => removeSessionGroup(group.id)}
+              onClose={() => setOpenMenu(false)}
+            />
+          </div>
+        )}
+      </div>
+
+      {pickingIcon && (
+        <div
+          className="absolute left-0 top-full mt-1 z-50 w-[248px] p-3
+                     bg-surface-overlay border border-white/[0.08] rounded-lg shadow-xl"
+        >
+          <IconColorPicker
+            icon={group.icon ?? 'Folder'}
+            color={group.iconColor ?? '#6b7280'}
+            onIconChange={(icon) => updateSessionGroup(group.id, { icon })}
+            onColorChange={(iconColor) => updateSessionGroup(group.id, { iconColor })}
+          />
+          <button
+            onClick={() => setPickingIcon(false)}
+            className="mt-3 w-full px-2 py-1 text-[11px] text-gray-300 bg-white/[0.04]
+                       hover:bg-white/[0.08] border border-white/[0.08] rounded transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/project-sidebar/SessionItem.tsx
+++ b/src/renderer/components/project-sidebar/SessionItem.tsx
@@ -1,5 +1,13 @@
 import { useRef, useCallback, useEffect, useState } from 'react'
-import { X, FolderTree, Globe, Loader2, Smartphone, SquareTerminal } from 'lucide-react'
+import {
+  X,
+  FolderTree,
+  Globe,
+  Loader2,
+  Smartphone,
+  SquareTerminal,
+  MoreHorizontal
+} from 'lucide-react'
 import { useAppStore } from '../../stores'
 import { AgentStatusIcon } from '../AgentStatusIcon'
 import { closeTerminalSession } from '../../lib/terminal-close'
@@ -10,6 +18,8 @@ import { DevicePicker } from '../DevicePicker'
 import { shouldShowDeviceButton } from '../../lib/device-affordance'
 import { shouldOfferPane } from '../../lib/pane-affordance'
 import { PromotedCardItem } from './PromotedCardItem'
+import { SessionContextMenu } from './SessionContextMenu'
+import { useWorkspaceSessionGroups } from '../../hooks/useWorkspaceSessionGroups'
 import { usePromotedCardsFor } from '../../hooks/usePromotedCards'
 import type { SidebarSessionInfo } from './types'
 
@@ -43,6 +53,21 @@ export function SessionItem({
   const loadMobileProject = useAppStore((s) => s.loadMobileProject)
   const promotedCards = usePromotedCardsFor(session.id)
   const [isPickerOpen, setIsPickerOpen] = useState(false)
+  const [openMenu, setOpenMenu] = useState(false)
+  const groupId = useAppStore((s) => s.terminals.get(session.id)?.session.groupId)
+  const addSessionGroup = useAppStore((s) => s.addSessionGroup)
+  const moveSessionToGroup = useAppStore((s) => s.moveSessionToGroup)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  const workspaceGroups = useWorkspaceSessionGroups()
+
+  const createGroupWithSession = useCallback(() => {
+    const id = crypto.randomUUID()
+    // max + 1 over this workspace's own groups, the same as every other path;
+    // a plain count reused an order the moment one was deleted.
+    const order = workspaceGroups.reduce((max, g) => Math.max(max, g.order), -1) + 1
+    addSessionGroup({ id, name: 'New group', order, workspaceId: activeWorkspace })
+    moveSessionToGroup(session.id, id)
+  }, [addSessionGroup, workspaceGroups, activeWorkspace, moveSessionToGroup, session.id])
   // A claim in flight. Boot plus `bootstatus -b` can run tens of seconds, and
   // until this existed nothing on screen said so.
   const [claiming, setClaiming] = useState(false)
@@ -101,6 +126,11 @@ export function SessionItem({
       <div
         role="button"
         tabIndex={0}
+        draggable
+        onDragStart={(e) => {
+          e.dataTransfer.effectAllowed = 'move'
+          e.dataTransfer.setData('application/vorn-session', session.id)
+        }}
         onKeyDown={(e) => {
           // Keys bubbling from a nested control are that control's, not the row's.
           if (e.target !== e.currentTarget) return
@@ -243,6 +273,29 @@ export function SessionItem({
               })
             }}
           />
+        )}
+        <button
+          type="button"
+          aria-label={`More actions for ${session.name}`}
+          title="More"
+          onClick={(e) => {
+            e.stopPropagation()
+            setOpenMenu(!openMenu)
+          }}
+          className="opacity-0 group-hover/session:opacity-100 focus:opacity-100 text-gray-500
+                     hover:text-gray-200 p-0.5 rounded hover:bg-white/[0.08] transition-colors shrink-0"
+        >
+          <MoreHorizontal size={12} strokeWidth={2} />
+        </button>
+        {openMenu && (
+          <div className="relative">
+            <SessionContextMenu
+              sessionId={session.id}
+              currentGroupId={groupId}
+              onNewGroup={createGroupWithSession}
+              onClose={() => setOpenMenu(false)}
+            />
+          </div>
         )}
         <button
           type="button"

--- a/src/renderer/hooks/useScopedSessionIds.ts
+++ b/src/renderer/hooks/useScopedSessionIds.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../stores'
+
+/**
+ * Which sessions the current selection covers, or null for "no restriction".
+ *
+ * Selection is one value with three states — all, a group, a single project.
+ * A group cuts across the project tree, so it can only be answered in session
+ * ids; a project selection is still answered by project name, which is why both
+ * shapes come back from here rather than one.
+ */
+export function useSessionScope(): {
+  projectNames: Set<string> | null
+  sessionIds: Set<string> | null
+} {
+  const activeProject = useAppStore((s) => s.activeProject)
+  const activeGroupId = useAppStore((s) => s.activeGroupId)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  const projects = useAppStore((s) => s.config?.projects)
+  const groups = useAppStore((s) => s.config?.sessionGroups)
+  const terminals = useAppStore((s) => s.terminals)
+
+  return useMemo(() => {
+    const workspaceNames = projects
+      ? new Set(
+          projects
+            .filter((p) => (p.workspaceId ?? 'personal') === activeWorkspace)
+            .map((p) => p.name)
+        )
+      : null
+
+    // A selection left over from another workspace, or a group whose sessions
+    // have all ended, narrows to nothing — so it is read as no selection rather
+    // than blanking the board.
+    if (activeProject && workspaceNames?.has(activeProject)) {
+      return { projectNames: new Set([activeProject]), sessionIds: null }
+    }
+    // A group belongs to one workspace, and so does every session it can show.
+    const group = (groups ?? []).find(
+      (g) => g.id === activeGroupId && g.workspaceId === activeWorkspace
+    )
+    if (group) {
+      const ids = new Set<string>()
+      for (const [id, t] of terminals) {
+        if (t.session.groupId !== group.id) continue
+        if (workspaceNames && !workspaceNames.has(t.session.projectName)) continue
+        ids.add(id)
+      }
+      if (ids.size > 0) return { projectNames: workspaceNames, sessionIds: ids }
+    }
+    return { projectNames: workspaceNames, sessionIds: null }
+  }, [activeProject, activeGroupId, activeWorkspace, projects, groups, terminals])
+}

--- a/src/renderer/hooks/useVisibleTerminals.ts
+++ b/src/renderer/hooks/useVisibleTerminals.ts
@@ -3,6 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../stores'
 import { MAIN_WORKTREE_SENTINEL, type SortMode, type TerminalState } from '../stores/types'
 import { usePromotedCardsByOwner } from './usePromotedCards'
+import { useSessionScope } from './useScopedSessionIds'
 import { useClaimedTerminalIds } from './usePanelTerminals'
 
 /**
@@ -43,10 +44,7 @@ export function compareTerminalIds(
 export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: string[] } {
   const {
     terminals,
-    activeProject,
     activeWorktreePath,
-    activeWorkspace,
-    projects,
     sortMode,
     statusFilter,
     terminalOrder,
@@ -56,10 +54,7 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
   } = useAppStore(
     useShallow((s) => ({
       terminals: s.terminals,
-      activeProject: s.activeProject,
       activeWorktreePath: s.activeWorktreePath,
-      activeWorkspace: s.activeWorkspace,
-      projects: s.config?.projects,
       sortMode: s.sortMode,
       statusFilter: s.statusFilter,
       terminalOrder: s.terminalOrder,
@@ -80,26 +75,21 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
   // and the registry's one-slot-per-terminal rule depends on that staying true.
   const claimedTerminals = useClaimedTerminalIds()
 
-  const workspaceProjects = useMemo(() => {
-    if (!projects) return null
-    return new Set(
-      projects.filter((p) => (p.workspaceId ?? 'personal') === activeWorkspace).map((p) => p.name)
-    )
-  }, [projects, activeWorkspace])
+  const scope = useSessionScope()
 
   const { orderedIds, minimizedIds, focusableIds } = useMemo(() => {
-    const inActiveScope = (t: TerminalState): boolean => {
-      if (activeProject && t.session.projectName !== activeProject) return false
-      if (!activeProject && workspaceProjects && !workspaceProjects.has(t.session.projectName))
-        return false
-      return true
+    const inActiveScope = (t: TerminalState, id: string): boolean => {
+      // A group answers in session ids, because its members span projects.
+      if (scope.sessionIds) return scope.sessionIds.has(id)
+      if (!scope.projectNames) return true
+      return scope.projectNames.has(t.session.projectName)
     }
     const sortFn = ([aId]: [string, TerminalState], [bId]: [string, TerminalState]): number =>
       compareTerminalIds(aId, bId, terminals, sortMode, terminalOrder)
     const all = Array.from(terminals.entries()).filter(([id]) => !claimedTerminals.has(id))
     const filtered = all
-      .filter(([, t]) => {
-        if (!inActiveScope(t)) return false
+      .filter(([id, t]) => {
+        if (!inActiveScope(t, id)) return false
         if (activeWorktreePath) {
           if (activeWorktreePath === MAIN_WORKTREE_SENTINEL) {
             if (t.session.worktreePath) return false
@@ -134,7 +124,7 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     // index straight into it, so a card being focusable at all is decided here
     // and nowhere else — the shortcut handlers never learn what an id is.
     const focusable: string[] = []
-    for (const [id] of all.filter(([, t]) => inActiveScope(t)).sort(sortFn)) {
+    for (const [id] of all.filter(([tid, t]) => inActiveScope(t, tid)).sort(sortFn)) {
       focusable.push(id)
       focusable.push(...(cardsByOwner.get(id) ?? []))
     }
@@ -142,9 +132,8 @@ export function useVisibleTerminals(): { orderedIds: string[]; minimizedIds: str
     return { orderedIds: ordered, minimizedIds: minimized, focusableIds: focusable }
   }, [
     terminals,
-    activeProject,
     activeWorktreePath,
-    workspaceProjects,
+    scope,
     statusFilter,
     sortMode,
     terminalOrder,

--- a/src/renderer/hooks/useWorkspaceSessionGroups.ts
+++ b/src/renderer/hooks/useWorkspaceSessionGroups.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { useAppStore } from '../stores'
+import type { SessionGroupConfig } from '../../shared/types'
+
+const EMPTY: SessionGroupConfig[] = []
+
+/**
+ * Returns the groups belonging to the active workspace, in their own order.
+ */
+export function useWorkspaceSessionGroups(): SessionGroupConfig[] {
+  const groups = useAppStore((s) => s.config?.sessionGroups)
+  const activeWorkspace = useAppStore((s) => s.activeWorkspace)
+  return useMemo(() => {
+    if (!groups?.length) return EMPTY
+    return groups.filter((g) => g.workspaceId === activeWorkspace).sort((a, b) => a.order - b.order)
+  }, [groups, activeWorkspace])
+}

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -267,7 +267,7 @@ function resolveProjectForPath(p?: string): ProjectConfig | undefined {
 
 /**
  * Resolve the currently active project from the store.
- * Falls back to the first project in the active workspace.
+ * Falls back to the active group's most recent session, then the workspace.
  */
 export function resolveActiveProject() {
   const state = useAppStore.getState()
@@ -280,7 +280,21 @@ export function resolveActiveProject() {
     if (match) return match
   }
   const ws = state.activeWorkspace
-  return projects.find((p) => (p.workspaceId ?? 'personal') === ws)
+  const inWorkspace = projects.filter((p) => (p.workspaceId ?? 'personal') === ws)
+  // A group holds sessions from many projects, so launching from one starts in
+  // the project its most recent session belongs to.
+  if (state.activeGroupId) {
+    let newest: { name: string; at: number } | null = null
+    for (const t of state.terminals.values()) {
+      if (t.session.groupId !== state.activeGroupId) continue
+      if (!newest || t.lastOutputTimestamp > newest.at) {
+        newest = { name: t.session.projectName, at: t.lastOutputTimestamp }
+      }
+    }
+    const match = newest && inWorkspace.find((p) => p.name === newest.name)
+    if (match) return match
+  }
+  return inWorkspace[0]
 }
 
 /**

--- a/src/renderer/stores/projects-slice.ts
+++ b/src/renderer/stores/projects-slice.ts
@@ -17,6 +17,7 @@ function patchConfig(
 export const createProjectsSlice: StateCreator<AppStore, [], [], ProjectsSlice> = (set) => ({
   config: null,
   activeProject: loadView().activeProject,
+  activeGroupId: loadView().activeGroupId,
   activeWorktreePath: loadView().activeWorktreePath,
 
   setConfig: (config) =>
@@ -27,8 +28,12 @@ export const createProjectsSlice: StateCreator<AppStore, [], [], ProjectsSlice> 
     }),
 
   setActiveProject: (name) => {
-    saveView({ activeProject: name, activeWorktreePath: null })
-    set({ activeProject: name, activeWorktreePath: null })
+    saveView({ activeProject: name, activeGroupId: null, activeWorktreePath: null })
+    set({ activeProject: name, activeGroupId: null, activeWorktreePath: null })
+  },
+  setActiveGroup: (id) => {
+    saveView({ activeGroupId: id, activeProject: null, activeWorktreePath: null })
+    set({ activeGroupId: id, activeProject: null, activeWorktreePath: null })
   },
   setActiveWorktreePath: (path) => {
     saveView({ activeWorktreePath: path })
@@ -49,6 +54,49 @@ export const createProjectsSlice: StateCreator<AppStore, [], [], ProjectsSlice> 
         projects: c.projects.map((p) => (p.name === originalName ? project : p))
       }))
     ),
+
+  addSessionGroup: (group) =>
+    set((s) =>
+      patchConfig(s.config, (c) => ({ sessionGroups: [...(c.sessionGroups || []), group] }))
+    ),
+
+  updateSessionGroup: (id, updates) =>
+    set((s) =>
+      patchConfig(s.config, (c) => ({
+        sessionGroups: (c.sessionGroups || []).map((g) => (g.id === id ? { ...g, ...updates } : g))
+      }))
+    ),
+
+  removeSessionGroup: (id) =>
+    set((state) => {
+      if (!state.config) return {}
+      const clearSelection = state.activeGroupId === id
+      const updated = {
+        ...state.config,
+        sessionGroups: (state.config.sessionGroups || []).filter((g) => g.id !== id)
+      }
+      window.api.saveConfig(updated)
+      // The server owns membership, so the sessions are let go through it.
+      for (const [sessionId, t] of state.terminals) {
+        if (t.session.groupId === id) void window.api.setSessionGroup(sessionId, null)
+      }
+      if (clearSelection) saveView({ activeGroupId: null })
+      return { config: updated, ...(clearSelection && { activeGroupId: null }) }
+    }),
+
+  moveSessionToGroup: (sessionId, groupId) => {
+    void window.api.setSessionGroup(sessionId, groupId)
+    set((state) => {
+      const t = state.terminals.get(sessionId)
+      if (!t) return {}
+      const terminals = new Map(state.terminals)
+      const session = { ...t.session }
+      if (groupId) session.groupId = groupId
+      else delete session.groupId
+      terminals.set(sessionId, { ...t, session })
+      return { terminals }
+    })
+  },
 
   addWorkflow: (workflow) =>
     set((s) => patchConfig(s.config, (c) => ({ workflows: [...(c.workflows || []), workflow] }))),
@@ -95,6 +143,9 @@ export const createProjectsSlice: StateCreator<AppStore, [], [], ProjectsSlice> 
       const updated = {
         ...state.config,
         workspaces: (state.config.workspaces || []).filter((ws) => ws.id !== id),
+        // A group belongs to one workspace, so it goes with it. Its sessions keep
+        // a group_id pointing at nothing, which every reader treats as ungrouped.
+        sessionGroups: (state.config.sessionGroups || []).filter((g) => g.workspaceId !== id),
         projects: state.config.projects.map((p) =>
           (p.workspaceId ?? 'personal') === id ? { ...p, workspaceId: 'personal' } : p
         ),

--- a/src/renderer/stores/terminals-slice.ts
+++ b/src/renderer/stores/terminals-slice.ts
@@ -272,6 +272,20 @@ export const createTerminalsSlice: StateCreator<AppStore, [], [], TerminalsSlice
       return next ? { terminals: next } : state
     }),
 
+  // Ungrouping deletes the key rather than setting a falsy one, so this takes
+  // undefined as a real value and cannot use a truthiness check.
+  updateSessionGroupId: (id, groupId) =>
+    set((state) => {
+      const term = state.terminals.get(id)
+      if (!term || term.session.groupId === groupId) return state
+      const session = { ...term.session }
+      if (groupId === undefined) delete session.groupId
+      else session.groupId = groupId
+      const next = new Map(state.terminals)
+      next.set(id, { ...term, session })
+      return { terminals: next }
+    }),
+
   updateSessionWorktree: (id, updates) =>
     set((state) => {
       const term = state.terminals.get(id)

--- a/src/renderer/stores/types.ts
+++ b/src/renderer/stores/types.ts
@@ -3,6 +3,7 @@ import {
   AiAgentType,
   AppConfig,
   ProjectConfig,
+  SessionGroupConfig,
   WorkflowDefinition,
   WorkflowExecution,
   WorkspaceConfig,
@@ -49,7 +50,12 @@ export type WorkflowFilter = 'all' | 'manual' | 'scheduled'
 export type RunBucket = 'all' | 'running' | 'waiting' | 'success' | 'error'
 export type WorktreeSortMode = 'name' | 'recent'
 export type WorktreeFilter = 'all' | 'active'
-export type SidebarViewMode = 'worktrees' | 'worktrees-sessions' | 'sessions' | 'sessions-flat'
+export type SidebarViewMode =
+  | 'worktrees'
+  | 'worktrees-sessions'
+  | 'sessions'
+  | 'groups-sessions'
+  | 'sessions-flat'
 export type PanelTab = 'changes'
 
 export interface FlexibleLayoutRect {
@@ -293,6 +299,7 @@ export interface TerminalsSlice {
   updateSessionBranch: (id: string, branch: string) => void
   updateSessionCwd: (id: string, shellCwd: string) => void
   setBranchForCwd: (cwd: string, branch: string) => void
+  updateSessionGroupId: (id: string, groupId: string | undefined) => void
   updateSessionWorktree: (
     id: string,
     updates: { worktreePath?: string; worktreeName?: string }
@@ -313,9 +320,11 @@ export interface TerminalsSlice {
 export interface ProjectsSlice {
   config: AppConfig | null
   activeProject: string | null
+  activeGroupId: string | null
   activeWorktreePath: string | null
   setConfig: (config: AppConfig) => void
   setActiveProject: (name: string | null) => void
+  setActiveGroup: (id: string | null) => void
   setActiveWorktreePath: (path: string | null) => void
   addProject: (project: ProjectConfig) => void
   removeProject: (name: string) => void
@@ -326,6 +335,10 @@ export interface ProjectsSlice {
   addRemoteHost: (host: RemoteHost) => void
   removeRemoteHost: (id: string) => void
   updateRemoteHost: (id: string, host: RemoteHost) => void
+  addSessionGroup: (group: SessionGroupConfig) => void
+  updateSessionGroup: (id: string, updates: Partial<SessionGroupConfig>) => void
+  removeSessionGroup: (id: string) => void
+  moveSessionToGroup: (sessionId: string, groupId: string | null) => void
   addWorkspace: (workspace: WorkspaceConfig) => void
   removeWorkspace: (id: string) => void
   updateWorkspace: (id: string, updates: Partial<WorkspaceConfig>) => void

--- a/src/renderer/stores/ui-slice.ts
+++ b/src/renderer/stores/ui-slice.ts
@@ -73,6 +73,7 @@ interface PersistedView {
   activeTabId: string | null
   maximizedPaneId: string | null
   activeProject: string | null
+  activeGroupId: string | null
   activeWorktreePath: string | null
 }
 
@@ -81,6 +82,7 @@ const EMPTY_VIEW: PersistedView = {
   activeTabId: null,
   maximizedPaneId: null,
   activeProject: null,
+  activeGroupId: null,
   activeWorktreePath: null
 }
 
@@ -95,6 +97,7 @@ function loadView(): PersistedView {
       activeTabId: orNull(parsed.activeTabId),
       maximizedPaneId: orNull(parsed.maximizedPaneId),
       activeProject: orNull(parsed.activeProject),
+      activeGroupId: orNull(parsed.activeGroupId),
       activeWorktreePath: orNull(parsed.activeWorktreePath)
     }
   } catch {
@@ -932,13 +935,27 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
   activeTabId: loadView().activeTabId,
 
   setActiveWorkspace: (id) => {
+    // Cleared in the store but not on disk, the old selection came back on the
+    // next launch pointing into a workspace that is no longer active.
+    saveView({ activeProject: null, activeGroupId: null, activeWorktreePath: null })
     const config = get().config
     if (config) {
       const updated = { ...config, defaults: { ...config.defaults, activeWorkspace: id } }
       window.api.saveConfig(updated)
-      set({ activeWorkspace: id, activeProject: null, config: updated })
+      set({
+        activeWorkspace: id,
+        activeProject: null,
+        activeGroupId: null,
+        activeWorktreePath: null,
+        config: updated
+      })
     } else {
-      set({ activeWorkspace: id, activeProject: null })
+      set({
+        activeWorkspace: id,
+        activeProject: null,
+        activeGroupId: null,
+        activeWorktreePath: null
+      })
     }
   },
   setFocusedTerminal: (id) =>

--- a/tests/database-defaults.test.ts
+++ b/tests/database-defaults.test.ts
@@ -14,7 +14,11 @@ import {
   saveConfig,
   dbInsertSourceConnection,
   dbInsertTaskSourceLink,
-  dbGetTaskSourceLink
+  dbGetTaskSourceLink,
+  dbDeleteSessionGroup,
+  dbListSessionGroups,
+  saveSessions,
+  getPreviousSessions
 } from '../packages/server/src/database'
 import type { AppConfig, TaskConfig } from '../packages/shared/src/types'
 
@@ -331,5 +335,66 @@ describe('reopening the panes you had open', () => {
     saveConfig({ ...config, defaults: { ...config.defaults, reopenSessions: false } })
 
     expect(loadConfig().defaults.reopenSessions).toBe(false)
+  })
+})
+
+describe('session groups', () => {
+  const group = { id: 'g1', name: 'Sidebar work', order: 0, workspaceId: 'personal' }
+  const config: AppConfig = {
+    version: 1,
+    defaults: { shell: '/bin/zsh', fontSize: 13, theme: 'dark' },
+    projects: [{ name: 'vorn', path: '/tmp/vorn', preferredAgents: [] }],
+    sessionGroups: [group]
+  } as AppConfig
+
+  const session = (id: string, groupId?: string) =>
+    ({
+      id,
+      agentType: 'claude',
+      projectName: 'vorn',
+      projectPath: '/tmp/vorn',
+      status: 'idle',
+      createdAt: 1,
+      pid: 1,
+      ...(groupId && { groupId })
+    }) as Parameters<typeof saveSessions>[0][number]
+
+  it('round-trips a group', () => {
+    saveConfig(config)
+    expect(loadConfig().sessionGroups).toEqual([group])
+  })
+
+  /** Membership rides on the session row the server already restores. */
+  it('brings a session back still filed under its group', () => {
+    saveConfig(config)
+    saveSessions([session('s1', 'g1'), session('s2')])
+    const restored = getPreviousSessions()
+    expect(restored.find((s) => s.id === 's1')?.groupId).toBe('g1')
+    expect(restored.find((s) => s.id === 's2')?.groupId).toBeUndefined()
+  })
+
+  it('lets the sessions go when the group is deleted, and kills none', () => {
+    saveConfig(config)
+    saveSessions([session('s1', 'g1'), session('s2', 'g1')])
+    dbDeleteSessionGroup('g1')
+    expect(dbListSessionGroups()).toEqual([])
+    const restored = getPreviousSessions()
+    expect(restored.map((s) => s.id).sort()).toEqual(['s1', 's2'])
+    expect(restored.every((s) => s.groupId === undefined)).toBe(true)
+  })
+
+  it('spares a group another client added after this snapshot was loaded', () => {
+    saveConfig(config)
+    const stale = loadConfig()
+    saveConfig({
+      ...stale,
+      sessionGroups: [...(stale.sessionGroups ?? []), { ...group, id: 'g2', name: 'Release' }]
+    })
+    saveConfig(stale)
+    expect(
+      dbListSessionGroups()
+        .map((g) => g.id)
+        .sort()
+    ).toEqual(['g1', 'g2'])
   })
 })

--- a/tests/group-menus.test.tsx
+++ b/tests/group-menus.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { SessionGroupConfig } from '../src/shared/types'
+
+const mockStore = {
+  moveSessionToGroup: vi.fn(),
+  activeWorkspace: 'personal',
+  config: {
+    sessionGroups: [
+      { id: 'g1', name: 'Sidebar work', order: 0, workspaceId: 'personal', icon: 'Terminal' },
+      { id: 'g2', name: 'Release', order: 1, workspaceId: 'personal' },
+      { id: 'g9', name: 'Elsewhere', order: 0, workspaceId: 'work' }
+    ]
+  }
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockStore) : mockStore
+}))
+
+const toastSuccess = vi.fn()
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: toastSuccess, error: vi.fn() }
+}))
+
+const { GroupContextMenu } =
+  await import('../src/renderer/components/project-sidebar/GroupContextMenu')
+const { SessionContextMenu } =
+  await import('../src/renderer/components/project-sidebar/SessionContextMenu')
+
+const group: SessionGroupConfig = {
+  id: 'g1',
+  name: 'Sidebar work',
+  order: 0,
+  workspaceId: 'personal'
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('the group menu', () => {
+  const handlers = () => ({
+    onRename: vi.fn(),
+    onChangeIcon: vi.fn(),
+    onUngroup: vi.fn(),
+    onDelete: vi.fn(),
+    onClose: vi.fn()
+  })
+
+  it('offers rename, icon, ungroup and delete', () => {
+    render(<GroupContextMenu group={group} {...handlers()} />)
+    expect(screen.getByText('Rename group')).toBeInTheDocument()
+    expect(screen.getByText('Change icon')).toBeInTheDocument()
+    expect(screen.getByText('Remove all sessions')).toBeInTheDocument()
+    expect(screen.getByText('Delete group')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['Rename group', 'onRename'],
+    ['Change icon', 'onChangeIcon'],
+    ['Remove all sessions', 'onUngroup']
+  ])('%s calls %s and closes', (label, handler) => {
+    const h = handlers()
+    render(<GroupContextMenu group={group} {...h} />)
+    fireEvent.click(screen.getByText(label))
+    expect(h[handler as keyof typeof h]).toHaveBeenCalledTimes(1)
+    expect(h.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  /** Delete is two clicks so a slip cannot take a group with it. */
+  it('does not delete on the first click', () => {
+    const h = handlers()
+    render(<GroupContextMenu group={group} {...h} />)
+    fireEvent.click(screen.getByText('Delete group'))
+    expect(h.onDelete).not.toHaveBeenCalled()
+    expect(screen.getByText('Confirm delete?')).toBeInTheDocument()
+  })
+
+  it('deletes on the second', () => {
+    const h = handlers()
+    render(<GroupContextMenu group={group} {...h} />)
+    fireEvent.click(screen.getByText('Delete group'))
+    fireEvent.click(screen.getByText('Confirm delete?'))
+    expect(h.onDelete).toHaveBeenCalledTimes(1)
+    expect(toastSuccess).toHaveBeenCalledWith('Group "Sidebar work" deleted')
+  })
+
+  it('closes when a click lands outside it', () => {
+    const h = handlers()
+    render(<GroupContextMenu group={group} {...h} />)
+    fireEvent.pointerDown(document.body)
+    expect(h.onClose).toHaveBeenCalled()
+  })
+})
+
+describe('the session menu', () => {
+  it('lists only the groups of the active workspace', () => {
+    render(<SessionContextMenu sessionId="s1" onNewGroup={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByText('Sidebar work')).toBeInTheDocument()
+    expect(screen.getByText('Release')).toBeInTheDocument()
+    expect(screen.queryByText('Elsewhere')).not.toBeInTheDocument()
+  })
+
+  it('files the session into the group that was picked', () => {
+    const onClose = vi.fn()
+    render(<SessionContextMenu sessionId="s1" onNewGroup={vi.fn()} onClose={onClose} />)
+    fireEvent.click(screen.getByText('Release'))
+    expect(mockStore.moveSessionToGroup).toHaveBeenCalledWith('s1', 'g2')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('takes it out again when its current group is picked', () => {
+    render(
+      <SessionContextMenu
+        sessionId="s1"
+        currentGroupId="g1"
+        onNewGroup={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByText('Sidebar work'))
+    expect(mockStore.moveSessionToGroup).toHaveBeenCalledWith('s1', null)
+  })
+
+  it('offers Remove from group only while it is in one', () => {
+    const { unmount } = render(
+      <SessionContextMenu sessionId="s1" onNewGroup={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(screen.queryByText('Remove from group')).not.toBeInTheDocument()
+    unmount()
+
+    render(
+      <SessionContextMenu
+        sessionId="s1"
+        currentGroupId="g1"
+        onNewGroup={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByText('Remove from group'))
+    expect(mockStore.moveSessionToGroup).toHaveBeenCalledWith('s1', null)
+  })
+
+  it('can make a new group instead', () => {
+    const onNewGroup = vi.fn()
+    render(<SessionContextMenu sessionId="s1" onNewGroup={onNewGroup} onClose={vi.fn()} />)
+    fireEvent.click(screen.getByText('New group…'))
+    expect(onNewGroup).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when a click lands outside it', () => {
+    const onClose = vi.fn()
+    render(<SessionContextMenu sessionId="s1" onNewGroup={vi.fn()} onClose={onClose} />)
+    fireEvent.pointerDown(document.body)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/tests/group-sessions-section.test.tsx
+++ b/tests/group-sessions-section.test.tsx
@@ -1,0 +1,207 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockStore = {
+  terminals: new Map(),
+  terminalsPanes: new Map(),
+  filesPanes: new Set(),
+  editorPanes: new Map(),
+  browserPanes: new Map(),
+  devicePanes: new Map(),
+  mobileProjectCache: new Map(),
+  loadMobileProject: vi.fn(),
+  toggleFilesPane: vi.fn(),
+  toggleBrowserPane: vi.fn(),
+  claimAndOpenDevicePane: vi.fn(),
+  closeDevicePane: vi.fn(),
+  setActiveTabId: vi.fn(),
+  setPreviewTerminal: vi.fn(),
+  focusedTerminalId: null as string | null,
+  previewTerminalId: null as string | null,
+  activeTabId: null as string | null,
+  activeProject: null as string | null,
+  setActiveProject: vi.fn(),
+  activeGroupId: null as string | null,
+  setActiveGroup: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  addSessionGroup: vi.fn(),
+  updateSessionGroup: vi.fn(),
+  removeSessionGroup: vi.fn(),
+  moveSessionToGroup: vi.fn(),
+  activeWorkspace: 'personal',
+  sidebarProjectSort: 'manual',
+  sidebarWorktreeSort: 'name',
+  sidebarWorktreeFilter: 'all',
+  sidebarViewMode: 'groups-sessions',
+  setSidebarProjectSort: vi.fn(),
+  setSidebarWorktreeSort: vi.fn(),
+  setSidebarWorktreeFilter: vi.fn(),
+  setSidebarViewMode: vi.fn(),
+  config: null as { projects?: unknown[]; sessionGroups?: unknown[] } | null
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockStore) : mockStore
+}))
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+const { GroupSessionsSection } =
+  await import('../src/renderer/components/project-sidebar/GroupSessionsSection')
+
+const session = (id: string, name: string, project: string, groupId?: string) => [
+  id,
+  {
+    session: {
+      id,
+      projectName: project,
+      agentType: 'claude',
+      displayName: name,
+      ...(groupId && { groupId })
+    },
+    status: 'idle',
+    lastOutputTimestamp: 1
+  }
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockStore.activeGroupId = null
+  mockStore.activeProject = null
+  mockStore.config = {
+    projects: [
+      { name: 'vorn', path: '/tmp/vorn', preferredAgents: [] },
+      { name: 'ode', path: '/tmp/ode', preferredAgents: [] }
+    ],
+    sessionGroups: [{ id: 'g1', name: 'Sidebar work', order: 0, workspaceId: 'personal' }]
+  }
+  mockStore.terminals = new Map([
+    session('s1', 'in-group', 'vorn', 'g1'),
+    session('s2', 'also-in-group', 'ode', 'g1'),
+    session('s3', 'loose', 'vorn')
+  ] as never)
+})
+
+const draw = () =>
+  render(
+    <GroupSessionsSection
+      isCollapsed={false}
+      workspaceProjectNames={new Set(['vorn', 'ode'])}
+      workspaceTerminalCount={3}
+    />
+  )
+
+describe('the Groups > Sessions mode', () => {
+  it('draws a group holding sessions from more than one repo', () => {
+    draw()
+    expect(screen.getByRole('button', { name: 'Sidebar work' })).toBeInTheDocument()
+    expect(screen.getByText('in-group')).toBeInTheDocument()
+    expect(screen.getByText('also-in-group')).toBeInTheDocument()
+  })
+
+  it('draws ungrouped sessions below, with no header of their own', () => {
+    draw()
+    expect(screen.getByText('loose')).toBeInTheDocument()
+    expect(screen.queryByText('Ungrouped')).not.toBeInTheDocument()
+  })
+
+  it('makes a group in the active workspace, after the last one', () => {
+    draw()
+    fireEvent.click(screen.getByRole('button', { name: 'New group' }))
+    expect(mockStore.addSessionGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'New group', order: 1, workspaceId: 'personal' })
+    )
+  })
+
+  it('scopes to a group when its row is clicked', () => {
+    draw()
+    fireEvent.click(screen.getByRole('button', { name: 'Sidebar work' }))
+    expect(mockStore.setActiveGroup).toHaveBeenCalledWith('g1')
+  })
+
+  it('keeps the group populated whichever group is selected', () => {
+    mockStore.activeGroupId = 'g1'
+    draw()
+    expect(screen.getByText('in-group')).toBeInTheDocument()
+    expect(screen.getByText('loose')).toBeInTheDocument()
+  })
+
+  it('says so only when there is genuinely nothing', () => {
+    mockStore.terminals = new Map()
+    draw()
+    expect(screen.getByText('No active sessions')).toBeInTheDocument()
+  })
+
+  /** A deleted group must not take its sessions off the screen with it. */
+  it('shows a session whose group no longer exists as ungrouped', () => {
+    mockStore.config = { projects: mockStore.config!.projects, sessionGroups: [] }
+    draw()
+    expect(screen.getByText('in-group')).toBeInTheDocument()
+    expect(screen.getByText('also-in-group')).toBeInTheDocument()
+  })
+})
+
+describe('filling and folding a group', () => {
+  it('collapses and expands, hiding its sessions', () => {
+    draw()
+    expect(screen.getByText('in-group')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Sidebar work' }))
+    expect(screen.queryByText('in-group')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Sidebar work' }))
+    expect(screen.getByText('in-group')).toBeInTheDocument()
+  })
+
+  it('says what an empty group is for', () => {
+    mockStore.terminals = new Map([session('s3', 'loose', 'vorn')] as never)
+    draw()
+    expect(screen.getByText('Drop a session here')).toBeInTheDocument()
+  })
+
+  it('files a session dropped onto the group', () => {
+    draw()
+    const row = screen.getByRole('button', { name: 'Sidebar work' }).closest('div')!.parentElement!
+    const dataTransfer = {
+      types: ['application/vorn-session'],
+      getData: () => 's3',
+      dropEffect: ''
+    }
+    fireEvent.dragOver(row, { dataTransfer })
+    fireEvent.drop(row, { dataTransfer })
+    expect(mockStore.moveSessionToGroup).toHaveBeenCalledWith('s3', 'g1')
+  })
+
+  it('ignores a drag that is not carrying a session', () => {
+    draw()
+    const row = screen.getByRole('button', { name: 'Sidebar work' }).closest('div')!.parentElement!
+    const dataTransfer = { types: ['text/plain'], getData: () => '', dropEffect: '' }
+    fireEvent.dragOver(row, { dataTransfer })
+    fireEvent.drop(row, { dataTransfer })
+    expect(mockStore.moveSessionToGroup).not.toHaveBeenCalled()
+  })
+
+  it('opens a freshly made group straight into its name field', () => {
+    draw()
+    fireEvent.click(screen.getByRole('button', { name: 'New group' }))
+    const id = mockStore.addSessionGroup.mock.calls[0][0].id
+    expect(id).toBeTruthy()
+  })
+
+  it('clears the selection through All Sessions', () => {
+    mockStore.activeGroupId = 'g1'
+    draw()
+    fireEvent.click(screen.getByRole('button', { name: /All Sessions/ }))
+    expect(mockStore.setActiveProject).toHaveBeenCalledWith(null)
+    expect(mockStore.setActiveGroup).toHaveBeenCalledWith(null)
+  })
+
+  it('folds the whole section away', () => {
+    draw()
+    fireEvent.click(screen.getByText('Groups'))
+    expect(screen.queryByRole('button', { name: 'Sidebar work' })).not.toBeInTheDocument()
+  })
+})

--- a/tests/icon-color-picker.test.tsx
+++ b/tests/icon-color-picker.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { IconColorPicker } from '../src/renderer/components/IconColorPicker'
+import { PROJECT_ICON_OPTIONS, ICON_COLOR_PALETTE } from '../src/renderer/lib/project-icons'
+
+/** Shared by the project dialog and a group's Change icon, so it holds no state. */
+describe('the icon and colour picker', () => {
+  const draw = (over: Partial<React.ComponentProps<typeof IconColorPicker>> = {}) =>
+    render(
+      <IconColorPicker
+        icon="Folder"
+        color="#6b7280"
+        onIconChange={vi.fn()}
+        onColorChange={vi.fn()}
+        {...over}
+      />
+    )
+
+  it('offers every icon and every colour', () => {
+    draw()
+    for (const opt of PROJECT_ICON_OPTIONS) {
+      expect(screen.getByRole('button', { name: opt.label })).toBeInTheDocument()
+    }
+    for (const swatch of ICON_COLOR_PALETTE) {
+      expect(screen.getByRole('button', { name: `Color ${swatch}` })).toBeInTheDocument()
+    }
+  })
+
+  it('reports which icon is chosen', () => {
+    draw({ icon: 'Terminal' })
+    expect(screen.getByRole('button', { name: 'Terminal' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Folder' })).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('reports which colour is chosen', () => {
+    draw({ color: ICON_COLOR_PALETTE[1] })
+    expect(screen.getByRole('button', { name: `Color ${ICON_COLOR_PALETTE[1]}` })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('hands back the icon that was picked', () => {
+    const onIconChange = vi.fn()
+    draw({ onIconChange })
+    fireEvent.click(screen.getByRole('button', { name: 'Launch' }))
+    expect(onIconChange).toHaveBeenCalledWith('Rocket')
+  })
+
+  it('hands back the colour that was picked', () => {
+    const onColorChange = vi.fn()
+    draw({ onColorChange })
+    fireEvent.click(screen.getByRole('button', { name: `Color ${ICON_COLOR_PALETTE[2]}` }))
+    expect(onColorChange).toHaveBeenCalledWith(ICON_COLOR_PALETTE[2])
+  })
+
+  it('shows a preview, and can be asked not to', () => {
+    const { unmount } = draw()
+    expect(screen.getByText('Preview')).toBeInTheDocument()
+    unmount()
+    draw({ showPreview: false })
+    expect(screen.queryByText('Preview')).not.toBeInTheDocument()
+  })
+
+  it('falls back to a folder for an icon it does not know', () => {
+    draw({ icon: 'not-a-real-icon' })
+    expect(screen.getByText('Preview')).toBeInTheDocument()
+  })
+})

--- a/tests/restored-resume.test.ts
+++ b/tests/restored-resume.test.ts
@@ -99,6 +99,25 @@ describe('claiming one', () => {
 
     expect(restoredRecords().map((s) => s.id)).toEqual(['two'])
   })
+
+  /**
+   * Resume rebuilds the session from a whitelist under the same id and saves it,
+   * so a field the whitelist forgets is written back as null and lost for good.
+   * The group is the value that has to reach the handler for it to carry it.
+   */
+  it('carries a group on the record the resume handler reads', () => {
+    seedRestored([session({ id: 'one', groupId: 'g1' })], NOW)
+
+    expect(restoredRecords()[0].groupId).toBe('g1')
+    expect(consumeRestored('one')?.session.groupId).toBe('g1')
+  })
+
+  /** The payload is client-shaped, so membership is applied server-side instead. */
+  it('is not something buildRestorePayload carries, by design', () => {
+    const payload = buildRestorePayload(session({ id: 'one', groupId: 'g1' }), undefined)
+
+    expect(payload).not.toHaveProperty('groupId')
+  })
 })
 
 describe('what is on disk when a session is claimed or let go', () => {

--- a/tests/session-group-crud.test.ts
+++ b/tests/session-group-crud.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, existsSync: vi.fn(() => true), mkdirSync: vi.fn() }
+})
+
+import {
+  initTestDatabase,
+  dbListSessionGroups,
+  dbInsertSessionGroup,
+  dbUpdateSessionGroup,
+  dbDeleteSessionGroup,
+  saveSessions,
+  getPreviousSessions
+} from '../packages/server/src/database'
+import type { SessionGroupConfig, TerminalSession } from '../packages/shared/src/types'
+
+let close: (() => void) | null = null
+
+beforeEach(() => {
+  close = initTestDatabase()
+})
+
+afterEach(() => {
+  close?.()
+  close = null
+})
+
+const group = (over: Partial<SessionGroupConfig> = {}): SessionGroupConfig => ({
+  id: 'g1',
+  name: 'Sidebar work',
+  order: 0,
+  workspaceId: 'personal',
+  ...over
+})
+
+const session = (id: string, groupId?: string) =>
+  ({
+    id,
+    agentType: 'claude',
+    projectName: 'vorn',
+    projectPath: '/tmp/vorn',
+    status: 'idle',
+    createdAt: 1,
+    pid: 1,
+    ...(groupId && { groupId })
+  }) as TerminalSession
+
+describe('the group rows themselves', () => {
+  it('comes back with everything it was given', () => {
+    dbInsertSessionGroup(group({ icon: 'Terminal', iconColor: '#eab308' }))
+
+    expect(dbListSessionGroups()).toEqual([
+      {
+        id: 'g1',
+        name: 'Sidebar work',
+        order: 0,
+        workspaceId: 'personal',
+        icon: 'Terminal',
+        iconColor: '#eab308'
+      }
+    ])
+  })
+
+  it('drops the fields it was not given rather than storing nulls', () => {
+    dbInsertSessionGroup(group())
+
+    const [loaded] = dbListSessionGroups()
+    expect(loaded).not.toHaveProperty('icon')
+    expect(loaded).not.toHaveProperty('iconColor')
+  })
+
+  it('lists in the order the person arranged, not insertion order', () => {
+    dbInsertSessionGroup(group({ id: 'b', name: 'Second', order: 2 }))
+    dbInsertSessionGroup(group({ id: 'a', name: 'First', order: 1 }))
+
+    expect(dbListSessionGroups().map((g) => g.name)).toEqual(['First', 'Second'])
+  })
+
+  it('updates one field without disturbing the rest', () => {
+    dbInsertSessionGroup(group({ icon: 'Terminal', iconColor: '#eab308' }))
+    dbUpdateSessionGroup('g1', { name: 'Renamed' })
+
+    expect(dbListSessionGroups()[0]).toMatchObject({
+      name: 'Renamed',
+      icon: 'Terminal',
+      iconColor: '#eab308',
+      order: 0
+    })
+  })
+
+  it('can be moved, recoloured and re-homed', () => {
+    dbInsertSessionGroup(group())
+    dbUpdateSessionGroup('g1', {
+      order: 5,
+      icon: 'Rocket',
+      iconColor: '#3b82f6',
+      workspaceId: 'work'
+    })
+
+    expect(dbListSessionGroups()[0]).toMatchObject({
+      order: 5,
+      icon: 'Rocket',
+      iconColor: '#3b82f6',
+      workspaceId: 'work'
+    })
+  })
+
+  it('writes nothing when asked to change nothing', () => {
+    dbInsertSessionGroup(group())
+    dbUpdateSessionGroup('g1', {})
+
+    expect(dbListSessionGroups()[0].name).toBe('Sidebar work')
+  })
+})
+
+describe('deleting a group', () => {
+  it('lets its sessions go without ending them', () => {
+    dbInsertSessionGroup(group())
+    saveSessions([session('s1', 'g1'), session('s2', 'g1'), session('s3')])
+
+    dbDeleteSessionGroup('g1')
+
+    expect(dbListSessionGroups()).toEqual([])
+    const left = getPreviousSessions()
+    expect(left.map((s) => s.id).sort()).toEqual(['s1', 's2', 's3'])
+    expect(left.every((s) => s.groupId === undefined)).toBe(true)
+  })
+
+  it("leaves another group's sessions filed where they were", () => {
+    dbInsertSessionGroup(group())
+    dbInsertSessionGroup(group({ id: 'g2', name: 'Release' }))
+    saveSessions([session('s1', 'g1'), session('s2', 'g2')])
+
+    dbDeleteSessionGroup('g1')
+
+    expect(getPreviousSessions().find((s) => s.id === 's2')?.groupId).toBe('g2')
+  })
+})

--- a/tests/session-group-item.test.tsx
+++ b/tests/session-group-item.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { SessionGroupConfig } from '../src/shared/types'
+
+const mockStore = {
+  activeGroupId: null as string | null,
+  setActiveGroup: vi.fn(),
+  setFocusedTerminal: vi.fn(),
+  updateSessionGroup: vi.fn(),
+  removeSessionGroup: vi.fn(),
+  moveSessionToGroup: vi.fn(),
+  terminals: new Map()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockStore) : mockStore
+}))
+
+vi.mock('../src/renderer/components/Toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() }
+}))
+
+const { SessionGroupItem } =
+  await import('../src/renderer/components/project-sidebar/SessionGroupItem')
+
+const group: SessionGroupConfig = {
+  id: 'g1',
+  name: 'Vorn',
+  order: 0,
+  workspaceId: 'personal'
+}
+
+function renderGroup(overrides: Partial<React.ComponentProps<typeof SessionGroupItem>> = {}) {
+  return render(
+    <SessionGroupItem
+      group={group}
+      sessionCount={0}
+      hasWaiting={false}
+      isExpanded={true}
+      onToggleExpanded={vi.fn()}
+      {...overrides}
+    />
+  )
+}
+
+beforeEach(() => {
+  mockStore.activeGroupId = null
+  mockStore.setActiveGroup.mockReset()
+  mockStore.setFocusedTerminal.mockReset()
+  mockStore.updateSessionGroup.mockReset()
+  mockStore.removeSessionGroup.mockReset()
+})
+
+describe('a group row is a scope, like All Projects', () => {
+  it('selects the group when the row is clicked', () => {
+    renderGroup()
+    fireEvent.click(screen.getByRole('button', { name: 'Vorn' }))
+    expect(mockStore.setActiveGroup).toHaveBeenCalledWith('g1')
+    expect(mockStore.setFocusedTerminal).toHaveBeenCalledWith(null)
+  })
+
+  it('deselects when the already-selected group is clicked again', () => {
+    mockStore.activeGroupId = 'g1'
+    renderGroup()
+    fireEvent.click(screen.getByRole('button', { name: 'Vorn' }))
+    expect(mockStore.setActiveGroup).toHaveBeenCalledWith(null)
+  })
+
+  it('reports its selected state', () => {
+    mockStore.activeGroupId = 'g1'
+    renderGroup()
+    expect(screen.getByRole('button', { name: 'Vorn' })).toHaveAttribute('aria-pressed', 'true')
+  })
+})
+
+describe('the disclosure is separate from the selection', () => {
+  it('toggles without selecting the group', () => {
+    const onToggleExpanded = vi.fn()
+    renderGroup({ onToggleExpanded })
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Vorn' }))
+    expect(onToggleExpanded).toHaveBeenCalledTimes(1)
+    expect(mockStore.setActiveGroup).not.toHaveBeenCalled()
+  })
+})
+
+describe('a shut group answers for the sessions it hides', () => {
+  it('shows the waiting mark when collapsed', () => {
+    renderGroup({ isExpanded: false, hasWaiting: true, sessionCount: 3 })
+    expect(screen.getByLabelText('A session in this group is waiting')).toBeInTheDocument()
+  })
+
+  it('does not, while the sessions are on screen themselves', () => {
+    renderGroup({ isExpanded: true, hasWaiting: true, sessionCount: 3 })
+    expect(screen.queryByLabelText('A session in this group is waiting')).not.toBeInTheDocument()
+  })
+
+  it('carries the session count', () => {
+    renderGroup({ isExpanded: false, sessionCount: 3 })
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+})
+
+describe('renaming', () => {
+  it('opens straight into the field for a group just created', () => {
+    renderGroup({ startRenaming: true })
+    expect(screen.getByRole('textbox')).toHaveValue('Vorn')
+  })
+
+  it('commits the new name on Enter', () => {
+    const onRenameSettled = vi.fn()
+    renderGroup({ startRenaming: true, onRenameSettled })
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Tooling' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockStore.updateSessionGroup).toHaveBeenCalledWith('g1', { name: 'Tooling' })
+    expect(onRenameSettled).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the old name on Escape', () => {
+    renderGroup({ startRenaming: true })
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Tooling' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(mockStore.updateSessionGroup).not.toHaveBeenCalled()
+  })
+})
+
+describe('the group row menu', () => {
+  const openMenu = () => {
+    renderGroup()
+    fireEvent.click(screen.getByRole('button', { name: 'More actions for Vorn' }))
+  }
+
+  it('opens from the row', () => {
+    openMenu()
+    expect(screen.getByText('Rename group')).toBeInTheDocument()
+  })
+
+  it('renames through the same inline field', () => {
+    openMenu()
+    fireEvent.click(screen.getByText('Rename group'))
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'Renamed' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockStore.updateSessionGroup).toHaveBeenCalledWith('g1', { name: 'Renamed' })
+  })
+
+  it('opens the icon picker, and closes it again', () => {
+    openMenu()
+    fireEvent.click(screen.getByText('Change icon'))
+    expect(screen.getByText('Preview')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(screen.queryByText('Preview')).not.toBeInTheDocument()
+  })
+
+  it('writes the icon and colour the picker hands back', () => {
+    openMenu()
+    fireEvent.click(screen.getByText('Change icon'))
+    fireEvent.click(screen.getByRole('button', { name: 'Launch' }))
+    expect(mockStore.updateSessionGroup).toHaveBeenCalledWith('g1', { icon: 'Rocket' })
+  })
+
+  it('lets every session in the group go, without ending any', () => {
+    mockStore.terminals = new Map([
+      ['s1', { session: { id: 's1', groupId: 'g1' } }],
+      ['s2', { session: { id: 's2', groupId: 'g2' } }],
+      ['s3', { session: { id: 's3', groupId: 'g1' } }]
+    ]) as never
+    openMenu()
+    fireEvent.click(screen.getByText('Remove all sessions'))
+    expect(mockStore.moveSessionToGroup).toHaveBeenCalledWith('s1', null)
+    expect(mockStore.moveSessionToGroup).toHaveBeenCalledWith('s3', null)
+    expect(mockStore.moveSessionToGroup).not.toHaveBeenCalledWith('s2', null)
+  })
+
+  it('deletes the group on the second click', () => {
+    openMenu()
+    fireEvent.click(screen.getByText('Delete group'))
+    fireEvent.click(screen.getByText('Confirm delete?'))
+    expect(mockStore.removeSessionGroup).toHaveBeenCalledWith('g1')
+  })
+})

--- a/tests/session-groups.test.tsx
+++ b/tests/session-groups.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAppStore } from '../src/renderer/stores'
+import { useSessionScope } from '../src/renderer/hooks/useScopedSessionIds'
+import type { AppConfig, TerminalSession } from '../src/shared/types'
+
+const setSessionGroup = vi.fn(() => Promise.resolve())
+Object.defineProperty(window, 'api', {
+  value: { saveConfig: () => Promise.resolve(), setSessionGroup },
+  writable: true
+})
+
+const config = {
+  version: 1,
+  defaults: {},
+  projects: [
+    { name: 'vorn', path: '/tmp/vorn', preferredAgents: [] },
+    { name: 'vorn-connectors', path: '/tmp/vc', preferredAgents: [] },
+    { name: 'ode', path: '/tmp/ode', preferredAgents: [] },
+    { name: 'work-thing', path: '/tmp/wt', preferredAgents: [], workspaceId: 'work' }
+  ],
+  sessionGroups: [
+    { id: 'g1', name: 'Sidebar work', order: 0, workspaceId: 'personal' },
+    { id: 'g9', name: 'Elsewhere', order: 0, workspaceId: 'work' }
+  ]
+} as unknown as AppConfig
+
+const term = (id: string, projectName: string, groupId?: string) => [
+  id,
+  {
+    session: {
+      id,
+      projectName,
+      agentType: 'claude',
+      ...(groupId && { groupId })
+    } as TerminalSession,
+    status: 'idle',
+    lastOutputTimestamp: 0
+  }
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useAppStore.setState({
+    config,
+    activeProject: null,
+    activeGroupId: null,
+    activeWorkspace: 'personal',
+    // The group's three sessions span two repos — the point of the feature.
+    terminals: new Map([
+      term('s1', 'vorn', 'g1'),
+      term('s2', 'vorn-connectors', 'g1'),
+      term('s3', 'vorn'),
+      term('s4', 'ode')
+    ] as never)
+  })
+})
+
+const scope = () => renderHook(() => useSessionScope()).result.current
+
+describe('a group scopes by session, because its members span projects', () => {
+  it('narrows to exactly the sessions filed under it', () => {
+    useAppStore.setState({ activeGroupId: 'g1' })
+    expect([...scope().sessionIds!].sort()).toEqual(['s1', 's2'])
+  })
+
+  it('picks up sessions from more than one repo', () => {
+    useAppStore.setState({ activeGroupId: 'g1' })
+    const ids = scope().sessionIds!
+    const projects = [...ids].map(
+      (id) => useAppStore.getState().terminals.get(id)!.session.projectName
+    )
+    expect(new Set(projects)).toEqual(new Set(['vorn', 'vorn-connectors']))
+  })
+
+  it('leaves a sibling session of the same project out', () => {
+    useAppStore.setState({ activeGroupId: 'g1' })
+    // s3 is also in `vorn`, but was never filed.
+    expect(scope().sessionIds!.has('s3')).toBe(false)
+  })
+
+  it('answers by project name when a project is selected instead', () => {
+    useAppStore.setState({ activeProject: 'vorn' })
+    expect(scope().sessionIds).toBeNull()
+    expect([...scope().projectNames!]).toEqual(['vorn'])
+  })
+
+  it('restricts nothing when neither is selected', () => {
+    expect(scope().sessionIds).toBeNull()
+    expect([...scope().projectNames!].sort()).toEqual(['ode', 'vorn', 'vorn-connectors'])
+  })
+})
+
+/**
+ * A selection can outlive what it pointed at. Narrowing to nothing would blank
+ * every list with no visible row to clear, so a stale one means no selection.
+ */
+describe('a selection that no longer matches anything', () => {
+  it('falls back rather than emptying the view when the group is another workspace’s', () => {
+    useAppStore.setState({ activeGroupId: 'g9' })
+    expect(scope().sessionIds).toBeNull()
+    expect([...scope().projectNames!].sort()).toEqual(['ode', 'vorn', 'vorn-connectors'])
+  })
+
+  /**
+   * A stale selection can name a group that still has sessions. Scoping to them
+   * would put another workspace's work on the board.
+   */
+  it('does not surface another workspace’s sessions even when that group has some', () => {
+    useAppStore.setState({
+      activeGroupId: 'g9',
+      terminals: new Map([term('s1', 'vorn', 'g1'), term('w1', 'work-thing', 'g9')] as never)
+    })
+    expect(scope().sessionIds).toBeNull()
+  })
+
+  it('drops a member whose project is outside the workspace', () => {
+    useAppStore.setState({
+      activeGroupId: 'g1',
+      terminals: new Map([term('s1', 'vorn', 'g1'), term('w1', 'work-thing', 'g1')] as never)
+    })
+    expect([...scope().sessionIds!]).toEqual(['s1'])
+  })
+
+  it('does the same once the group’s last session is killed', () => {
+    useAppStore.setState({
+      activeGroupId: 'g1',
+      terminals: new Map([term('s4', 'ode')] as never)
+    })
+    expect(scope().sessionIds).toBeNull()
+  })
+
+  it('and for a project from another workspace', () => {
+    useAppStore.setState({ activeProject: 'work-thing' })
+    expect([...scope().projectNames!].sort()).toEqual(['ode', 'vorn', 'vorn-connectors'])
+  })
+})
+
+describe('filing a session', () => {
+  it('tells the server, which is what owns membership', () => {
+    useAppStore.getState().moveSessionToGroup('s3', 'g1')
+    expect(setSessionGroup).toHaveBeenCalledWith('s3', 'g1')
+    expect(useAppStore.getState().terminals.get('s3')!.session.groupId).toBe('g1')
+  })
+
+  it('takes it out again with null', () => {
+    useAppStore.getState().moveSessionToGroup('s1', null)
+    expect(setSessionGroup).toHaveBeenCalledWith('s1', null)
+    expect(useAppStore.getState().terminals.get('s1')!.session.groupId).toBeUndefined()
+  })
+
+  it('lets every member go when the group is deleted, and kills none', () => {
+    useAppStore.getState().removeSessionGroup('g1')
+    expect(setSessionGroup).toHaveBeenCalledWith('s1', null)
+    expect(setSessionGroup).toHaveBeenCalledWith('s2', null)
+    expect(useAppStore.getState().config!.sessionGroups).toHaveLength(1)
+    expect(useAppStore.getState().terminals.size).toBe(4)
+  })
+})
+
+/**
+ * Resume rebuilds a session from a whitelist and saves it under the same id, so
+ * anything the whitelist omits is written back as null and gone for good. The
+ * group came back from a restart and then vanished the moment you resumed.
+ */
+describe('a resumed session keeps its group', () => {
+  it('applies an inbound group change from another client', () => {
+    useAppStore.setState({
+      terminals: new Map([term('s1', 'vorn', 'g1')] as never)
+    })
+    useAppStore.getState().updateSessionGroupId('s1', 'g2')
+    expect(useAppStore.getState().terminals.get('s1')!.session.groupId).toBe('g2')
+  })
+
+  it('applies an inbound ungrouping, which arrives as undefined not null', () => {
+    useAppStore.setState({
+      terminals: new Map([term('s1', 'vorn', 'g1')] as never)
+    })
+    useAppStore.getState().updateSessionGroupId('s1', undefined)
+    expect(useAppStore.getState().terminals.get('s1')!.session).not.toHaveProperty('groupId')
+  })
+
+  it('leaves the map alone when nothing changed', () => {
+    useAppStore.setState({
+      terminals: new Map([term('s1', 'vorn', 'g1')] as never)
+    })
+    const before = useAppStore.getState().terminals
+    useAppStore.getState().updateSessionGroupId('s1', 'g1')
+    expect(useAppStore.getState().terminals).toBe(before)
+  })
+})

--- a/tests/session-item.test.tsx
+++ b/tests/session-item.test.tsx
@@ -442,3 +442,104 @@ describe('SessionItem controls', () => {
     expect(useAppStore.getState().browserPanes.has(session.id)).toBe(false)
   })
 })
+
+describe('filing a session into a group', () => {
+  afterEach(() => {
+    useAppStore.setState(initialState)
+  })
+
+  const seedGroups = (groupId?: string) => {
+    const terminals = new Map()
+    terminals.set(session.id, {
+      id: session.id,
+      session: {
+        id: session.id,
+        projectPath: '/proj',
+        projectName: 'p',
+        agentType: 'claude',
+        ...(groupId && { groupId })
+      },
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    act(() => {
+      useAppStore.setState({
+        terminals,
+        devicePanes: new Map(),
+        mobileProjectCache: new Map(),
+        loadMobileProject: async () => {},
+        activeWorkspace: 'personal',
+        config: {
+          projects: [],
+          sessionGroups: [{ id: 'g1', name: 'Sidebar work', order: 0, workspaceId: 'personal' }]
+        }
+      } as never)
+    })
+  }
+
+  /**
+   * A plain count reused an order the moment a group was deleted, and counted
+   * other workspaces' groups on the way.
+   */
+  it('orders a new group after this workspace last one', () => {
+    const terminals = new Map()
+    terminals.set(session.id, {
+      id: session.id,
+      session: { id: session.id, projectPath: '/proj', projectName: 'p', agentType: 'claude' },
+      status: 'idle',
+      lastOutputTimestamp: 1
+    })
+    const addSessionGroup = vi.fn()
+    act(() => {
+      useAppStore.setState({
+        terminals,
+        devicePanes: new Map(),
+        mobileProjectCache: new Map(),
+        loadMobileProject: async () => {},
+        activeWorkspace: 'personal',
+        addSessionGroup,
+        moveSessionToGroup: vi.fn(),
+        config: {
+          projects: [],
+          sessionGroups: [
+            { id: 'a', name: 'First', order: 4, workspaceId: 'personal' },
+            { id: 'z', name: 'Far away', order: 99, workspaceId: 'work' }
+          ]
+        }
+      } as never)
+    })
+    render(<SessionItem session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: `More actions for ${session.name}` }))
+    fireEvent.click(screen.getByText('New group…'))
+
+    expect(addSessionGroup).toHaveBeenCalledWith(
+      expect.objectContaining({ order: 5, workspaceId: 'personal' })
+    )
+  })
+
+  it('offers the group menu from the row', () => {
+    seedGroups()
+    render(<SessionItem session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: `More actions for ${session.name}` }))
+    expect(screen.getByText('Move to group')).toBeInTheDocument()
+    expect(screen.getByText('Sidebar work')).toBeInTheDocument()
+  })
+
+  it('shows Remove from group only once it is in one', () => {
+    seedGroups('g1')
+    render(<SessionItem session={session} />)
+    fireEvent.click(screen.getByRole('button', { name: `More actions for ${session.name}` }))
+    expect(screen.getByText('Remove from group')).toBeInTheDocument()
+  })
+
+  /** The row is the drag handle; the group rows are the drop targets. */
+  it('carries its id on a drag', () => {
+    seedGroups()
+    render(<SessionItem session={session} />)
+    const setData = vi.fn()
+    fireEvent.dragStart(screen.getByText('My Session').closest('[draggable]')!, {
+      dataTransfer: { setData, effectAllowed: '' }
+    })
+    expect(setData).toHaveBeenCalledWith('application/vorn-session', session.id)
+  })
+})

--- a/tests/session-utils.test.ts
+++ b/tests/session-utils.test.ts
@@ -2,7 +2,12 @@
 import { describe, it, expect } from 'vitest'
 import type { TerminalSession, RecentSession, AgentType } from '../packages/shared/src/types'
 
-import { resolveProjectName, buildRestorePayload } from '../src/renderer/lib/session-utils'
+import {
+  resolveProjectName,
+  buildRestorePayload,
+  resolveActiveProject
+} from '../src/renderer/lib/session-utils'
+import { useAppStore } from '../src/renderer/stores'
 
 function makeSession(overrides: Partial<TerminalSession> = {}): TerminalSession {
   return {
@@ -140,5 +145,85 @@ describe('buildRestorePayload', () => {
     expect(() => buildRestorePayload(shell)).toThrow(
       /shell sessions restore via createShellTerminal/
     )
+  })
+})
+
+/**
+ * A group holds sessions from many projects, so it cannot name one on its own.
+ * Launching from a group starts where its most recent session is.
+ */
+describe('the project a launch starts in', () => {
+  const project = (name: string, workspaceId = 'personal') => ({
+    name,
+    path: `/tmp/${name}`,
+    preferredAgents: [],
+    workspaceId
+  })
+  const term = (id: string, projectName: string, at: number, groupId?: string) => [
+    id,
+    {
+      session: { id, projectName, ...(groupId && { groupId }) },
+      status: 'idle',
+      lastOutputTimestamp: at
+    }
+  ]
+
+  const seed = (over: Record<string, unknown> = {}) =>
+    useAppStore.setState({
+      config: {
+        projects: [project('vorn'), project('ode'), project('work-thing', 'work')]
+      },
+      activeProject: null,
+      activeGroupId: null,
+      activeWorkspace: 'personal',
+      terminals: new Map(),
+      ...over
+    } as never)
+
+  it('is the selected project when there is one', () => {
+    seed({ activeProject: 'ode' })
+    expect(resolveActiveProject()?.name).toBe('ode')
+  })
+
+  it('is the workspace first project when nothing is selected', () => {
+    seed()
+    expect(resolveActiveProject()?.name).toBe('vorn')
+  })
+
+  // Pre-existing: a named project wins by name alone, workspace unchecked.
+  it('honours a named project even from another workspace', () => {
+    seed({ activeProject: 'work-thing' })
+    expect(resolveActiveProject()?.name).toBe('work-thing')
+  })
+
+  it('stays inside the workspace when falling back', () => {
+    seed({ activeProject: 'deleted-project' })
+    expect(resolveActiveProject()?.name).toBe('vorn')
+  })
+
+  it('follows the most recent session of a selected group', () => {
+    seed({
+      activeGroupId: 'g1',
+      terminals: new Map([term('s1', 'vorn', 1, 'g1'), term('s2', 'ode', 9, 'g1')] as never)
+    })
+    expect(resolveActiveProject()?.name).toBe('ode')
+  })
+
+  it('ignores sessions that are not in the group', () => {
+    seed({
+      activeGroupId: 'g1',
+      terminals: new Map([term('s1', 'vorn', 1, 'g1'), term('s2', 'ode', 9)] as never)
+    })
+    expect(resolveActiveProject()?.name).toBe('vorn')
+  })
+
+  it('falls back to the workspace when the group has no sessions left', () => {
+    seed({ activeGroupId: 'g1' })
+    expect(resolveActiveProject()?.name).toBe('vorn')
+  })
+
+  it('has nothing to offer when there are no projects', () => {
+    useAppStore.setState({ config: { projects: [] } } as never)
+    expect(resolveActiveProject()).toBeUndefined()
   })
 })

--- a/tests/sidebar-view-modes.test.tsx
+++ b/tests/sidebar-view-modes.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const mockStore = {
+  sidebarProjectSort: 'manual',
+  sidebarWorktreeSort: 'name',
+  sidebarWorktreeFilter: 'all',
+  sidebarViewMode: 'worktrees' as string,
+  setSidebarProjectSort: vi.fn(),
+  setSidebarWorktreeSort: vi.fn(),
+  setSidebarWorktreeFilter: vi.fn(),
+  setSidebarViewMode: vi.fn()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (selector?: (state: unknown) => unknown) =>
+    selector ? selector(mockStore) : mockStore
+}))
+
+const { ProjectsSectionToolbar } =
+  await import('../src/renderer/components/project-sidebar/ProjectsSectionToolbar')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockStore.sidebarViewMode = 'worktrees'
+})
+
+const open = () => {
+  render(<ProjectsSectionToolbar />)
+  fireEvent.click(screen.getByRole('button', { name: 'Filter & sort' }))
+}
+
+describe('the Show menu', () => {
+  it('offers Groups > Sessions beside the others', () => {
+    open()
+    expect(screen.getByText('Projects > Worktrees')).toBeInTheDocument()
+    expect(screen.getByText('Groups > Sessions')).toBeInTheDocument()
+    expect(screen.getByText('Sessions (Flat)')).toBeInTheDocument()
+  })
+
+  it('switches to it', () => {
+    open()
+    fireEvent.click(screen.getByText('Groups > Sessions'))
+    expect(mockStore.setSidebarViewMode).toHaveBeenCalledWith('groups-sessions')
+  })
+
+  /**
+   * The mode draws no project or worktree rows, so the controls that reorder and
+   * filter them have nothing to act on.
+   */
+  it('hides the filter and both sorts in that mode', () => {
+    mockStore.sidebarViewMode = 'groups-sessions'
+    open()
+    expect(screen.queryByText('Filter')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sort projects')).not.toBeInTheDocument()
+    expect(screen.queryByText('Sort worktrees')).not.toBeInTheDocument()
+  })
+
+  it('still offers them in a project mode', () => {
+    open()
+    expect(screen.getByText('Filter')).toBeInTheDocument()
+    expect(screen.getByText('Sort projects')).toBeInTheDocument()
+    expect(screen.getByText('Sort worktrees')).toBeInTheDocument()
+  })
+
+  it('marks the mode as non-default once it is chosen', () => {
+    mockStore.sidebarViewMode = 'groups-sessions'
+    render(<ProjectsSectionToolbar />)
+    expect(screen.getByRole('button', { name: 'Filter & sort' })).toBeInTheDocument()
+  })
+})

--- a/tests/toolbar-breadcrumb.test.tsx
+++ b/tests/toolbar-breadcrumb.test.tsx
@@ -74,3 +74,56 @@ describe('ToolbarBreadcrumb', () => {
     await waitFor(() => expect(screen.queryByText('main')).not.toBeInTheDocument())
   })
 })
+
+/**
+ * The crumb is the only thing that names the current scope, so it must agree
+ * with what the scope actually is — including when the selection is stale.
+ */
+describe('the crumb for a group', () => {
+  const groups = [
+    { id: 'g1', name: 'Sidebar work', order: 0, workspaceId: 'personal' },
+    { id: 'g9', name: 'Elsewhere', order: 0, workspaceId: 'work' }
+  ]
+
+  const seed = (activeGroupId: string | null) =>
+    act(() => {
+      useAppStore.setState({
+        activeProject: null,
+        activeWorktreePath: null,
+        activeGroupId,
+        activeWorkspace: 'personal',
+        config: { projects: [], sessionGroups: groups }
+      } as never)
+    })
+
+  afterEach(() => {
+    act(() => {
+      useAppStore.setState(initialState)
+    })
+  })
+
+  it('names the selected group', () => {
+    seed('g1')
+    render(<ToolbarBreadcrumb />)
+    expect(screen.getByText('Sidebar work')).toBeInTheDocument()
+  })
+
+  it('clears the selection when the crumb is clicked', () => {
+    seed('g1')
+    render(<ToolbarBreadcrumb />)
+    fireEvent.click(screen.getByText('Sidebar work'))
+    expect(useAppStore.getState().activeGroupId).toBeNull()
+  })
+
+  it('says nothing for a group belonging to another workspace', () => {
+    seed('g9')
+    const { container } = render(<ToolbarBreadcrumb />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('says nothing when nothing is selected', () => {
+    seed(null)
+    const { container } = render(<ToolbarBreadcrumb />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/tests/view-restore.test.ts
+++ b/tests/view-restore.test.ts
@@ -12,6 +12,7 @@ beforeEach(() => {
     maximizedPaneId: null,
     activeTabId: null,
     activeProject: null,
+    activeGroupId: null,
     activeWorktreePath: null,
     visibleTerminalIds: [],
     knownSessionIds: new Set<string>(),
@@ -226,5 +227,26 @@ describe('a session opened after the launch sync', () => {
     useAppStore.getState().setVisibleTerminalIds(['term-1'])
 
     expect([...useAppStore.getState().minimizedTerminals]).toEqual([])
+  })
+})
+
+describe('the group scope', () => {
+  it('survives a reload', () => {
+    useAppStore.getState().setActiveGroup('g1')
+    expect(JSON.parse(localStorage.getItem(KEY)!).activeGroupId).toBe('g1')
+  })
+
+  it('is cleared by picking a project, because it is the same selection', () => {
+    useAppStore.getState().setActiveGroup('g1')
+    useAppStore.getState().setActiveProject('vorn')
+    expect(useAppStore.getState().activeGroupId).toBeNull()
+    expect(JSON.parse(localStorage.getItem(KEY)!).activeGroupId).toBeNull()
+  })
+
+  it('clears the project in turn', () => {
+    useAppStore.getState().setActiveProject('vorn')
+    useAppStore.getState().setActiveGroup('g1')
+    expect(useAppStore.getState().activeProject).toBeNull()
+    expect(JSON.parse(localStorage.getItem(KEY)!).activeProject).toBeNull()
   })
 })


### PR DESCRIPTION
The sidebar organises by where code lives: workspace, project, worktree, session. Work does not respect that. A change spans two repos and three checkouts, and nothing in the tree can show those four sessions together.

A group is a bucket with a name that holds sessions. Membership cuts across the project tree on purpose, and a session keeps its own project and branch while it is in one.

## Where it appears

Groups render in one place: a new **Groups > Sessions** entry in the sidebar's Show menu. Every other mode is byte-identical to `main` — `ProjectsSection`, `FlatSessionsSection`, `ProjectItem` and `ProjectContextMenu` have an empty diff against it. Make no groups and the sidebar is the one you have today; ungrouped sessions are drawn exactly where they were, with no header of their own.

The one thing shared across modes is the session row's overflow menu, which is how a session is filed without dragging.

## How it is stored

Membership rides on the session, beside the sort order that row already carries, so it is set through a new `terminal:setGroup` RPC rather than the config blob and survives a relaunch with the sessions themselves. Only the group entity lives in config, where a workspace owns it.

Schema 18 adds `sessions.group_id`; `createSchema` creates `session_groups`; `verifySchema` repairs both. Verified against a copy of a real database at 17, and against one already stamped 18.

## Selection

Selecting a group scopes the view to its sessions. That is the one place selection had to grow a second shape: All Projects and a project still answer in project names, but a group can only answer in session ids, because its members have no project in common. A group whose sessions have all ended, or one belonging to another workspace, scopes to nothing — so it is read as no selection at all rather than blanking every list.

## Two bugs the review caught

- **Resume dropped the group.** `terminal:resume` rebuilds a session from a whitelist and saves it under the same id, so a field left out is written back as null and gone. Groups survived a restart and then emptied the moment you resumed. Carried across on the server in both branches, rather than through the client payload.
- **A group filed from another client never reached an open board.** `onSessionUpdated` applies targeted field updates and ignored `groupId`, so a change made on the phone was silently discarded on the desktop until a reload.

## Testing

Three new suites and additions to three existing ones. The cross-repo case is pinned specifically: a group spanning two projects, with a sibling session of one of those projects correctly left out. Deleting a group releases its sessions and kills none; a session whose group is gone renders as ungrouped rather than disappearing.

Locally: all five typecheck targets, lint, `prettier --check`, and 6326 tests pass. Four test files fail in my worktree for environmental reasons — they fail identically on `origin/main` there, including `extension-pane-pty` from the extension work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrdUEDQwqwsaABp7sa8yUC