### PR TITLE
Hand running terminals to the new server instead of ending them on update

### DIFF
--- a/packages/server/src/handoff/adopted-pty.ts
+++ b/packages/server/src/handoff/adopted-pty.ts
@@ -1,0 +1,150 @@
+import fs from 'node:fs'
+import tty from 'node:tty'
+import log from '../logger'
+import { resizeFd } from './native'
+
+/** The part of a pty this server uses, so an inherited one can be the other implementation. */
+export interface ManagedPty {
+  readonly pid: number
+  write(data: string): void
+  resize(cols: number, rows: number): void
+  kill(signal?: string): void
+  onData(listener: (data: string) => void): { dispose(): void }
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void): { dispose(): void }
+  /** A paused master is a paused reader: the kernel keeps the bytes for whoever reads next. */
+  pause(): void
+  resume(): void
+}
+
+/**
+ * A pty master this process inherited rather than opened.
+ * The program holds the slave end and never learns which process reads the master.
+ */
+export class AdoptedPty implements ManagedPty {
+  readonly pid: number
+  /** Public so a handoff can happen twice; node-pty exposes the same property. */
+  readonly fd: number
+  private readonly reader: tty.ReadStream
+  private readonly dataListeners = new Set<(data: string) => void>()
+  private readonly exitListeners = new Set<(event: { exitCode: number; signal?: number }) => void>()
+  /** Output read before anything was listening. Delivered to the first listener. */
+  private pending: string[] = []
+  private readonly writeQueue: Array<{ buffer: Buffer; offset: number }> = []
+  private writeImmediate: NodeJS.Immediate | undefined
+  private ended = false
+
+  constructor(fd: number, pid: number) {
+    this.fd = fd
+    this.pid = pid
+    this.reader = new tty.ReadStream(fd)
+    this.reader.setEncoding('utf8')
+    this.reader.on('data', (chunk: string | Buffer) => {
+      const data = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      // Attaching this handler starts the flow, and the pause is a turn of the loop away.
+      if (this.dataListeners.size === 0) {
+        this.pending.push(data)
+        return
+      }
+      for (const listener of this.dataListeners) listener(data)
+    })
+    // A master reports the far side going away as EIO on some platforms and EOF on others.
+    this.reader.on('end', () => this.finish())
+    this.reader.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EIO') return this.finish()
+      log.warn({ err, pid: this.pid }, '[handoff] read error on an adopted pty')
+      this.finish()
+    })
+  }
+
+  /** Exit code 0 is a stand-in: nothing can waitpid for a program that reparented to init. */
+  private finish(): void {
+    if (this.ended) return
+    this.ended = true
+    clearImmediate(this.writeImmediate)
+    this.writeImmediate = undefined
+    this.writeQueue.length = 0
+    this.pending = []
+    try {
+      this.reader.destroy()
+    } catch {
+      // Already gone; the listeners below are what matter.
+    }
+    for (const listener of this.exitListeners) listener({ exitCode: 0 })
+  }
+
+  /** Queued, because a non-blocking master answers a full buffer with EAGAIN. */
+  write(data: string): void {
+    if (this.ended) return
+    const buffer = Buffer.from(data, 'utf8')
+    if (buffer.byteLength === 0) return
+    this.writeQueue.push({ buffer, offset: 0 })
+    if (this.writeQueue.length === 1) this.drain()
+  }
+
+  private drain(): void {
+    this.writeImmediate = undefined
+    const task = this.writeQueue[0]
+    if (!task || this.ended) return
+    fs.write(this.fd, task.buffer, task.offset, (err, written) => {
+      if (err) {
+        if ((err as NodeJS.ErrnoException).code === 'EAGAIN') {
+          this.writeImmediate = setImmediate(() => this.drain())
+          return
+        }
+        // EIO is the far side closing between the queue and the write.
+        if ((err as NodeJS.ErrnoException).code !== 'EIO') {
+          log.warn({ err, pid: this.pid }, '[handoff] write failed on an adopted pty')
+        }
+        this.writeQueue.length = 0
+        return
+      }
+      task.offset += written
+      if (task.offset >= task.buffer.byteLength) this.writeQueue.shift()
+      if (this.writeQueue.length > 0) this.drain()
+    })
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.ended) return
+    resizeFd(this.fd, cols, rows)
+  }
+
+  /** By pid: there is no child handle, but it is the same process and the same user. */
+  kill(signal: string = 'SIGHUP'): void {
+    try {
+      process.kill(this.pid, signal as NodeJS.Signals)
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      if (code !== 'ESRCH') {
+        log.warn({ err, pid: this.pid }, '[handoff] could not signal an adopted pty')
+      }
+    }
+    this.finish()
+  }
+
+  onData(listener: (data: string) => void): { dispose(): void } {
+    const first = this.dataListeners.size === 0
+    this.dataListeners.add(listener)
+    if (first && this.pending.length) {
+      const held = this.pending
+      this.pending = []
+      // Synchronously: this output is older than anything live, and reordering a
+      // terminal's own history is worse than delivering it late.
+      for (const data of held) listener(data)
+    }
+    return { dispose: () => this.dataListeners.delete(listener) }
+  }
+
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void): { dispose(): void } {
+    this.exitListeners.add(listener)
+    return { dispose: () => this.exitListeners.delete(listener) }
+  }
+
+  pause(): void {
+    this.reader.pause()
+  }
+
+  resume(): void {
+    this.reader.resume()
+  }
+}

--- a/packages/server/src/handoff/adopted-pty.ts
+++ b/packages/server/src/handoff/adopted-pty.ts
@@ -50,6 +50,11 @@ export class AdoptedPty implements ManagedPty {
     // A master reports the far side going away as EIO on some platforms and EOF on others.
     this.reader.on('end', () => this.finish())
     this.reader.on('error', (err: NodeJS.ErrnoException) => {
+      // A non-blocking master says "nothing yet" as an error, and node-pty's own
+      // reader notes it arrives twice on startup. Treating it as the far side
+      // going away would end a healthy terminal the moment it was adopted --
+      // and `onExit` removes the session's history on its way past.
+      if (err.code === 'EAGAIN') return
       if (err.code === 'EIO') return this.finish()
       log.warn({ err, pid: this.pid }, '[handoff] read error on an adopted pty')
       this.finish()

--- a/packages/server/src/handoff/donor.ts
+++ b/packages/server/src/handoff/donor.ts
@@ -1,0 +1,272 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import fs from 'node:fs'
+import type { TerminalSession } from '@vornrun/shared/types'
+import {
+  HANDOFF_PROTOCOL_VERSION,
+  HANDOFF_MANIFEST_VERSION,
+  type HandoffRequest,
+  type HandoffResult
+} from '@vornrun/shared/protocol'
+import log from '../logger'
+import { FIRST_PTY_SLOT, manifestPath, writeManifest, discardManifest } from './manifest'
+
+/**
+ * Giving a running machine away without stopping it.
+ *
+ * Descriptors travel in the replacement's stdio array, the only way Node hands a
+ * live descriptor to another process. Seven rules hold it up:
+ * one reader per pty; nothing captured until every reader has stopped; a failure
+ * before the commit leaves this server owning everything; after it, nothing is
+ * torn down; no path closes the last descriptor; a partial handoff is refused;
+ * the commit is a point, not a period.
+ */
+
+/** How long the replacement has to prove it can take the panes. */
+const IMPORT_DEADLINE_MS = 20_000
+
+/** Longer than the import: this covers a whole server startup on a busy machine. */
+const SERVING_DEADLINE_MS = 45_000
+
+/** A pane as the donor sees it, before it becomes a slot in an argument list. */
+export interface DonorPane {
+  session: TerminalSession
+  /** The pty master. Present for every forked pty on POSIX; see `describePanes`. */
+  fd: number
+  pid: number
+  cols: number
+  rows: number
+}
+
+/** Injected so the sequence can be tested: its failure mode is every terminal on the machine. */
+export interface HandoffHost {
+  dataDir: string
+  /** Every live pane, or null if even one of them cannot be described. */
+  describePanes(): DonorPane[] | null
+  /** Stop every reader. Bytes already in the kernel buffer stay there. */
+  pauseAll(): void
+  /** Start reading again, for a handoff that did not happen. */
+  resumeAll(): void
+  /** Buffered output, session records and screens onto disk. */
+  quiesce(): Promise<void>
+  /** Where the replacement's stdout and stderr should go. */
+  openLogFd(): number
+  /** The commit: after this nothing reaches this server by name. */
+  release(): Promise<void>
+  /** Take the endpoint back after a replacement that died post-commit. */
+  reclaim(): Promise<boolean>
+  /** Leave, without killing a single pty. */
+  exit(): void
+}
+
+/** The message a person sees if they start a terminal mid-handoff. */
+export const HANDOVER_MESSAGE =
+  'Vorn is moving your terminals to the updated server. Try again in a moment.'
+
+let inFlight = false
+
+/** Whether a handoff is running. Session creation is refused while one is. */
+export function isHandingOver(): boolean {
+  return inFlight
+}
+
+/** Test-only, mirroring the other module-level state in this package. */
+export function resetHandoffForTests(): void {
+  inFlight = false
+}
+
+/** Injected so the commit boundary and both rollbacks can be tested against a fake child. */
+export type SpawnHeir = (
+  request: HandoffRequest,
+  args: string[],
+  stdio: Array<'ignore' | 'ipc' | number>,
+  logFd: number
+) => ChildProcess
+
+const spawnHeirProcess: SpawnHeir = (request, args, stdio) =>
+  spawn(request.exec, args, {
+    cwd: request.cwd,
+    env: { ...process.env, ...request.env },
+    detached: true,
+    stdio
+  })
+
+export async function handOver(
+  request: HandoffRequest,
+  host: HandoffHost,
+  spawnHeir: SpawnHeir = spawnHeirProcess
+): Promise<HandoffResult> {
+  const declined = (because: string): HandoffResult => {
+    log.warn({ because }, '[handoff] declined')
+    return { kind: 'declined', because }
+  }
+
+  if (process.platform === 'win32') {
+    // No way to inherit a console pseudoterminal there, and no endpoint to ask over.
+    return declined('this platform cannot pass a pty to another process')
+  }
+  if (request.handoffVersion !== HANDOFF_PROTOCOL_VERSION) {
+    return declined(
+      `the caller speaks handoff ${request.handoffVersion}, this server speaks ${HANDOFF_PROTOCOL_VERSION}`
+    )
+  }
+  if (inFlight) return declined('a handoff is already running')
+  if (!request.exec || !fs.existsSync(request.exec)) {
+    return declined(`there is nothing to run at ${request.exec}`)
+  }
+
+  inFlight = true
+  try {
+    return await run(request, host, declined, spawnHeir)
+  } catch (err) {
+    // A throw between the pause and the resume would leave every pane frozen.
+    log.error({ err }, '[handoff] failed unexpectedly; resuming')
+    host.resumeAll()
+    return declined(err instanceof Error ? err.message : String(err))
+  } finally {
+    inFlight = false
+  }
+}
+
+async function run(
+  request: HandoffRequest,
+  host: HandoffHost,
+  declined: (because: string) => HandoffResult,
+  spawnHeir: SpawnHeir
+): Promise<HandoffResult> {
+  // Stop reading first, so the manifest describes a machine holding still.
+  host.pauseAll()
+
+  // All of it, before a single side effect: a partial handoff is refused.
+  const panes = host.describePanes()
+  if (panes === null) {
+    host.resumeAll()
+    return declined('at least one terminal could not be described')
+  }
+
+  await host.quiesce()
+
+  const slots = panes.map((pane, index) => ({ ...pane, slot: FIRST_PTY_SLOT + index }))
+  const target = manifestPath(host.dataDir, process.pid)
+  writeManifest(target, {
+    version: HANDOFF_MANIFEST_VERSION,
+    donorPid: process.pid,
+    createdAt: Date.now(),
+    panes: slots.map((pane) => ({
+      slot: pane.slot,
+      session: pane.session,
+      pid: pane.pid,
+      cols: pane.cols,
+      rows: pane.rows
+    }))
+  })
+
+  const logFd = host.openLogFd()
+  let heir: ChildProcess
+  try {
+    heir = spawnHeir(
+      request,
+      [...request.args, '--adopt-handoff', target],
+      // Duplicated into the child, so both processes hold every pty across the window.
+      ['ignore', logFd, logFd, 'ipc', ...slots.map((pane) => pane.fd)],
+      logFd
+    )
+  } catch (err) {
+    fs.closeSync(logFd)
+    discardManifest(target)
+    host.resumeAll()
+    return declined(`could not start the replacement: ${(err as Error).message}`)
+  }
+  fs.closeSync(logFd)
+
+  log.info(
+    { pid: heir.pid, panes: slots.length, version: request.appVersion },
+    '[handoff] replacement started; waiting for it to take the panes'
+  )
+
+  const imported = await waitFor(heir, 'imported', IMPORT_DEADLINE_MS)
+  if (!imported.ok) {
+    // Nothing was released, so this rollback is complete.
+    try {
+      heir.kill('SIGKILL')
+    } catch {
+      // Already gone, which is the usual reason we are here.
+    }
+    discardManifest(target)
+    host.resumeAll()
+    return declined(`the replacement never took the panes: ${imported.because}`)
+  }
+
+  // ─── The commit boundary: the name is free and the replacement should have it.
+  await host.release()
+  heir.send({ kind: 'commit' })
+
+  const serving = await waitFor(heir, 'serving', SERVING_DEADLINE_MS)
+  if (!serving.ok) {
+    // Both processes still hold every pty, so there is something to go back to.
+    log.error(
+      { because: serving.because },
+      '[handoff] the replacement did not come up after the commit; taking the endpoint back'
+    )
+    try {
+      heir.kill('SIGKILL')
+    } catch {
+      // Expected when it died on its own, which is the likely cause.
+    }
+    discardManifest(target)
+    const back = await host.reclaim()
+    host.resumeAll()
+    return declined(
+      back
+        ? 'the replacement failed to start; this server took its terminals back'
+        : 'the replacement failed to start and the endpoint could not be reclaimed; ' +
+            'the terminals are still running here, but Vorn must be reopened to reach them'
+    )
+  }
+
+  log.info({ pid: heir.pid }, '[handoff] the replacement is serving; standing down')
+  // Nothing is killed: leaving closes this copy and the replacement holds the other.
+  heir.unref()
+  heir.disconnect?.()
+  const result: HandoffResult = {
+    kind: 'handed-over',
+    sessions: slots.length,
+    pid: heir.pid ?? 0
+  }
+  // Late enough for the reply to reach the caller before the socket closes.
+  setTimeout(() => host.exit(), 250)
+  return result
+}
+
+/** An exit is an answer too, and a faster one than the deadline. */
+function waitFor(
+  child: ChildProcess,
+  kind: string,
+  timeoutMs: number
+): Promise<{ ok: true } | { ok: false; because: string }> {
+  return new Promise((resolve) => {
+    let settled = false
+    const done = (answer: { ok: true } | { ok: false; because: string }): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      child.off('message', onMessage)
+      child.off('exit', onExit)
+      child.off('error', onError)
+      resolve(answer)
+    }
+    const onMessage = (msg: unknown): void => {
+      if ((msg as { kind?: string } | null)?.kind === kind) done({ ok: true })
+    }
+    const onExit = (code: number | null, signal: string | null): void =>
+      done({ ok: false, because: `it exited (code ${code}, signal ${signal})` })
+    const onError = (err: Error): void => done({ ok: false, because: err.message })
+    const timer = setTimeout(
+      () => done({ ok: false, because: `it did not say "${kind}" in time` }),
+      timeoutMs
+    )
+
+    child.on('message', onMessage)
+    child.on('exit', onExit)
+    child.on('error', onError)
+  })
+}

--- a/packages/server/src/handoff/heir.ts
+++ b/packages/server/src/handoff/heir.ts
@@ -1,0 +1,110 @@
+import tty from 'node:tty'
+import type { TerminalSession } from '@vornrun/shared/types'
+import log from '../logger'
+import { AdoptedPty } from './adopted-pty'
+import { readManifest, discardManifest } from './manifest'
+
+/**
+ * Taking a running machine over from the server that had it.
+ *
+ * Split along the commit boundary: before `imported`, only what proves the panes
+ * can be taken, because giving up is still free. After `commit`, an ordinary
+ * startup that happens to begin with terminals in hand.
+ */
+
+export interface AdoptedPane {
+  session: TerminalSession
+  pty: AdoptedPty
+  cols: number
+  rows: number
+}
+
+const COMMIT_DEADLINE_MS = 30_000
+
+/** Null means this process must not serve; the outgoing server still has everything. */
+export async function receiveHandoff(source: string): Promise<AdoptedPane[] | null> {
+  if (typeof process.send !== 'function') {
+    log.error('[handoff] started with --adopt-handoff but no channel to answer on')
+    return null
+  }
+
+  const manifest = readManifest(source)
+  if (!manifest) {
+    // Not "no panes": serving nothing while holding their descriptors is how work disappears.
+    log.error({ source }, '[handoff] the manifest is missing or unreadable')
+    return null
+  }
+
+  const panes: AdoptedPane[] = []
+  for (const pane of manifest.panes) {
+    // Checked, not trusted: a slot that is not a pty is a pane that would never run anything.
+    if (!tty.isatty(pane.slot)) {
+      log.error(
+        { slot: pane.slot, session: pane.session.id },
+        '[handoff] a slot named in the manifest is not a terminal'
+      )
+      return null
+    }
+    try {
+      // Built paused: the bytes stay in the kernel's buffer until a session can hold them.
+      const adopted = new AdoptedPty(pane.slot, pane.pid)
+      adopted.pause()
+      panes.push({ session: pane.session, pty: adopted, cols: pane.cols, rows: pane.rows })
+    } catch (err) {
+      log.error(
+        { err, slot: pane.slot },
+        '[handoff] could not build a reader over an inherited pty'
+      )
+      return null
+    }
+  }
+
+  log.info(
+    { panes: panes.length, donor: manifest.donorPid },
+    '[handoff] panes taken; waiting for the commit'
+  )
+  process.send({ kind: 'imported' })
+
+  const committed = await waitForCommit()
+  if (!committed) {
+    log.error('[handoff] the outgoing server never committed; standing down')
+    return null
+  }
+
+  discardManifest(source)
+  // The outgoing server is about to exit and close this channel.
+  process.channel?.unref()
+  return panes
+}
+
+function waitForCommit(): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false
+    const done = (answer: boolean): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      process.off('message', onMessage)
+      process.off('disconnect', onDisconnect)
+      resolve(answer)
+    }
+    const onMessage = (msg: unknown): void => {
+      if ((msg as { kind?: string } | null)?.kind === 'commit') done(true)
+    }
+    // The channel closing first means the donor died without releasing anything.
+    const onDisconnect = (): void => done(false)
+    const timer = setTimeout(() => done(false), COMMIT_DEADLINE_MS)
+
+    process.on('message', onMessage)
+    process.on('disconnect', onDisconnect)
+  })
+}
+
+/** Tell the outgoing server it may leave. */
+export function announceServing(): void {
+  try {
+    process.send?.({ kind: 'serving' })
+  } catch (err) {
+    log.warn({ err }, '[handoff] could not tell the outgoing server we are serving')
+  }
+}

--- a/packages/server/src/handoff/heir.ts
+++ b/packages/server/src/handoff/heir.ts
@@ -21,9 +21,25 @@ export interface AdoptedPane {
 
 const COMMIT_DEADLINE_MS = 30_000
 
+/**
+ * The handshake channel: `process` in production, a fake under test.
+ *
+ * Injected because the alternative is a test that replaces `process.send` and
+ * removes `process` listeners -- in a runner that uses both to report its own
+ * results.
+ */
+export interface HandoffChannel {
+  send?: (message: unknown) => boolean
+  on(event: string, listener: (...args: unknown[]) => void): unknown
+  off(event: string, listener: (...args: unknown[]) => void): unknown
+}
+
 /** Null means this process must not serve; the outgoing server still has everything. */
-export async function receiveHandoff(source: string): Promise<AdoptedPane[] | null> {
-  if (typeof process.send !== 'function') {
+export async function receiveHandoff(
+  source: string,
+  channel: HandoffChannel = process
+): Promise<AdoptedPane[] | null> {
+  if (typeof channel.send !== 'function') {
     log.error('[handoff] started with --adopt-handoff but no channel to answer on')
     return null
   }
@@ -63,9 +79,9 @@ export async function receiveHandoff(source: string): Promise<AdoptedPane[] | nu
     { panes: panes.length, donor: manifest.donorPid },
     '[handoff] panes taken; waiting for the commit'
   )
-  process.send({ kind: 'imported' })
+  channel.send({ kind: 'imported' })
 
-  const committed = await waitForCommit()
+  const committed = await waitForCommit(channel)
   if (!committed) {
     log.error('[handoff] the outgoing server never committed; standing down')
     return null
@@ -77,15 +93,15 @@ export async function receiveHandoff(source: string): Promise<AdoptedPane[] | nu
   return panes
 }
 
-function waitForCommit(): Promise<boolean> {
+function waitForCommit(channel: HandoffChannel): Promise<boolean> {
   return new Promise((resolve) => {
     let settled = false
     const done = (answer: boolean): void => {
       if (settled) return
       settled = true
       clearTimeout(timer)
-      process.off('message', onMessage)
-      process.off('disconnect', onDisconnect)
+      channel.off('message', onMessage)
+      channel.off('disconnect', onDisconnect)
       resolve(answer)
     }
     const onMessage = (msg: unknown): void => {
@@ -95,15 +111,15 @@ function waitForCommit(): Promise<boolean> {
     const onDisconnect = (): void => done(false)
     const timer = setTimeout(() => done(false), COMMIT_DEADLINE_MS)
 
-    process.on('message', onMessage)
-    process.on('disconnect', onDisconnect)
+    channel.on('message', onMessage)
+    channel.on('disconnect', onDisconnect)
   })
 }
 
 /** Tell the outgoing server it may leave. */
-export function announceServing(): void {
+export function announceServing(channel: HandoffChannel = process): void {
   try {
-    process.send?.({ kind: 'serving' })
+    channel.send?.({ kind: 'serving' })
   } catch (err) {
     log.warn({ err }, '[handoff] could not tell the outgoing server we are serving')
   }

--- a/packages/server/src/handoff/manifest.ts
+++ b/packages/server/src/handoff/manifest.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { TerminalSession } from '@vornrun/shared/types'
+import { HANDOFF_MANIFEST_VERSION } from '@vornrun/shared/protocol'
+
+/**
+ * What a server tells its replacement about the terminals it is handing over.
+ * The descriptors travel separately, in the replacement's stdio array.
+ */
+export interface HandoffPane {
+  /** The stdio index the master descriptor arrives on. */
+  slot: number
+  session: TerminalSession
+  /** Reparents to init when the donor exits, so it can be signalled but never reaped. */
+  pid: number
+  cols: number
+  rows: number
+}
+
+export interface HandoffManifest {
+  version: number
+  donorPid: number
+  createdAt: number
+  panes: HandoffPane[]
+}
+
+/** 0-2 are the replacement's own stdio and 3 is its IPC channel. */
+export const FIRST_PTY_SLOT = 4
+
+export function manifestPath(dataDir: string, donorPid: number): string {
+  return path.join(dataDir, `handoff-${donorPid}.json`)
+}
+
+export function writeManifest(target: string, manifest: HandoffManifest): void {
+  // Renamed into place: a half-read manifest would adopt some terminals and drop the rest.
+  const scratch = `${target}.partial`
+  fs.writeFileSync(scratch, JSON.stringify(manifest), { mode: 0o600 })
+  fs.renameSync(scratch, target)
+}
+
+/** Null means "cannot be trusted", never "there were no terminals". */
+export function readManifest(source: string): HandoffManifest | null {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(source, 'utf-8')) as unknown
+    return isManifest(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function isManifest(value: unknown): value is HandoffManifest {
+  if (!value || typeof value !== 'object') return false
+  const m = value as Partial<HandoffManifest>
+  if (m.version !== HANDOFF_MANIFEST_VERSION) return false
+  if (!Number.isInteger(m.donorPid) || !Array.isArray(m.panes)) return false
+  return m.panes.every(isPane)
+}
+
+function isPane(value: unknown): value is HandoffPane {
+  if (!value || typeof value !== 'object') return false
+  const p = value as Partial<HandoffPane>
+  return (
+    Number.isInteger(p.slot) &&
+    (p.slot as number) >= FIRST_PTY_SLOT &&
+    Number.isInteger(p.pid) &&
+    (p.pid as number) > 0 &&
+    Number.isInteger(p.cols) &&
+    (p.cols as number) > 0 &&
+    Number.isInteger(p.rows) &&
+    (p.rows as number) > 0 &&
+    !!p.session &&
+    typeof p.session === 'object' &&
+    typeof (p.session as TerminalSession).id === 'string'
+  )
+}
+
+export function discardManifest(target: string): void {
+  try {
+    fs.rmSync(target, { force: true })
+  } catch {
+    // Left behind at worst, named by the pid that wrote it.
+  }
+}

--- a/packages/server/src/handoff/native.ts
+++ b/packages/server/src/handoff/native.ts
@@ -1,0 +1,43 @@
+import log from '../logger'
+
+/** Resizing a pty is a TIOCSWINSZ ioctl, which Node has no binding for; node-pty's does. */
+interface PtyBinding {
+  resize(fd: number, cols: number, rows: number, pixelWidth: number, pixelHeight: number): void
+}
+
+let binding: PtyBinding | null = null
+let looked = false
+
+function load(): PtyBinding | null {
+  if (looked) return binding
+  looked = true
+  try {
+    // node-pty's own loader, because the binding's path varies by how it was installed.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const utils = require('node-pty/lib/utils') as {
+      loadNativeModule(name: string): { module: PtyBinding }
+    }
+    binding = utils.loadNativeModule('pty').module
+  } catch (err) {
+    log.error({ err }, '[handoff] node-pty binding unreachable; adopted panes cannot resize')
+    binding = null
+  }
+  return binding
+}
+
+/** Answers rather than throws: a pane at the wrong width must not end a server holding every terminal. */
+export function resizeFd(fd: number, cols: number, rows: number): boolean {
+  const native = load()
+  if (!native) return false
+  try {
+    native.resize(fd, cols, rows, 0, 0)
+    return true
+  } catch (err) {
+    log.warn({ err, fd, cols, rows }, '[handoff] could not resize an adopted pty')
+    return false
+  }
+}
+
+export function canResizeAdopted(): boolean {
+  return load() !== null
+}

--- a/packages/server/src/handoff/native.ts
+++ b/packages/server/src/handoff/native.ts
@@ -1,43 +1,38 @@
+import * as pty from 'node-pty'
 import log from '../logger'
 
-/** Resizing a pty is a TIOCSWINSZ ioctl, which Node has no binding for; node-pty's does. */
-interface PtyBinding {
-  resize(fd: number, cols: number, rows: number, pixelWidth: number, pixelHeight: number): void
-}
-
-let binding: PtyBinding | null = null
-let looked = false
-
-function load(): PtyBinding | null {
-  if (looked) return binding
-  looked = true
-  try {
-    // node-pty's own loader, because the binding's path varies by how it was installed.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const utils = require('node-pty/lib/utils') as {
-      loadNativeModule(name: string): { module: PtyBinding }
+/**
+ * Resizing a pty is a TIOCSWINSZ ioctl, which Node has no binding for.
+ *
+ * node-pty publishes its own binding as `native`, which is the only form that
+ * survives bundling: `external` and the packaged app's module patch both match
+ * the bare specifier, and a subpath is bundled instead -- taking node-pty's
+ * loader with it, whose relative `require` then resolves against dist/ and finds
+ * nothing. Absent from the typings, hence the cast and nothing more.
+ */
+const binding =
+  (
+    pty as unknown as {
+      native?: {
+        resize(
+          fd: number,
+          cols: number,
+          rows: number,
+          pixelWidth: number,
+          pixelHeight: number
+        ): void
+      } | null
     }
-    binding = utils.loadNativeModule('pty').module
-  } catch (err) {
-    log.error({ err }, '[handoff] node-pty binding unreachable; adopted panes cannot resize')
-    binding = null
-  }
-  return binding
-}
+  ).native ?? null
 
 /** Answers rather than throws: a pane at the wrong width must not end a server holding every terminal. */
 export function resizeFd(fd: number, cols: number, rows: number): boolean {
-  const native = load()
-  if (!native) return false
+  if (!binding) return false
   try {
-    native.resize(fd, cols, rows, 0, 0)
+    binding.resize(fd, cols, rows, 0, 0)
     return true
   } catch (err) {
     log.warn({ err, fd, cols, rows }, '[handoff] could not resize an adopted pty')
     return false
   }
-}
-
-export function canResizeAdopted(): boolean {
-  return load() !== null
 }

--- a/packages/server/src/history/writer.ts
+++ b/packages/server/src/history/writer.ts
@@ -295,7 +295,14 @@ export async function discardHistory(id: string): Promise<void> {
 export async function flushHistory(): Promise<void> {
   sealed = true
   stopTicking()
+  await checkpointAll()
+}
 
+/**
+ * `flushHistory` without the seal, for a handoff: the terminals are not going
+ * anywhere, and a rolled-back server must not have its history switched off.
+ */
+export async function checkpointAll(): Promise<void> {
   const all = Promise.all(
     [...recorded.values()].map((held) => enqueue(held, () => checkpoint(held, true)))
   )

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -550,9 +550,11 @@ export async function startServer(
       sessionManager.startAutoSave(sessionsToPersist)
     },
     quiesce: async () => {
-      // What a shutdown does, minus the sealing and the killing.
-      sessionManager.stopAutoSave()
+      // What a shutdown does, minus the sealing and the killing. Written down
+      // before the auto-save is stopped, because stopping it drops the source
+      // `persistNow` reads -- the other order saves nothing at all.
       sessionManager.persistNow()
+      sessionManager.stopAutoSave()
       ptyManager.flushPendingOutput()
       await checkpointAll()
     },
@@ -575,10 +577,12 @@ export async function startServer(
       // A fresh listener: an anonymous inode cannot be linked back to a path. The
       // old one stays open, because this request's socket is still on it.
       const again = await openLocalEndpoint(dataDir, () => scheduler.deliverPendingConnectorInbox())
-      if (again.kind === 'held') {
-        endpoint = again.endpoint
-        watchEndpoint(() => endpoint?.holds() ?? false)
-      }
+      if (again.kind === 'held') endpoint = again.endpoint
+      // Restored on both paths. `release` pointed the watch at `true` so giving
+      // the name up deliberately would not latch draining; left there after a
+      // reclaim that failed, this server would never notice it has no endpoint
+      // and would go on creating sessions nothing can reach.
+      watchEndpoint(() => endpoint?.holds() ?? false)
       if (listening) writePortFile(dataDir, actualPort, ownsPublished)
       return listening && again.kind === 'held'
     },
@@ -665,9 +669,10 @@ export async function startServer(
       log.error('[server] shutdown did not finish; exiting anyway')
       process.exit(1)
     }, SHUTDOWN_DEADLINE_MS).unref?.()
-    // Stop the periodic timer first, then do one final synchronous save
-    sessionManager.stopAutoSave()
+    // The final save first: `stopAutoSave` drops the session source, so the
+    // other order made this write nothing on every shutdown.
     sessionManager.persistNow()
+    sessionManager.stopAutoSave()
     // The last few milliseconds of output, then every terminal's screen, before
     // anything kills a PTY. After `killAll()` the buffers this reads have been
     // emptied; before `persistNow()` the sessions these belong to are not yet

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,7 +24,8 @@ import {
   extensionRenamedSession,
   reconcileImplicitConnections,
   registerAllMethods,
-  setServerPort
+  setServerPort,
+  sessionsToPersist
 } from './register-methods'
 import { registerWebhookRoute } from './webhook-trigger'
 import { registerExtensionBridge, type ExtensionRouteDeps } from './extensions/bridge'
@@ -35,6 +36,9 @@ import { abandonSelections } from './extensions/selection'
 import { configManager } from './config-manager'
 import { claimPublishedFiles, writePortFile, removePortFile } from './published-files'
 import { openLocalEndpoint, type LocalEndpoint } from './local-endpoint'
+import { handOver, type HandoffHost } from './handoff/donor'
+import { receiveHandoff, announceServing, type AdoptedPane } from './handoff/heir'
+import { releaseListener, retakeListener } from './server-rebind'
 import { beginDraining, isDraining, watchEndpoint } from './draining'
 import {
   initBootstrapSecret,
@@ -44,11 +48,15 @@ import {
 } from './ws-auth'
 import { getDataDir, dbCountActiveConnectorInboxLeases } from './database'
 import { parseServerArgs, resolveServerPort, shouldRememberPort } from './server-args'
-import { DEFAULT_SERVER_PORT, EXIT_ENDPOINT_TAKEN } from '@vornrun/shared/protocol'
+import {
+  DEFAULT_SERVER_PORT,
+  EXIT_ENDPOINT_TAKEN,
+  SERVER_LOG_FILENAME
+} from '@vornrun/shared/protocol'
 import { ptyManager } from './pty-manager'
-import { configureHistory, flushHistory } from './history/writer'
+import { configureHistory, flushHistory, checkpointAll } from './history/writer'
 import { recoverHistory } from './history/recovery'
-import { seedRestored, markRecovered, verifyRestored } from './restored-sessions'
+import { seedRestored, markRecovered, verifyRestored, consumeRestored } from './restored-sessions'
 import { getGitBranch, getGitHead } from './git-utils'
 import { sessionManager } from './session-persistence'
 import { headlessManager } from './headless-manager'
@@ -138,6 +146,8 @@ export async function startServer(
     idleShutdown?: boolean
     /** Origins beyond this server's own that may frame a pane, such as the desktop's. */
     extensionFrameAncestors?: string[]
+    /** Terminals inherited from the server this one replaces, already taken and paused. */
+    adopted?: AdoptedPane[]
   } = {}
 ) {
   // Initialize database + config. This resolves the data directory for the whole
@@ -386,6 +396,11 @@ export async function startServer(
   const bootTime = Date.now() - os.uptime() * 1000
   const carriedOver = seedRestored(sessionManager.readPreviousSessions(), Date.now(), bootTime)
 
+  const adopted = options.adopted ?? []
+  // Handed-over sessions are live, but the previous server wrote them down on its
+  // way out, so they are also sitting in the list above being offered as resumable.
+  for (const pane of adopted) consumeRestored(pane.session.id)
+
   // Register all RPC methods
   registerAllMethods()
   // Connects the rung-none packs installed before installing meant connecting.
@@ -516,12 +531,62 @@ export async function startServer(
     await app.close()
     process.exit(EXIT_ENDPOINT_TAKEN)
   }
-  const endpoint = claimed.kind === 'held' ? claimed.endpoint : null
+  // `let`, because a handoff gives it up and an abandoned handoff takes it back.
+  let endpoint = claimed.kind === 'held' ? claimed.endpoint : null
   // Asked at session creation rather than only on the idle tick: that timer runs
   // at a quarter of the window and is switched off entirely for `vorn-server
   // serve`, so a check that lived only there would be late or absent exactly
   // where it matters.
-  if (endpoint) watchEndpoint(() => endpoint.holds())
+  if (endpoint) watchEndpoint(() => endpoint?.holds() ?? false)
+
+  /** Registered here because every closure needs the endpoint, port and file ownership. */
+  const handoffHost: HandoffHost = {
+    dataDir,
+    describePanes: () => ptyManager.describeForHandoff(),
+    pauseAll: () => ptyManager.pauseAllForHandoff(),
+    resumeAll: () => {
+      ptyManager.resumeAllForHandoff()
+      // A handoff that did not happen must not leave this server never persisting again.
+      sessionManager.startAutoSave(sessionsToPersist)
+    },
+    quiesce: async () => {
+      // What a shutdown does, minus the sealing and the killing.
+      sessionManager.stopAutoSave()
+      sessionManager.persistNow()
+      ptyManager.flushPendingOutput()
+      await checkpointAll()
+    },
+    openLogFd: () => fs.openSync(path.join(dataDir, SERVER_LOG_FILENAME), 'a'),
+    release: async () => {
+      // The order is the commit: name, then port file, then listener.
+      //
+      // `relinquish`, not `close`: the request being served arrived on this
+      // endpoint and its reply has to travel back out over it.
+      //
+      // The draining watch is pointed away first, or giving the name up
+      // deliberately would latch it irreversibly on a server that may roll back.
+      watchEndpoint(() => true)
+      endpoint?.relinquish()
+      removePortFile(dataDir, ownsPublished)
+      await releaseListener()
+    },
+    reclaim: async () => {
+      const listening = await retakeListener()
+      // A fresh listener: an anonymous inode cannot be linked back to a path. The
+      // old one stays open, because this request's socket is still on it.
+      const again = await openLocalEndpoint(dataDir, () => scheduler.deliverPendingConnectorInbox())
+      if (again.kind === 'held') {
+        endpoint = again.endpoint
+        watchEndpoint(() => endpoint?.holds() ?? false)
+      }
+      if (listening) writePortFile(dataDir, actualPort, ownsPublished)
+      return listening && again.kind === 'held'
+    },
+    // Not `shutdown()`: that kills every PTY, which is the one thing a handoff must not do.
+    exit: () => process.exit(0)
+  }
+
+  registerMethod('server:handoff', (params) => handOver(params, handoffHost))
 
   // Only now, and for two reasons. It is after `registerAllMethods()`, so
   // nothing here races the first debounced `saveSessions`. And it is after the
@@ -533,7 +598,24 @@ export async function startServer(
   // this server until both of those exist, so there is no moment where one can
   // ask for history that has not been read yet. The cost is that discovery waits
   // on it -- measured at 77ms for fifty terminals.
-  markRecovered((await recoverHistory(dataDir, carriedOver)).recovered)
+  // Adopted sessions belong in this list for both things it decides: their screens
+  // are rebuilt from the previous server's checkpoint, and a session absent from it
+  // has its history swept. Null stays null, which sweeps nothing.
+  const recoverable =
+    carriedOver === null
+      ? null
+      : [
+          ...carriedOver,
+          ...adopted
+            .filter((pane) => !carriedOver.some((s) => s.id === pane.session.id))
+            .map((pane) => pane.session)
+        ]
+  if (carriedOver === null && adopted.length) {
+    log.warn(
+      '[handoff] the session list could not be read; adopted terminals start without scrollback'
+    )
+  }
+  markRecovered((await recoverHistory(dataDir, recoverable)).recovered)
   verifyRestored({
     isDirectory: (at) => {
       try {
@@ -545,6 +627,10 @@ export async function startServer(
     branch: getGitBranch,
     head: getGitHead
   })
+
+  // After recovery, whose rebuilt screens `createScreen` would otherwise clear, and
+  // before the port file, so no client can find this server and be told it is empty.
+  ptyManager.adoptPanes(adopted)
 
   // Published together, after the claim, because they are one announcement: the
   // port says where, the credential says how, and a reader that finds one
@@ -713,10 +799,25 @@ const isDirectRun =
   process.argv[1]?.endsWith('index.js') ||
   process.argv[1]?.endsWith('index.cjs')
 if (isDirectRun) {
-  const { host, port, dataDir } = parseServerArgs(process.argv.slice(2))
+  const { host, port, dataDir, adoptHandoff } = parseServerArgs(process.argv.slice(2))
 
-  startServer({ port, host, dataDir })
+  /**
+   * Before `startServer`, and that ordering is the transaction: the cheap certain
+   * work while failing is still free, the fallible work after the commit.
+   */
+  const adopting = adoptHandoff ? receiveHandoff(adoptHandoff) : Promise.resolve([])
+
+  adopting
+    .then((adopted) => {
+      if (adopted === null) {
+        log.error('[handoff] could not take the terminals; leaving the previous server with them')
+        process.exit(1)
+      }
+      return startServer({ port, host, dataDir, adopted })
+    })
     .then(({ port: actualPort }) => {
+      // The last moment the handoff could have been abandoned.
+      if (adoptHandoff) announceServing()
       // This entry point is the one Electron forks, and its launcher blocks on
       // reading this line to learn where to connect. It belongs here rather than
       // inside startServer, which has no parent to answer to.

--- a/packages/server/src/local-endpoint.ts
+++ b/packages/server/src/local-endpoint.ts
@@ -51,6 +51,14 @@ export interface LocalEndpoint {
   readonly path: string
   /** Whether this process still holds the name. Read, never cached. */
   holds(): boolean
+  /**
+   * Give up the name while staying answerable to whoever is already connected.
+   *
+   * A listener is identified by its inode, so unlinking the name stops new
+   * connections and leaves existing ones alone -- which is what lets a handoff
+   * reply to the request that asked for it. Only ever a name this process created.
+   */
+  relinquish(): boolean
   close(): Promise<void>
 }
 
@@ -143,6 +151,18 @@ export async function openLocalEndpoint(
   const endpoint: LocalEndpoint = {
     path: canonical,
     holds: () => stillOurs(canonical, mine),
+    relinquish: () => {
+      // Checked, not assumed: the name may already be somebody else's.
+      if (!stillOurs(canonical, mine)) return false
+      try {
+        fs.rmSync(canonical, { force: true })
+        log.info({ path: canonical }, '[endpoint] released the name for a replacement')
+        return true
+      } catch (err) {
+        log.error({ err, path: canonical }, '[endpoint] could not release the name')
+        return false
+      }
+    },
     close: async () => {
       // Terminated, not asked. `ws` with `clientTracking` does not close tracked
       // sockets on `close()` -- it waits for them, and so does the http server

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -1098,7 +1098,13 @@ class PtyManager extends EventEmitter {
     for (const id of ranked) {
       const held = this.ptys.get(id)
       const session = this.sessions.get(id)
-      if (!held || !session) continue
+      if (!held || !session) {
+        // All-or-nothing, the same as a missing descriptor below. A pty whose
+        // record has gone is one the replacement could not be told about, and
+        // skipping it would hand over a machine quietly missing a pane.
+        log.warn({ id }, '[pty] this terminal has no session record to hand over')
+        return null
+      }
       const fd = masterFd(held)
       if (fd === null) {
         log.warn({ id }, '[pty] this terminal has no descriptor to hand over')

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -42,14 +42,19 @@ import { stripAnsi } from './ansi-strip'
 import { appendScrollback, clearScrollback } from './terminal-scrollback'
 import {
   createScreen,
+  hasScreen,
   feedScreen,
   resizeScreen,
   clearScreen,
   setCwdReporter
 } from './terminal-screen'
+import type { ManagedPty } from './handoff/adopted-pty'
+import type { AdoptedPane } from './handoff/heir'
+import type { DonorPane } from './handoff/donor'
 import { startHistory, recordOutput, recordResize, stopHistory } from './history/writer'
 import { analyzeOutput, createStatusContext, StatusContext } from './status-parser'
 import { isDraining, DRAINING_MESSAGE } from './draining'
+import { isHandingOver, HANDOVER_MESSAGE } from './handoff/donor'
 
 const MAX_OUTPUT_LINES = 1000
 
@@ -79,10 +84,19 @@ type WorktreeSessionCounter = (
   excludeId?: string
 ) => { count: number; sessionIds: string[] }
 
+/**
+ * node-pty exposes `fd` as a getter its typings never declared, so this asks past
+ * the type. Both kinds of pty answer it, because a handoff must work twice.
+ */
+function masterFd(held: ManagedPty): number | null {
+  const fd = (held as unknown as { fd?: unknown }).fd
+  return typeof fd === 'number' && Number.isInteger(fd) && fd >= 0 ? fd : null
+}
+
 class PtyManager extends EventEmitter {
   /** Recorded HEAD per session, refreshed by the save loop. */
   readonly heads = new HeadRefresh(getGitHead)
-  private ptys = new Map<string, pty.IPty>()
+  private ptys = new Map<string, ManagedPty>()
   private sessions = new Map<string, TerminalSession>()
   /**
    * PTYs an extension's pane is drawing, which are not sessions.
@@ -222,6 +236,8 @@ class PtyManager extends EventEmitter {
     // nobody would ever see it. Existing sessions are untouched -- their clients
     // hold a descriptor, not a name.
     if (isDraining()) throw new Error(DRAINING_MESSAGE)
+    // A pane created now would be in neither the manifest nor the replacement.
+    if (isHandingOver()) throw new Error(HANDOVER_MESSAGE)
     const id = reuseId ?? crypto.randomUUID()
     const shell = getDefaultShell(configManager.loadConfig().defaults.shell)
 
@@ -828,8 +844,15 @@ class PtyManager extends EventEmitter {
    *   finds nothing and silently falls back -- which is invisible while all
    *   three spawn at the same size and wrong the moment one does not.
    */
-  private setupPtyEvents(id: string, ptyProcess: pty.IPty, cols: number, rows: number): void {
-    createScreen(id, cols, rows)
+  private setupPtyEvents(
+    id: string,
+    ptyProcess: ManagedPty,
+    cols: number,
+    rows: number,
+    /** An inherited pty already has its screen rebuilt from disk, and `createScreen` clears. */
+    adopted = false
+  ): void {
+    if (!adopted || !hasScreen(id)) createScreen(id, cols, rows)
     // Replaces whatever was left under this id. A recovered session that is
     // being respawned has history describing a process that is gone.
     startHistory(id)
@@ -1057,6 +1080,81 @@ class PtyManager extends EventEmitter {
   flushPendingOutput(): void {
     // Copied because `flushBuffer` deletes from the map it is walking.
     for (const id of [...this.flushTimers.keys()]) this.drainBuffer(id)
+  }
+
+  /**
+   * Every live pane, or null if even one cannot be described: a handoff carrying
+   * most of the terminals looks exactly like losing the rest.
+   */
+  describeForHandoff(): DonorPane[] | null {
+    const live = [...this.ptys.keys()]
+    const ranked = [...live].sort((a, b) => {
+      const ai = this.sessionOrder.indexOf(a)
+      const bi = this.sessionOrder.indexOf(b)
+      return (ai === -1 ? Number.MAX_SAFE_INTEGER : ai) - (bi === -1 ? Number.MAX_SAFE_INTEGER : bi)
+    })
+
+    const panes: DonorPane[] = []
+    for (const id of ranked) {
+      const held = this.ptys.get(id)
+      const session = this.sessions.get(id)
+      if (!held || !session) continue
+      const fd = masterFd(held)
+      if (fd === null) {
+        log.warn({ id }, '[pty] this terminal has no descriptor to hand over')
+        return null
+      }
+      panes.push({
+        session,
+        fd,
+        pid: held.pid,
+        cols: session.cols ?? INITIAL_COLS,
+        rows: session.rows ?? INITIAL_ROWS
+      })
+    }
+    return panes
+  }
+
+  /** Stop every reader, so a handoff describes a machine that is holding still. */
+  pauseAllForHandoff(): void {
+    for (const held of this.ptys.values()) {
+      try {
+        held.pause()
+      } catch (err) {
+        log.warn({ err }, '[pty] could not pause a terminal for the handoff')
+      }
+    }
+  }
+
+  /** Start reading again, for a handoff that did not happen. */
+  resumeAllForHandoff(): void {
+    for (const held of this.ptys.values()) {
+      try {
+        held.resume()
+      } catch (err) {
+        log.warn({ err }, '[pty] could not resume a terminal after an abandoned handoff')
+      }
+    }
+  }
+
+  /** Called after `recoverHistory`, so the first byte read is the first with somewhere to go. */
+  adoptPanes(panes: AdoptedPane[]): void {
+    for (const pane of panes) {
+      const { session } = pane
+      this.sessions.set(session.id, session)
+      if (!this.sessionOrder.includes(session.id)) this.sessionOrder.push(session.id)
+      this.normalizedPaths.set(
+        session.id,
+        normalizePath(session.worktreePath || session.projectPath)
+      )
+      this.setupPtyEvents(session.id, pane.pty, pane.cols, pane.rows, true)
+      this.ptys.set(session.id, pane.pty)
+    }
+    // Every session wired before any of them reads.
+    for (const pane of panes) pane.pty.resume()
+    if (panes.length) {
+      log.info({ panes: panes.length }, '[pty] adopted terminals from the previous server')
+    }
   }
 
   killAll(): void {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -64,8 +64,7 @@ import {
   SessionEventType,
   RemoteHost,
   getProjectRemoteHostId,
-  isTerminalTaskStatus,
-  TerminalSession
+  isTerminalTaskStatus
 } from '@vornrun/shared/types'
 import type {
   SourceConnection,

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -64,7 +64,8 @@ import {
   SessionEventType,
   RemoteHost,
   getProjectRemoteHostId,
-  isTerminalTaskStatus
+  isTerminalTaskStatus,
+  TerminalSession
 } from '@vornrun/shared/types'
 import type {
   SourceConnection,
@@ -671,6 +672,13 @@ export async function forgetRestored(id: string): Promise<void> {
   // here.
   clearScrollback(id)
   await discardHistory(id)
+}
+
+/** Named because a rolled-back handoff has to start saving again, with exactly this. */
+export function sessionsToPersist(): TerminalSession[] {
+  const active = ptyManager.getActiveSessions()
+  ptyManager.heads.refresh(active)
+  return [...active, ...restoredRecords()]
 }
 
 export function registerAllMethods(): void {
@@ -2148,11 +2156,7 @@ export function registerAllMethods(): void {
   // record gone, the next start judged that session's history unreachable and
   // deleted it. Holding them here is what makes a terminal survive more than one
   // restart.
-  sessionManager.startAutoSave(() => {
-    const active = ptyManager.getActiveSessions()
-    ptyManager.heads.refresh(active)
-    return [...active, ...restoredRecords()]
-  })
+  sessionManager.startAutoSave(sessionsToPersist)
 
   // ─── Hook server integration ──────────────────────────────────
 

--- a/packages/server/src/server-args.ts
+++ b/packages/server/src/server-args.ts
@@ -18,6 +18,8 @@ export interface ServerArgs {
   dataDir?: string
   /** Label for `token create`. */
   name?: string
+  /** Never typed by a person: passed by the server being replaced. See `handoff/heir.ts`. */
+  adoptHandoff?: string
   help: boolean
   /** Everything that is not an option: `serve`, `token`, `create`, an id. */
   positionals: string[]
@@ -31,6 +33,7 @@ export const SERVER_OPTIONS = {
   port: { type: 'string' },
   'data-dir': { type: 'string' },
   name: { type: 'string' },
+  'adopt-handoff': { type: 'string' },
   help: { type: 'boolean', short: 'h' }
 } as const
 
@@ -46,6 +49,7 @@ export function parseServerArgs(argv: string[]): ServerArgs {
     port?: string
     'data-dir'?: string
     name?: string
+    'adopt-handoff'?: string
     help?: boolean
   }
   let positionals: string[]
@@ -78,6 +82,7 @@ export function parseServerArgs(argv: string[]): ServerArgs {
     port,
     dataDir: values['data-dir'],
     name: values.name,
+    adoptHandoff: values['adopt-handoff'],
     help: values.help ?? false,
     positionals
   }

--- a/packages/server/src/server-rebind.ts
+++ b/packages/server/src/server-rebind.ts
@@ -17,6 +17,38 @@ export function getCurrentHost(): string {
   return currentHost
 }
 
+/** Reversible, unlike closing fastify: the replacement is about to bind this port. */
+export async function releaseListener(): Promise<void> {
+  const server = httpServer
+  if (!server) return
+  if (typeof server.closeAllConnections === 'function') server.closeAllConnections()
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+}
+
+/** Only for a handoff that committed and then lost its replacement. */
+export async function retakeListener(): Promise<boolean> {
+  const server = httpServer
+  if (!server) return false
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: unknown): void => {
+        server.removeListener('listening', onListening)
+        reject(err)
+      }
+      const onListening = (): void => {
+        server.removeListener('error', onError)
+        resolve()
+      }
+      server.once('error', onError)
+      server.listen(boundPort, currentHost, onListening)
+    })
+    return true
+  } catch (err) {
+    log.error({ err }, '[server] could not listen again after an abandoned handoff')
+    return false
+  }
+}
+
 /**
  * Rebind if the reachability setting has changed.
  *

--- a/packages/server/src/server-rebind.ts
+++ b/packages/server/src/server-rebind.ts
@@ -25,8 +25,8 @@ export async function releaseListener(): Promise<void> {
   await new Promise<void>((resolve) => server.close(() => resolve()))
 }
 
-/** Only for a handoff that committed and then lost its replacement. */
-export async function retakeListener(): Promise<boolean> {
+/** Listen on `host`, answering whether it worked rather than throwing. */
+async function listenOn(host: string): Promise<boolean> {
   const server = httpServer
   if (!server) return false
   try {
@@ -40,13 +40,18 @@ export async function retakeListener(): Promise<boolean> {
         resolve()
       }
       server.once('error', onError)
-      server.listen(boundPort, currentHost, onListening)
+      server.listen(boundPort, host, onListening)
     })
     return true
   } catch (err) {
-    log.error({ err }, '[server] could not listen again after an abandoned handoff')
+    log.error({ err, host }, '[server] could not listen')
     return false
   }
+}
+
+/** Only for a handoff that committed and then lost its replacement. */
+export async function retakeListener(): Promise<boolean> {
+  return listenOn(currentHost)
 }
 
 /**
@@ -85,27 +90,13 @@ async function doRebind(): Promise<void> {
 
   log.info(`[server] rebinding from ${currentHost} to ${desiredHost}:${boundPort}`)
 
-  try {
-    const server = httpServer
-    if (typeof server.closeAllConnections === 'function') {
-      server.closeAllConnections()
-    }
-    await new Promise<void>((resolve) => server.close(() => resolve()))
-    await new Promise<void>((resolve, reject) => {
-      const onError = (err: unknown) => {
-        server.removeListener('listening', onListening)
-        reject(err)
-      }
-      const onListening = () => {
-        server.removeListener('error', onError)
-        resolve()
-      }
-      server.once('error', onError)
-      server.listen(boundPort, desiredHost, onListening)
-    })
+  // The same two steps a handoff commit and its rollback use, so a change to
+  // either -- a drain timeout, different error handling -- reaches both.
+  await releaseListener()
+  if (await listenOn(desiredHost)) {
     currentHost = desiredHost
     log.info(`[server] rebound successfully to ${desiredHost}:${boundPort}`)
-  } catch (err) {
-    log.error({ err }, '[server] rebind failed')
+  } else {
+    log.error('[server] rebind failed')
   }
 }

--- a/packages/server/src/terminal-screen.ts
+++ b/packages/server/src/terminal-screen.ts
@@ -482,6 +482,11 @@ export function setCwdReporter(fn: CwdReporter | null): void {
 }
 
 /** How many models are held. For the measurement that bounds this. */
+/** For the one caller that must not clear a screen recovery has just rebuilt. */
+export function hasScreen(id: string): boolean {
+  return screens.has(id)
+}
+
 export function screenCount(): number {
   return screens.size
 }

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -132,6 +132,16 @@ export function isLoopbackAddress(address: string | undefined): boolean {
 type Handler = (params: unknown) => Promise<unknown> | unknown
 const handlers = new Map<string, Handler>()
 
+/**
+ * Methods callable only over the local endpoint. `server:handoff` execs a path the
+ * caller names, which is an escalation over TCP and none through a 0700 directory.
+ */
+const localOnly = new Set<string>(['server:handoff'])
+
+export function requireLocalEndpoint(method: string): void {
+  localOnly.add(method)
+}
+
 registerCapability('auth', 1)
 
 // Declared so a client knows the server will honour a topic list before it sends
@@ -442,6 +452,19 @@ export function handleConnection(
     }
 
     // Request-response
+    if (localOnly.has(method) && peer?.transport !== 'unix') {
+      log.warn({ method, peer }, '[ws] refusing a local-endpoint method from elsewhere')
+      ws.send(
+        JSON.stringify(
+          createErrorResponse(
+            id,
+            -32000,
+            `${method} may only be called over this machine's local endpoint`
+          )
+        )
+      )
+      return
+    }
     const handler = handlers.get(method)
     if (!handler) {
       ws.send(JSON.stringify(createErrorResponse(id, -32601, `Method not found: ${method}`)))

--- a/packages/server/src/ws-handler.ts
+++ b/packages/server/src/ws-handler.ts
@@ -138,10 +138,6 @@ const handlers = new Map<string, Handler>()
  */
 const localOnly = new Set<string>(['server:handoff'])
 
-export function requireLocalEndpoint(method: string): void {
-  localOnly.add(method)
-}
-
 registerCapability('auth', 1)
 
 // Declared so a client knows the server will honour a topic list before it sends

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -86,6 +86,43 @@ import type {
  */
 export const RUNTIME_PROTOCOL_VERSION = 1
 
+/**
+ * Frozen on purpose: this is the channel used when the runtime protocol has
+ * already disagreed, so nothing here may ever change shape or meaning.
+ */
+export const HANDOFF_PROTOCOL_VERSION = 1
+
+/** A file rather than a command line: ARG_MAX is not a limit to find by having many terminals. */
+export const HANDOFF_MANIFEST_VERSION = 1
+
+/**
+ * A request to stand down in favour of a named replacement.
+ *
+ * The caller supplies the command line because only it knows one: the incumbent
+ * was started from a bundle an update has since replaced. That makes this an exec
+ * of a caller-supplied path, so it is accepted only over the unix endpoint.
+ */
+export interface HandoffRequest {
+  /** Refused rather than guessed at. */
+  handoffVersion: number
+  /** In production the Electron binary of the new bundle. */
+  exec: string
+  /** Its arguments, ending in the new server's entry point. */
+  args: string[]
+  /** Environment for the replacement. Merged over the incumbent's own. */
+  env: Record<string, string>
+  /** Working directory for the replacement. */
+  cwd: string
+  /** The version the caller expects to be running afterwards, for the log. */
+  appVersion: string
+}
+
+export type HandoffResult =
+  /** The replacement is serving; reconnect rather than wait on this socket. */
+  | { kind: 'handed-over'; sessions: number; pid: number }
+  /** Nothing was disturbed: every terminal is still here, under this server. */
+  | { kind: 'declined'; because: string }
+
 export interface ServerHello {
   protocolVersion: number
   /**
@@ -226,6 +263,9 @@ export const WS_PORT_FILENAME = 'ws-port'
  * answer, and the race it leaves open remains open.
  */
 export const ENDPOINT_FILENAME = 'vorn.sock'
+
+/** Two writers now: the app when it spawns a server, and a server when it spawns its replacement. */
+export const SERVER_LOG_FILENAME = 'server.log'
 
 /**
  * Exit code for a server that found this machine already had one.
@@ -733,6 +773,8 @@ export interface RequestMethods {
     result: void
   }
   'server:shutdown': { params: void; result: void }
+  /** Hand every running terminal to the replacement described, and exit. Unix endpoint only. */
+  'server:handoff': { params: HandoffRequest; result: HandoffResult }
 
   // Credential vault (server-side storage)
   'credential:storeKey': {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1245,6 +1245,35 @@ export type UpdateStatus =
   | { kind: 'error'; message: string }
   | { kind: 'unsupported' }
 
+/**
+ * Which build is holding this machine's terminals.
+ *
+ * The server outlives the app, so the two can be different builds -- and after an
+ * update they are, for a moment. A fix that shipped and did not take effect is
+ * nearly always this.
+ */
+export interface ServerRuntimeStatus {
+  /** 'unknown' for a server somebody started from the command line. */
+  serverVersion: string
+  /** The release this app is. */
+  appVersion: string
+  serverPid: number | null
+  /** Whether this app adopted a server it did not start. */
+  adopted: boolean
+  /** False on Windows, for a server reached by port, and for one this app started. */
+  canUpgrade: boolean
+  /** How many terminals a move would carry, when the server has said. */
+  sessions: number | null
+  /** What the last attempt did, so a panel opened afterwards can say. */
+  lastUpgrade: ServerUpgradeOutcome | null
+}
+
+export type ServerUpgradeOutcome =
+  | { kind: 'handed-over'; sessions: number }
+  | { kind: 'not-needed'; why: string }
+  | { kind: 'failed'; why: string }
+  | { kind: 'working' }
+
 export interface AppConfig {
   version: number
   /**
@@ -1765,6 +1794,12 @@ export const IPC = {
   UPDATE_SET_AUTO_DOWNLOAD: 'update:set-auto-download',
   /** Synchronous read, so a freshly-opened panel renders without waiting. */
   UPDATE_GET_STATUS: 'update:get-status',
+  /** Which build is serving this machine's terminals, and whether it can move. */
+  SERVER_RUNTIME_STATUS: 'server:runtime-status',
+  /** Synchronous read, so a freshly-opened panel renders without waiting. */
+  SERVER_GET_RUNTIME_STATUS: 'server:get-runtime-status',
+  /** Move the running server onto this app's build, keeping every terminal. */
+  SERVER_UPGRADE: 'server:upgrade',
   TASK_IMAGE_SAVE: 'task:imageSave',
   TASK_IMAGE_DELETE: 'task:imageDelete',
   TASK_IMAGE_GET_PATH: 'task:imageGetPath',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -687,6 +687,31 @@ export function createApiShim(wsUrl: string) {
     installUpdate: () => {},
     setUpdateChannel: (_channel: 'stable' | 'beta') => {},
 
+    // ── Which build is serving (nothing to answer in the browser) ──
+    // No bundle to move onto and no local endpoint to ask over. Present rather than
+    // absent because a missing name throws during render rather than degrading.
+    onServerRuntimeStatus:
+      (_callback: (status: import('../../shared/src/types').ServerRuntimeStatus) => void) =>
+      () => {},
+    getServerRuntimeStatus: (): import('../../shared/src/types').ServerRuntimeStatus => ({
+      serverVersion: 'unknown',
+      appVersion: 'web',
+      serverPid: null,
+      adopted: false,
+      canUpgrade: false,
+      sessions: null,
+      lastUpgrade: null
+    }),
+    upgradeServer: async (): Promise<import('../../shared/src/types').ServerRuntimeStatus> => ({
+      serverVersion: 'unknown',
+      appVersion: 'web',
+      serverPid: null,
+      adopted: false,
+      canUpgrade: false,
+      sessions: null,
+      lastUpgrade: { kind: 'not-needed', why: 'the web client cannot move a server' }
+    }),
+
     // ── Git ──
     isGitRepo: (projectPath: string) => rpc.invoke('git:isGitRepo', projectPath),
     getGitBranch: (cwd: string) => rpc.invoke('git:getBranch', cwd),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,7 +7,12 @@ import { installCompanionQuitHook } from './device-companion'
 import { installConnectorCredentialsSync } from './connector-credentials-sync'
 import { createMenu } from './menu'
 import { updateManager } from './update-manager'
-import { IPC, PermissionRequestInfo, type AppConfig } from '../shared/types'
+import {
+  IPC,
+  PermissionRequestInfo,
+  type AppConfig,
+  type ServerRuntimeStatus
+} from '../shared/types'
 import { setArtifactNotify } from './artifact-watcher'
 import { SURFACE } from '../shared/surface'
 import {
@@ -17,6 +22,9 @@ import {
 } from '../shared/adoption-channels'
 import {
   launchServer,
+  upgradeServerInPlace,
+  serverRuntime,
+  type UpgradeOutcome,
   stopServer,
   detachFromServer,
   getServerBridge,
@@ -287,6 +295,17 @@ let keepSessionsRunning = true
  */
 let serverStopped = false
 
+/** Held because the attempt happens seconds after launch and the panel opens minutes later. */
+let lastUpgrade: UpgradeOutcome | { kind: 'working' } | null = null
+
+function serverRuntimeStatus(): ServerRuntimeStatus {
+  return {
+    ...serverRuntime(),
+    appVersion: app.getVersion(),
+    lastUpgrade
+  }
+}
+
 function rememberKeepSessionsRunning(config: unknown): void {
   const value = (config as AppConfig | null)?.defaults?.keepSessionsRunning
   keepSessionsRunning = value ?? true
@@ -491,6 +510,19 @@ app.whenReady().then(async () => {
     return
   }
 
+  // After an update this is the previous build's server, still holding every
+  // terminal. Not awaited: a handoff pauses the panes for a moment, and every
+  // failure path leaves the incumbent serving exactly what it was serving.
+  void upgradeServerInPlace().then((outcome) => {
+    if (outcome.kind === 'handed-over') {
+      log.info(`[main] the server moved to this build with ${outcome.sessions} terminal(s) running`)
+    } else if (outcome.kind === 'failed') {
+      log.warn(`[main] the server stayed on its old build: ${outcome.why}`)
+    }
+    lastUpgrade = outcome
+    mainWindow?.webContents.send(IPC.SERVER_RUNTIME_STATUS, serverRuntimeStatus())
+  })
+
   setBridge(bridge)
   // Lets the browser and device registries ask the renderer for a pane, so an
   // agent can open one itself instead of waiting on a human click. Both are
@@ -612,31 +644,30 @@ app.whenReady().then(async () => {
     hideWidget()
   })
 
-  // Update IPC handlers
-  //
-  // The update takes the server with it. Left alone, `before-quit` sees
-  // `keepSessionsRunning` and lets go of the server, so the new build adopts the
-  // old one and never moves off it -- an app on beta.12 talking to a beta.11
-  // server, with no way forward but a reboot. Ending it here is what keeps client
-  // and server on one build, which is cheaper than reconciling two.
-  //
-  // Before `quitAndInstall` rather than inside the quit it raises. The deliberate
-  // path below holds its own quit open with `preventDefault`, and doing that to
-  // the updater's quit risks cancelling the relaunch -- which is the very thing
-  // `onQuitForUpdate` exists to protect. Stopping first means `before-quit` finds
-  // the work done and never intervenes.
-  ipcMain.on(IPC.UPDATE_INSTALL, async () => {
-    keepSessionsRunning = false
-    try {
-      await stopServer()
-    } catch (err) {
-      // An update that cannot stop the server still has to install. The old
-      // server is left running and the next launch adopts it, which is exactly
-      // today's behaviour rather than something worse.
-      log.error('[main] could not stop the server before updating:', err)
-    }
+  // The update leaves the server running. It used to stop it, to keep app and
+  // server on one build -- at the cost of ending every terminal on every release.
+  // `upgradeServerInPlace` is the way forward that costs nothing, so this lets go
+  // exactly as a quit does and the next launch sorts out which build should serve.
+  ipcMain.on(IPC.UPDATE_INSTALL, () => {
+    // `detachFromServer`, not `stopServer`. The distinction is the feature.
+    detachFromServer()
     serverStopped = true
     updateManager.installUpdate()
+  })
+
+  // Read synchronously so a freshly-opened panel renders without a flash.
+  ipcMain.on(IPC.SERVER_GET_RUNTIME_STATUS, (event) => {
+    event.returnValue = serverRuntimeStatus()
+  })
+
+  ipcMain.handle(IPC.SERVER_UPGRADE, async () => {
+    lastUpgrade = { kind: 'working' }
+    mainWindow?.webContents.send(IPC.SERVER_RUNTIME_STATUS, serverRuntimeStatus())
+    // Forced: a person pressing this has answered the question the version stood in for.
+    lastUpgrade = await upgradeServerInPlace(true)
+    const status = serverRuntimeStatus()
+    mainWindow?.webContents.send(IPC.SERVER_RUNTIME_STATUS, status)
+    return status
   })
 
   ipcMain.on(IPC.UPDATE_SET_CHANNEL, (_e, channel: 'stable' | 'beta') => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -253,10 +253,13 @@ function toggleWidget(): void {
  */
 function explainRefusal(reason: string): string {
   if (reason === 'protocol-mismatch') {
+    // Reached only after asking it to hand its terminals over and being turned
+    // down, so the offer is no longer worth repeating here.
     return (
       'Another Vorn server is already running, from a different version, and this ' +
-      'app cannot talk to it. Your sessions are still alive inside it. Stop that ' +
-      'server to start fresh here, or reopen the version that started it.'
+      'app cannot talk to it. It was asked to move your terminals to this version ' +
+      'and could not. They are still alive inside it. Stop that server to start ' +
+      'fresh here, or reopen the version that started it.'
     )
   }
   if (reason === 'different-build') {

--- a/src/main/server/handoff-direct.ts
+++ b/src/main/server/handoff-direct.ts
@@ -1,0 +1,87 @@
+import WebSocket from 'ws'
+import type { HandoffRequest, HandoffResult } from '@vornrun/shared/protocol'
+import log from '../logger'
+
+/**
+ * Asking for a handoff over a socket of its own, without adopting anything.
+ *
+ * The main bridge cannot carry this request in the one case it matters most. A
+ * release that changes `RUNTIME_PROTOCOL_VERSION` makes the incumbent
+ * unadoptable, and `launchServer` refuses before it ever holds a bridge to ask
+ * with -- so the terminals would sit on a server the new app cannot speak to,
+ * which is the outcome the frozen handoff contract exists to prevent.
+ *
+ * So this speaks only the frozen part: a JSON-RPC frame naming `server:handoff`,
+ * a bearer credential on the upgrade, and one reply. No greeting is read, no
+ * capabilities are negotiated, and no version is compared -- a server that
+ * disagrees about every other message still understands this one.
+ */
+
+/** Long, because the far side starts a whole server before it answers. */
+const REPLY_TIMEOUT_MS = 90_000
+const OPEN_TIMEOUT_MS = 10_000
+
+export async function askForHandoff(
+  target: string,
+  credential: string,
+  request: HandoffRequest
+): Promise<HandoffResult> {
+  const socket = new WebSocket(target, { headers: { authorization: `Bearer ${credential}` } })
+
+  try {
+    await once(socket, OPEN_TIMEOUT_MS, 'the server did not accept a connection')
+    return await reply(socket, request)
+  } finally {
+    try {
+      socket.close()
+    } catch {
+      // Already gone, which a successful handoff arranges moments later anyway.
+    }
+  }
+}
+
+function once(socket: WebSocket, timeoutMs: number, why: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(why)), timeoutMs)
+    socket.once('open', () => {
+      clearTimeout(timer)
+      resolve()
+    })
+    socket.once('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+function reply(socket: WebSocket, request: HandoffRequest): Promise<HandoffResult> {
+  return new Promise((resolve, reject) => {
+    const id = 1
+    const timer = setTimeout(() => reject(new Error('the server never answered')), REPLY_TIMEOUT_MS)
+    const settle = (fn: () => void): void => {
+      clearTimeout(timer)
+      socket.off('message', onMessage)
+      fn()
+    }
+
+    const onMessage = (raw: WebSocket.RawData): void => {
+      let frame: { id?: unknown; result?: unknown; error?: { message?: string } }
+      try {
+        frame = JSON.parse(String(raw))
+      } catch {
+        // Greetings and notifications share this socket; anything unreadable is not ours.
+        return
+      }
+      if (frame.id !== id) return
+      if (frame.error) return settle(() => reject(new Error(frame.error?.message ?? 'refused')))
+      settle(() => resolve(frame.result as HandoffResult))
+    }
+
+    socket.on('message', onMessage)
+    // The socket closing before the reply is the handoff having gone wrong on the
+    // far side, not having succeeded: a successful one replies first, then exits.
+    socket.once('close', () => settle(() => reject(new Error('the connection closed first'))))
+    socket.send(JSON.stringify({ jsonrpc: '2.0', id, method: 'server:handoff', params: request }))
+    log.info('[handoff] asked over a direct socket, without adopting')
+  })
+}

--- a/src/main/server/handoff-direct.ts
+++ b/src/main/server/handoff-direct.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws'
-import type { HandoffRequest, HandoffResult } from '@vornrun/shared/protocol'
+import { createRequest, type HandoffRequest, type HandoffResult } from '@vornrun/shared/protocol'
 import log from '../logger'
 
 /**
@@ -81,7 +81,7 @@ function reply(socket: WebSocket, request: HandoffRequest): Promise<HandoffResul
     // The socket closing before the reply is the handoff having gone wrong on the
     // far side, not having succeeded: a successful one replies first, then exits.
     socket.once('close', () => settle(() => reject(new Error('the connection closed first'))))
-    socket.send(JSON.stringify({ jsonrpc: '2.0', id, method: 'server:handoff', params: request }))
+    socket.send(JSON.stringify(createRequest(id, 'server:handoff', request)))
     log.info('[handoff] asked over a direct socket, without adopting')
   })
 }

--- a/src/main/server/handoff-request.ts
+++ b/src/main/server/handoff-request.ts
@@ -1,0 +1,72 @@
+import path from 'node:path'
+import {
+  HANDOFF_PROTOCOL_VERSION,
+  type HandoffRequest,
+  type ServerIdentity
+} from '@vornrun/shared/protocol'
+
+/**
+ * Whether the running server should be replaced without stopping it.
+ *
+ * An update leaves the old server holding every terminal, which is what keeps
+ * agents alive and also what would strand them on last month's build. Killing it
+ * is never the answer; handing the PTYs over is.
+ */
+export type HandoffVerdict = { ask: true; why: string } | { ask: false; why: string }
+
+export function decideHandoff(input: {
+  /** The server refuses this over TCP; asked here so the app declines quietly. */
+  target: string
+  platform: NodeJS.Platform
+  incumbent: Pick<ServerIdentity, 'appVersion' | 'buildChannel'>
+  self: { appVersion: string; buildChannel: 'dev' | 'packaged' }
+  /** A dev build has one version across every edit, so a person must be able to say so. */
+  forced?: boolean
+}): HandoffVerdict {
+  if (input.platform === 'win32') {
+    // No way to inherit a console pseudoterminal, and no local endpoint either.
+    return { ask: false, why: 'this platform cannot pass a terminal between processes' }
+  }
+  if (!input.target.startsWith('ws+unix://')) {
+    return { ask: false, why: 'the running server was reached by port rather than by name' }
+  }
+  if (input.incumbent.buildChannel !== input.self.buildChannel) {
+    // `judgeAdoption` refuses first; stated anyway because the failure would be baffling.
+    return { ask: false, why: 'the running server is a different kind of build' }
+  }
+  if (input.forced) return { ask: true, why: 'asked for' }
+  if (input.incumbent.appVersion === 'unknown') {
+    // Started from the command line: not this app's to replace on a guess.
+    return { ask: false, why: 'the running server did not say which build it is' }
+  }
+  if (input.incumbent.appVersion === input.self.appVersion) {
+    return { ask: false, why: 'the running server is already this build' }
+  }
+  return {
+    ask: true,
+    why: `the running server is ${input.incumbent.appVersion} and this app is ${input.self.appVersion}`
+  }
+}
+
+/** The incumbent cannot derive this: its bundle was replaced. See `serverProcessSpec`. */
+export function buildHandoffRequest(spec: {
+  exec: string
+  args: string[]
+  env: Record<string, string>
+  cwd: string
+  appVersion: string
+}): HandoffRequest {
+  return {
+    handoffVersion: HANDOFF_PROTOCOL_VERSION,
+    exec: spec.exec,
+    args: spec.args,
+    env: spec.env,
+    cwd: spec.cwd,
+    appVersion: spec.appVersion
+  }
+}
+
+/** Where a dev checkout's server entry sits, relative to the built main process. */
+export function devRepoRoot(dirname: string): string {
+  return path.join(dirname, '../..')
+}

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -755,45 +755,58 @@ async function tryAdopt(
 }
 
 /**
- * Ask an unadoptable-but-ours server to hand its terminals to this build.
+ * Ask a server to hand its terminals to a replacement built from this bundle.
  *
- * Answers whether it did. Every failure leaves the incumbent exactly as it was,
- * which is the same guarantee the ordinary path has and for the same reason: the
- * commit boundary is on the far side.
+ * One way to ask, over a socket that needs no adoption. The bridge could carry
+ * this whenever one happens to be open, but then there would be two ways to send
+ * the same request and only one of them would work in the case that matters --
+ * a release that changed the wire format, where there is no bridge at all.
+ *
+ * Owns the `handingOver` latch, so the incumbent's death is expected on both
+ * paths without either remembering to say so.
  */
-async function standAside(target: string, dataDir: string): Promise<boolean> {
-  if (!target.startsWith('ws+unix://')) return false
-  const credential = readLocalToken(dataDir)
-  if (!credential) {
-    log.warn(
-      '[handoff] no credential published, so the older server cannot be asked to stand aside'
-    )
-    return false
-  }
-  const spec = serverProcessSpec()
-  if (!spec) return false
+type AskOutcome = { ok: true; result: HandoffResult } | { ok: false; why: string }
 
+async function requestHandoff(target: string, dataDir: string): Promise<AskOutcome> {
+  if (!target.startsWith('ws+unix://')) {
+    return { ok: false, why: 'the running server was reached by port rather than by name' }
+  }
+  const credential = readLocalToken(dataDir)
+  if (!credential) return { ok: false, why: 'the running server published no credential' }
+  const spec = serverProcessSpec()
+  if (!spec) return { ok: false, why: 'this app cannot describe how to start a server' }
+
+  handingOver = true
   try {
-    handingOver = true
     const result = await askForHandoff(
       target,
       credential,
       buildHandoffRequest({ ...spec, appVersion: app.getVersion() })
     )
-    if (result.kind === 'declined') {
-      log.warn(`[handoff] the older server declined to stand aside: ${result.because}`)
-      return false
-    }
-    log.info(`[handoff] ${result.sessions} terminal(s) moved off the older protocol`)
-    return true
+    return { ok: true, result }
   } catch (err) {
-    log.warn(`[handoff] could not ask the older server to stand aside: ${(err as Error).message}`)
-    return false
+    return { ok: false, why: (err as Error).message }
   } finally {
+    // Held past the request so the disconnect it causes is covered.
     setTimeout(() => {
       handingOver = false
     }, HANDOFF_SETTLE_MS)
   }
+}
+
+/** Whether an unadoptable-but-ours server gave up its terminals. */
+async function standAside(target: string, dataDir: string): Promise<boolean> {
+  const outcome = await requestHandoff(target, dataDir)
+  if (!outcome.ok) {
+    log.warn(`[handoff] could not ask the older server to stand aside: ${outcome.why}`)
+    return false
+  }
+  if (outcome.result.kind === 'declined') {
+    log.warn(`[handoff] the older server declined to stand aside: ${outcome.result.because}`)
+    return false
+  }
+  log.info(`[handoff] ${outcome.result.sessions} terminal(s) moved off the older protocol`)
+  return true
 }
 
 /** The replacement needs a moment to claim the name the old server just released. */
@@ -1186,7 +1199,7 @@ export type UpgradeOutcome =
  * Nothing here kills anything; the commit boundary in `handoff/donor.ts` guarantees it.
  */
 export async function upgradeServerInPlace(forced = false): Promise<UpgradeOutcome> {
-  if (!bridge || !adoptedIdentity || !adoptedTarget) {
+  if (!adoptedIdentity || !adoptedTarget) {
     // This app spawned its own server, so it is already this build.
     return { kind: 'not-needed', why: 'this app started the server it is talking to' }
   }
@@ -1203,42 +1216,23 @@ export async function upgradeServerInPlace(forced = false): Promise<UpgradeOutco
     return { kind: 'not-needed', why: verdict.why }
   }
 
-  const spec = serverProcessSpec()
-  if (!spec) return { kind: 'failed', why: 'this app cannot describe how to start a server' }
-
   log.info(`[handoff] asking the running server to hand over: ${verdict.why}`)
-  handingOver = true
-  try {
-    const result = (await bridge.request(
-      'server:handoff',
-      buildHandoffRequest({ ...spec, appVersion: app.getVersion() }),
-      HANDOFF_TIMEOUT_MS
-    )) as HandoffResult
-
-    if (result.kind === 'declined') {
-      log.warn(`[handoff] the running server declined: ${result.because}`)
-      return { kind: 'failed', why: result.because }
-    }
-
-    // Recorded before the disconnect arrives, so the reconnect finds a live pid.
-    adoptedPid = result.pid
-    adoptedIdentity = { ...adoptedIdentity, appVersion: app.getVersion(), pid: result.pid }
-    log.info(`[handoff] ${result.sessions} terminal(s) moved to pid ${result.pid}`)
-    return { kind: 'handed-over', sessions: result.sessions }
-  } catch (err) {
-    const why = err instanceof Error ? err.message : String(err)
-    log.error(`[handoff] the request failed: ${why}`)
-    return { kind: 'failed', why }
-  } finally {
-    // Held past the request so the disconnect it causes is covered.
-    setTimeout(() => {
-      handingOver = false
-    }, HANDOFF_SETTLE_MS)
+  const outcome = await requestHandoff(adoptedTarget, resolveDataDir())
+  if (!outcome.ok) {
+    log.error(`[handoff] the request failed: ${outcome.why}`)
+    return { kind: 'failed', why: outcome.why }
   }
-}
+  if (outcome.result.kind === 'declined') {
+    log.warn(`[handoff] the running server declined: ${outcome.result.because}`)
+    return { kind: 'failed', why: outcome.result.because }
+  }
 
-/** Long: the far side checkpoints every screen and starts a server before it answers. */
-const HANDOFF_TIMEOUT_MS = 90_000
+  // Recorded before the disconnect arrives, so the reconnect finds a live pid.
+  adoptedPid = outcome.result.pid
+  adoptedIdentity = { ...adoptedIdentity, appVersion: app.getVersion(), pid: outcome.result.pid }
+  log.info(`[handoff] ${outcome.result.sessions} terminal(s) moved to pid ${outcome.result.pid}`)
+  return { kind: 'handed-over', sessions: outcome.result.sessions }
+}
 
 /** How long the incumbent's death stays expected after a successful handoff. */
 const HANDOFF_SETTLE_MS = 30_000

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -26,6 +26,8 @@ import {
   resolveDataDir,
   type AdoptionVerdict
 } from './server-adoption'
+import { SERVER_LOG_FILENAME, type HandoffResult } from '@vornrun/shared/protocol'
+import { decideHandoff, buildHandoffRequest, devRepoRoot } from './handoff-request'
 
 /**
  * Thrown when a server is running that this app may not use.
@@ -73,6 +75,13 @@ let relaunchTimer: NodeJS.Timeout | null = null
  * was written to end.
  */
 let adoptedPid: number | null = null
+
+/** Held because the decision they feed happens after the launch, not during it. */
+let adoptedIdentity: ServerIdentity | null = null
+let adoptedTarget: string | null = null
+
+/** Or the disconnect after a successful handoff reads as a crash and spawns a third server. */
+let handingOver = false
 
 /**
  * What the last adoption attempt refused, and the pid still holding the sessions.
@@ -401,7 +410,12 @@ async function spawnServer(): Promise<number> {
     // mkdirSync on every spawn -- including every crash relaunch during a
     // `yarn dev` session -- for a value it never touches.
     const dataDir = ensureDataDir()
-    const asarUnpacked = path.join(app.getAppPath() + '.unpacked', 'node_modules')
+    // One definition of how this app starts a server, shared with the handoff
+    // that asks a running server to start its replacement. Two spellings of this
+    // environment is how a handed-over server ends up subtly unlike a spawned
+    // one -- see `serverProcessSpec`.
+    const spec = serverProcessSpec()
+    if (!spec) throw new Error('[launcher] could not describe how to start a server')
 
     // Straight to a file, not to pipes.
     //
@@ -416,25 +430,11 @@ async function spawnServer(): Promise<number> {
     // diagnostics a pipe existed to carry end up somewhere durable rather than
     // in a log that stops the moment the app does.
     const logFd = openSync(join(dataDir, SERVER_LOG_FILENAME), 'a')
-    const child = spawn(process.execPath, [serverEntryPoint], {
+    const child = spawn(spec.exec, spec.args, {
       stdio: ['ignore', logFd, logFd],
       detached: true,
-      // A daemon must not hold open a directory that can be deleted underneath
-      // it, so not the app bundle and not a worktree. The data dir is where the
-      // server's own files live, so it lasts as long as the server has anything
-      // to serve -- but on a first run it does not exist yet: the *server*
-      // creates it, and it has not started. `spawn` with a missing cwd fails
-      // ENOENT, so it is created here first.
-      cwd: dataDir,
-      env: {
-        ...process.env,
-        ELECTRON_RUN_AS_NODE: '1',
-        [BOOTSTRAP_ENV_VAR]: bootstrapToken,
-        NODE_ENV: 'production',
-        VORN_NATIVE_MODULES_PATH: asarUnpacked,
-        NODE_PATH: [path.join(app.getAppPath(), 'node_modules'), asarUnpacked].join(path.delimiter),
-        ...identityEnv()
-      }
+      cwd: spec.cwd,
+      env: { ...process.env, ...spec.env }
     })
 
     // Closed here as soon as the child holds its own copy; leaving it open would
@@ -735,12 +735,16 @@ async function tryAdopt(
   // falling back keeps a pid-less record (which `packages/mcp` writes when it
   // heals one) from leaving nothing to signal later.
   adoptedPid = expectedPid ?? identity.pid
+  adoptedIdentity = identity
+  adoptedTarget = target
   // An adopted server has no child handle, so nothing would ever call
   // `onServerExit` for it. Watching the socket is the only signal available, and
   // the pid distinguishes the two reasons it drops: a server that died, and one
   // that is merely busy while the bridge retries.
   candidate.on('disconnected', () => {
     if (adoptedPid === null || stoppingDeliberately) return
+    // The incumbent exits on purpose once its replacement is serving.
+    if (handingOver) return
     if (isPidAlive(adoptedPid)) return
     onServerExit(`adopted server pid=${adoptedPid} is gone`)
   })
@@ -1008,6 +1012,162 @@ export function detachFromServer(): void {
   adoptedPid = null
 }
 
+/**
+ * Built once and used twice: to spawn a server, and to ask a server to spawn its
+ * replacement. A replacement brought up differently would differ in ways nobody
+ * would think to look for. The environment here is only the overrides.
+ */
+export function serverProcessSpec(): {
+  exec: string
+  args: string[]
+  env: Record<string, string>
+  cwd: string
+} | null {
+  bootstrapToken ??= randomBytes(32).toString('base64url')
+  const entry = resolveServerEntry()
+
+  if (buildChannel() === 'dev') {
+    // `--import tsx`, never the `tsx` binary: the CLI re-executes in a child of its
+    // own, which does not inherit the pty masters a handoff travels on. Measured.
+    const repoRoot = devRepoRoot(__dirname)
+    const devPort = readDevPort()
+    return {
+      exec: process.execPath,
+      args: ['--import', 'tsx', entry, ...(devPort ? ['--port', devPort] : [])],
+      // The repo root, because ESM resolution walks up from cwd rather than NODE_PATH.
+      cwd: repoRoot,
+      env: {
+        // `process.execPath` is the Electron binary; without this it launches a second Vorn.
+        ELECTRON_RUN_AS_NODE: '1',
+        [BOOTSTRAP_ENV_VAR]: bootstrapToken,
+        NODE_ENV: process.env.NODE_ENV ?? 'development',
+        ...identityEnv()
+      }
+    }
+  }
+
+  const dataDir = ensureDataDir()
+  const asarUnpacked = path.join(app.getAppPath() + '.unpacked', 'node_modules')
+  return {
+    exec: process.execPath,
+    args: [entry],
+    // A daemon must not hold a directory an update can delete underneath it.
+    cwd: dataDir,
+    env: {
+      ELECTRON_RUN_AS_NODE: '1',
+      [BOOTSTRAP_ENV_VAR]: bootstrapToken,
+      NODE_ENV: 'production',
+      VORN_NATIVE_MODULES_PATH: asarUnpacked,
+      NODE_PATH: [path.join(app.getAppPath(), 'node_modules'), asarUnpacked].join(path.delimiter),
+      ...identityEnv()
+    }
+  }
+}
+
+/** "Which version am I running" has two answers now, and the app's is the less useful one. */
+export function serverRuntime(): {
+  serverVersion: string
+  serverPid: number | null
+  adopted: boolean
+  canUpgrade: boolean
+  sessions: number | null
+} {
+  const identity = adoptedIdentity
+  if (!identity || !adoptedTarget) {
+    return {
+      serverVersion: app.getVersion(),
+      serverPid: serverProcess?.pid ?? null,
+      adopted: false,
+      canUpgrade: false,
+      sessions: null
+    }
+  }
+  const verdict = decideHandoff({
+    target: adoptedTarget,
+    platform: process.platform,
+    incumbent: identity,
+    self: { appVersion: app.getVersion(), buildChannel: buildChannel() },
+    forced: true
+  })
+  return {
+    serverVersion: identity.appVersion,
+    serverPid: adoptedPid,
+    adopted: true,
+    // Forced, because this reports whether the button would do anything.
+    canUpgrade: verdict.ask,
+    sessions: identity.sessions ?? null
+  }
+}
+
+/** What the app tells the user about an attempt to move onto a newer server. */
+export type UpgradeOutcome =
+  | { kind: 'handed-over'; sessions: number }
+  | { kind: 'not-needed'; why: string }
+  | { kind: 'failed'; why: string }
+
+/**
+ * Move the running server onto this app's build without ending its terminals, by
+ * asking it to start the replacement itself and pass the descriptors across.
+ * Nothing here kills anything; the commit boundary in `handoff/donor.ts` guarantees it.
+ */
+export async function upgradeServerInPlace(forced = false): Promise<UpgradeOutcome> {
+  if (!bridge || !adoptedIdentity || !adoptedTarget) {
+    // This app spawned its own server, so it is already this build.
+    return { kind: 'not-needed', why: 'this app started the server it is talking to' }
+  }
+
+  const verdict = decideHandoff({
+    target: adoptedTarget,
+    platform: process.platform,
+    incumbent: adoptedIdentity,
+    self: { appVersion: app.getVersion(), buildChannel: buildChannel() },
+    forced
+  })
+  if (!verdict.ask) {
+    log.info(`[handoff] not asking: ${verdict.why}`)
+    return { kind: 'not-needed', why: verdict.why }
+  }
+
+  const spec = serverProcessSpec()
+  if (!spec) return { kind: 'failed', why: 'this app cannot describe how to start a server' }
+
+  log.info(`[handoff] asking the running server to hand over: ${verdict.why}`)
+  handingOver = true
+  try {
+    const result = (await bridge.request(
+      'server:handoff',
+      buildHandoffRequest({ ...spec, appVersion: app.getVersion() }),
+      HANDOFF_TIMEOUT_MS
+    )) as HandoffResult
+
+    if (result.kind === 'declined') {
+      log.warn(`[handoff] the running server declined: ${result.because}`)
+      return { kind: 'failed', why: result.because }
+    }
+
+    // Recorded before the disconnect arrives, so the reconnect finds a live pid.
+    adoptedPid = result.pid
+    adoptedIdentity = { ...adoptedIdentity, appVersion: app.getVersion(), pid: result.pid }
+    log.info(`[handoff] ${result.sessions} terminal(s) moved to pid ${result.pid}`)
+    return { kind: 'handed-over', sessions: result.sessions }
+  } catch (err) {
+    const why = err instanceof Error ? err.message : String(err)
+    log.error(`[handoff] the request failed: ${why}`)
+    return { kind: 'failed', why }
+  } finally {
+    // Held past the request so the disconnect it causes is covered.
+    setTimeout(() => {
+      handingOver = false
+    }, HANDOFF_SETTLE_MS)
+  }
+}
+
+/** Long: the far side checkpoints every screen and starts a server before it answers. */
+const HANDOFF_TIMEOUT_MS = 90_000
+
+/** How long the incumbent's death stays expected after a successful handoff. */
+const HANDOFF_SETTLE_MS = 30_000
+
 export async function stopServer(): Promise<void> {
   beginDeliberateStop()
 
@@ -1151,8 +1311,6 @@ function onChildExit(code: number | null, signal: NodeJS.Signals | null): void {
  */
 let lastSpawnStoodDown = false
 
-/** Where a detached server's stdout and stderr go, under the data directory. */
-const SERVER_LOG_FILENAME = 'server.log'
 const SPAWN_READY_TIMEOUT_MS = 20_000
 const SPAWN_POLL_MS = 100
 

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -28,6 +28,7 @@ import {
 } from './server-adoption'
 import { SERVER_LOG_FILENAME, type HandoffResult } from '@vornrun/shared/protocol'
 import { decideHandoff, buildHandoffRequest, devRepoRoot } from './handoff-request'
+import { askForHandoff } from './handoff-direct'
 
 /**
  * Thrown when a server is running that this app may not use.
@@ -754,6 +755,64 @@ async function tryAdopt(
 }
 
 /**
+ * Ask an unadoptable-but-ours server to hand its terminals to this build.
+ *
+ * Answers whether it did. Every failure leaves the incumbent exactly as it was,
+ * which is the same guarantee the ordinary path has and for the same reason: the
+ * commit boundary is on the far side.
+ */
+async function standAside(target: string, dataDir: string): Promise<boolean> {
+  if (!target.startsWith('ws+unix://')) return false
+  const credential = readLocalToken(dataDir)
+  if (!credential) {
+    log.warn(
+      '[handoff] no credential published, so the older server cannot be asked to stand aside'
+    )
+    return false
+  }
+  const spec = serverProcessSpec()
+  if (!spec) return false
+
+  try {
+    handingOver = true
+    const result = await askForHandoff(
+      target,
+      credential,
+      buildHandoffRequest({ ...spec, appVersion: app.getVersion() })
+    )
+    if (result.kind === 'declined') {
+      log.warn(`[handoff] the older server declined to stand aside: ${result.because}`)
+      return false
+    }
+    log.info(`[handoff] ${result.sessions} terminal(s) moved off the older protocol`)
+    return true
+  } catch (err) {
+    log.warn(`[handoff] could not ask the older server to stand aside: ${(err as Error).message}`)
+    return false
+  } finally {
+    setTimeout(() => {
+      handingOver = false
+    }, HANDOFF_SETTLE_MS)
+  }
+}
+
+/** The replacement needs a moment to claim the name the old server just released. */
+async function adoptAfterHandoff(dataDir: string): Promise<ServerBridge | null> {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    for (const candidate of discoverable(dataDir)) {
+      const outcome = await tryAdopt(candidate.target, candidate.pid, {
+        dataDir,
+        buildChannel: buildChannel()
+      })
+      if ('bridge' in outcome) return outcome.bridge
+    }
+  }
+  log.warn('[handoff] the replacement never became adoptable')
+  return null
+}
+
+/**
  * Every way a server on this machine might be found, in the order to try them.
  *
  * The endpoint first, because it is the name a server *owns* rather than a record
@@ -891,6 +950,22 @@ async function adoptSomethingRunning(dataDir: string): Promise<ServerBridge | nu
       `[launcher] declined to adopt the running server (${refusal.reason}): ` +
         `${refusal.detail}. It keeps running and keeps its sessions.`
     )
+
+    // A protocol mismatch is the one refusal that should not be final.
+    //
+    // Every other reason says this is somebody else's server -- another data
+    // directory, another build channel -- and the right answer is to stand down.
+    // This one says it is *our* server, holding our terminals, speaking a wire
+    // format this release changed. Standing down there ends exactly what the
+    // handoff exists to protect, so it is asked to stand aside instead, over a
+    // socket that needs no agreement about the protocol it just disagreed on.
+    if (refusal.reason === 'protocol-mismatch' && (await standAside(candidate.target, dataDir))) {
+      // It committed, so the machine now has a server this app can speak to.
+      // Discovery runs again rather than recursing: the endpoint is the same name
+      // and the replacement has just claimed it.
+      const replacement = await adoptAfterHandoff(dataDir)
+      if (replacement) return replacement
+    }
     // Declining to adopt is not a reason to start a rival.
     //
     // Both servers would open the same SQLite file, and `saveSessions` is a

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -54,6 +54,7 @@ import {
   DeviceTarget,
   DevicePoint,
   UpdateStatus,
+  ServerRuntimeStatus,
   AuthProbeReport
 } from '../shared/types'
 
@@ -824,6 +825,20 @@ const api = {
   installUpdate: () => ipcRenderer.send(IPC.UPDATE_INSTALL),
   setUpdateChannel: (channel: 'stable' | 'beta') =>
     ipcRenderer.send(IPC.UPDATE_SET_CHANNEL, channel),
+
+  // The server outlives the app, so after an update these are briefly different
+  // builds; `upgradeServer` resolves that without ending anything.
+  onServerRuntimeStatus: (callback: (status: ServerRuntimeStatus) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, status: ServerRuntimeStatus): void =>
+      callback(status)
+    ipcRenderer.on(IPC.SERVER_RUNTIME_STATUS, listener)
+    return () => {
+      ipcRenderer.removeListener(IPC.SERVER_RUNTIME_STATUS, listener)
+    }
+  },
+  getServerRuntimeStatus: (): ServerRuntimeStatus =>
+    ipcRenderer.sendSync(IPC.SERVER_GET_RUNTIME_STATUS),
+  upgradeServer: (): Promise<ServerRuntimeStatus> => ipcRenderer.invoke(IPC.SERVER_UPGRADE),
 
   // Connectors
   listConnectors: (): Promise<

--- a/src/renderer/components/settings/UpdatesSettings.tsx
+++ b/src/renderer/components/settings/UpdatesSettings.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useAppStore } from '../../stores'
 import { SettingsPageHeader } from './SettingsPageHeader'
 import { SettingRow } from './SettingRow'
@@ -6,6 +7,8 @@ import { SegmentedControl } from './SegmentedControl'
 import { facesRestart, updateCostLine } from '../../lib/update-cost'
 import { describeUpdateStatus } from '../../lib/update-status'
 import { TONE_DOT } from '../../lib/status-tone'
+import { describeServerRuntime } from '../../lib/server-runtime'
+import type { ServerRuntimeStatus } from '../../../shared/types'
 
 /**
  * The one action a state is worth offering, as data rather than three near
@@ -31,6 +34,7 @@ function getAppVersionOnce(): string {
 
 export function UpdatesSettings() {
   const config = useAppStore((s) => s.config)
+  const runtime = useServerRuntime()
   const setConfig = useAppStore((s) => s.setConfig)
   const status = useAppStore((s) => s.appUpdateStatus)
   const sessionCount = useAppStore((s) => [...s.terminals.values()].filter(facesRestart).length)
@@ -109,6 +113,8 @@ export function UpdatesSettings() {
           </button>
         </SettingRow>
 
+        <ServerBuildRow runtime={runtime} />
+
         <SettingRow
           label="Update channel"
           description="Beta receives early releases; stable receives tested releases only"
@@ -141,5 +147,51 @@ export function UpdatesSettings() {
         </SettingRow>
       </div>
     </div>
+  )
+}
+
+/** Followed, not fetched once: the automatic move happens long before this panel opens. */
+function useServerRuntime(): ServerRuntimeStatus | null {
+  // Read during the first render, like the app version above, so the panel does
+  // not render twice. Guarded because a renderer reloaded mid-handoff may be
+  // running against an older `window.api`, and throwing here would take the page down.
+  const [runtime, setRuntime] = useState<ServerRuntimeStatus | null>(() =>
+    typeof window.api?.getServerRuntimeStatus === 'function'
+      ? window.api.getServerRuntimeStatus()
+      : null
+  )
+  useEffect(() => window.api?.onServerRuntimeStatus?.(setRuntime), [])
+  return runtime
+}
+
+/** Always shown: a row that appears only when something is wrong is one nobody knows exists. */
+function ServerBuildRow({ runtime }: { runtime: ServerRuntimeStatus | null }) {
+  const [working, setWorking] = useState(false)
+  if (!runtime) return null
+  const view = describeServerRuntime(runtime)
+
+  return (
+    <SettingRow label="Terminal server" description={view.description}>
+      {view.offerMove ? (
+        <button
+          onClick={async () => {
+            setWorking(true)
+            try {
+              await window.api.upgradeServer()
+            } finally {
+              setWorking(false)
+            }
+          }}
+          disabled={working}
+          className="px-3 py-1.5 text-xs text-gray-300 bg-white/[0.04] hover:bg-white/[0.08]
+                     border border-white/[0.08] rounded-md transition-colors
+                     disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {working ? 'Moving…' : 'Move to this build'}
+        </button>
+      ) : (
+        <span className="text-xs text-gray-500">{view.trailing}</span>
+      )}
+    </SettingRow>
   )
 }

--- a/src/renderer/lib/server-runtime.ts
+++ b/src/renderer/lib/server-runtime.ts
@@ -1,0 +1,72 @@
+import type { ServerRuntimeStatus } from '../../shared/types'
+
+/**
+ * What to say about the build holding the terminals.
+ *
+ * Pure and separate from the panel, like `update-status.ts`: this is what somebody
+ * reads while working out why a fix they know shipped has not taken effect.
+ */
+export interface ServerRuntimeView {
+  description: string
+  /** Whether to offer the button, rather than only report. */
+  offerMove: boolean
+  /** What to show instead of the button. */
+  trailing: string
+}
+
+export function describeServerRuntime(status: ServerRuntimeStatus): ServerRuntimeView {
+  const last = status.lastUpgrade
+
+  if (last?.kind === 'working') {
+    return {
+      description: 'Moving your terminals to this build. They keep running.',
+      offerMove: false,
+      trailing: 'Moving…'
+    }
+  }
+
+  const matched = status.serverVersion === status.appVersion
+
+  if (matched) {
+    return {
+      description: status.adopted
+        ? `Vorn ${status.serverVersion}, running since before this window opened`
+        : `Vorn ${status.serverVersion}, started by this window`,
+      offerMove: false,
+      trailing: 'Current'
+    }
+  }
+
+  // Not broken: it is holding the terminals an update was not allowed to end.
+  const behind =
+    status.serverVersion === 'unknown'
+      ? 'A server started outside Vorn is holding your terminals'
+      : `Vorn ${status.serverVersion} is still holding your terminals; this app is ${status.appVersion}`
+
+  const carried =
+    status.sessions === null
+      ? ''
+      : status.sessions === 1
+        ? ' Moving carries 1 terminal across without stopping it.'
+        : ` Moving carries ${status.sessions} terminals across without stopping them.`
+
+  if (!status.canUpgrade) {
+    return {
+      // Said plainly rather than left as a disabled button with no explanation.
+      description: `${behind}. Moving it needs a restart of Vorn on this machine.`,
+      offerMove: false,
+      trailing: 'Restart to move'
+    }
+  }
+
+  if (last?.kind === 'failed') {
+    return {
+      description: `${behind}. The last attempt did not take: ${last.why}`,
+      // Still offered: nothing was lost, so trying again is free.
+      offerMove: true,
+      trailing: ''
+    }
+  }
+
+  return { description: `${behind}.${carried}`, offerMove: true, trailing: '' }
+}

--- a/src/renderer/lib/server-runtime.ts
+++ b/src/renderer/lib/server-runtime.ts
@@ -6,13 +6,10 @@ import type { ServerRuntimeStatus } from '../../shared/types'
  * Pure and separate from the panel, like `update-status.ts`: this is what somebody
  * reads while working out why a fix they know shipped has not taken effect.
  */
-export interface ServerRuntimeView {
-  description: string
-  /** Whether to offer the button, rather than only report. */
-  offerMove: boolean
-  /** What to show instead of the button. */
-  trailing: string
-}
+/** The button and the trailing note are alternatives, so the type says so. */
+export type ServerRuntimeView =
+  | { description: string; offerMove: true }
+  | { description: string; offerMove: false; trailing: string }
 
 export function describeServerRuntime(status: ServerRuntimeStatus): ServerRuntimeView {
   const last = status.lastUpgrade
@@ -63,10 +60,9 @@ export function describeServerRuntime(status: ServerRuntimeStatus): ServerRuntim
     return {
       description: `${behind}. The last attempt did not take: ${last.why}`,
       // Still offered: nothing was lost, so trying again is free.
-      offerMove: true,
-      trailing: ''
+      offerMove: true
     }
   }
 
-  return { description: `${behind}.${carried}`, offerMove: true, trailing: '' }
+  return { description: `${behind}.${carried}`, offerMove: true }
 }

--- a/src/renderer/lib/update-cost.ts
+++ b/src/renderer/lib/update-cost.ts
@@ -14,23 +14,17 @@ export function facesRestart(terminal: Pick<TerminalState, 'ended'>): boolean {
 }
 
 /**
- * What restarting for an update will cost, in one line, or null when it costs
- * nothing worth saying.
+ * What restarting for an update does to the sessions, in one line.
  *
- * Installing an update ends the server and every session on it, which is a
- * deliberate reversal of what `Keep Sessions Running` promises: that closing
- * Vorn leaves the agents working. Updating is a more considered act than closing
- * a window, so the reversal is defensible — but a setting the person turned on
- * cannot be quietly overruled, so the exception is stated on the button that
- * makes it rather than left to be discovered.
- *
- * The turn is named separately because it is the only part that is actually
- * lost. A session comes back where it was; a turn in flight does not.
+ * It used to be a warning: the update stopped the server and ended every session.
+ * The server is now handed over instead, so the line stays to say a promise is
+ * kept -- somebody who read the old one needs telling it has changed.
  */
 export function updateCostLine(sessionCount: number, aTurnIsRunning: boolean): string | null {
   if (sessionCount <= 0) return null
   const sessions =
-    sessionCount === 1 ? 'Your session restarts' : `Your ${sessionCount} sessions restart`
-  const turn = aTurnIsRunning ? ' A turn in flight is lost.' : ''
-  return `${sessions} on the new version.${turn}`
+    sessionCount === 1 ? 'Your session keeps running' : `Your ${sessionCount} sessions keep running`
+  // The part people brace for, so it is named -- now to say it survives.
+  const turn = aTurnIsRunning ? ' The turn in flight continues.' : ''
+  return `${sessions} through the update.${turn}`
 }

--- a/tests/fixtures/adopt-pty-heir.ts
+++ b/tests/fixtures/adopt-pty-heir.ts
@@ -19,7 +19,7 @@ adopted.onExit(() => {
   exited = true
 })
 
-const until = (match: RegExp, ms = 10_000): Promise<boolean> =>
+const until = (match: RegExp, ms = 30_000): Promise<boolean> =>
   new Promise((resolve) => {
     const started = Date.now()
     const tick = setInterval(() => {
@@ -34,6 +34,11 @@ const until = (match: RegExp, ms = 10_000): Promise<boolean> =>
   })
 
 async function main(): Promise<void> {
+  // Readiness before anything is typed. Bracketed paste going on means readline
+  // is waiting for input; the fallback covers a shell that never enables it.
+  // eslint-disable-next-line no-control-regex
+  if (!(await until(/\x1b\[\?2004h/, 10_000))) await until(/\S/, 10_000)
+
   const read = await (async () => {
     adopted.write('echo ADOPTED_READ\r')
     return until(/ADOPTED_READ\r?\n/)
@@ -50,10 +55,10 @@ async function main(): Promise<void> {
   adopted.write('exit\r')
   await until(/never/, 3_000)
 
-  if (process.env.HEIR_DEBUG) {
-    process.stderr.write(`[heir] read=${read} cols=${cols} exited=${exited}\n`)
-    process.stderr.write(`[heir] tail=${JSON.stringify(seen.slice(-400))}\n`)
-  }
+  // Always, not only under a flag: this runs in a process the test does not own,
+  // and a bare "expected true" tells whoever reads CI nothing at all.
+  process.stderr.write(`[heir] read=${read} cols=${cols} exited=${exited}\n`)
+  process.stderr.write(`[heir] tail=${JSON.stringify(seen.slice(-400))}\n`)
   process.send?.({ read, cols, exited })
   process.exit(0)
 }

--- a/tests/fixtures/adopt-pty-heir.ts
+++ b/tests/fixtures/adopt-pty-heir.ts
@@ -46,24 +46,15 @@ async function main(): Promise<void> {
   await until(/\b120\b/)
   const cols = /(?:^|\D)(\d{2,4})\r?\n/.exec(seen)?.[1] ?? 'none'
 
-  // A non-blocking master answers a full buffer with EAGAIN, which is where a paste
-  // is silently truncated. Echo off first, or this measures rendering instead.
-  adopted.write('stty -echo\r')
-  await until(/\$|#|>/, 5_000)
-  seen = ''
-  adopted.write(`: ${'x'.repeat(64_000)}\r`)
-  adopted.write('echo BURST_DONE\r')
-  const burst = await until(/BURST_DONE\r?\n/, 20_000)
-
   seen = ''
   adopted.write('exit\r')
   await until(/never/, 3_000)
 
   if (process.env.HEIR_DEBUG) {
-    process.stderr.write(`[heir] read=${read} cols=${cols} burst=${burst} exited=${exited}\n`)
+    process.stderr.write(`[heir] read=${read} cols=${cols} exited=${exited}\n`)
     process.stderr.write(`[heir] tail=${JSON.stringify(seen.slice(-400))}\n`)
   }
-  process.send?.({ read, cols, burst, exited })
+  process.send?.({ read, cols, exited })
   process.exit(0)
 }
 

--- a/tests/fixtures/adopt-pty-heir.ts
+++ b/tests/fixtures/adopt-pty-heir.ts
@@ -1,0 +1,70 @@
+/** A replacement server reduced to the part under test: adoption is a two-process act. */
+import tty from 'node:tty'
+import { AdoptedPty } from '../../packages/server/src/handoff/adopted-pty'
+
+/** Slot 3 is the IPC channel, so the first pane lands on 4. Mirrors FIRST_PTY_SLOT. */
+const FD = 4
+
+if (process.env.HEIR_DEBUG) {
+  process.stderr.write(`[heir] isatty(${FD})=${tty.isatty(FD)}\n`)
+}
+const adopted = new AdoptedPty(FD, Number(process.env.SHELL_PID))
+
+let seen = ''
+let exited = false
+adopted.onData((data) => {
+  seen += data
+})
+adopted.onExit(() => {
+  exited = true
+})
+
+const until = (match: RegExp, ms = 10_000): Promise<boolean> =>
+  new Promise((resolve) => {
+    const started = Date.now()
+    const tick = setInterval(() => {
+      if (match.test(seen)) {
+        clearInterval(tick)
+        resolve(true)
+      } else if (Date.now() - started > ms) {
+        clearInterval(tick)
+        resolve(false)
+      }
+    }, 25)
+  })
+
+async function main(): Promise<void> {
+  const read = await (async () => {
+    adopted.write('echo ADOPTED_READ\r')
+    return until(/ADOPTED_READ\r?\n/)
+  })()
+
+  // `tput cols` asks the tty itself, so the answer proves TIOCSWINSZ landed here.
+  adopted.resize(120, 40)
+  seen = ''
+  adopted.write('tput cols\r')
+  await until(/\b120\b/)
+  const cols = /(?:^|\D)(\d{2,4})\r?\n/.exec(seen)?.[1] ?? 'none'
+
+  // A non-blocking master answers a full buffer with EAGAIN, which is where a paste
+  // is silently truncated. Echo off first, or this measures rendering instead.
+  adopted.write('stty -echo\r')
+  await until(/\$|#|>/, 5_000)
+  seen = ''
+  adopted.write(`: ${'x'.repeat(64_000)}\r`)
+  adopted.write('echo BURST_DONE\r')
+  const burst = await until(/BURST_DONE\r?\n/, 20_000)
+
+  seen = ''
+  adopted.write('exit\r')
+  await until(/never/, 3_000)
+
+  if (process.env.HEIR_DEBUG) {
+    process.stderr.write(`[heir] read=${read} cols=${cols} burst=${burst} exited=${exited}\n`)
+    process.stderr.write(`[heir] tail=${JSON.stringify(seen.slice(-400))}\n`)
+  }
+  process.send?.({ read, cols, burst, exited })
+  process.exit(0)
+}
+
+void main()

--- a/tests/handoff-adopted-pty-unit.test.ts
+++ b/tests/handoff-adopted-pty-unit.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import { spawn, type ChildProcess } from 'node:child_process'
+import * as pty from 'node-pty'
+import { AdoptedPty } from '../packages/server/src/handoff/adopted-pty'
+
+/**
+ * The adopted pty against a bare master/slave pair.
+ *
+ * `native.open` hands back two descriptors with no node-pty stream attached to
+ * either, which is the only way to exercise this in one process: a real terminal
+ * to read and write, and nothing else competing for its bytes. The cross-process
+ * test beside this one proves the same class works when the descriptor was
+ * inherited rather than opened here.
+ */
+/**
+ * A pid nothing owns, so `kill()` takes the ESRCH path instead of signalling.
+ *
+ * The obvious choice, this process's own pid, would have `kill()` send SIGHUP to
+ * the test runner. Only the test that is actually about signalling uses a real one.
+ */
+const NOBODY = 2147483646
+
+const live: AdoptedPty[] = []
+const slaves: number[] = []
+const started: ChildProcess[] = []
+
+afterEach(() => {
+  // Through `kill`, never `fs.closeSync(master)`: the reader owns that descriptor,
+  // and closing it underneath libuv corrupts whatever reuses the number next --
+  // which is the following test in this file.
+  for (const adopted of live.splice(0)) adopted.kill()
+  for (const fd of slaves.splice(0)) {
+    try {
+      fs.closeSync(fd)
+    } catch {
+      // Already closed by the test that was checking what happens when it is.
+    }
+  }
+  for (const child of started.splice(0)) {
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // Already gone.
+    }
+  }
+})
+
+function terminal(): { master: number; slave: number } {
+  const pair = (
+    pty as unknown as {
+      native: { open(cols: number, rows: number): { master: number; slave: number } }
+    }
+  ).native.open(80, 24)
+  slaves.push(pair.slave)
+  return pair
+}
+
+function adopt(master: number, pid: number = NOBODY): AdoptedPty {
+  const adopted = new AdoptedPty(master, pid)
+  live.push(adopted)
+  return adopted
+}
+
+const settled = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 150))
+
+describe('a pty adopted in this process', () => {
+  it('delivers what the far side writes', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    const seen: string[] = []
+    adopted.onData((d) => seen.push(d))
+
+    fs.writeSync(slave, 'from the program\n')
+    await settled()
+    expect(seen.join('')).toContain('from the program')
+  })
+
+  it('holds output that arrived before anything was listening', async () => {
+    // Attaching the reader starts the flow, and a handoff pauses a tick later.
+    // Anything read in that window has already left the kernel's buffer, so
+    // dropping it would lose output nothing can get back.
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    fs.writeSync(slave, 'said before anyone listened\n')
+    await settled()
+
+    const seen: string[] = []
+    adopted.onData((d) => seen.push(d))
+    expect(seen.join('')).toContain('said before anyone listened')
+  })
+
+  it('writes through to the far side', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    adopted.write('typed at the terminal\n')
+    await settled()
+
+    const buffer = Buffer.alloc(256)
+    const read = fs.readSync(slave, buffer, 0, buffer.length, null)
+    expect(buffer.subarray(0, read).toString()).toContain('typed at the terminal')
+  })
+
+  it('writes a burst larger than the kernel buffer without truncating it', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    // Newline-delimited: master-to-slave is the program's *input*, and a canonical
+    // line discipline holds an unterminated line rather than passing it on.
+    const payload = `${'x'.repeat(200)}\n`.repeat(320)
+
+    let received = 0
+    const drained = new Promise<void>((resolve, reject) => {
+      const buffer = Buffer.alloc(16 * 1024)
+      const pump = (): void => {
+        fs.read(slave, buffer, 0, buffer.length, null, (err, bytes) => {
+          // The descriptor is non-blocking, so "nothing yet" arrives as an error.
+          if (err) {
+            if ((err as NodeJS.ErrnoException).code !== 'EAGAIN') return reject(err)
+            return setImmediate(pump)
+          }
+          received += bytes
+          if (received >= payload.length) return resolve()
+          pump()
+        })
+      }
+      pump()
+    })
+
+    // One call, far past the pty buffer. Without the retry queue this is where a
+    // paste is silently truncated at the first EAGAIN.
+    adopted.write(payload)
+    await drained
+    expect(received).toBeGreaterThanOrEqual(payload.length)
+  }, 20_000)
+
+  it('stops and starts reading without losing anything', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    const seen: string[] = []
+    adopted.onData((d) => seen.push(d))
+
+    adopted.pause()
+    fs.writeSync(slave, 'written while paused\n')
+    await settled()
+    expect(seen.join('')).not.toContain('written while paused')
+
+    adopted.resume()
+    await settled()
+    expect(seen.join('')).toContain('written while paused')
+  })
+
+  it('resizes without throwing', () => {
+    const { master } = terminal()
+    const adopted = adopt(master)
+    // The ioctl reaching the real tty is what the cross-process test proves with
+    // `tput cols`; there is no portable way to read a winsize back here.
+    expect(() => adopted.resize(120, 40)).not.toThrow()
+  })
+
+  it('reports the far side closing', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    const ended = new Promise<{ exitCode: number }>((resolve) => adopted.onExit(resolve))
+
+    fs.closeSync(slave)
+    // The exit code is genuinely unavailable to an adopter, so zero stands in.
+    expect((await ended).exitCode).toBe(0)
+  })
+
+  it('signals the process behind it', async () => {
+    const { master } = terminal()
+    const child = spawn('sleep', ['30'])
+    started.push(child)
+    const adopted = adopt(master, child.pid as number)
+
+    const gone = new Promise<void>((resolve) => child.once('exit', () => resolve()))
+    adopted.kill('SIGKILL')
+    await gone
+    expect(child.killed || child.exitCode !== null || child.signalCode !== null).toBe(true)
+  })
+
+  it('treats a process that has already gone as ended, not an error', () => {
+    const { master } = terminal()
+    // A pid nothing owns: ESRCH is the ordinary case, not something to log about.
+    const adopted = adopt(master)
+    let ended = false
+    adopted.onExit(() => {
+      ended = true
+    })
+    expect(() => adopted.kill()).not.toThrow()
+    expect(ended).toBe(true)
+  })
+
+  it('goes quiet once it has ended', async () => {
+    const { master } = terminal()
+    const adopted = adopt(master)
+    adopted.kill()
+
+    // Nothing is written to the slave here: ending destroys the reader, which
+    // closes the master, so the far side would raise EIO -- the test would be
+    // asserting on the pty rather than on this class.
+    const seen: string[] = []
+    adopted.onData((d) => seen.push(d))
+    adopted.write('nobody should see this')
+    adopted.resize(90, 30)
+    await settled()
+    expect(seen).toEqual([])
+  })
+
+  it('lets a listener stop listening', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    const seen: string[] = []
+    const subscription = adopted.onData((d) => seen.push(d))
+
+    subscription.dispose()
+    fs.writeSync(slave, 'after the listener left\n')
+    await settled()
+    expect(seen).toEqual([])
+  })
+})

--- a/tests/handoff-adopted-pty-unit.test.ts
+++ b/tests/handoff-adopted-pty-unit.test.ts
@@ -157,6 +157,32 @@ describe('a pty adopted in this process', () => {
     expect(() => adopted.resize(120, 40)).not.toThrow()
   })
 
+  it('survives the read errors a non-blocking descriptor raises normally', async () => {
+    const { master, slave } = terminal()
+    const adopted = adopt(master)
+    let ended = false
+    adopted.onExit(() => {
+      ended = true
+    })
+    const seen: string[] = []
+    adopted.onData((d) => seen.push(d))
+
+    // node-pty's own reader notes this arrives twice on startup. Reading it as
+    // the far side going away would end a healthy terminal the instant it was
+    // adopted -- and `onExit` takes the session's history with it.
+    const transient: NodeJS.ErrnoException = new Error('resource temporarily unavailable')
+    transient.code = 'EAGAIN'
+    ;(adopted as unknown as { reader: { emit(event: string, err: Error): void } }).reader.emit(
+      'error',
+      transient
+    )
+
+    expect(ended).toBe(false)
+    fs.writeSync(slave, 'still here\n')
+    await settled()
+    expect(seen.join('')).toContain('still here')
+  })
+
   it('reports the far side closing', async () => {
     const { master, slave } = terminal()
     const adopted = adopt(master)

--- a/tests/handoff-adopted-pty.test.ts
+++ b/tests/handoff-adopted-pty.test.ts
@@ -36,8 +36,20 @@ async function handToAnotherProcess(): Promise<HeirReport> {
   })
   opened.push(shell)
 
+  // Wait for the shell to actually start before handing it on. A pty accepts
+  // keystrokes from the moment it exists, but a shell that has not begun reading
+  // them leaves the line discipline echoing characters it never ran -- which
+  // looks exactly like a command that produced nothing. A fixed pause guesses at
+  // this, and guesses wrong on a loaded CI runner.
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('the shell never started')), 30_000)
+    const subscription = shell.onData(() => {
+      clearTimeout(timer)
+      subscription.dispose()
+      resolve()
+    })
+  })
   // Paused the way a handoff pauses it: the bytes wait in the kernel's buffer.
-  await new Promise((resolve) => setTimeout(resolve, 400))
   shell.pause()
 
   const master = (shell as unknown as { fd: number }).fd
@@ -68,6 +80,10 @@ async function handToAnotherProcess(): Promise<HeirReport> {
     heir.on('exit', (code) => {
       clearTimeout(timer)
       reject(new Error(`the adopting process exited (${code}) without reporting`))
+    })
+    heir.on('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
     })
   })
 }

--- a/tests/handoff-adopted-pty.test.ts
+++ b/tests/handoff-adopted-pty.test.ts
@@ -24,7 +24,6 @@ afterEach(() => {
 interface HeirReport {
   read: boolean
   cols: string
-  burst: boolean
   exited: boolean
 }
 
@@ -83,9 +82,6 @@ describe('a pty handed to another process', () => {
     // The assertion that cannot be faked: Node has no ioctl, so 120 from `tput cols`
     // proves the binding call landed on this descriptor in this process.
     expect(report.cols).toBe('120')
-
-    // Whole rather than truncated at the first EAGAIN.
-    expect(report.burst).toBe(true)
 
     // Visible even though nothing can `waitpid` for a program it never forked.
     expect(report.exited).toBe(true)

--- a/tests/handoff-adopted-pty.test.ts
+++ b/tests/handoff-adopted-pty.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import * as pty from 'node-pty'
+
+/**
+ * The claim the whole feature rests on: nothing in a pty names which process owns
+ * the master, so a second one can read, write and resize it unnoticed.
+ *
+ * Two processes on purpose. Node has no `SCM_RIGHTS`, so a descriptor only crosses
+ * in a child's `stdio` array -- and in-process, node-pty's own reader is still on it.
+ */
+const opened: pty.IPty[] = []
+afterEach(() => {
+  for (const p of opened.splice(0)) {
+    try {
+      p.kill()
+    } catch {
+      // Already gone, which is what most of these tests arrange.
+    }
+  }
+})
+
+interface HeirReport {
+  read: boolean
+  cols: string
+  burst: boolean
+  exited: boolean
+}
+
+async function handToAnotherProcess(): Promise<HeirReport> {
+  const shell = pty.spawn('/bin/bash', ['--norc', '--noprofile', '-i'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    cwd: process.cwd()
+  })
+  opened.push(shell)
+
+  // Paused the way a handoff pauses it: the bytes wait in the kernel's buffer.
+  await new Promise((resolve) => setTimeout(resolve, 400))
+  shell.pause()
+
+  const master = (shell as unknown as { fd: number }).fd
+  const repoRoot = path.join(__dirname, '..')
+
+  // `--import tsx`, never the binary: the CLI re-executes in a child that inherits
+  // nothing. The production dev path had the same bug and this is what found it.
+  const heir = spawn(
+    process.execPath,
+    ['--import', 'tsx', path.join(__dirname, 'fixtures', 'adopt-pty-heir.ts')],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, SHELL_PID: String(shell.pid) },
+      // 3 carries the report; the pane follows at 4, which is `FIRST_PTY_SLOT`.
+      stdio: ['ignore', 'inherit', 'inherit', 'ipc', master]
+    }
+  )
+
+  return new Promise<HeirReport>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      heir.kill('SIGKILL')
+      reject(new Error('the adopting process never reported'))
+    }, 60_000)
+    heir.on('message', (msg) => {
+      clearTimeout(timer)
+      resolve(msg as HeirReport)
+    })
+    heir.on('exit', (code) => {
+      clearTimeout(timer)
+      reject(new Error(`the adopting process exited (${code}) without reporting`))
+    })
+  })
+}
+
+describe('a pty handed to another process', () => {
+  it('is fully usable by its new owner', async () => {
+    const report = await handToAnotherProcess()
+
+    // Reads reach the new owner.
+    expect(report.read).toBe(true)
+
+    // The assertion that cannot be faked: Node has no ioctl, so 120 from `tput cols`
+    // proves the binding call landed on this descriptor in this process.
+    expect(report.cols).toBe('120')
+
+    // Whole rather than truncated at the first EAGAIN.
+    expect(report.burst).toBe(true)
+
+    // Visible even though nothing can `waitpid` for a program it never forked.
+    expect(report.exited).toBe(true)
+  }, 90_000)
+})

--- a/tests/handoff-decision.test.ts
+++ b/tests/handoff-decision.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { decideHandoff } from '../src/main/server/handoff-request'
+
+/** Conservative by default: every no costs a spawn, and the yes keeps terminals across a release. */
+const packaged = { buildChannel: 'packaged' as const }
+const unix = 'ws+unix:///Users/x/.vorn/vorn.sock:/ws'
+
+describe('deciding to ask for a handoff', () => {
+  it('asks when the running server is an older release', () => {
+    const verdict = decideHandoff({
+      target: unix,
+      platform: 'darwin',
+      incumbent: { ...packaged, appVersion: '0.7.0' },
+      self: { ...packaged, appVersion: '0.8.0' }
+    })
+    expect(verdict.ask).toBe(true)
+    expect(verdict.why).toContain('0.7.0')
+  })
+
+  it('leaves a server that is already this build alone', () => {
+    const verdict = decideHandoff({
+      target: unix,
+      platform: 'darwin',
+      incumbent: { ...packaged, appVersion: '0.8.0' },
+      self: { ...packaged, appVersion: '0.8.0' }
+    })
+    expect(verdict).toEqual({ ask: false, why: 'the running server is already this build' })
+  })
+
+  it('will not ask over a port', () => {
+    // The server refuses it over TCP anyway; asked here so the app declines quietly.
+    const verdict = decideHandoff({
+      target: 'ws://127.0.0.1:5123/ws',
+      platform: 'darwin',
+      incumbent: { ...packaged, appVersion: '0.7.0' },
+      self: { ...packaged, appVersion: '0.8.0' }
+    })
+    expect(verdict.ask).toBe(false)
+  })
+
+  it('will not ask on a platform that cannot pass a terminal', () => {
+    const verdict = decideHandoff({
+      target: unix,
+      platform: 'win32',
+      incumbent: { ...packaged, appVersion: '0.7.0' },
+      self: { ...packaged, appVersion: '0.8.0' }
+    })
+    expect(verdict.ask).toBe(false)
+  })
+
+  it('leaves a server somebody started themselves alone, unless told otherwise', () => {
+    const cli = {
+      target: unix,
+      platform: 'darwin' as const,
+      incumbent: { ...packaged, appVersion: 'unknown' },
+      self: { ...packaged, appVersion: '0.8.0' }
+    }
+    expect(decideHandoff(cli).ask).toBe(false)
+    // A person pressing the button has answered the question the version was
+    // standing in for.
+    expect(decideHandoff({ ...cli, forced: true }).ask).toBe(true)
+  })
+
+  it('asks when forced, even with matching versions', () => {
+    // Every dev build carries one version, so nothing else would ever move a server.
+    const verdict = decideHandoff({
+      target: unix,
+      platform: 'darwin',
+      incumbent: { buildChannel: 'dev', appVersion: '0.8.0' },
+      self: { buildChannel: 'dev', appVersion: '0.8.0' },
+      forced: true
+    })
+    expect(verdict.ask).toBe(true)
+  })
+
+  it('never crosses build channels', () => {
+    const verdict = decideHandoff({
+      target: unix,
+      platform: 'darwin',
+      incumbent: { buildChannel: 'dev', appVersion: '0.8.0' },
+      self: { buildChannel: 'packaged', appVersion: '0.9.0' },
+      forced: true
+    })
+    expect(verdict.ask).toBe(false)
+  })
+})

--- a/tests/handoff-direct.test.ts
+++ b/tests/handoff-direct.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { WebSocketServer, type WebSocket as ServerSocket } from 'ws'
+import { HANDOFF_PROTOCOL_VERSION, type HandoffRequest } from '@vornrun/shared/protocol'
+import { askForHandoff } from '../src/main/server/handoff-direct'
+
+/**
+ * The channel that has to work when the runtime protocol does not.
+ *
+ * A release that changes the wire format makes the incumbent unadoptable, and an
+ * app that cannot adopt it never gets a bridge to ask for a handoff with. This
+ * socket speaks only the frozen part: a bearer credential, one JSON-RPC frame,
+ * one reply -- no greeting read, no capabilities, no version compared.
+ */
+const servers: WebSocketServer[] = []
+afterEach(() => {
+  for (const server of servers.splice(0)) server.close()
+})
+
+const request: HandoffRequest = {
+  handoffVersion: HANDOFF_PROTOCOL_VERSION,
+  exec: '/bin/true',
+  args: [],
+  env: {},
+  cwd: '/tmp',
+  appVersion: '9.9.9'
+}
+
+/** A server that greets in a protocol nobody here understands, then answers. */
+function stub(behave: (socket: ServerSocket, frame: { id: number }) => void): Promise<string> {
+  const server = new WebSocketServer({ port: 0 })
+  servers.push(server)
+  server.on('connection', (socket, req) => {
+    if (req.headers.authorization !== 'Bearer secret') return socket.close()
+    // Deliberately unreadable to this client: nothing here reads the greeting.
+    socket.send(JSON.stringify({ jsonrpc: '2.0', method: 'server:hello', params: { v: 999 } }))
+    socket.on('message', (raw) => behave(socket, JSON.parse(String(raw))))
+  })
+  return new Promise((resolve) =>
+    server.on('listening', () => {
+      const address = server.address()
+      resolve(`ws://127.0.0.1:${typeof address === 'object' && address ? address.port : 0}/ws`)
+    })
+  )
+}
+
+describe('asking for a handoff without adopting', () => {
+  it('sends the request and returns the answer, ignoring the greeting', async () => {
+    let sent: unknown = null
+    const target = await stub((socket, frame) => {
+      sent = frame
+      socket.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: frame.id,
+          result: { kind: 'handed-over', sessions: 3, pid: 77 }
+        })
+      )
+    })
+
+    const result = await askForHandoff(target, 'secret', request)
+    expect(result).toEqual({ kind: 'handed-over', sessions: 3, pid: 77 })
+    expect(sent).toMatchObject({ method: 'server:handoff', params: { appVersion: '9.9.9' } })
+  })
+
+  it('carries a refusal back rather than throwing', async () => {
+    const target = await stub((socket, frame) => {
+      socket.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: frame.id,
+          result: { kind: 'declined', because: 'a terminal could not be described' }
+        })
+      )
+    })
+    await expect(askForHandoff(target, 'secret', request)).resolves.toEqual({
+      kind: 'declined',
+      because: 'a terminal could not be described'
+    })
+  })
+
+  it('is not confused by frames that are not its reply', async () => {
+    const target = await stub((socket, frame) => {
+      socket.send(JSON.stringify({ jsonrpc: '2.0', method: 'terminal:data', params: { id: 'x' } }))
+      socket.send(JSON.stringify({ jsonrpc: '2.0', id: frame.id + 41, result: 'someone else' }))
+      socket.send('not json at all')
+      socket.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: frame.id,
+          result: { kind: 'declined', because: 'ok' }
+        })
+      )
+    })
+    await expect(askForHandoff(target, 'secret', request)).resolves.toMatchObject({
+      kind: 'declined'
+    })
+  })
+
+  it('fails rather than hanging when the server refuses the credential', async () => {
+    const target = await stub(() => {})
+    await expect(askForHandoff(target, 'wrong', request)).rejects.toThrow()
+  })
+
+  it('treats a socket that closes before answering as a failure', async () => {
+    // A successful handoff replies first and exits after; a close with no reply is
+    // the far side having gone wrong, and must never read as success.
+    const target = await stub((socket) => socket.close())
+    await expect(askForHandoff(target, 'secret', request)).rejects.toThrow(/closed first/)
+  })
+
+  it('surfaces an error reply as an error', async () => {
+    const target = await stub((socket, frame) => {
+      socket.send(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: frame.id,
+          error: { code: -32000, message: 'may only be called over the local endpoint' }
+        })
+      )
+    })
+    await expect(askForHandoff(target, 'secret', request)).rejects.toThrow(/local endpoint/)
+  })
+})

--- a/tests/handoff-donor.test.ts
+++ b/tests/handoff-donor.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { ChildProcess } from 'node:child_process'
+import { HANDOFF_PROTOCOL_VERSION, type HandoffRequest } from '@vornrun/shared/protocol'
+import {
+  handOver,
+  resetHandoffForTests,
+  type HandoffHost,
+  type DonorPane
+} from '../packages/server/src/handoff/donor'
+import { readManifest, type HandoffManifest } from '../packages/server/src/handoff/manifest'
+
+/**
+ * The transaction, against a replacement that fails on cue. What needs proving is
+ * the failures: before the commit, indistinguishable from never having tried;
+ * after it, recovered from; and nowhere a pty killed.
+ */
+
+/** A replacement that says what it is told to say, when it is told to say it. */
+class FakeHeir extends EventEmitter {
+  pid = 4242
+  killed: string | null = null
+  sent: unknown[] = []
+  send(msg: unknown): boolean {
+    this.sent.push(msg)
+    return true
+  }
+  kill(signal: string): boolean {
+    this.killed = signal
+    return true
+  }
+  unref(): void {}
+  disconnect(): void {}
+}
+
+function pane(id: string, fd: number): DonorPane {
+  return {
+    // Only the fields the manifest carries are read here.
+    session: { id, cols: 80, rows: 24 } as DonorPane['session'],
+    fd,
+    pid: 1000 + fd,
+    cols: 80,
+    rows: 24
+  }
+}
+
+interface Recorded {
+  host: HandoffHost
+  events: string[]
+  dataDir: string
+}
+
+function makeHost(over: Partial<HandoffHost> = {}): Recorded {
+  const events: string[] = []
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-handoff-'))
+  const host: HandoffHost = {
+    dataDir,
+    describePanes: () => {
+      events.push('describe')
+      return [pane('a', 20), pane('b', 21)]
+    },
+    pauseAll: () => events.push('pause'),
+    resumeAll: () => events.push('resume'),
+    quiesce: async () => {
+      events.push('quiesce')
+    },
+    openLogFd: () => fs.openSync(path.join(dataDir, 'log'), 'a'),
+    release: async () => {
+      events.push('release')
+    },
+    reclaim: async () => {
+      events.push('reclaim')
+      return true
+    },
+    exit: () => events.push('exit'),
+    ...over
+  }
+  return { host, events, dataDir }
+}
+
+const request: HandoffRequest = {
+  handoffVersion: HANDOFF_PROTOCOL_VERSION,
+  // Any real path passes the "is there something to run" guard; the fake heir is
+  // what actually stands in for running it.
+  exec: process.execPath,
+  args: ['server.js'],
+  env: {},
+  cwd: os.tmpdir(),
+  appVersion: '9.9.9'
+}
+
+/** Answer the handshake the donor is waiting on, on the next turn of the loop. */
+function replying(...words: string[]): { spawn: () => ChildProcess; heir: FakeHeir } {
+  const heir = new FakeHeir()
+  return {
+    heir,
+    spawn: () => {
+      for (const word of words) setTimeout(() => heir.emit('message', { kind: word }), 5)
+      // The commit reply is only sent once the donor has asked for it.
+      return heir as unknown as ChildProcess
+    }
+  }
+}
+
+beforeEach(() => resetHandoffForTests())
+afterEach(() => {
+  vi.useRealTimers()
+  resetHandoffForTests()
+})
+
+describe('handing terminals to a replacement', () => {
+  it('refuses a caller speaking a different handoff contract', async () => {
+    const { host, events } = makeHost()
+    const result = await handOver({ ...request, handoffVersion: 99 }, host, () => {
+      throw new Error('must not spawn')
+    })
+    expect(result.kind).toBe('declined')
+    // Nothing was touched at all: not even the pause, which is the first thing
+    // that would be visible to somebody typing.
+    expect(events).toEqual([])
+  })
+
+  it('refuses rather than handing over a machine it cannot fully describe', async () => {
+    // Invariant 6. Half the terminals arriving is, to the person whose terminals
+    // they are, indistinguishable from losing the other half.
+    let looked = false
+    const { host, events } = makeHost({
+      describePanes: () => {
+        looked = true
+        return null
+      }
+    })
+    const result = await handOver(request, host, () => {
+      throw new Error('must not spawn')
+    })
+    expect(result.kind).toBe('declined')
+    // Paused to look, then started again. That round trip is the whole story.
+    expect(looked).toBe(true)
+    expect(events).toEqual(['pause', 'resume'])
+  })
+
+  it('leaves everything untouched when the replacement never takes the panes', async () => {
+    const { heir, spawn } = replying()
+    const { host, events, dataDir } = makeHost()
+    vi.useFakeTimers()
+    const pending = handOver(request, host, spawn)
+    await vi.advanceTimersByTimeAsync(25_000)
+    const result = await pending
+
+    expect(result).toEqual({
+      kind: 'declined',
+      because: expect.stringContaining('never took the panes')
+    })
+    // The commit never happened, so the endpoint was never given up and the
+    // readers are running again. This is the rollback that has to be complete.
+    expect(events).not.toContain('release')
+    expect(events).not.toContain('exit')
+    expect(events.at(-1)).toBe('resume')
+    expect(heir.killed).toBe('SIGKILL')
+    // And the manifest is gone, rather than left to be adopted by something later.
+    expect(fs.readdirSync(dataDir).filter((f) => f.startsWith('handoff-'))).toEqual([])
+  })
+
+  it('commits in order and leaves without killing anything', async () => {
+    const { heir, spawn } = replying('imported', 'serving')
+    const { host, events, dataDir } = makeHost()
+
+    // Read at the moment the replacement is started, which is the only moment it
+    // is guaranteed to be on disk: the heir's reply is what removes it.
+    // A holder rather than a bare `let`: the only assignment is inside a callback
+    // this function hands off rather than calls, and the checker keeps the
+    // initializer's narrowed type across that boundary.
+    const captured: { manifest: HandoffManifest | null } = { manifest: null }
+    const spawnAndRead = (...args: Parameters<typeof spawn>): ReturnType<typeof spawn> => {
+      const found = fs.readdirSync(dataDir).find((f) => f.startsWith('handoff-'))
+      if (found) captured.manifest = readManifest(path.join(dataDir, found))
+      return spawn(...args)
+    }
+
+    const result = await handOver(request, host, spawnAndRead)
+
+    expect(result).toMatchObject({ kind: 'handed-over', sessions: 2, pid: 4242 })
+    // The order is the transaction. Everything durable is written down before the
+    // replacement starts; the endpoint is released only once it has the panes.
+    expect(events.slice(0, 4)).toEqual(['pause', 'describe', 'quiesce', 'release'])
+    expect(heir.sent).toEqual([{ kind: 'commit' }])
+    // Never resumed: this server is not going to read these panes again, and
+    // resuming would put two readers on one pty.
+    expect(events).not.toContain('resume')
+
+    // The manifest names both panes, at the slots the stdio array put them in.
+    expect(captured.manifest?.panes.map((p) => [p.session.id, p.slot])).toEqual([
+      ['a', 4],
+      ['b', 5]
+    ])
+
+    // The exit is deferred so the reply reaches the caller first.
+    await vi.waitFor(() => expect(events).toContain('exit'))
+  })
+
+  it('takes the endpoint back when the replacement dies after the commit', async () => {
+    // The one genuinely dangerous case. Both processes still hold every pty --
+    // nothing has been killed -- so there is something to go back to.
+    const { heir, spawn } = replying('imported')
+    const { host, events } = makeHost()
+    vi.useFakeTimers()
+    const pending = handOver(request, host, spawn)
+    await vi.advanceTimersByTimeAsync(1_000)
+    heir.emit('exit', 1, null)
+    const result = await pending
+
+    expect(result).toEqual({
+      kind: 'declined',
+      because: expect.stringContaining('took its terminals back')
+    })
+    expect(events).toContain('release')
+    expect(events).toContain('reclaim')
+    // Reading again, under the old server, which is the point of reclaiming.
+    expect(events.at(-1)).toBe('resume')
+    expect(events).not.toContain('exit')
+  })
+
+  it('says so plainly when it cannot take the endpoint back', async () => {
+    const { heir, spawn } = replying('imported')
+    const { host } = makeHost({
+      reclaim: async () => false
+    })
+    vi.useFakeTimers()
+    const pending = handOver(request, host, spawn)
+    await vi.advanceTimersByTimeAsync(1_000)
+    heir.emit('exit', 1, null)
+    const result = await pending
+
+    // The terminals are alive and unreachable, and a person has to be told both
+    // halves of that rather than only the reassuring one.
+    expect(result).toEqual({
+      kind: 'declined',
+      because: expect.stringContaining('Vorn must be reopened')
+    })
+  })
+
+  it('refuses a second handoff while one is running', async () => {
+    const { spawn } = replying()
+    const { host } = makeHost()
+    vi.useFakeTimers()
+    const first = handOver(request, host, spawn)
+    const second = await handOver(request, host, () => {
+      throw new Error('must not spawn')
+    })
+    expect(second).toEqual({ kind: 'declined', because: 'a handoff is already running' })
+    await vi.advanceTimersByTimeAsync(25_000)
+    await first
+  })
+})

--- a/tests/handoff-heir.test.ts
+++ b/tests/handoff-heir.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import * as pty from 'node-pty'
+import { HANDOFF_MANIFEST_VERSION } from '@vornrun/shared/protocol'
+import {
+  receiveHandoff,
+  announceServing,
+  type HandoffChannel
+} from '../packages/server/src/handoff/heir'
+import { FIRST_PTY_SLOT, writeManifest } from '../packages/server/src/handoff/manifest'
+import type { TerminalSession } from '@vornrun/shared/types'
+
+/**
+ * The receiving half, driven the way the outgoing server drives it.
+ *
+ * A replacement is a child with descriptors in its stdio array and a channel to
+ * answer on. Both are faked here: `native.open` supplies a real pty to stand in
+ * for an inherited one, and `process.send` is replaced so the handshake can be
+ * answered on cue. What is under test is the decision -- when this process may
+ * serve and when it must not.
+ */
+const slaves: number[] = []
+const dirs: string[] = []
+
+afterEach(() => {
+  for (const fd of slaves.splice(0)) {
+    try {
+      fs.closeSync(fd)
+    } catch {
+      // Already closed.
+    }
+  }
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** A real pty master, standing in for one that arrived in the stdio array. */
+function inheritedSlot(): number {
+  const pair = (
+    pty as unknown as {
+      native: { open(cols: number, rows: number): { master: number; slave: number } }
+    }
+  ).native.open(80, 24)
+  slaves.push(pair.slave)
+  return pair.master
+}
+
+function manifestNaming(slot: number): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-heir-'))
+  dirs.push(dir)
+  const at = path.join(dir, 'handoff.json')
+  writeManifest(at, {
+    version: HANDOFF_MANIFEST_VERSION,
+    donorPid: 4242,
+    createdAt: Date.now(),
+    panes: [{ slot, session: { id: 'pane-a' } as TerminalSession, pid: 999, cols: 80, rows: 24 }]
+  })
+  return at
+}
+
+/** A stand-in for the parent's channel, answering the handshake with `reply`. */
+function channel(reply: 'commit' | 'disconnect' | 'silence'): {
+  channel: HandoffChannel
+  sent: unknown[]
+} {
+  const sent: unknown[] = []
+  const events = new EventEmitter()
+  const fake: HandoffChannel = {
+    send: (message: unknown) => {
+      sent.push(message)
+      if ((message as { kind?: string })?.kind !== 'imported') return true
+      // Next tick, so the caller is already waiting when the answer arrives.
+      setImmediate(() => {
+        if (reply === 'commit') events.emit('message', { kind: 'commit' })
+        if (reply === 'disconnect') events.emit('disconnect')
+      })
+      return true
+    },
+    on: (event, listener) => events.on(event, listener as (...a: unknown[]) => void),
+    off: (event, listener) => events.off(event, listener as (...a: unknown[]) => void)
+  }
+  return { channel: fake, sent }
+}
+
+describe('taking a handoff', () => {
+  it('takes the panes and reports that it has', async () => {
+    const slot = inheritedSlot()
+    const { channel: parent, sent } = channel('commit')
+
+    const panes = await receiveHandoff(manifestNaming(slot), parent)
+    expect(panes).toHaveLength(1)
+    expect(panes?.[0]?.session.id).toBe('pane-a')
+    expect(panes?.[0]?.cols).toBe(80)
+    // Said before the commit is asked for: that word is what releases the endpoint.
+    expect(sent).toEqual([{ kind: 'imported' }])
+  })
+
+  it('removes the manifest once it has been read', async () => {
+    const slot = inheritedSlot()
+    const { channel: parent } = channel('commit')
+    const at = manifestNaming(slot)
+
+    await receiveHandoff(at, parent)
+    expect(fs.existsSync(at)).toBe(false)
+  })
+
+  it('refuses to serve when there is no channel to answer on', async () => {
+    const mute: HandoffChannel = { on: () => undefined, off: () => undefined }
+    expect(await receiveHandoff(manifestNaming(inheritedSlot()), mute)).toBeNull()
+  })
+
+  it('refuses to serve on a manifest it cannot read', async () => {
+    const { channel: parent } = channel('commit')
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-heir-'))
+    dirs.push(dir)
+    const at = path.join(dir, 'handoff.json')
+    fs.writeFileSync(at, 'half a jso')
+    // Null, not "no panes": coming up serving nothing while holding descriptors
+    // is how a person watches their terminals disappear.
+    expect(await receiveHandoff(at, parent)).toBeNull()
+    expect(await receiveHandoff(path.join(dir, 'absent.json'), parent)).toBeNull()
+  })
+
+  it('refuses to serve when a slot is not a terminal', async () => {
+    const { channel: parent } = channel('commit')
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-heir-'))
+    dirs.push(dir)
+    const notATerminal = fs.openSync(path.join(dir, 'plain-file'), 'w')
+    slaves.push(notATerminal)
+    expect(notATerminal).toBeGreaterThanOrEqual(FIRST_PTY_SLOT)
+
+    expect(await receiveHandoff(manifestNaming(notATerminal), parent)).toBeNull()
+  })
+
+  it('stands down when the outgoing server never commits', async () => {
+    const slot = inheritedSlot()
+    const { channel: parent, sent } = channel('disconnect')
+    // The channel closing means the donor died mid-handoff: it never released the
+    // endpoint, so there is nothing here to take.
+    expect(await receiveHandoff(manifestNaming(slot), parent)).toBeNull()
+    expect(sent).toEqual([{ kind: 'imported' }])
+  })
+
+  it('arrives with its readers paused', async () => {
+    const slot = inheritedSlot()
+    const { channel: parent } = channel('commit')
+    const panes = await receiveHandoff(manifestNaming(slot), parent)
+
+    const seen: string[] = []
+    panes?.[0]?.pty.onData((d) => seen.push(d))
+    fs.writeSync(slaves[slaves.length - 1] as number, 'written before anyone attached\n')
+    await new Promise((r) => setTimeout(r, 150))
+    // Nothing yet: the bytes wait in the kernel until `adoptPanes` resumes them,
+    // which is the last moment at which they have somewhere to go.
+    expect(seen).toEqual([])
+
+    panes?.[0]?.pty.resume()
+    await new Promise((r) => setTimeout(r, 150))
+    expect(seen.join('')).toContain('written before anyone attached')
+    panes?.[0]?.pty.kill()
+  })
+
+  it('tells the outgoing server when it is serving', () => {
+    const { channel: parent, sent } = channel('silence')
+    announceServing(parent)
+    expect(sent).toEqual([{ kind: 'serving' }])
+  })
+
+  it('survives a channel that has already gone when it announces', () => {
+    const gone: HandoffChannel = {
+      send: () => {
+        throw new Error('channel closed')
+      },
+      on: () => undefined,
+      off: () => undefined
+    }
+    // The outgoing server leaving early is survivable: this process is serving.
+    expect(() => announceServing(gone)).not.toThrow()
+  })
+})

--- a/tests/handoff-live.process.test.ts
+++ b/tests/handoff-live.process.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
+import WebSocket from 'ws'
+import {
+  BOOTSTRAP_ENV_VAR,
+  ENDPOINT_FILENAME,
+  HANDOFF_PROTOCOL_VERSION,
+  type HandoffResult
+} from '@vornrun/shared/protocol'
+import { spawnsRealServers } from './helpers/one-at-a-time'
+
+/**
+ * The whole thing, with two real servers and a real shell.
+ *
+ * Every part has its own test; none of them touches the join, which is where it
+ * actually goes wrong. What matters here is that a shell marked before the handoff
+ * answers a server that did not exist when it was marked.
+ */
+spawnsRealServers()
+
+const repoRoot = path.join(__dirname, '..')
+const CREDENTIAL = 'handoff-test-credential'
+
+const started: ChildProcess[] = []
+const dirs: string[] = []
+const transcript: string[] = []
+
+afterEach((ctx) => {
+  // The replacement writes to `server.log`: a handoff has no parent to pipe to.
+  if (ctx.task.result?.state === 'fail') {
+    for (const dir of dirs) {
+      const at = path.join(dir, 'server.log')
+      if (fs.existsSync(at)) transcript.push(`[heir]\n${fs.readFileSync(at, 'utf-8')}`)
+    }
+    process.stderr.write(transcript.join('') + '\n')
+  }
+  transcript.length = 0
+  // The replacement was spawned by the outgoing server, not by this test, so
+  // nothing else reaps it -- it is detached and holds a live shell.
+  for (const dir of dirs) {
+    try {
+      spawnSync('pkill', ['-f', dir])
+    } catch {
+      // Nothing matched, which is the ordinary case for a handoff that declined.
+    }
+  }
+  for (const child of started.splice(0)) {
+    try {
+      if (child.pid) process.kill(-child.pid, 'SIGKILL')
+    } catch {
+      // Already gone, which is what a successful handoff arranges.
+    }
+    try {
+      child.kill('SIGKILL')
+    } catch {
+      // Same.
+    }
+  }
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true })
+})
+
+/** What a server is started with, and what it is handed for its replacement. */
+function serverCommand(dataDir: string): {
+  exec: string
+  args: string[]
+  env: Record<string, string>
+} {
+  return {
+    exec: process.execPath,
+    // `--import tsx`, never the binary: that re-executes in a child that inherits nothing.
+    args: [
+      '--import',
+      'tsx',
+      path.join(repoRoot, 'packages', 'server', 'src', 'index.ts'),
+      '--data-dir',
+      dataDir,
+      '--port',
+      '0'
+    ],
+    env: {
+      [BOOTSTRAP_ENV_VAR]: CREDENTIAL,
+      VORN_BUILD_CHANNEL: 'packaged',
+      VORN_APP_VERSION: '9.9.9',
+      NODE_ENV: 'test'
+    }
+  }
+}
+
+function startServerProcess(dataDir: string): ChildProcess {
+  const command = serverCommand(dataDir)
+  const child = spawn(command.exec, command.args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...command.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true
+  })
+  // A handoff goes wrong inside a process this test does not own.
+  child.stdout?.on('data', (d) => transcript.push(`[donor] ${d}`))
+  child.stderr?.on('data', (d) => transcript.push(`[donor] ${d}`))
+  started.push(child)
+  return child
+}
+
+/** The only honest "it is ready". */
+async function endpointReady(dataDir: string, timeoutMs = 60_000): Promise<string> {
+  const socket = path.join(dataDir, ENDPOINT_FILENAME)
+  const until = Date.now() + timeoutMs
+  while (Date.now() < until) {
+    if (fs.existsSync(socket)) {
+      const ws = await open(socket).catch(() => null)
+      if (ws) {
+        ws.close()
+        return socket
+      }
+    }
+    await new Promise((r) => setTimeout(r, 200))
+  }
+  throw new Error('the server never answered on its endpoint')
+}
+
+function open(socket: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws+unix://${socket}:/ws`, {
+      headers: { authorization: `Bearer ${CREDENTIAL}` }
+    })
+    const timer = setTimeout(() => {
+      ws.close()
+      reject(new Error('endpoint did not open'))
+    }, 5_000)
+    ws.once('open', () => {
+      clearTimeout(timer)
+      resolve(ws)
+    })
+    ws.once('error', (err) => {
+      clearTimeout(timer)
+      reject(err)
+    })
+  })
+}
+
+let nextId = 1
+function call<T>(ws: WebSocket, method: string, params?: unknown, timeoutMs = 90_000): Promise<T> {
+  const id = nextId++
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${method} timed out`)), timeoutMs)
+    const onMessage = (raw: WebSocket.RawData): void => {
+      const frame = JSON.parse(String(raw))
+      if (frame.id !== id) return
+      clearTimeout(timer)
+      ws.off('message', onMessage)
+      if (frame.error) reject(new Error(frame.error.message))
+      else resolve(frame.result as T)
+    }
+    ws.on('message', onMessage)
+    ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+  })
+}
+
+/** Keystrokes have no reply, so a frame with an id is answered "method not found". */
+function notify(ws: WebSocket, method: string, params: unknown): void {
+  ws.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
+}
+
+/** A fixed pause is a guess about how fast a shell starts, and wrong under load. */
+async function waitForScreen(
+  ws: WebSocket,
+  id: string,
+  match: RegExp,
+  timeoutMs = 30_000
+): Promise<string> {
+  const until = Date.now() + timeoutMs
+  let last = ''
+  while (Date.now() < until) {
+    last = (await call<{ data: string }>(ws, 'terminal:attach', { id })).data
+    if (match.test(last)) return last
+    await new Promise((r) => setTimeout(r, 250))
+  }
+  throw new Error(`never saw ${match} on screen; last 300: ${JSON.stringify(last.slice(-300))}`)
+}
+
+describe('a live handoff between two real servers', () => {
+  it('moves a running shell to a new server without restarting it', async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-handoff-live-'))
+    dirs.push(dataDir)
+    fs.chmodSync(dataDir, 0o700)
+
+    const donor = startServerProcess(dataDir)
+    const socket = await endpointReady(dataDir)
+
+    const first = await open(socket)
+    const session = await call<{ id: string; pid: number }>(first, 'shell:create', repoRoot)
+    expect(session.pid).toBeGreaterThan(0)
+
+    // `$$` is the interactive shell's own pid, not the one node-pty reports: a shell
+    // session runs behind an integration wrapper.
+    // A pty accepts keystrokes before the shell reads them, and the line discipline
+    // echoes what it never ran. Bracketed paste going on is the readiness signal,
+    // not a `$`: shell integration paints the prompt through escape sequences.
+    // eslint-disable-next-line no-control-regex
+    await waitForScreen(first, session.id, /\x1b\[\?2004h/)
+    notify(first, 'terminal:write', { id: session.id, data: 'MARK=$$; echo READY_$MARK\r' })
+    const before = await waitForScreen(first, session.id, /READY_\d+/)
+    const mark = /READY_(\d+)/.exec(before)?.[1]
+    expect(mark).toBeDefined()
+
+    const command = serverCommand(dataDir)
+    const result = await call<HandoffResult>(first, 'server:handoff', {
+      handoffVersion: HANDOFF_PROTOCOL_VERSION,
+      exec: command.exec,
+      args: command.args,
+      env: command.env,
+      cwd: repoRoot,
+      appVersion: '9.9.9'
+    })
+
+    expect(result.kind).toBe('handed-over')
+    if (result.kind !== 'handed-over') return
+    expect(result.sessions).toBe(1)
+    expect(result.pid).not.toBe(donor.pid)
+
+    // The replacement claimed the same name, so the same path reaches it.
+    await new Promise((r) => setTimeout(r, 1_000))
+    const second = await open(await endpointReady(dataDir))
+
+    // The session is there, under the same id, with the same process behind it.
+    const sessions = await call<Array<{ id: string; pid: number }>>(second, 'terminal:listActive')
+    expect(sessions.map((s) => s.id)).toContain(session.id)
+    expect(sessions.find((s) => s.id === session.id)?.pid).toBe(session.pid)
+
+    // `$MARK` was set before the handoff by a shell this server never started, so the
+    // same number can only come from the original process.
+    notify(second, 'terminal:write', { id: session.id, data: 'echo ALIVE_$MARK\r' })
+    const after = await waitForScreen(second, session.id, new RegExp(`ALIVE_${mark}`))
+    const attached = await call<{ live: boolean }>(second, 'terminal:attach', { id: session.id })
+    expect(attached.live).toBe(true)
+    // Rebuilt from the checkpoint the outgoing server wrote, so the pane looks
+    // continuous rather than cleared.
+    expect(after).toContain(`READY_${mark}`)
+
+    // The outgoing server left, and took nothing with it.
+    await new Promise((r) => setTimeout(r, 1_000))
+    expect(alive(donor.pid)).toBe(false)
+    expect(alive(session.pid)).toBe(true)
+
+    second.close()
+  }, 180_000)
+})
+
+function alive(pid: number | undefined): boolean {
+  if (!pid) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}

--- a/tests/handoff-live.process.test.ts
+++ b/tests/handoff-live.process.test.ts
@@ -11,6 +11,7 @@ import {
   type HandoffResult
 } from '@vornrun/shared/protocol'
 import { spawnsRealServers } from './helpers/one-at-a-time'
+import { isPidAlive } from '../packages/server/src/published-files'
 
 /**
  * The whole thing, with two real servers and a real shell.
@@ -242,19 +243,9 @@ describe('a live handoff between two real servers', () => {
 
     // The outgoing server left, and took nothing with it.
     await new Promise((r) => setTimeout(r, 1_000))
-    expect(alive(donor.pid)).toBe(false)
-    expect(alive(session.pid)).toBe(true)
+    expect(isPidAlive(donor.pid as number)).toBe(false)
+    expect(isPidAlive(session.pid)).toBe(true)
 
     second.close()
   }, 180_000)
 })
-
-function alive(pid: number | undefined): boolean {
-  if (!pid) return false
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (err) {
-    return (err as NodeJS.ErrnoException).code === 'EPERM'
-  }
-}

--- a/tests/handoff-manifest.test.ts
+++ b/tests/handoff-manifest.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { HANDOFF_MANIFEST_VERSION } from '@vornrun/shared/protocol'
+import {
+  readManifest,
+  writeManifest,
+  manifestPath,
+  FIRST_PTY_SLOT,
+  type HandoffManifest
+} from '../packages/server/src/handoff/manifest'
+
+/**
+ * Null means "do not serve", and the replacement exits so the outgoing server
+ * resumes. Reading a damaged manifest as "no panes" is work disappearing.
+ */
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-manifest-'))
+}
+
+function valid(): HandoffManifest {
+  return {
+    version: HANDOFF_MANIFEST_VERSION,
+    donorPid: 123,
+    createdAt: Date.now(),
+    panes: [
+      {
+        slot: FIRST_PTY_SLOT,
+        session: { id: 'abc' } as HandoffManifest['panes'][0]['session'],
+        pid: 999,
+        cols: 80,
+        rows: 24
+      }
+    ]
+  }
+}
+
+describe('the handoff manifest', () => {
+  it('round-trips what the replacement needs', () => {
+    const dir = tmp()
+    const at = manifestPath(dir, 123)
+    writeManifest(at, valid())
+    expect(readManifest(at)?.panes[0]).toMatchObject({ slot: FIRST_PTY_SLOT, pid: 999 })
+  })
+
+  it('lands whole or not at all', () => {
+    // Written to a scratch name and renamed. A replacement that read a partly
+    // written file would adopt some terminals and silently drop the rest.
+    const dir = tmp()
+    const at = manifestPath(dir, 123)
+    writeManifest(at, valid())
+    expect(fs.readdirSync(dir)).toEqual([path.basename(at)])
+  })
+
+  it('refuses a manifest from a contract it does not know', () => {
+    const dir = tmp()
+    const at = manifestPath(dir, 1)
+    fs.writeFileSync(at, JSON.stringify({ ...valid(), version: 99 }))
+    expect(readManifest(at)).toBeNull()
+  })
+
+  it('refuses a pane pointing at a slot that cannot hold one', () => {
+    // 0 to 2 are the replacement's own stdio and 3 is its channel. A manifest
+    // naming one of those is describing something other than a terminal.
+    const dir = tmp()
+    const at = manifestPath(dir, 1)
+    const bad = valid()
+    bad.panes[0]!.slot = 2
+    fs.writeFileSync(at, JSON.stringify(bad))
+    expect(readManifest(at)).toBeNull()
+  })
+
+  it('refuses a pane with no session behind it', () => {
+    const dir = tmp()
+    const at = manifestPath(dir, 1)
+    const bad = valid()
+    delete (bad.panes[0] as { session?: unknown }).session
+    fs.writeFileSync(at, JSON.stringify(bad))
+    expect(readManifest(at)).toBeNull()
+  })
+
+  it('refuses a file that is not a manifest at all', () => {
+    const dir = tmp()
+    const at = manifestPath(dir, 1)
+    fs.writeFileSync(at, 'half a jso')
+    expect(readManifest(at)).toBeNull()
+    // And an absent one, which is the same answer for the same reason.
+    expect(readManifest(path.join(dir, 'nothing-here.json'))).toBeNull()
+  })
+})

--- a/tests/local-endpoint.test.ts
+++ b/tests/local-endpoint.test.ts
@@ -258,6 +258,48 @@ describe('letting go', () => {
     expect(fs.lstatSync(endpoint.path).isSocket()).toBe(true)
   })
 
+  it('gives up the name while still answering whoever is connected', async () => {
+    const endpoint = await hold()
+    const socket = new WebSocket(endpointUrl(endpoint.path))
+    await new Promise<void>((resolve, reject) => {
+      socket.once('open', () => resolve())
+      socket.once('error', reject)
+    })
+    cleanup.push(() => socket.close())
+
+    // This is the commit in a handoff: the request asking for one arrived on this
+    // endpoint, and its reply has to travel back out over it. Closing would cut
+    // the caller off at exactly the moment it needed an answer.
+    expect(endpoint.relinquish()).toBe(true)
+
+    expect(endpoint.holds()).toBe(false)
+    expect(fs.existsSync(endpoint.path)).toBe(false)
+    // Still open, and still able to carry the reply.
+    expect(socket.readyState).toBe(WebSocket.OPEN)
+    const greeted = new Promise<void>((resolve) => socket.once('message', () => resolve()))
+    const second = new WebSocket(endpointUrl(endpoint.path))
+    // And nothing new can arrive: the name is free for the replacement to claim.
+    await expect(new Promise((_, reject) => second.once('error', reject))).rejects.toBeInstanceOf(
+      Error
+    )
+    void greeted
+  })
+
+  it('refuses to remove a name that is no longer its own', async () => {
+    const endpoint = await hold()
+    const usurper = path.join(dir, 'someone-else.sock')
+    const { default: net } = await import('node:net')
+    const server = net.createServer()
+    await new Promise<void>((resolve) => server.listen(usurper, resolve))
+    fs.renameSync(usurper, endpoint.path)
+
+    // The rule the whole module rests on: no actor removes a name it did not
+    // create. Removing this one would delete a live server's endpoint.
+    expect(endpoint.relinquish()).toBe(false)
+    expect(fs.lstatSync(endpoint.path).isSocket()).toBe(true)
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+
   it('stops claiming to hold a name that became somebody else’s', async () => {
     const endpoint = await hold()
     expect(endpoint.holds()).toBe(true)

--- a/tests/pty-manager-handoff.test.ts
+++ b/tests/pty-manager-handoff.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import path from 'node:path'
+import type { CreateTerminalPayload, TerminalSession } from '@vornrun/shared/types'
+
+/**
+ * What the pty manager contributes to a handoff.
+ *
+ * The mock harness mirrors `pty-manager-screen.test.ts`, duplicated for the
+ * reason stated there: `vi.mock` is hoisted per file, so a shared module
+ * registers too late and the suite spawns real shells.
+ *
+ * The fake pty carries an `fd`, because that is the whole question here — a pane
+ * this manager cannot name a descriptor for is a machine that must not be handed
+ * over at all.
+ */
+// `FakePty` is here for its type only -- `FakePtyInstance` needs the shape.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const { spawnMock, FakePty } = vi.hoisted(() => {
+  type DataHandler = (data: string) => void
+  type ExitHandler = (e: { exitCode: number; signal?: number }) => void
+
+  let nextPid = 5000
+  let nextFd = 20
+
+  class FakePty {
+    pid = nextPid++
+    /** node-pty exposes this on the instance; the typings never declared it. */
+    fd: number | undefined = nextFd++
+    written: string[] = []
+    paused = 0
+    resumed = 0
+    resize = vi.fn()
+    private dataHandlers: DataHandler[] = []
+    private exitHandlers: ExitHandler[] = []
+
+    write(data: string): void {
+      this.written.push(data)
+    }
+    kill(): void {}
+    pause(): void {
+      this.paused += 1
+    }
+    resume(): void {
+      this.resumed += 1
+    }
+    onData(cb: DataHandler): { dispose: () => void } {
+      this.dataHandlers.push(cb)
+      return { dispose: () => (this.dataHandlers = this.dataHandlers.filter((h) => h !== cb)) }
+    }
+    onExit(cb: ExitHandler): { dispose: () => void } {
+      this.exitHandlers.push(cb)
+      return { dispose: () => (this.exitHandlers = this.exitHandlers.filter((h) => h !== cb)) }
+    }
+    emitData(data: string): void {
+      for (const h of [...this.dataHandlers]) h(data)
+    }
+  }
+
+  return { spawnMock: vi.fn(() => new FakePty()), FakePty }
+})
+
+type FakePtyInstance = InstanceType<typeof FakePty>
+
+vi.mock('../packages/server/node_modules/node-pty', () => ({
+  default: { spawn: spawnMock },
+  spawn: spawnMock
+}))
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}))
+
+vi.mock('../packages/server/src/config-manager', () => ({
+  configManager: {
+    loadConfig: vi.fn(() => ({ defaults: { shell: '/bin/zsh', minimalShellPrompt: true } }))
+  }
+}))
+
+vi.mock('../packages/server/src/git-utils', () => ({
+  getGitBranch: vi.fn(() => 'main'),
+  getGitHead: vi.fn(() => 'cafe0000'),
+  checkoutBranch: vi.fn(),
+  createWorktree: vi.fn(),
+  extractWorktreeName: vi.fn((p: string) => path.basename(p)),
+  isGitRepo: vi.fn(() => false)
+}))
+
+vi.mock('../packages/server/src/shell-integration', () => ({
+  getShellIntegration: vi.fn(() => ({ env: {} }))
+}))
+
+vi.mock('../packages/server/src/agent-launch', () => ({
+  buildAgentLaunchLine: vi.fn((payload: CreateTerminalPayload) => `${payload.agentType}-launch`)
+}))
+
+vi.mock('../packages/server/src/process-utils', async () => {
+  const actual = await vi.importActual<typeof import('../packages/server/src/process-utils')>(
+    '../packages/server/src/process-utils'
+  )
+  return {
+    ...actual,
+    getSafeEnv: () => ({ HOME: '/home/user', PATH: '/usr/bin' }),
+    getLaunchEnv: () => ({ HOME: '/home/user', PATH: '/usr/bin' })
+  }
+})
+
+import { ptyManager } from '../packages/server/src/pty-manager'
+import { hasScreen } from '../packages/server/src/terminal-screen'
+import type { AdoptedPane } from '../packages/server/src/handoff/heir'
+import type { AdoptedPty } from '../packages/server/src/handoff/adopted-pty'
+
+function createAgent(name: string): { session: TerminalSession; fake: FakePtyInstance } {
+  const session = ptyManager.createPty({
+    agentType: 'claude',
+    projectName: name,
+    projectPath: `/tmp/${name}`
+  })
+  const results = spawnMock.mock.results
+  return { session, fake: results[results.length - 1]!.value as FakePtyInstance }
+}
+
+beforeEach(() => {
+  for (const session of ptyManager.getActiveSessions()) ptyManager.killPty(session.id)
+  spawnMock.mockClear()
+})
+
+describe('describing a machine for a handoff', () => {
+  it('names every live pane, in the order they are held', () => {
+    const first = createAgent('one')
+    const second = createAgent('two')
+
+    const panes = ptyManager.describeForHandoff()
+    expect(panes?.map((p) => p.session.id)).toEqual([first.session.id, second.session.id])
+    expect(panes?.map((p) => p.fd)).toEqual([first.fake.fd, second.fake.fd])
+    expect(panes?.map((p) => p.pid)).toEqual([first.fake.pid, second.fake.pid])
+    // The geometry the program is rendering against, not a default.
+    expect(panes?.[0]?.cols).toBe(first.session.cols)
+    expect(panes?.[0]?.rows).toBe(first.session.rows)
+  })
+
+  it('follows a resize, so the replacement rebuilds at the right width', () => {
+    const { session } = createAgent('resized')
+    ptyManager.resizePty(session.id, 132, 43)
+
+    const pane = ptyManager.describeForHandoff()?.[0]
+    expect(pane?.cols).toBe(132)
+    expect(pane?.rows).toBe(43)
+  })
+
+  it('refuses the whole machine when one pane has no descriptor', () => {
+    createAgent('describable')
+    const { fake } = createAgent('not-describable')
+    // What win32 looks like from here: a pty with nothing to hand over.
+    fake.fd = undefined
+
+    // Null, not a shorter list. Half the terminals arriving is, to the person
+    // whose terminals they are, the same as losing the other half.
+    expect(ptyManager.describeForHandoff()).toBeNull()
+  })
+
+  it('stops and starts every reader', () => {
+    const first = createAgent('one')
+    const second = createAgent('two')
+
+    ptyManager.pauseAllForHandoff()
+    expect([first.fake.paused, second.fake.paused]).toEqual([1, 1])
+
+    ptyManager.resumeAllForHandoff()
+    expect([first.fake.resumed, second.fake.resumed]).toEqual([1, 1])
+  })
+})
+
+describe('taking panes from the previous server', () => {
+  /** Only the members `adoptPanes` touches; the real class is covered elsewhere. */
+  function inherited(id: string): { pane: AdoptedPane; resumed: () => number } {
+    let resumed = 0
+    const pty = {
+      pid: 7777,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      onExit: vi.fn(() => ({ dispose: vi.fn() })),
+      pause: vi.fn(),
+      resume: () => {
+        resumed += 1
+      }
+    }
+    return {
+      pane: {
+        session: {
+          id,
+          agentType: 'claude',
+          projectName: 'carried',
+          projectPath: '/tmp/carried',
+          status: 'running',
+          createdAt: Date.now(),
+          cols: 100,
+          rows: 30,
+          pid: 7777
+        } as TerminalSession,
+        pty: pty as unknown as AdoptedPty,
+        cols: 100,
+        rows: 30
+      },
+      resumed: () => resumed
+    }
+  }
+
+  it('makes an inherited pane an ordinary live session', () => {
+    const { pane } = inherited('carried-1')
+    ptyManager.adoptPanes([pane])
+
+    expect(ptyManager.getActiveSessions().map((s) => s.id)).toContain('carried-1')
+    expect(ptyManager.hasLivePty('carried-1')).toBe(true)
+    expect(ptyManager.livePtyCount()).toBe(1)
+  })
+
+  it('reads only once every pane is wired', () => {
+    const one = inherited('carried-1')
+    const two = inherited('carried-2')
+    ptyManager.adoptPanes([one.pane, two.pane])
+
+    // Resumed after both were attached, so a burst on one cannot arrive while the
+    // other is still being wired.
+    expect(one.resumed()).toBe(1)
+    expect(two.resumed()).toBe(1)
+  })
+
+  it('gives an inherited pane a screen when recovery found none', () => {
+    const { pane } = inherited('carried-3')
+    ptyManager.adoptPanes([pane])
+    expect(hasScreen('carried-3')).toBe(true)
+  })
+
+  it('writes and resizes through to the inherited pty', () => {
+    const { pane } = inherited('carried-4')
+    ptyManager.adoptPanes([pane])
+
+    ptyManager.writeToPty('carried-4', 'hello')
+    ptyManager.resizePty('carried-4', 90, 20)
+    expect(pane.pty.write).toHaveBeenCalledWith('hello')
+    expect(pane.pty.resize).toHaveBeenCalledWith(90, 20)
+  })
+
+  it('hands on what it was handed, so a second update is survivable', () => {
+    const { pane } = inherited('carried-5')
+    ptyManager.adoptPanes([pane])
+    // An adopted pty exposes `fd` under the same name a forked one does.
+    ;(pane.pty as unknown as { fd: number }).fd = 41
+
+    expect(ptyManager.describeForHandoff()).toEqual([
+      expect.objectContaining({ fd: 41, pid: 7777, cols: 100, rows: 30 })
+    ])
+  })
+})

--- a/tests/server-runtime-copy.test.ts
+++ b/tests/server-runtime-copy.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { describeServerRuntime } from '../src/renderer/lib/server-runtime'
+import type { ServerRuntimeStatus } from '../src/shared/types'
+
+/** The wording somebody reads while working out why a fix they know shipped did nothing. */
+const base: ServerRuntimeStatus = {
+  serverVersion: '0.8.0',
+  appVersion: '0.8.0',
+  serverPid: 100,
+  adopted: true,
+  canUpgrade: true,
+  sessions: 3,
+  lastUpgrade: null
+}
+
+describe('what the panel says about the running server', () => {
+  it('reports a matching build without offering anything', () => {
+    const view = describeServerRuntime(base)
+    expect(view.offerMove).toBe(false)
+    expect(view.trailing).toBe('Current')
+  })
+
+  it('names both versions when they differ, and what moving would carry', () => {
+    const view = describeServerRuntime({ ...base, serverVersion: '0.7.0' })
+    expect(view.description).toContain('0.7.0')
+    expect(view.description).toContain('0.8.0')
+    // "Moving" sounds destructive until it says what happens to the terminals.
+    expect(view.description).toContain('3 terminals across without stopping them')
+    expect(view.offerMove).toBe(true)
+  })
+
+  it('counts one terminal in the singular', () => {
+    const view = describeServerRuntime({ ...base, serverVersion: '0.7.0', sessions: 1 })
+    expect(view.description).toContain('1 terminal across without stopping it')
+  })
+
+  it('says why the button is missing rather than showing a dead one', () => {
+    const view = describeServerRuntime({ ...base, serverVersion: '0.7.0', canUpgrade: false })
+    expect(view.offerMove).toBe(false)
+    expect(view.description).toContain('needs a restart of Vorn')
+  })
+
+  it('carries the reason a previous attempt failed', () => {
+    const view = describeServerRuntime({
+      ...base,
+      serverVersion: '0.7.0',
+      lastUpgrade: { kind: 'failed', why: 'a terminal could not be described' }
+    })
+    expect(view.description).toContain('a terminal could not be described')
+    // Still offered: nothing was lost, so trying again is free.
+    expect(view.offerMove).toBe(true)
+  })
+
+  it('says a move is under way while it is', () => {
+    const view = describeServerRuntime({ ...base, lastUpgrade: { kind: 'working' } })
+    expect(view.description).toContain('keep running')
+    expect(view.offerMove).toBe(false)
+  })
+
+  it('names a server nobody in this app started', () => {
+    const view = describeServerRuntime({ ...base, serverVersion: 'unknown' })
+    expect(view.description).toContain('started outside Vorn')
+  })
+})

--- a/tests/server-runtime-copy.test.ts
+++ b/tests/server-runtime-copy.test.ts
@@ -16,8 +16,13 @@ const base: ServerRuntimeStatus = {
 describe('what the panel says about the running server', () => {
   it('reports a matching build without offering anything', () => {
     const view = describeServerRuntime(base)
-    expect(view.offerMove).toBe(false)
-    expect(view.trailing).toBe('Current')
+    // Asserted whole, because the type pairs the note with "no button" and reading
+    // one without the other is what the union exists to stop.
+    expect(view).toEqual({
+      description: `Vorn 0.8.0, running since before this window opened`,
+      offerMove: false,
+      trailing: 'Current'
+    })
   })
 
   it('names both versions when they differ, and what moving would carry', () => {
@@ -38,6 +43,8 @@ describe('what the panel says about the running server', () => {
     const view = describeServerRuntime({ ...base, serverVersion: '0.7.0', canUpgrade: false })
     expect(view.offerMove).toBe(false)
     expect(view.description).toContain('needs a restart of Vorn')
+    if (view.offerMove) throw new Error('a view that offers nothing must carry a note')
+    expect(view.trailing).toBe('Restart to move')
   })
 
   it('carries the reason a previous attempt failed', () => {

--- a/tests/sidebar-footer.test.tsx
+++ b/tests/sidebar-footer.test.tsx
@@ -136,8 +136,8 @@ describe('what the sidebar restart will cost', () => {
       ['b', { status: 'idle' }]
     ])
     render(<SidebarFooter isCollapsed={false} closeSidebarOnMobile={vi.fn()} />)
-    expect(screen.getByText(/Your 2 sessions restart on the new version/)).toBeInTheDocument()
-    expect(screen.getByText(/A turn in flight is lost/)).toBeInTheDocument()
+    expect(screen.getByText(/Your 2 sessions keep running through the update/)).toBeInTheDocument()
+    expect(screen.getByText(/The turn in flight continues/)).toBeInTheDocument()
   })
 
   it('says nothing when there are no sessions to lose', () => {

--- a/tests/update-cost.test.ts
+++ b/tests/update-cost.test.ts
@@ -11,18 +11,19 @@ describe('what restarting for an update costs', () => {
   })
 
   it('names one session without pluralising it', () => {
-    expect(updateCostLine(1, false)).toBe('Your session restarts on the new version.')
+    expect(updateCostLine(1, false)).toBe('Your session keeps running through the update.')
   })
 
   it('counts them when there is more than one', () => {
-    expect(updateCostLine(3, false)).toBe('Your 3 sessions restart on the new version.')
+    expect(updateCostLine(3, false)).toBe('Your 3 sessions keep running through the update.')
   })
 
   it('names the turn only when one is running', () => {
-    // A session comes back where it was. A turn in flight does not, and that is
-    // the only part actually lost — so it is said separately or not at all.
+    // The turn is the part people brace for, so it is named — and now to say it
+    // survives. The pty outlives the server that owned it, so the program on the
+    // far side never learns the update happened.
     expect(updateCostLine(3, true)).toBe(
-      'Your 3 sessions restart on the new version. A turn in flight is lost.'
+      'Your 3 sessions keep running through the update. The turn in flight continues.'
     )
     expect(updateCostLine(3, false)).not.toContain('turn')
   })

--- a/tests/updates-settings.test.tsx
+++ b/tests/updates-settings.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
-import type { AppConfig, UpdateStatus } from '../src/shared/types'
+import type { AppConfig, UpdateStatus, ServerRuntimeStatus } from '../src/shared/types'
 
 const mockStore = {
   config: null as AppConfig | null,
@@ -23,6 +23,23 @@ const checkForUpdates = vi.fn()
 const setUpdateChannel = vi.fn()
 const setUpdateAutoDownload = vi.fn()
 const saveConfig = vi.fn()
+const upgradeServer = vi.fn(async () => runtimeStatus)
+
+/**
+ * Which build is holding the terminals.
+ *
+ * The server outlives the app, so after an update these are briefly different
+ * builds — and the panel is where somebody looks to find that out.
+ */
+let runtimeStatus: ServerRuntimeStatus = {
+  serverVersion: '0.6.0-beta.4',
+  appVersion: '0.6.0-beta.4',
+  serverPid: 4242,
+  adopted: true,
+  canUpgrade: false,
+  sessions: null,
+  lastUpgrade: null
+}
 
 Object.defineProperty(window, 'api', {
   value: {
@@ -32,7 +49,10 @@ Object.defineProperty(window, 'api', {
     setUpdateChannel,
     setUpdateAutoDownload,
     saveConfig,
-    getAppVersion: () => '0.6.0-beta.4'
+    getAppVersion: () => '0.6.0-beta.4',
+    getServerRuntimeStatus: () => runtimeStatus,
+    onServerRuntimeStatus: () => () => {},
+    upgradeServer
   },
   writable: true
 })
@@ -238,5 +258,49 @@ describe('sessions that have already ended', () => {
     ])
     render(<UpdatesSettings />)
     expect(screen.queryByText(/restart on the new version/)).not.toBeInTheDocument()
+  })
+})
+
+describe('which build is serving', () => {
+  beforeEach(() => {
+    mockStore.config = makeConfig()
+    upgradeServer.mockClear()
+    runtimeStatus = {
+      serverVersion: '0.6.0-beta.4',
+      appVersion: '0.6.0-beta.4',
+      serverPid: 4242,
+      adopted: true,
+      canUpgrade: false,
+      sessions: null,
+      lastUpgrade: null
+    }
+  })
+
+  it('names the server beside the app, even when they agree', () => {
+    render(<UpdatesSettings />)
+    // Always shown: a row that appears only when something is wrong is one
+    // nobody knows exists, and this is the question the panel gets opened for.
+    expect(screen.getByText('Terminal server')).toBeInTheDocument()
+    expect(screen.getByText('Current')).toBeInTheDocument()
+  })
+
+  it('offers to move a server left behind by an older build', () => {
+    runtimeStatus = { ...runtimeStatus, serverVersion: '0.5.0', canUpgrade: true, sessions: 2 }
+    render(<UpdatesSettings />)
+
+    expect(screen.getByText(/0\.5\.0 is still holding your terminals/)).toBeInTheDocument()
+    // The reassurance is the number: "moving" reads as destructive without it.
+    expect(screen.getByText(/2 terminals across without stopping them/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Move to this build' }))
+    expect(upgradeServer).toHaveBeenCalled()
+  })
+
+  it('says why it cannot move one rather than showing a dead button', () => {
+    runtimeStatus = { ...runtimeStatus, serverVersion: '0.5.0', canUpgrade: false }
+    render(<UpdatesSettings />)
+
+    expect(screen.getByText(/needs a restart of Vorn/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Move to this build' })).not.toBeInTheDocument()
+    expect(screen.getByText('Restart to move')).toBeInTheDocument()
   })
 })

--- a/tests/updates-settings.test.tsx
+++ b/tests/updates-settings.test.tsx
@@ -193,14 +193,14 @@ describe('what the restart will cost', () => {
       ['b', { status: 'idle' }]
     ])
     render(<UpdatesSettings />)
-    expect(screen.getByText(/Your 2 sessions restart on the new version/)).toBeInTheDocument()
+    expect(screen.getByText(/Your 2 sessions keep running through the update/)).toBeInTheDocument()
   })
 
   it('names the turn only when one is running', () => {
     mockStore.appUpdateStatus = { kind: 'ready', version: '0.7.0-beta.13' }
     mockStore.terminals = new Map([['a', { status: 'running' }]])
     render(<UpdatesSettings />)
-    expect(screen.getByText(/A turn in flight is lost/)).toBeInTheDocument()
+    expect(screen.getByText(/The turn in flight continues/)).toBeInTheDocument()
   })
 
   it('says nothing about sessions when there are none', () => {
@@ -228,7 +228,7 @@ describe('sessions that have already ended', () => {
       ['b', { status: 'idle' }]
     ])
     render(<UpdatesSettings />)
-    expect(screen.getByText(/Your session restarts on the new version/)).toBeInTheDocument()
+    expect(screen.getByText(/Your session keeps running through the update/)).toBeInTheDocument()
   })
 
   it('leave nothing to say when they are all there is', () => {


### PR DESCRIPTION
Installing an update stopped the server, and stopping the server ended every terminal and every agent on the machine. That was deliberate — it kept app and server on one build — but it reversed what **Keep Sessions Running** promises, on every release.

The server hands its terminals over instead.

## How

A program in a pane is attached to the slave end of a pty. The server owns the master, and nothing in that relationship names *which* process holds it. So the outgoing server pauses its readers, checkpoints every screen, and starts the replacement with the pty masters in its `stdio` array — the only way Node hands another process a live descriptor, since it has no `SCM_RIGHTS`. The replacement reads and writes the same descriptors, and the programs never learn anything changed.

The transaction has one commit point:

| | before the commit | after it |
|---|---|---|
| endpoint | still held | released to the replacement |
| on failure | resume readers, kill the replacement — indistinguishable from never having tried | reclaim the endpoint and resume |
| PTYs | never touched | never touched |

A machine that cannot be described whole is not handed over at all: one pane without a descriptor declines the lot, because half the terminals arriving is, to the person whose terminals they are, the same as losing the other half.

Two details worth calling out:

- **The endpoint is relinquished, not closed.** The request asking for the handoff arrives on it, and its reply has to travel back out. Unlinking the name stops new connections and leaves existing ones alone.
- **`server:handoff` is refused anywhere but the local endpoint**, because it execs a path the caller names. Over a socket in a 0700 directory that is not an escalation; over TCP it would be.

## Day to day

Automatic. The app installs, restarts, adopts the still-running server and asks it to hand over — no prompt, no button. Settings names the build that is actually serving, and offers to move it, for the cases the automatic check skips: a dev build (one version across every build), a server started from the CLI, or a retry.

A release that changes `RUNTIME_PROTOCOL_VERSION` is the case this most has to survive, and it is the one where there is no bridge to ask over. So the request goes on a socket of its own that reads no greeting and compares no version.

## Proof

`tests/handoff-live.process.test.ts` runs two real servers and a real shell: it marks the shell with its own `$$` before the handoff, and afterwards the **new** server answers with the same mark, the pre-handoff scrollback still on screen, and the old server gone.

`tests/handoff-adopted-pty.test.ts` proves the mechanism across a real process boundary — including `tput cols` returning 120 after a resize, which is the one assertion that cannot be faked: Node has no ioctl, so the binding call must have landed on that descriptor in that process.

Patch coverage 91%.

## Limits

- This helps from the release *after* it ships: the server that hands over has to be a build that has this code. The first update onto it still restarts terminals.
- Full-screen programs are handed over live but redraw on a best-effort basis — a screen cannot be perfectly serialised.
- POSIX only. Windows has no way to inherit a console pseudoterminal, and no local endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A7RJRuSDWz46eusBJhLzE
