### PR TITLE
Let Google Search Console verify vorn.run

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,6 @@ yarn.lock
 src/renderer/lib/completion-index/names.json
 src/renderer/lib/completion-index/outlines/
 src/renderer/lib/completion-index/LICENSE
+
+# Google Search Console reads this byte for byte.
+website/google21afb44e7186463c.html

--- a/website/google21afb44e7186463c.html
+++ b/website/google21afb44e7186463c.html
@@ -1,0 +1,1 @@
+google-site-verification: google21afb44e7186463c.html


### PR DESCRIPTION
Adds the Search Console verification file at the site root. It has to stay in place for the verification to hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE