### PR TITLE
List extensions in a Plugins section with what they add and ask for

### DIFF
--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -64,6 +64,12 @@ function summarize(entry: ConnectorCatalogSummary): { type: string; label: strin
 }
 
 /** What an extension adds, named by id so an agent can open a pane it reads about. */
+/** "a, b and c" — a list read aloud rather than joined. */
+function andList(values: string[]): string {
+  if (values.length <= 1) return values[0] ?? ''
+  return `${values.slice(0, -1).join(', ')} and ${values[values.length - 1]}`
+}
+
 function contributionSummary(contributes: ExtensionContributions | undefined): {
   panes: Array<{ id: string; title: string }>
   footers: Array<{ id: string; title: string }>
@@ -143,9 +149,15 @@ export function registerConnectorTools(server: McpServer): void {
             ...(entry.triggers && { triggers: entry.triggers.map(summarize) }),
             ...(entry.actions && { actions: entry.actions.map(summarize) }),
             ...(entry.env && { env: entry.env.map((e) => e.name) }),
+            // Only what was stated: an empty list would read as "adds nothing",
+            // which is a claim an older catalog never made.
             ...(kind === 'extension' && {
-              contributes: contributionSummary(pack?.contributes ?? entry.contributes),
-              permissions: pack?.permissions ?? entry.permissions ?? [],
+              ...((pack?.contributes ?? entry.contributes) && {
+                contributes: contributionSummary(pack?.contributes ?? entry.contributes)
+              }),
+              ...((pack?.permissions ?? entry.permissions) && {
+                permissions: pack?.permissions ?? entry.permissions
+              }),
               ...((pack?.activates ?? entry.activates) && {
                 activates: pack?.activates ?? entry.activates
               })
@@ -313,7 +325,10 @@ export function registerConnectorTools(server: McpServer): void {
       if (installed?.kind === 'extension') {
         const ignored = [
           args.trigger !== undefined && 'trigger',
-          args.sync_interval_minutes !== undefined && 'sync_interval_minutes'
+          args.sync_interval_minutes !== undefined && 'sync_interval_minutes',
+          args.env !== undefined && 'env',
+          args.name !== undefined && 'name',
+          args.project !== undefined && 'project'
         ].filter(Boolean) as string[]
         return json({
           installed: installed.name,
@@ -325,7 +340,9 @@ export function registerConnectorTools(server: McpServer): void {
           ...(installed.activates && { activates: installed.activates }),
           note:
             'Extensions have no connection: they show on the cards their activation names.' +
-            (ignored.length > 0 ? ` Ignored ${ignored.join(' and ')}, which only a poll uses.` : '')
+            (ignored.length > 0
+              ? ` Ignored ${andList(ignored)}, which only a connection uses.`
+              : '')
         })
       }
 

--- a/packages/mcp/src/tools/connectors.ts
+++ b/packages/mcp/src/tools/connectors.ts
@@ -21,6 +21,7 @@ import type {
   ConnectorCatalogSummary,
   ConnectorManifest,
   ConnectorPackResult,
+  ExtensionContributions,
   InstalledConnectorPack,
   SdkProbeResult,
   SourceConnection
@@ -62,32 +63,55 @@ function summarize(entry: ConnectorCatalogSummary): { type: string; label: strin
   return { type: entry.type, label: entry.label }
 }
 
+/** What an extension adds, named by id so an agent can open a pane it reads about. */
+function contributionSummary(contributes: ExtensionContributions | undefined): {
+  panes: Array<{ id: string; title: string }>
+  footers: Array<{ id: string; title: string }>
+  linkHandlers: Array<{ id: string; title: string }>
+} {
+  const named = (entries: Array<{ id: string; title: string }> | undefined) =>
+    (entries ?? []).map((entry) => ({ id: entry.id, title: entry.title }))
+  return {
+    panes: named(contributes?.panes),
+    footers: named(contributes?.footers),
+    linkHandlers: named(contributes?.linkHandlers)
+  }
+}
+
 export function registerConnectorTools(server: McpServer): void {
   server.tool(
     'list_connectors',
-    'List every connector: the ones built into Vorn, the ones installable from a package, ' +
-      'and how many connections each already has. Use this before creating a workflow that ' +
-      'calls a connector action, or to find the id of a connector to install.',
+    'List every connector and extension: the ones built into Vorn, the ones installable from a ' +
+      'package, and how many connections each already has. A connector polls a service; an ' +
+      'extension adds footers and panes to a session card and says what it may touch. Use this ' +
+      'before creating a workflow that calls a connector action, or to find an id to install.',
     {
-      installable_only: z.boolean().optional().describe('Only connectors that are not set up yet')
+      installable_only: z.boolean().optional().describe('Only connectors that are not set up yet'),
+      kind: z
+        .enum(['connector', 'extension'])
+        .optional()
+        .describe('Only one kind: what polls a service, or what shows on a card')
     },
     async (args) => {
-      const [builtIns, snapshot, connections, statuses] = await Promise.all([
+      const [builtIns, snapshot, connections, statuses, packs] = await Promise.all([
         rpcCall<ConnectorListEntry[]>('connector:list'),
         rpcCall<ConnectorCatalogSnapshot>('connector:catalog'),
         rpcCall<SourceConnection[]>('connection:list', { connectorId: undefined }),
-        rpcCall<ConnectorStatus[]>('connector:status')
+        rpcCall<ConnectorStatus[]>('connector:status'),
+        rpcCall<InstalledConnectorPack[]>('connector:listPacks')
       ])
 
       const countFor = (id: string) =>
         connections.filter((conn) => connectionConnectorId(conn) === id).length
       const statusFor = (id: string) => statuses.find((s) => s.connectorId === id)
+      const packFor = (id: string) => packs.find((pack) => pack.id === id)
 
       const entries = [
         ...builtIns.map((c) => ({
           id: c.id,
           name: c.name,
           source: 'built-in' as const,
+          kind: 'connector' as const,
           capabilities: c.capabilities,
           connections: countFor(c.id),
           // Only meaningful for connectors that authenticate up front; the
@@ -97,26 +121,48 @@ export function registerConnectorTools(server: McpServer): void {
             ...(statusFor(c.id)!.message && { authMessage: statusFor(c.id)!.message })
           })
         })),
-        ...snapshot.items.map((entry) => ({
-          id: entry.id,
-          name: entry.name,
-          source: 'package' as const,
-          description: entry.description,
-          package: entry.packageName,
-          ...(entry.version && { version: entry.version }),
-          capabilities: entry.capabilities,
-          connections: countFor(entry.id),
-          ...(entry.auth && { auth: entry.auth }),
-          // Generated upstream from the connector's own manifest, so an agent
-          // can tell whether a connector is worth installing without launching
-          // it — which for a list of twenty would be twenty npx processes.
-          ...(entry.triggers && { triggers: entry.triggers.map(summarize) }),
-          ...(entry.actions && { actions: entry.actions.map(summarize) }),
-          ...(entry.env && { env: entry.env.map((e) => e.name) })
-        }))
+        ...snapshot.items.map((entry) => {
+          const pack = packFor(entry.id)
+          // The files on disk answer for themselves; the catalog says what installing would bring.
+          const kind = pack?.kind ?? entry.kind ?? 'connector'
+          return {
+            id: entry.id,
+            name: entry.name,
+            source: 'package' as const,
+            kind,
+            description: entry.description,
+            package: entry.packageName,
+            ...(entry.version && { version: entry.version }),
+            capabilities: entry.capabilities,
+            connections: countFor(entry.id),
+            ...(pack && { installed: pack.version }),
+            ...(entry.auth && { auth: entry.auth }),
+            // Generated upstream from the connector's own manifest, so an agent
+            // can tell whether a connector is worth installing without launching
+            // it — which for a list of twenty would be twenty npx processes.
+            ...(entry.triggers && { triggers: entry.triggers.map(summarize) }),
+            ...(entry.actions && { actions: entry.actions.map(summarize) }),
+            ...(entry.env && { env: entry.env.map((e) => e.name) }),
+            ...(kind === 'extension' && {
+              contributes: contributionSummary(pack?.contributes ?? entry.contributes),
+              permissions: pack?.permissions ?? entry.permissions ?? [],
+              ...((pack?.activates ?? entry.activates) && {
+                activates: pack?.activates ?? entry.activates
+              })
+            })
+          }
+        })
       ]
 
-      return json(args.installable_only ? entries.filter((e) => e.connections === 0) : entries)
+      const ofKind = args.kind ? entries.filter((e) => e.kind === args.kind) : entries
+      // An extension has no connections to count, so "not set up yet" means it is not installed.
+      return json(
+        args.installable_only
+          ? ofKind.filter((e) =>
+              e.kind === 'extension' ? !('installed' in e && e.installed) : e.connections === 0
+            )
+          : ofKind
+      )
     }
   )
 
@@ -178,8 +224,9 @@ export function registerConnectorTools(server: McpServer): void {
   server.tool(
     'inspect_connector_package',
     'Start a connector package and read what it offers — its triggers, actions and required ' +
-      'environment variables — without installing it. Use this to review a connector before ' +
-      'install_connector, or to check a local build.',
+      'environment variables, or for an extension what it contributes to a card and what it ' +
+      'asks to touch — without installing it. Use this to review one before install_connector, ' +
+      'or to check a local build.',
     {
       package: V.shortText.describe(
         'npm package name, or a command to run a local build (e.g. "node /path/to/dist/index.js")'
@@ -195,9 +242,11 @@ export function registerConnectorTools(server: McpServer): void {
   server.tool(
     'install_connector',
     'Install a connector from a pack file, from the catalog, or by a launch command, creating ' +
-      'a connection ready to poll. Call list_connectors for catalog ids and ' +
-      'inspect_connector_package to see which environment variables are needed. Secrets cannot ' +
-      'be set this way — see the error it returns if the connector requires one.',
+      'a connection ready to poll. Installing an extension is the whole of setting it up: it ' +
+      'takes no trigger and makes no connection, and shows on the cards its activation names. ' +
+      'Call list_connectors for catalog ids and inspect_connector_package to see which ' +
+      'environment variables are needed. Secrets cannot be set this way — see the error it ' +
+      'returns if the connector requires one.',
     {
       connector_id: V.id
         .optional()
@@ -242,11 +291,30 @@ export function registerConnectorTools(server: McpServer): void {
         })
         if (!outcome.ok) return failure(`The pack was refused: ${outcome.error}`)
         installed = outcome.pack
+      } else if (entry?.kind === 'extension') {
+        // An extension is its pack: there is no launch line to probe and no
+        // connection to make, so the catalog's own pack is what gets installed.
+        if (!entry.packUrl) {
+          return failure(
+            `${entry.name} is in the catalog but no release has published a pack for it yet.`
+          )
+        }
+        const outcome = await rpcCall<ConnectorPackResult>('connector:installPack', {
+          kind: 'url',
+          url: entry.packUrl,
+          ...(entry.sha256 && { sha256: entry.sha256 })
+        })
+        if (!outcome.ok) return failure(`The pack was refused: ${outcome.error}`)
+        installed = outcome.pack
       }
 
       // An extension contributes to the card rather than polling a service, so
       // installing it is the whole of connecting it: there is no trigger to pick.
       if (installed?.kind === 'extension') {
+        const ignored = [
+          args.trigger !== undefined && 'trigger',
+          args.sync_interval_minutes !== undefined && 'sync_interval_minutes'
+        ].filter(Boolean) as string[]
         return json({
           installed: installed.name,
           kind: 'extension',
@@ -254,7 +322,10 @@ export function registerConnectorTools(server: McpServer): void {
           path: installed.path,
           contributes: installed.contributes ?? {},
           permissions: installed.permissions ?? [],
-          note: 'Extensions have no connection: they show on the cards their activation names.'
+          ...(installed.activates && { activates: installed.activates }),
+          note:
+            'Extensions have no connection: they show on the cards their activation names.' +
+            (ignored.length > 0 ? ` Ignored ${ignored.join(' and ')}, which only a poll uses.` : '')
         })
       }
 

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -173,7 +173,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
       },
       {
         key: 'connectors',
-        label: 'Connectors',
+        label: 'Plugins',
         icon: (
           <svg
             width="16"

--- a/src/renderer/components/settings/ConnectionGroups.tsx
+++ b/src/renderer/components/settings/ConnectionGroups.tsx
@@ -4,6 +4,7 @@ import { ConnectorIcon } from '../ConnectorIcon'
 import { ConnectionRow } from './ConnectionRow'
 import type { RowActivity } from '../../lib/use-row-action'
 import { groupConnections, type ConnectorListing } from '../../lib/connector-browse'
+import { count } from '../../lib/extension-copy'
 import type { ConnectorManifest, SourceConnection, WorkflowDefinition } from '../../../shared/types'
 
 export interface ConnectorStatus {
@@ -56,6 +57,15 @@ export function ConnectionGroups({
   onRefresh: () => void
 }) {
   const groups = groupConnections(connections, listings)
+  // A connector on disk with nothing connected has no group of its own, and
+  // without this the only sign it is installed is the tab next door.
+  const unconnected = listings.filter(
+    (listing) =>
+      listing.pack &&
+      listing.kind === 'connector' &&
+      listing.connectedCount === 0 &&
+      !listing.implicitlyConnected
+  )
 
   return (
     <div className="space-y-5">
@@ -124,6 +134,42 @@ export function ConnectionGroups({
           </div>
         )
       })}
+
+      {unconnected.length > 0 && (
+        <div>
+          <h3 className="text-[10px] uppercase tracking-[0.08em] text-gray-600 pb-1">
+            Installed, no connection yet
+          </h3>
+          {unconnected.map((listing) => (
+            <div
+              key={listing.key}
+              className="flex items-center gap-3 py-2.5 border-t border-white/[0.06]"
+            >
+              <span className="w-8 h-8 shrink-0 flex items-center justify-center bg-white/[0.04] rounded-sm">
+                <ConnectorIcon
+                  connectorId={listing.id}
+                  icon={listing.catalogItem?.icon ?? listing.icon}
+                  size={17}
+                  className="text-gray-200"
+                />
+              </span>
+              <div className="min-w-0">
+                <div className="text-[13.5px] text-gray-200 font-medium">{listing.name}</div>
+                <div className="text-[11px] text-gray-600">
+                  {listing.pack && `v${listing.pack.version}`}
+                </div>
+              </div>
+              <button
+                onClick={() => onAdd(listing)}
+                title="Connect this connector to an account"
+                className="ml-auto text-[11px] text-gray-500 hover:text-gray-200 px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+              >
+                <Plus size={11} /> Add connection
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }
@@ -149,10 +195,6 @@ function missingFor(
   return (manifest?.defaultWorkflows ?? []).filter(
     (e) => !seeded.some((w) => w.id === `connector:${conn.id}:${e.event}`)
   )
-}
-
-function count(n: number, noun: string): string {
-  return `${n} ${noun}${n === 1 ? '' : 's'}`
 }
 
 /**

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -17,6 +17,13 @@ import {
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
+import {
+  describeActivation,
+  describeFooterInterval,
+  describePaneKind,
+  notAsked,
+  permissionRows
+} from '../../lib/extension-copy'
 import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
 import type { RowState } from '../../lib/use-row-action'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
@@ -42,6 +49,8 @@ export function ConnectorDetail({
   progress,
   activity,
   pending,
+  activeCards,
+  openCards,
   onAdd,
   onInstall,
   onRollback,
@@ -53,6 +62,9 @@ export function ConnectorDetail({
   builtIns: BuiltInConnector[]
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
+  /** Open cards this extension is active on, and how many are open at all. */
+  activeCards?: number
+  openCards?: number
   /** What this connector's own actions are doing, and what the last one answered. */
   activity?: RowState
   /** The confirm sheet for this connector's pack, once it has been verified. */
@@ -111,6 +123,8 @@ export function ConnectorDetail({
         <p className="text-[12px] text-gray-500 mt-5">
           This connector does not describe itself yet. Add it to see what it offers.
         </p>
+      ) : listing.kind === 'extension' ? (
+        <ExtensionSections listing={listing} />
       ) : (
         <>
           <Section label="Starts a workflow when">
@@ -163,13 +177,35 @@ export function ConnectorDetail({
         </Section>
       )}
 
+      {/* An extension carries no rung, and silence there would read as unknown. */}
+      {listing.kind === 'extension' && !listing.authRung && !entry?.auth && (
+        <Section label="Signs in with">
+          <p className="text-[12.5px] text-gray-300">
+            Nothing. It only reads what the session already has.
+          </p>
+        </Section>
+      )}
+
       {/* The question this page could not answer while a connector was a package name. */}
       {listing.pack && (
         <Section label="On this machine">
           <dl className="text-[12px] leading-relaxed">
             <Fact term="Installed" value={`v${listing.pack.version}`} />
             <Fact term="On disk" value={listing.pack.path} mono />
-            <Fact term="Runs via" value={`node ${listing.pack.path}/index.js`} mono />
+            {listing.kind === 'extension' ? (
+              activeCards !== undefined && (
+                <Fact
+                  term="Active"
+                  value={
+                    openCards === undefined
+                      ? `on ${count(activeCards, 'card')}`
+                      : `on ${activeCards} of ${count(openCards, 'open card')}`
+                  }
+                />
+              )
+            ) : (
+              <Fact term="Runs via" value={`node ${listing.pack.path}/index.js`} mono />
+            )}
           </dl>
         </Section>
       )}
@@ -199,6 +235,7 @@ export function ConnectorDetail({
         ) : (
           canAddConnection(state, {
             source: listing.source,
+            kind: listing.kind,
             hasLegacyLaunch: Boolean(entry?.packageName)
           }) && (
             <button
@@ -244,7 +281,8 @@ export function ConnectorDetail({
             title="Delete the installed files"
             className="text-xs text-danger hover:text-danger px-2.5 py-1.5 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
           >
-            <BusyIcon busy={busy} icon={Trash2} size={12} /> Remove
+            <BusyIcon busy={busy} icon={Trash2} size={12} />{' '}
+            {listing.kind === 'extension' ? 'Uninstall' : 'Remove'}
           </button>
         )}
 
@@ -271,6 +309,88 @@ export function ConnectorDetail({
       {pending && <div className="mt-3">{pending}</div>}
     </div>
   )
+}
+
+/**
+ * What an extension adds, what it may touch, and where it shows.
+ *
+ * The three questions a person asks before trusting one, in the order they ask
+ * them. Every line is read from the manifest, so a page cannot advertise a pane
+ * the pack does not ship, and what is *not* asked for is stated beside what is
+ * — a grant reads as small only against the list it was drawn from.
+ */
+function ExtensionSections({ listing }: { listing: ConnectorListing }) {
+  const contributes = listing.contributes
+  const panes = contributes?.panes ?? []
+  const footers = contributes?.footers ?? []
+  const handlers = contributes?.linkHandlers ?? []
+  const rows = permissionRows(listing.permissions)
+  const unasked = notAsked(listing.permissions)
+
+  return (
+    <>
+      <Section label="Contributes">
+        {panes.length + footers.length + handlers.length === 0 ? (
+          <p className="text-[12px] text-gray-600">Nothing — this one adds no surface yet.</p>
+        ) : (
+          <>
+            {panes.map((pane) => (
+              <Item
+                key={`pane:${pane.id}`}
+                title={`${pane.title} · pane`}
+                detail={pane.description ?? describePaneKind(pane)}
+                when={describeWhen(pane.when)}
+              />
+            ))}
+            {footers.map((footer) => (
+              <Item
+                key={`footer:${footer.id}`}
+                title={`${footer.title} · footer`}
+                detail={footer.description ?? describeFooterInterval(footer.every)}
+                when={describeWhen(footer.when)}
+              />
+            ))}
+            {handlers.map((handler) => (
+              <Item
+                key={`link:${handler.id}`}
+                title={`${handler.title} · link`}
+                detail={handler.description ?? `matches ${handler.pattern}`}
+                when={describeWhen(handler.when)}
+              />
+            ))}
+          </>
+        )}
+      </Section>
+
+      <Section label="Asks to">
+        {rows.length === 0 ? (
+          <p className="text-[12px] text-gray-600">Nothing. It draws what it is given.</p>
+        ) : (
+          rows.map((row) => (
+            <p key={row.label} className="text-[12.5px] text-gray-300">
+              <span className="text-gray-500">{row.label} </span>
+              {row.items.join(', ')}
+            </p>
+          ))
+        )}
+        {unasked.length > 0 && (
+          <p className="text-[12px] text-gray-600">Not asked: {unasked.join(', ')}.</p>
+        )}
+      </Section>
+
+      <Section label="Shows when">
+        <p className="text-[12.5px] text-gray-300">
+          {describeActivation(listing.activates).join(', ')}
+        </p>
+      </Section>
+    </>
+  )
+}
+
+/** A contribution's own rule, said only when it is narrower than the extension's. */
+function describeWhen(when: ConnectorListing['activates']): string | undefined {
+  if (!when) return undefined
+  return `Shows on ${describeActivation(when).join(', ')}`
 }
 
 /**
@@ -322,11 +442,12 @@ function Section({ label, children }: { label: string; children: React.ReactNode
   )
 }
 
-function Item({ title, detail }: { title: string; detail?: string }) {
+function Item({ title, detail, when }: { title: string; detail?: string; when?: string }) {
   return (
     <div className="text-[12.5px]">
       <div className="text-gray-300">{title}</div>
       {detail && <div className="text-gray-600 mt-0.5">{detail}</div>}
+      {when && <div className="text-gray-600 mt-0.5">{when}</div>}
     </div>
   )
 }

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -18,6 +18,7 @@ import {
   type ConnectorListing
 } from '../../lib/connector-browse'
 import {
+  count,
   describeActivation,
   describeFooterInterval,
   describePaneKind,
@@ -49,8 +50,7 @@ export function ConnectorDetail({
   progress,
   activity,
   pending,
-  activeCards,
-  openCards,
+  cards,
   onAdd,
   onInstall,
   onRollback,
@@ -63,8 +63,7 @@ export function ConnectorDetail({
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
   /** Open cards this extension is active on, and how many are open at all. */
-  activeCards?: number
-  openCards?: number
+  cards?: { active: number; open: number }
   /** What this connector's own actions are doing, and what the last one answered. */
   activity?: RowState
   /** The confirm sheet for this connector's pack, once it has been verified. */
@@ -167,22 +166,19 @@ export function ConnectorDetail({
         </>
       )}
 
-      {/* The rung answers "what will this ask of me"; the connector's own sentence says it in its terms. */}
-      {(listing.authRung || entry?.auth) && (
+      {/* The rung answers "what will this ask of me"; the connector's own sentence says it in
+          its terms. An extension carries no rung, and silence there would read as unknown. */}
+      {(listing.authRung || entry?.auth || listing.kind === 'extension') && (
         <Section label="Signs in with">
           {listing.authRung && (
             <p className="text-[12.5px] text-gray-300">{AUTH_RUNG[listing.authRung].detail}</p>
           )}
           {entry?.auth && <p className="text-[12.5px] text-gray-500">{entry.auth}</p>}
-        </Section>
-      )}
-
-      {/* An extension carries no rung, and silence there would read as unknown. */}
-      {listing.kind === 'extension' && !listing.authRung && !entry?.auth && (
-        <Section label="Signs in with">
-          <p className="text-[12.5px] text-gray-300">
-            Nothing. It only reads what the session already has.
-          </p>
+          {listing.kind === 'extension' && !listing.authRung && !entry?.auth && (
+            <p className="text-[12.5px] text-gray-300">
+              Nothing. It only reads what the session already has.
+            </p>
+          )}
         </Section>
       )}
 
@@ -193,14 +189,10 @@ export function ConnectorDetail({
             <Fact term="Installed" value={`v${listing.pack.version}`} />
             <Fact term="On disk" value={listing.pack.path} mono />
             {listing.kind === 'extension' ? (
-              activeCards !== undefined && (
+              cards && (
                 <Fact
                   term="Active"
-                  value={
-                    openCards === undefined
-                      ? `on ${count(activeCards, 'card')}`
-                      : `on ${activeCards} of ${count(openCards, 'open card')}`
-                  }
+                  value={`on ${cards.active} of ${count(cards.open, 'open card')}`}
                 />
               )
             ) : (
@@ -321,66 +313,77 @@ export function ConnectorDetail({
  */
 function ExtensionSections({ listing }: { listing: ConnectorListing }) {
   const contributes = listing.contributes
-  const panes = contributes?.panes ?? []
-  const footers = contributes?.footers ?? []
-  const handlers = contributes?.linkHandlers ?? []
+  const surfaces = [
+    ...(contributes?.panes ?? []).map((pane) => ({
+      key: `pane:${pane.id}`,
+      title: `${pane.title} · pane`,
+      detail: pane.description ?? describePaneKind(pane),
+      when: pane.when
+    })),
+    ...(contributes?.footers ?? []).map((footer) => ({
+      key: `footer:${footer.id}`,
+      title: `${footer.title} · footer`,
+      detail: footer.description ?? describeFooterInterval(footer.every),
+      when: footer.when
+    })),
+    ...(contributes?.linkHandlers ?? []).map((handler) => ({
+      key: `link:${handler.id}`,
+      title: `${handler.title} · link`,
+      detail: handler.description ?? `matches ${handler.pattern}`,
+      when: handler.when
+    }))
+  ]
+  // An installed pack answered for itself, so no permissions there means none.
+  // A catalog published before the field existed says nothing, which is not the same.
+  const stated = listing.permissions !== undefined || listing.pack !== undefined
   const rows = permissionRows(listing.permissions)
-  const unasked = notAsked(listing.permissions)
 
   return (
     <>
       <Section label="Contributes">
-        {panes.length + footers.length + handlers.length === 0 ? (
+        {surfaces.length === 0 ? (
           <p className="text-[12px] text-gray-600">Nothing — this one adds no surface yet.</p>
         ) : (
-          <>
-            {panes.map((pane) => (
-              <Item
-                key={`pane:${pane.id}`}
-                title={`${pane.title} · pane`}
-                detail={pane.description ?? describePaneKind(pane)}
-                when={describeWhen(pane.when)}
-              />
-            ))}
-            {footers.map((footer) => (
-              <Item
-                key={`footer:${footer.id}`}
-                title={`${footer.title} · footer`}
-                detail={footer.description ?? describeFooterInterval(footer.every)}
-                when={describeWhen(footer.when)}
-              />
-            ))}
-            {handlers.map((handler) => (
-              <Item
-                key={`link:${handler.id}`}
-                title={`${handler.title} · link`}
-                detail={handler.description ?? `matches ${handler.pattern}`}
-                when={describeWhen(handler.when)}
-              />
-            ))}
-          </>
+          surfaces.map((surface) => (
+            <Item
+              key={surface.key}
+              title={surface.title}
+              detail={surface.detail}
+              when={describeWhen(surface.when)}
+            />
+          ))
         )}
       </Section>
 
       <Section label="Asks to">
-        {rows.length === 0 ? (
-          <p className="text-[12px] text-gray-600">Nothing. It draws what it is given.</p>
+        {!stated ? (
+          <p className="text-[12px] text-gray-600">
+            The catalog does not say what it asks for yet.
+          </p>
         ) : (
-          rows.map((row) => (
-            <p key={row.label} className="text-[12.5px] text-gray-300">
-              <span className="text-gray-500">{row.label} </span>
-              {row.items.join(', ')}
-            </p>
-          ))
-        )}
-        {unasked.length > 0 && (
-          <p className="text-[12px] text-gray-600">Not asked: {unasked.join(', ')}.</p>
+          <>
+            {rows.length === 0 ? (
+              <p className="text-[12px] text-gray-600">Nothing. It draws what it is given.</p>
+            ) : (
+              rows.map((row) => (
+                <p key={row.label} className="text-[12.5px] text-gray-300">
+                  <span className="text-gray-500">{row.label} </span>
+                  {row.items.join(', ')}
+                </p>
+              ))
+            )}
+            {notAsked(listing.permissions).length > 0 && (
+              <p className="text-[12px] text-gray-600">
+                Not asked: {notAsked(listing.permissions).join(', ')}.
+              </p>
+            )}
+          </>
         )}
       </Section>
 
       <Section label="Shows when">
         <p className="text-[12.5px] text-gray-300">
-          {describeActivation(listing.activates).join(', ')}
+          {describeActivation(listing.activates).join(' and ')}
         </p>
       </Section>
     </>
@@ -390,7 +393,7 @@ function ExtensionSections({ listing }: { listing: ConnectorListing }) {
 /** A contribution's own rule, said only when it is narrower than the extension's. */
 function describeWhen(when: ConnectorListing['activates']): string | undefined {
   if (!when) return undefined
-  return `Shows on ${describeActivation(when).join(', ')}`
+  return `Shows on ${describeActivation(when).join(' and ')}`
 }
 
 /**
@@ -450,8 +453,4 @@ function Item({ title, detail, when }: { title: string; detail?: string; when?: 
       {when && <div className="text-gray-600 mt-0.5">{when}</div>}
     </div>
   )
-}
-
-function count(n: number, noun: string): string {
-  return `${n} ${noun}${n === 1 ? '' : 's'}`
 }

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -51,6 +51,7 @@ export function ConnectorDetail({
   activity,
   pending,
   cards,
+  backLabel,
   onAdd,
   onInstall,
   onRollback,
@@ -60,6 +61,8 @@ export function ConnectorDetail({
 }: {
   listing: ConnectorListing
   builtIns: BuiltInConnector[]
+  /** Where closing goes back to, named after the tab this was opened from. */
+  backLabel?: string
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
   /** Open cards this extension is active on, and how many are open at all. */
@@ -88,7 +91,7 @@ export function ConnectorDetail({
         onClick={onClose}
         className="flex items-center gap-1.5 text-[12px] text-gray-500 hover:text-gray-300 transition-colors mb-4"
       >
-        <ArrowLeft size={12} /> All connectors
+        <ArrowLeft size={12} /> {backLabel ?? 'All connectors'}
       </button>
 
       <div className="flex items-start gap-3">

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -448,7 +448,8 @@ function facts(
         ].filter(Boolean) as string[])
   if (offers.length > 0) parts.push(offers.join(', '))
 
-  const version = listing.catalogItem?.version ?? listing.pack?.version
+  // Only what installing would bring: an installed pack says its version on the status line below.
+  const version = listing.catalogItem?.version
   if (version) parts.push(`v${version}`)
   if (listing.kind === 'extension') {
     // Only worth saying once it is installed; before that there are no cards to be on.

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -133,8 +133,8 @@ export function ConnectorDirectory({
       }
       data-drop-active={dragOver ? 'true' : undefined}
     >
-      <div className="flex items-center gap-2 mb-1">
-        <div className="relative flex-1">
+      <div className="mb-1">
+        <div className="relative mb-2">
           <Search size={12} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-600" />
           <input
             type="text"
@@ -144,69 +144,72 @@ export function ConnectorDirectory({
             className="w-full pl-7 pr-2 py-1.5 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-200 focus:border-white/[0.2] outline-none"
           />
         </div>
-        {onInstallFile && onPickFile && (
-          <button
-            onClick={async () => {
-              const filePath = await onPickFile()
-              if (filePath) onInstallFile(filePath)
-            }}
-            title="Install a .vorn.tgz you already have"
-            className="shrink-0 py-1.5 px-2 text-xs text-gray-300 hover:text-white border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
-          >
-            <FolderOpen size={11} /> Install from file
-          </button>
-        )}
-        {/* A dropdown rather than a row of chips, which wrapped to a second
+        {/* Filters on their own row, so the search box keeps its width when three of them show. */}
+        <div className="flex flex-wrap items-center gap-2">
+          {onInstallFile && onPickFile && (
+            <button
+              onClick={async () => {
+                const filePath = await onPickFile()
+                if (filePath) onInstallFile(filePath)
+              }}
+              title="Install a .vorn.tgz you already have"
+              className="shrink-0 py-1.5 px-2 text-xs text-gray-300 hover:text-white border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+            >
+              <FolderOpen size={11} /> Install from file
+            </button>
+          )}
+          {/* A dropdown rather than a row of chips, which wrapped to a second
             line and pushed the list down. */}
-        {categories.length > 1 && (
-          <select
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            aria-label="Filter by category"
-            className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
-          >
-            <option value="">All categories</option>
-            {categories.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </select>
-        )}
-        {/* A connector and an extension answer different questions, so which
+          {categories.length > 1 && (
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              aria-label="Filter by category"
+              className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
+            >
+              <option value="">All categories</option>
+              {categories.map((name) => (
+                <option key={name} value={name}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          )}
+          {/* A connector and an extension answer different questions, so which
             one you came for narrows the list before anything else does. */}
-        {kinds.length > 1 && (
-          <select
-            value={kind}
-            onChange={(e) => setKind(e.target.value as '' | ConnectorKind)}
-            aria-label="Filter by kind"
-            className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
-          >
-            <option value="">Everything</option>
-            {kinds.map((name) => (
-              <option key={name} value={name}>
-                {CONNECTOR_KIND[name].label}
-              </option>
-            ))}
-          </select>
-        )}
-        {/* What setting one up will ask of you is the question people bring
+          {kinds.length > 1 && (
+            <select
+              value={kind}
+              onChange={(e) => setKind(e.target.value as '' | ConnectorKind)}
+              aria-label="Filter by kind"
+              className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
+            >
+              <option value="">Everything</option>
+              {kinds.map((name) => (
+                <option key={name} value={name}>
+                  {CONNECTOR_KIND[name].label}
+                </option>
+              ))}
+            </select>
+          )}
+          {/* What setting one up will ask of you is the question people bring
             here second, right after what it talks to. */}
-        {rungs.length > 1 && (
-          <select
-            value={rung}
-            onChange={(e) => setRung(e.target.value as '' | ConnectorAuthRung)}
-            aria-label="Filter by sign-in"
-            className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
-          >
-            <option value="">Any sign-in</option>
-            {rungs.map((name) => (
-              <option key={name} value={name}>
-                {AUTH_RUNG[name].label}
-              </option>
-            ))}
-          </select>
-        )}
+          {rungs.length > 1 && (
+            <select
+              value={rung}
+              onChange={(e) => setRung(e.target.value as '' | ConnectorAuthRung)}
+              aria-label="Filter by sign-in"
+              className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
+            >
+              <option value="">Any sign-in</option>
+              {rungs.map((name) => (
+                <option key={name} value={name}>
+                  {AUTH_RUNG[name].label}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
       </div>
 
       {installError && (

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -1,20 +1,28 @@
 import { Fragment, useMemo, useState } from 'react'
 import { Search, Plus, RefreshCw, ChevronRight, Check, Download, FolderOpen } from 'lucide-react'
 import { ConnectorIcon } from '../ConnectorIcon'
-import type { ConnectorAuthRung, ConnectorInstallProgress } from '../../../shared/types'
+import type {
+  ConnectorAuthRung,
+  ConnectorInstallProgress,
+  ConnectorKind
+} from '../../../shared/types'
 import {
   describeCatalogAge,
   filterConnectorListings,
   filterByAuthRung,
   filterByCategory,
+  filterByKind,
   connectorAuthRungs,
   connectorCategories,
+  connectorKinds,
   groupListingsByCategory,
   listingDetails,
   AUTH_RUNG,
+  CONNECTOR_KIND,
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
+import { describeContributions } from '../../lib/extension-copy'
 import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
 
@@ -40,6 +48,7 @@ export function ConnectorDirectory({
   installError,
   pending,
   progress,
+  activeCards,
   fetchedAt,
   onRefresh
 }: {
@@ -58,6 +67,8 @@ export function ConnectorDirectory({
   pending?: { sheet: React.ReactNode; rowKey?: string }
   /** Installs running right now, by connector id. */
   progress?: Record<string, ConnectorInstallProgress>
+  /** How many open cards each installed extension is active on, by extension id. */
+  activeCards?: Record<string, number>
   /** When the published list was last read. Absent until one has been. */
   fetchedAt?: number
   onRefresh?: () => Promise<void> | void
@@ -65,18 +76,23 @@ export function ConnectorDirectory({
   const [search, setSearch] = useState('')
   const [category, setCategory] = useState('')
   const [rung, setRung] = useState<'' | ConnectorAuthRung>('')
+  const [kind, setKind] = useState<'' | ConnectorKind>('')
   const [refreshing, setRefreshing] = useState(false)
   const [dragOver, setDragOver] = useState(false)
 
   const categories = useMemo(() => connectorCategories(listings), [listings])
   const rungs = useMemo(() => connectorAuthRungs(listings), [listings])
+  const kinds = useMemo(() => connectorKinds(listings), [listings])
   const visible = useMemo(
     () =>
-      filterByAuthRung(
-        filterByCategory(filterConnectorListings(listings, search), category || undefined),
-        rung || undefined
+      filterByKind(
+        filterByAuthRung(
+          filterByCategory(filterConnectorListings(listings, search), category || undefined),
+          rung || undefined
+        ),
+        kind || undefined
       ),
-    [listings, search, category, rung]
+    [listings, search, category, rung, kind]
   )
   // Sections earn their keep once there is more than one; below that they are
   // a heading over the whole list, which says nothing.
@@ -157,6 +173,23 @@ export function ConnectorDirectory({
             ))}
           </select>
         )}
+        {/* A connector and an extension answer different questions, so which
+            one you came for narrows the list before anything else does. */}
+        {kinds.length > 1 && (
+          <select
+            value={kind}
+            onChange={(e) => setKind(e.target.value as '' | ConnectorKind)}
+            aria-label="Filter by kind"
+            className="py-1.5 px-2 bg-white/[0.05] border border-white/[0.1] rounded-sm text-xs text-gray-300 outline-none focus:border-white/[0.2]"
+          >
+            <option value="">Everything</option>
+            {kinds.map((name) => (
+              <option key={name} value={name}>
+                {CONNECTOR_KIND[name].label}
+              </option>
+            ))}
+          </select>
+        )}
         {/* What setting one up will ask of you is the question people bring
             here second, right after what it talks to. */}
         {rungs.length > 1 && (
@@ -199,6 +232,9 @@ export function ConnectorDirectory({
                 listing={listing}
                 builtIns={builtIns}
                 {...(progress?.[listing.id] && { progress: progress[listing.id] })}
+                {...(activeCards?.[listing.id] !== undefined && {
+                  activeCards: activeCards[listing.id]
+                })}
                 onSelect={() => onSelect(listing)}
                 onAdd={() => onAdd(listing)}
                 {...(onInstall && { onInstall: () => onInstall(listing) })}
@@ -211,7 +247,7 @@ export function ConnectorDirectory({
 
       {visible.length === 0 && (
         <p className="text-sm text-gray-500 py-4">
-          {search || category || rung
+          {search || category || rung || kind
             ? 'No connectors match that.'
             : 'No connectors available. Check your connection and try again.'}
         </p>
@@ -246,6 +282,7 @@ export function ConnectorRow({
   listing,
   builtIns,
   progress,
+  activeCards,
   onSelect,
   onAdd,
   onInstall
@@ -254,6 +291,8 @@ export function ConnectorRow({
   builtIns: BuiltInConnector[]
   /** The install running for this connector, when one is. */
   progress?: ConnectorInstallProgress
+  /** Open cards this extension is active on, when it is installed. */
+  activeCards?: number
   onSelect: () => void
   onAdd: () => void
   onInstall?: () => void
@@ -290,6 +329,11 @@ export function ConnectorRow({
               {listing.name}
             </span>
             {/* Both are facts rather than states, so they are lettered, not coloured. */}
+            {listing.kind === 'extension' && (
+              <span className="shrink-0 text-[10px] text-gray-500 border border-white/[0.1] rounded-sm px-1.5 py-px">
+                {CONNECTOR_KIND.extension.badge}
+              </span>
+            )}
             {listing.authRung && (
               <span className="shrink-0 text-[10px] text-gray-500 border border-white/[0.1] rounded-sm px-1.5 py-px">
                 {AUTH_RUNG[listing.authRung].badge}
@@ -309,7 +353,9 @@ export function ConnectorRow({
               {listing.description}
             </span>
           )}
-          <span className="block text-[11px] text-gray-600 mt-1.5">{facts(listing, details)}</span>
+          <span className="block text-[11px] text-gray-600 mt-1.5">
+            {facts(listing, details, activeCards)}
+          </span>
 
           {status.percent !== null && (
             <span className="block h-px w-full max-w-[220px] bg-white/[0.08] mt-2 overflow-hidden">
@@ -357,6 +403,7 @@ export function ConnectorRow({
         {!listing.implicitlyConnected &&
           canAddConnection(state, {
             source: listing.source,
+            kind: listing.kind,
             hasLegacyLaunch: Boolean(listing.catalogItem?.packageName)
           }) && (
             <button
@@ -384,18 +431,31 @@ export function ConnectorRow({
  * carries three of it, and the only thing on this page that earns colour is a
  * connection that is failing.
  */
-function facts(listing: ConnectorListing, details: ReturnType<typeof listingDetails>): string {
+function facts(
+  listing: ConnectorListing,
+  details: ReturnType<typeof listingDetails>,
+  activeCards?: number
+): string {
   const parts = [listing.category]
 
-  const offers = [
-    details.triggers.length > 0 && count(details.triggers.length, 'trigger'),
-    details.actions.length > 0 && count(details.actions.length, 'action')
-  ].filter(Boolean) as string[]
+  // An extension adds to a card rather than firing a workflow, so it counts what it adds.
+  const offers =
+    listing.kind === 'extension'
+      ? [describeContributions(listing.contributes)].filter(Boolean)
+      : ([
+          details.triggers.length > 0 && count(details.triggers.length, 'trigger'),
+          details.actions.length > 0 && count(details.actions.length, 'action')
+        ].filter(Boolean) as string[])
   if (offers.length > 0) parts.push(offers.join(', '))
 
-  const version = listing.catalogItem?.version
+  const version = listing.catalogItem?.version ?? listing.pack?.version
   if (version) parts.push(`v${version}`)
-  if (listing.connectedCount > 0) parts.push('in use')
+  if (listing.kind === 'extension') {
+    // Only worth saying once it is installed; before that there are no cards to be on.
+    if (listing.pack && activeCards !== undefined) {
+      parts.push(activeCards > 0 ? `on ${count(activeCards, 'card')}` : 'on no open card')
+    }
+  } else if (listing.connectedCount > 0) parts.push('in use')
   // Nothing was connected, and nothing needs to be: it is usable as it stands.
   else if (listing.implicitlyConnected) parts.push('ready')
 

--- a/src/renderer/components/settings/ConnectorDirectory.tsx
+++ b/src/renderer/components/settings/ConnectorDirectory.tsx
@@ -22,7 +22,7 @@ import {
   type BuiltInConnector,
   type ConnectorListing
 } from '../../lib/connector-browse'
-import { describeContributions } from '../../lib/extension-copy'
+import { count, describeContributions } from '../../lib/extension-copy'
 import { canAddConnection, describePackStatus, packStateFor } from '../../lib/pack-status'
 import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
 
@@ -248,7 +248,7 @@ export function ConnectorDirectory({
       {visible.length === 0 && (
         <p className="text-sm text-gray-500 py-4">
           {search || category || rung || kind
-            ? 'No connectors match that.'
+            ? 'Nothing matches that.'
             : 'No connectors available. Check your connection and try again.'}
         </p>
       )}
@@ -461,8 +461,4 @@ function facts(
   else if (listing.implicitlyConnected) parts.push('ready')
 
   return parts.join(' · ')
-}
-
-function count(n: number, noun: string): string {
-  return `${n} ${noun}${n === 1 ? '' : 's'}`
 }

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -16,6 +16,7 @@ import { SdkConnectorForm } from './SdkConnectorForm'
 import { PackInstallConfirm } from './PackInstallConfirm'
 import { AddConnectionForm, MCP_CONNECTOR_ID, type ConnectorInfo } from './AddConnectionForm'
 import { refreshExtensions } from '../../lib/use-extensions'
+import { useClaimedTerminalIds } from '../../hooks/usePanelTerminals'
 
 export function ConnectorSettings() {
   const workflows = useAppStore((s) => s.config?.workflows ?? [])
@@ -136,19 +137,26 @@ export function ConnectorSettings() {
   // The map itself, which the store owns; counting inside the selector would
   // hand `useShallow` a fresh object every call and never settle.
   const activation = useAppStore((s) => s.extensionActivation)
+  // A shell inside a card's panel is a session of its own and deliberately not a
+  // card, so counting sessions would inflate both halves of the fraction.
+  const claimed = useClaimedTerminalIds()
   // One pass for the whole panel, with the honest denominator beside it: a card
   // this window never opened cannot be counted, and a total would overstate it.
-  const activeCards = useMemo(() => {
+  const { activeCards, openCards } = useMemo(() => {
     const counts: Record<string, number> = {}
-    for (const states of activation.values()) {
+    let open = 0
+    for (const [sessionId, states] of activation) {
+      if (claimed.has(sessionId)) continue
+      open += 1
       for (const state of states) {
-        if (!state.active) continue
-        counts[state.extensionId] = (counts[state.extensionId] ?? 0) + 1
+        // Seeded either way, so an extension on no card says so rather than going quiet.
+        counts[state.extensionId] ??= 0
+        const draws = state.panes.length + state.footers.length + state.linkHandlers.length > 0
+        if (state.active && draws) counts[state.extensionId] += 1
       }
     }
-    return counts
-  }, [activation])
-  const openCards = activation.size
+    return { activeCards: counts, openCards: open }
+  }, [activation, claimed])
   // Re-read from the current listings so a connection made while the panel is
   // open updates its "connected" count rather than showing the stale copy.
   const selectedListing = selected
@@ -279,8 +287,7 @@ export function ConnectorSettings() {
           })}
           activity={activity.state(selectedListing.id, ['rollback', 'remove'])}
           {...(selectedListing.kind === 'extension' && {
-            activeCards: activeCards[selectedListing.id] ?? 0,
-            openCards
+            cards: { active: activeCards[selectedListing.id] ?? 0, open: openCards }
           })}
           pending={pendingPack?.rowKey === selectedListing.key ? pendingSheet : null}
           onAdd={() => setAdding(selectedListing)}

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -8,6 +8,7 @@ import { refreshConnections } from '../../lib/use-connections'
 import { SDK_FILTER_KEYS } from '../../../shared/types'
 import { ConnectorDirectory } from './ConnectorDirectory'
 import { ConnectorDetail } from './ConnectorDetail'
+import { InstalledPlugins } from './InstalledPlugins'
 import { ConnectionGroups, type ConnectorStatus } from './ConnectionGroups'
 import { useRowAction } from '../../lib/use-row-action'
 import { waitForSync } from '../../lib/connection-sync'
@@ -17,6 +18,12 @@ import { PackInstallConfirm } from './PackInstallConfirm'
 import { AddConnectionForm, MCP_CONNECTOR_ID, type ConnectorInfo } from './AddConnectionForm'
 import { refreshExtensions } from '../../lib/use-extensions'
 import { useClaimedTerminalIds } from '../../hooks/usePanelTerminals'
+
+const TAB_LABEL = {
+  installed: 'Installed',
+  connections: 'Connections',
+  browse: 'Browse'
+} as const
 
 export function ConnectorSettings() {
   const workflows = useAppStore((s) => s.config?.workflows ?? [])
@@ -39,18 +46,18 @@ export function ConnectorSettings() {
   const { items: catalog, mcpServers, fetchedAt: catalogFetchedAt } = useConnectorCatalog()
   // What the detail view is describing.
   const [selected, setSelected] = useState<ConnectorListing | null>(null)
-  // Connections lead once there are any; with none there is nothing to lead
-  // with, so the catalog opens instead of a second empty-state layout.
-  const [view, setView] = useState<'connections' | 'browse'>('connections')
+  // What is installed leads: it is what a person came back for. With nothing on
+  // disk there is nothing to lead with, so the catalog opens instead.
+  const [view, setView] = useState<'installed' | 'connections' | 'browse'>('installed')
   const [packs, setPacks] = useState<InstalledConnectorPack[]>([])
   const activity = useRowAction()
   const [backfillResult, setBackfillResult] = useState<
     Record<string, { imported: number; updated: number; error?: string }>
   >({})
 
-  // Decided once, from the first load: switching away from an empty
-  // connections view mid-session because the last one was deleted would be the
-  // page moving under someone's hands.
+  // Decided once, from the first load: switching away from an empty view
+  // mid-session because the last pack was removed would be the page moving
+  // under someone's hands.
   const decidedView = useRef(false)
 
   const load = useCallback(async () => {
@@ -64,7 +71,7 @@ export function ConnectorSettings() {
     setConnections(conns)
     setStatuses(st)
     setPacks(installed)
-    if (!decidedView.current && conns.length === 0) setView('browse')
+    if (!decidedView.current && installed.length === 0) setView('browse')
     decidedView.current = true
   }, [])
 
@@ -209,12 +216,12 @@ export function ConnectorSettings() {
   return (
     <div>
       <SettingsPageHeader
-        title="Connections"
-        description="Vorn watches these and starts a workflow when something happens. Each connection seeds a visible, editable workflow that polls on cron. Extensions add footers and panes to a card instead."
+        title="Plugins"
+        description="Connectors watch a service and start workflows. Extensions add footers and panes to a card. Both install as packs from the same directory."
       />
 
       <div className="inline-flex bg-white/[0.04] rounded-sm p-0.5 mb-4">
-        {(['connections', 'browse'] as const).map((tab) => (
+        {(['installed', 'connections', 'browse'] as const).map((tab) => (
           <button
             key={tab}
             onClick={() => {
@@ -227,10 +234,27 @@ export function ConnectorSettings() {
               view === tab ? 'bg-white/[0.08] text-gray-200' : 'text-gray-500 hover:text-gray-300'
             }`}
           >
-            {tab === 'connections' ? 'Your connections' : 'Browse'}
+            {TAB_LABEL[tab]}
           </button>
         ))}
       </div>
+
+      {view === 'installed' && !adding && !selectedListing && (
+        <InstalledPlugins
+          listings={listings}
+          builtIns={connectors}
+          progress={installProgress}
+          activeCards={activeCards}
+          openCards={openCards}
+          activity={activity}
+          pending={pendingPack ? { sheet: pendingSheet, rowKey: pendingPack.rowKey } : undefined}
+          onSelect={setSelected}
+          onInstall={handleInstall}
+          onAdd={setAdding}
+          onRemove={(listing) => handleRemovePack(listing.id)}
+          onBrowse={() => setView('browse')}
+        />
+      )}
 
       {view === 'connections' && !adding && (
         <>
@@ -250,7 +274,7 @@ export function ConnectorSettings() {
             onOpenWorkflow={openWorkflowEditor}
             onRefresh={load}
           />
-          {connections.length === 0 && (
+          {connections.length === 0 && packs.length === 0 && (
             <p className="text-sm text-gray-500">
               No connections yet. Browse the connectors Vorn can talk to.
             </p>
@@ -278,9 +302,11 @@ export function ConnectorSettings() {
         />
       )}
 
-      {view === 'browse' && !adding && selectedListing && (
+      {/* Opened from whichever tab was showing, and closing goes back to it. */}
+      {view !== 'connections' && !adding && selectedListing && (
         <ConnectorDetail
           listing={selectedListing}
+          backLabel={view === 'installed' ? 'All plugins' : 'All connectors'}
           builtIns={connectors}
           {...(installProgress[selectedListing.id] && {
             progress: installProgress[selectedListing.id]

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -133,6 +133,22 @@ export function ConnectorSettings() {
     () => buildConnectorListings(connectors, catalog, connections, packs, mcpServers),
     [connectors, catalog, connections, packs, mcpServers]
   )
+  // The map itself, which the store owns; counting inside the selector would
+  // hand `useShallow` a fresh object every call and never settle.
+  const activation = useAppStore((s) => s.extensionActivation)
+  // One pass for the whole panel, with the honest denominator beside it: a card
+  // this window never opened cannot be counted, and a total would overstate it.
+  const activeCards = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const states of activation.values()) {
+      for (const state of states) {
+        if (!state.active) continue
+        counts[state.extensionId] = (counts[state.extensionId] ?? 0) + 1
+      }
+    }
+    return counts
+  }, [activation])
+  const openCards = activation.size
   // Re-read from the current listings so a connection made while the panel is
   // open updates its "connected" count rather than showing the stale copy.
   const selectedListing = selected
@@ -186,7 +202,7 @@ export function ConnectorSettings() {
     <div>
       <SettingsPageHeader
         title="Connections"
-        description="Vorn watches these and starts a workflow when something happens. Each connection seeds a visible, editable workflow that polls on cron."
+        description="Vorn watches these and starts a workflow when something happens. Each connection seeds a visible, editable workflow that polls on cron. Extensions add footers and panes to a card instead."
       />
 
       <div className="inline-flex bg-white/[0.04] rounded-sm p-0.5 mb-4">
@@ -243,6 +259,7 @@ export function ConnectorSettings() {
           onRefresh={async () => {
             await refreshConnectorCatalog()
           }}
+          activeCards={activeCards}
           onSelect={setSelected}
           onAdd={setAdding}
           onInstall={handleInstall}
@@ -261,6 +278,10 @@ export function ConnectorSettings() {
             progress: installProgress[selectedListing.id]
           })}
           activity={activity.state(selectedListing.id, ['rollback', 'remove'])}
+          {...(selectedListing.kind === 'extension' && {
+            activeCards: activeCards[selectedListing.id] ?? 0,
+            openCards
+          })}
           pending={pendingPack?.rowKey === selectedListing.key ? pendingSheet : null}
           onAdd={() => setAdding(selectedListing)}
           onUse={() => openWorkflowEditor(null)}

--- a/src/renderer/components/settings/InstalledPlugins.tsx
+++ b/src/renderer/components/settings/InstalledPlugins.tsx
@@ -1,0 +1,295 @@
+import { useMemo } from 'react'
+import { ChevronRight, Download, Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { ConnectorIcon } from '../ConnectorIcon'
+import type { ConnectorInstallProgress, ConnectorKind } from '../../../shared/types'
+import {
+  listingDetails,
+  CONNECTOR_KIND,
+  type BuiltInConnector,
+  type ConnectorListing
+} from '../../lib/connector-browse'
+import { count, describeContributions } from '../../lib/extension-copy'
+import { describePackStatus, packStateFor } from '../../lib/pack-status'
+import type { RowActivity } from '../../lib/use-row-action'
+import { TONE_DOT, TONE_TEXT } from '../../lib/status-tone'
+import { ActivityLine } from './ActivityLine'
+import { BusyIcon } from './BusyIcon'
+
+/**
+ * What is on this machine, before what could be.
+ *
+ * The catalog answers "what is there"; this answers "what did I install, and is
+ * it doing anything". They were one tab, and an extension fell through the gap:
+ * it makes no connection, so the connections list never showed it and the only
+ * way to find it was to browse the whole catalog for something already owned.
+ *
+ * Grouped by kind rather than category, because the question that brings a
+ * person here is which sort of thing they are looking for, and the two answer
+ * different questions — one watches a service, one draws on a card.
+ */
+export function InstalledPlugins({
+  listings,
+  builtIns,
+  progress,
+  activeCards,
+  openCards,
+  activity,
+  pending,
+  onSelect,
+  onInstall,
+  onAdd,
+  onRemove,
+  onBrowse
+}: {
+  listings: ConnectorListing[]
+  builtIns: BuiltInConnector[]
+  /** Installs running right now, by connector id. */
+  progress?: Record<string, ConnectorInstallProgress>
+  /** How many open cards each extension is active on, by extension id. */
+  activeCards?: Record<string, number>
+  /** Cards this window has open at all, the honest denominator. */
+  openCards?: number
+  activity: RowActivity
+  /** The confirm sheet for a pack being updated, and the row it opens under. */
+  pending?: { sheet: React.ReactNode; rowKey?: string }
+  onSelect: (listing: ConnectorListing) => void
+  onInstall?: (listing: ConnectorListing) => void
+  onAdd: (listing: ConnectorListing) => void
+  onRemove: (listing: ConnectorListing) => void
+  onBrowse: () => void
+}) {
+  // Only what has files: a catalog row is something to install, not something installed.
+  const installed = useMemo(() => listings.filter((listing) => listing.pack), [listings])
+  const groups = useMemo(() => {
+    const order: ConnectorKind[] = ['extension', 'connector']
+    return order
+      .map((kind) => ({ kind, listings: installed.filter((listing) => listing.kind === kind) }))
+      .filter((group) => group.listings.length > 0)
+  }, [installed])
+
+  if (installed.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 py-4">
+        Nothing is installed yet.{' '}
+        <button onClick={onBrowse} className="text-gray-300 hover:text-white underline">
+          Browse
+        </button>{' '}
+        for a connector or an extension.
+      </p>
+    )
+  }
+
+  return (
+    <div>
+      {groups.map((group) => (
+        <div key={group.kind}>
+          {/* Headings earn their keep once both kinds are here; one alone says nothing. */}
+          {groups.length > 1 && (
+            <h3 className="text-[10px] uppercase tracking-[0.08em] text-gray-600 pt-4 pb-1">
+              {CONNECTOR_KIND[group.kind].label}
+            </h3>
+          )}
+          {group.listings.map((listing) => (
+            <div key={listing.key}>
+              <InstalledRow
+                listing={listing}
+                builtIns={builtIns}
+                {...(progress?.[listing.id] && { progress: progress[listing.id] })}
+                {...(activeCards?.[listing.id] !== undefined && {
+                  activeCards: activeCards[listing.id]
+                })}
+                {...(openCards !== undefined && { openCards })}
+                activity={activity}
+                onSelect={() => onSelect(listing)}
+                {...(onInstall && { onInstall: () => onInstall(listing) })}
+                onAdd={() => onAdd(listing)}
+                onRemove={() => onRemove(listing)}
+              />
+              {listing.key === pending?.rowKey && <div className="mt-2 mb-3">{pending.sheet}</div>}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function InstalledRow({
+  listing,
+  builtIns,
+  progress,
+  activeCards,
+  openCards,
+  activity,
+  onSelect,
+  onInstall,
+  onAdd,
+  onRemove
+}: {
+  listing: ConnectorListing
+  builtIns: BuiltInConnector[]
+  progress?: ConnectorInstallProgress
+  activeCards?: number
+  openCards?: number
+  activity: RowActivity
+  onSelect: () => void
+  onInstall?: () => void
+  onAdd: () => void
+  onRemove: () => void
+}) {
+  const details = listingDetails(listing, builtIns)
+  const state = packStateFor({
+    installed: listing.pack,
+    catalogItem: listing.catalogItem,
+    progress
+  })
+  const status = describePackStatus(state)
+  const rowActivity = activity.state(listing.id, ['remove'])
+  const busy = Boolean(rowActivity.phrase)
+  const extension = listing.kind === 'extension'
+
+  return (
+    <div className="flex items-start gap-3 py-3 border-t border-white/[0.06]">
+      <button
+        onClick={onSelect}
+        className="flex items-start gap-3 flex-1 min-w-0 text-left group"
+        aria-label={`About ${listing.name}`}
+      >
+        <span className="w-8 h-8 shrink-0 flex items-center justify-center bg-white/[0.05] rounded-md mt-0.5">
+          <ConnectorIcon
+            connectorId={listing.id}
+            icon={listing.catalogItem?.icon ?? listing.icon}
+            size={17}
+            className="text-gray-200"
+          />
+        </span>
+        <span className="min-w-0">
+          <span className="flex items-center gap-1.5 min-w-0">
+            <span className="text-[13.5px] text-gray-200 font-medium group-hover:underline underline-offset-2 decoration-white/25 truncate">
+              {listing.name}
+            </span>
+            {extension && (
+              <span className="shrink-0 text-[10px] text-gray-500 border border-white/[0.1] rounded-sm px-1.5 py-px">
+                {CONNECTOR_KIND.extension.badge}
+              </span>
+            )}
+          </span>
+          <span className="block text-[12.5px] text-gray-500 leading-snug mt-0.5">
+            {offers(listing, details)}
+          </span>
+          <span className="block text-[11px] text-gray-600 mt-1.5">
+            {facts(listing, state, activeCards, openCards)}
+          </span>
+
+          {status.percent !== null && (
+            <span className="block h-px w-full max-w-[220px] bg-white/[0.08] mt-2 overflow-hidden">
+              <span
+                className="block h-px bg-ink transition-[width] duration-200"
+                style={{ width: `${status.percent}%` }}
+                role="progressbar"
+                aria-valuenow={status.percent}
+                aria-label={`Installing ${listing.name}`}
+              />
+            </span>
+          )}
+
+          {/* The one coloured line: an update waiting, or an install that was refused. */}
+          {status.tone !== 'settled' && status.detail && (
+            <span
+              className={`flex items-center gap-1.5 text-[11px] mt-1.5 ${TONE_TEXT[status.tone]}`}
+            >
+              <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${TONE_DOT[status.tone]}`} />
+              {status.detail}
+            </span>
+          )}
+
+          <ActivityLine {...rowActivity} className="text-[11px] mt-1.5" />
+
+          <span className="inline-flex items-center gap-0.5 text-[11px] text-gray-500 group-hover:text-gray-300 transition-colors mt-1.5">
+            Details <ChevronRight size={11} />
+          </span>
+        </span>
+      </button>
+
+      <div className="shrink-0 self-center flex items-center gap-1.5">
+        {onInstall && status.action && (
+          <button
+            onClick={onInstall}
+            disabled={status.busy}
+            title={
+              status.action === 'update' ? 'Install the newer version' : 'Try installing again'
+            }
+            className="text-[11.5px] text-gray-300 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
+          >
+            {status.action === 'install' ? <Download size={11} /> : <RefreshCw size={11} />}
+            {status.label}
+          </button>
+        )}
+        {/* An extension shows where its rule names; only a connector waits on a connection. */}
+        {!extension && !listing.implicitlyConnected && listing.connectedCount === 0 && (
+          <button
+            onClick={onAdd}
+            title="Connect this connector to an account"
+            className="text-[11.5px] text-gray-300 hover:text-white px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1"
+          >
+            <Plus size={11} /> Add connection
+          </button>
+        )}
+        <button
+          onClick={onRemove}
+          disabled={busy}
+          title="Delete the installed files"
+          className="text-[11.5px] text-gray-400 hover:text-gray-200 px-2.5 py-1 border border-white/[0.1] rounded-sm hover:bg-white/[0.06] transition-colors flex items-center gap-1 disabled:opacity-50"
+        >
+          <BusyIcon busy={busy} icon={Trash2} size={11} /> Uninstall
+        </button>
+      </div>
+    </div>
+  )
+}
+
+/** What the thing offers, in its own terms: surfaces for one, triggers and actions for the other. */
+function offers(listing: ConnectorListing, details: ReturnType<typeof listingDetails>): string {
+  if (listing.kind === 'extension') {
+    return describeContributions(listing.contributes) || 'Adds no surface yet'
+  }
+  const parts = [
+    details.triggers.length > 0 && count(details.triggers.length, 'trigger'),
+    details.actions.length > 0 && count(details.actions.length, 'action')
+  ].filter(Boolean) as string[]
+  return parts.length > 0 ? parts.join(', ') : 'Nothing declared yet'
+}
+
+/**
+ * The muted line: what is on disk, then what it is doing.
+ *
+ * An installed row leads with its own version rather than the catalog's, which
+ * is the number a person came to check. What it is doing differs by kind, and
+ * saying "no connection yet" or "on no open card" beats saying nothing — a row
+ * that goes quiet reads as broken.
+ */
+function facts(
+  listing: ConnectorListing,
+  state: ReturnType<typeof packStateFor>,
+  activeCards?: number,
+  openCards?: number
+): string {
+  const parts: string[] = []
+  if (listing.pack) parts.push(`v${listing.pack.version}`)
+  if (state.kind === 'installed' && state.availableVersion) {
+    parts.push(`v${state.availableVersion} available`)
+  }
+  if (listing.kind === 'extension') {
+    if (activeCards !== undefined) {
+      parts.push(
+        activeCards > 0
+          ? `on ${activeCards} of ${count(openCards ?? activeCards, 'open card')}`
+          : 'on no open card'
+      )
+    }
+  } else if (listing.connectedCount > 0) {
+    parts.push(count(listing.connectedCount, 'connection'))
+  } else if (listing.implicitlyConnected) parts.push('ready')
+  else parts.push('no connection yet')
+  return parts.join(' · ')
+}

--- a/src/renderer/components/settings/PackInstallConfirm.tsx
+++ b/src/renderer/components/settings/PackInstallConfirm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { borrowableFromManifest, type ConnectorPackSummary } from '../../../shared/types'
 import { ConnectorIcon } from '../ConnectorIcon'
+import { permissionRows } from '../../lib/extension-copy'
 
 /**
  * What a pack is and what it can do, before any of it is kept.
@@ -23,6 +24,12 @@ export function PackInstallConfirm({
   const replacing = preview.installedVersion && preview.installedVersion !== preview.version
   const required = (preview.env ?? []).filter((entry) => entry.required)
   const borrows = borrowableFromManifest(preview.auth, preview.env ?? [])
+  const contributes = preview.contributes
+  const adds = [
+    ...(contributes?.panes ?? []).map((pane) => `${pane.title} pane`),
+    ...(contributes?.footers ?? []).map((footer) => `${footer.title} footer`),
+    ...(contributes?.linkHandlers ?? []).map((handler) => `${handler.title} link`)
+  ]
   const root = useRef<HTMLDivElement>(null)
 
   // It opens beside the button that raised it, which can be below the fold.
@@ -74,6 +81,11 @@ export function PackInstallConfirm({
             )}
           />
         )}
+        {/* What an extension would add to a card, and what it would reach to do it. */}
+        <PackCapability label="Adds" items={adds} />
+        {permissionRows(preview.permissions).map((row) => (
+          <PackCapability key={row.label} label={row.label} items={row.items} />
+        ))}
       </dl>
 
       <div className="flex justify-end gap-2 mt-3">

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../shared/types'
 import { isImplicitConnection } from '../../shared/types'
 import { connectionConnectorId, connectionIcon } from './connection-icon'
+import { EXTENSION_PERMISSION } from './extension-copy'
 
 /**
  * One row in the connector list, whether it came from a built-in connector, a
@@ -162,7 +163,9 @@ export function listingDetails(
     // nothing rather than saying "no triggers", which would be a lie. An
     // extension states what it adds instead, and having said it is known.
     if (!entry?.triggers && !entry?.actions) {
-      return listing.contributes ? { ...EMPTY_DETAILS, known: true } : EMPTY_DETAILS
+      return listing.kind === 'extension' || listing.contributes
+        ? { ...EMPTY_DETAILS, known: true }
+        : EMPTY_DETAILS
     }
     return {
       triggers: entry.triggers ?? [],
@@ -245,12 +248,6 @@ export function buildConnectorListings(
     })),
     ...catalog.map((entry) => {
       const pack = packFor(entry.id)
-      // The installed files answer for themselves; the catalog only says what
-      // installing would ask for, which a newer pack on disk may have changed.
-      const rung = pack?.auth?.rung ?? entry.authRung
-      const contributes = pack?.contributes ?? entry.contributes
-      const permissions = pack?.permissions ?? entry.permissions
-      const activates = pack?.activates ?? entry.activates
       return {
         ...entry,
         key: `catalog:${entry.id}`,
@@ -261,11 +258,12 @@ export function buildConnectorListings(
         connectedCount: countFor(entry.id),
         implicitlyConnected: implicitFor(entry.id),
         catalogItem: entry,
-        ...(rung !== undefined && { authRung: rung }),
-        ...(entry.verified !== undefined && { verified: entry.verified }),
-        ...(contributes !== undefined && { contributes }),
-        ...(permissions !== undefined && { permissions }),
-        ...(activates !== undefined && { activates }),
+        // The entry above says what installing would bring; the files on disk
+        // answer for themselves, so each of these overrides it where it exists.
+        ...(pack?.auth?.rung !== undefined && { authRung: pack.auth.rung }),
+        ...(pack?.contributes !== undefined && { contributes: pack.contributes }),
+        ...(pack?.permissions !== undefined && { permissions: pack.permissions }),
+        ...(pack?.activates !== undefined && { activates: pack.activates }),
         ...(pack && { pack })
       }
     }),
@@ -426,7 +424,9 @@ export function filterConnectorListings(
         ...(contributes?.panes ?? []),
         ...(contributes?.footers ?? []),
         ...(contributes?.linkHandlers ?? [])
-      ].map((contribution) => contribution.title)
+      ].map((contribution) => contribution.title),
+      // And by what it reaches, in the words the page uses rather than the manifest's.
+      ...(listing.permissions ?? []).map((name) => EXTENSION_PERMISSION[name].phrase)
     ]
       .join(' ')
       .toLowerCase()
@@ -487,8 +487,9 @@ export function connectorAuthRungs(listings: ConnectorListing[]): ConnectorAuthR
 }
 
 /** What a kind is called where a person picks one. */
-export const CONNECTOR_KIND: Record<ConnectorKind, { label: string; badge: string }> = {
-  connector: { label: 'Connectors', badge: 'connector' },
+export const CONNECTOR_KIND: Record<ConnectorKind, { label: string; badge?: string }> = {
+  connector: { label: 'Connectors' },
+  // Only the extension wears a badge; a row without one is the ordinary case.
   extension: { label: 'Extensions', badge: 'extension' }
 }
 

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -3,7 +3,11 @@ import type {
   ConnectorCatalogActionInput,
   ConnectorCatalogItem,
   ConnectorCatalogVerification,
+  ConnectorKind,
   ConnectorPackSummary,
+  ExtensionActivation,
+  ExtensionContributions,
+  ExtensionPermission,
   InstalledConnectorPack,
   McpServerCatalogEntry,
   SdkConnectorIcon,
@@ -28,6 +32,8 @@ export interface ConnectorListing {
   description?: string
   capabilities: string[]
   category: string
+  /** Whether this polls a service or contributes to a card. A built-in is always a connector. */
+  kind: ConnectorKind
   /** `installed` is a pack the catalog does not carry; it brings its own manifest. */
   source: 'builtin' | 'catalog' | 'installed' | 'mcp'
   /** Set for an MCP server, which is a launch line rather than a package. */
@@ -47,6 +53,24 @@ export interface ConnectorListing {
   verified?: ConnectorCatalogVerification
   // Connected without anyone being asked to connect it — a connector that signs in with nothing is ready the moment it.
   implicitlyConnected?: boolean
+  /** What an extension adds to a card, what it may touch, and where it shows. */
+  contributes?: ExtensionContributions
+  permissions?: ExtensionPermission[]
+  activates?: ExtensionActivation
+}
+
+/**
+ * What a row is, deciding between the pack on disk and the catalog's claim.
+ *
+ * The installed files answer for themselves, the same precedence the sign-in
+ * rung already follows: a catalog published before a pack changed kind would
+ * otherwise describe something that is no longer what it says.
+ */
+export function kindOf(listing: {
+  pack?: InstalledConnectorPack
+  catalogItem?: { kind?: ConnectorKind }
+}): ConnectorKind {
+  return listing.pack?.kind ?? listing.catalogItem?.kind ?? 'connector'
 }
 
 // Whether a checked pack is the one the row already described, down to the version, the sign-in and the receipt.
@@ -135,8 +159,11 @@ export function listingDetails(
   if (listing.source === 'catalog') {
     const entry = listing.catalogItem
     // An entry from a catalog published before these fields existed says
-    // nothing rather than saying "no triggers", which would be a lie.
-    if (!entry?.triggers && !entry?.actions) return EMPTY_DETAILS
+    // nothing rather than saying "no triggers", which would be a lie. An
+    // extension states what it adds instead, and having said it is known.
+    if (!entry?.triggers && !entry?.actions) {
+      return listing.contributes ? { ...EMPTY_DETAILS, known: true } : EMPTY_DETAILS
+    }
     return {
       triggers: entry.triggers ?? [],
       actions: entry.actions ?? [],
@@ -210,6 +237,7 @@ export function buildConnectorListings(
       name: c.name,
       capabilities: c.capabilities,
       category: 'Built in',
+      kind: 'connector' as const,
       source: 'builtin' as const,
       keywords: [],
       connectedCount: countFor(c.id),
@@ -220,10 +248,14 @@ export function buildConnectorListings(
       // The installed files answer for themselves; the catalog only says what
       // installing would ask for, which a newer pack on disk may have changed.
       const rung = pack?.auth?.rung ?? entry.authRung
+      const contributes = pack?.contributes ?? entry.contributes
+      const permissions = pack?.permissions ?? entry.permissions
+      const activates = pack?.activates ?? entry.activates
       return {
         ...entry,
         key: `catalog:${entry.id}`,
         category: entry.category ?? UNCATEGORIZED,
+        kind: kindOf({ ...(pack && { pack }), catalogItem: entry }),
         source: 'catalog' as const,
         keywords: entry.keywords ?? [],
         connectedCount: countFor(entry.id),
@@ -231,6 +263,9 @@ export function buildConnectorListings(
         catalogItem: entry,
         ...(rung !== undefined && { authRung: rung }),
         ...(entry.verified !== undefined && { verified: entry.verified }),
+        ...(contributes !== undefined && { contributes }),
+        ...(permissions !== undefined && { permissions }),
+        ...(activates !== undefined && { activates }),
         ...(pack && { pack })
       }
     }),
@@ -250,12 +285,16 @@ export function buildConnectorListings(
         ...(pack.description !== undefined && { description: pack.description }),
         capabilities: packCapabilities(pack),
         category: 'Installed',
+        kind: kindOf({ pack }),
         source: 'installed' as const,
         keywords: [],
         connectedCount: countFor(pack.id),
         implicitlyConnected: implicitFor(pack.id),
         ...(pack.auth?.rung !== undefined && { authRung: pack.auth.rung }),
         ...(pack.icon !== undefined && { icon: pack.icon }),
+        ...(pack.contributes !== undefined && { contributes: pack.contributes }),
+        ...(pack.permissions !== undefined && { permissions: pack.permissions }),
+        ...(pack.activates !== undefined && { activates: pack.activates }),
         pack
       })),
     // A server Vorn starts and speaks MCP to. Its connections are `mcp` rows
@@ -267,6 +306,7 @@ export function buildConnectorListings(
       ...(server.description !== undefined && { description: server.description }),
       capabilities: ['actions'],
       category: server.category ?? 'MCP servers',
+      kind: 'connector' as const,
       source: 'mcp' as const,
       keywords: server.keywords ?? [],
       connectedCount: countFor(server.id),
@@ -374,12 +414,19 @@ export function filterConnectorListings(
   if (terms.length === 0) return listings
 
   return listings.filter((listing) => {
+    const contributes = listing.contributes
     const haystack = [
       listing.name,
       listing.description ?? '',
       listing.category,
       ...listing.capabilities,
-      ...listing.keywords
+      ...listing.keywords,
+      // An extension is worth finding by what it adds, the way a connector is by what it triggers on.
+      ...[
+        ...(contributes?.panes ?? []),
+        ...(contributes?.footers ?? []),
+        ...(contributes?.linkHandlers ?? [])
+      ].map((contribution) => contribution.title)
     ]
       .join(' ')
       .toLowerCase()
@@ -437,6 +484,27 @@ export const AUTH_RUNG: Record<
 export function connectorAuthRungs(listings: ConnectorListing[]): ConnectorAuthRung[] {
   const order: ConnectorAuthRung[] = ['none', 'cli', 'key', 'oauth']
   return order.filter((rung) => listings.some((listing) => listing.authRung === rung))
+}
+
+/** What a kind is called where a person picks one. */
+export const CONNECTOR_KIND: Record<ConnectorKind, { label: string; badge: string }> = {
+  connector: { label: 'Connectors', badge: 'connector' },
+  extension: { label: 'Extensions', badge: 'extension' }
+}
+
+/** The kinds actually present, so the filter never offers an empty answer. */
+export function connectorKinds(listings: ConnectorListing[]): ConnectorKind[] {
+  const order: ConnectorKind[] = ['connector', 'extension']
+  return order.filter((kind) => listings.some((listing) => listing.kind === kind))
+}
+
+/** Narrow to what polls a service, or to what shows on a card. */
+export function filterByKind(
+  listings: ConnectorListing[],
+  kind: ConnectorKind | undefined
+): ConnectorListing[] {
+  if (!kind) return listings
+  return listings.filter((listing) => listing.kind === kind)
 }
 
 /** Narrow to the connectors that sign in a particular way. */

--- a/src/renderer/lib/extension-copy.ts
+++ b/src/renderer/lib/extension-copy.ts
@@ -1,0 +1,161 @@
+import type {
+  ExtensionActivation,
+  ExtensionAgent,
+  ExtensionContributions,
+  ExtensionPermission,
+  ExtensionPlatform
+} from '../../shared/types'
+import { AGENT_DEFINITIONS } from './agent-definitions'
+
+/**
+ * An extension in the words a person reads before installing it.
+ *
+ * The manifest states a permission as `terminal.selection` and an activation as
+ * a glob, which is right for a pack and wrong for the page that asks whether to
+ * trust one. Everything that turns either into a sentence lives here, so the
+ * row, the detail page and the confirm sheet cannot describe the same extension
+ * three different ways.
+ */
+
+/** Which verb a permission answers to, and what it reaches. */
+export const EXTENSION_PERMISSION: Record<
+  ExtensionPermission,
+  { bucket: 'Reads' | 'Sends' | 'Renames'; phrase: string }
+> = {
+  'git.read': { bucket: 'Reads', phrase: "the worktree's diff and status" },
+  'terminal.read': { bucket: 'Reads', phrase: "the session's recent terminal output" },
+  'terminal.selection': { bucket: 'Reads', phrase: 'the text selected in the terminal' },
+  'agent.usage': { bucket: 'Reads', phrase: "the agent's context and provider allowance" },
+  'terminal.send': { bucket: 'Sends', phrase: "text into the session's terminal" },
+  'card.rename': { bucket: 'Renames', phrase: 'the session card' }
+}
+
+/**
+ * Every permission, in the order they are worth reading.
+ *
+ * Rows follow this rather than the manifest's order, so two extensions asking
+ * for the same things read identically and a reordered manifest cannot look
+ * like a changed request.
+ */
+const PERMISSION_ORDER: ExtensionPermission[] = [
+  'git.read',
+  'terminal.read',
+  'terminal.selection',
+  'agent.usage',
+  'terminal.send',
+  'card.rename'
+]
+
+const BUCKET_ORDER: Array<'Reads' | 'Sends' | 'Renames'> = ['Reads', 'Sends', 'Renames']
+
+/** What an extension asks for, grouped under the verb it answers to. */
+export function permissionRows(
+  permissions: ExtensionPermission[] | undefined
+): Array<{ label: 'Reads' | 'Sends' | 'Renames'; items: string[] }> {
+  const asked = new Set(permissions ?? [])
+  return BUCKET_ORDER.map((label) => ({
+    label,
+    items: PERMISSION_ORDER.filter(
+      (name) => asked.has(name) && EXTENSION_PERMISSION[name].bucket === label
+    ).map((name) => EXTENSION_PERMISSION[name].phrase)
+  })).filter((row) => row.items.length > 0)
+}
+
+/**
+ * What it did not ask for, from the same closed list.
+ *
+ * A grant reads as small only against what could have been asked, and this is
+ * the only honest way to say it: the complement of the set, not a reassuring
+ * sentence about things no extension can reach anyway.
+ */
+export function notAsked(permissions: ExtensionPermission[] | undefined): string[] {
+  const asked = new Set(permissions ?? [])
+  return PERMISSION_ORDER.filter((name) => !asked.has(name)).map(
+    (name) => EXTENSION_PERMISSION[name].phrase
+  )
+}
+
+const PLATFORM_LABEL: Record<ExtensionPlatform, string> = {
+  darwin: 'macOS',
+  linux: 'Linux',
+  win32: 'Windows'
+}
+
+// A shell is not one of the agents, so it is named here rather than in their table.
+function agentLabel(agent: ExtensionAgent): string {
+  if (agent === 'shell') return 'shell'
+  return AGENT_DEFINITIONS[agent]?.displayName ?? agent
+}
+
+/** Well-known hosts said as their names; anything else says the host itself. */
+const HOST_LABEL: Record<string, string> = {
+  'github.com': 'GitHub',
+  'gitlab.com': 'GitLab',
+  'bitbucket.org': 'Bitbucket'
+}
+
+/** "a, b or c" — any one of them is enough, which is what the predicate means. */
+function anyOf(values: string[]): string {
+  if (values.length <= 1) return values[0] ?? ''
+  return `${values.slice(0, -1).join(', ')} or ${values[values.length - 1]}`
+}
+
+/**
+ * Where an extension shows, as clauses rather than a predicate.
+ *
+ * Each declared field has to hold and each is satisfied by any one of its
+ * values, so every clause is an "or" inside and an "and" between. Nothing
+ * declared means it shows everywhere, which is worth saying rather than leaving
+ * the section empty.
+ */
+export function describeActivation(activates: ExtensionActivation | undefined): string[] {
+  const clauses: string[] = []
+  const contains = activates?.workspaceContains?.filter(Boolean) ?? []
+  if (contains.length > 0) clauses.push(`projects with ${anyOf(contains)}`)
+
+  const hosts = activates?.remoteHost?.filter(Boolean) ?? []
+  if (hosts.length > 0) {
+    const named = hosts.filter((host) => HOST_LABEL[host] !== undefined)
+    const rest = hosts.filter((host) => HOST_LABEL[host] === undefined)
+    if (named.length > 0) clauses.push(`${anyOf(named.map((host) => HOST_LABEL[host]))} remotes`)
+    if (rest.length > 0) clauses.push(`remotes on ${anyOf(rest)}`)
+  }
+
+  const agents = activates?.agent ?? []
+  if (agents.length > 0) clauses.push(`${anyOf(agents.map(agentLabel))} sessions`)
+
+  const platforms = activates?.platform ?? []
+  if (platforms.length > 0)
+    clauses.push(anyOf(platforms.map((name) => PLATFORM_LABEL[name] ?? name)))
+
+  return clauses.length > 0 ? clauses : ['every session']
+}
+
+/** "2 panes, 1 footer" — what it adds, counted the way the row counts triggers. */
+export function describeContributions(contributes: ExtensionContributions | undefined): string {
+  const parts = [
+    count(contributes?.panes?.length ?? 0, 'pane'),
+    count(contributes?.footers?.length ?? 0, 'footer'),
+    count(contributes?.linkHandlers?.length ?? 0, 'link handler')
+  ].filter((part): part is string => part !== null)
+  return parts.join(', ')
+}
+
+/** How a pane is drawn, or how often a footer runs: the one fact per kind worth a line. */
+export function describePaneKind(pane: { web?: string; command?: string[] }): string {
+  if (pane.command && pane.command.length > 0) return `runs ${pane.command.join(' ')}`
+  return 'a page it ships'
+}
+
+export function describeFooterInterval(seconds: number): string {
+  if (seconds % 60 === 0 && seconds >= 60) {
+    const minutes = seconds / 60
+    return `every ${minutes === 1 ? 'minute' : `${minutes} minutes`}`
+  }
+  return `every ${seconds}s`
+}
+
+function count(n: number, noun: string): string | null {
+  if (n === 0) return null
+  return `${n} ${noun}${n === 1 ? '' : 's'}`
+}

--- a/src/renderer/lib/extension-copy.ts
+++ b/src/renderer/lib/extension-copy.ts
@@ -113,13 +113,10 @@ export function describeActivation(activates: ExtensionActivation | undefined): 
   const contains = activates?.workspaceContains?.filter(Boolean) ?? []
   if (contains.length > 0) clauses.push(`projects with ${anyOf(contains)}`)
 
+  // One clause for the field, whatever it lists: two would read as both being required.
   const hosts = activates?.remoteHost?.filter(Boolean) ?? []
-  if (hosts.length > 0) {
-    const named = hosts.filter((host) => HOST_LABEL[host] !== undefined)
-    const rest = hosts.filter((host) => HOST_LABEL[host] === undefined)
-    if (named.length > 0) clauses.push(`${anyOf(named.map((host) => HOST_LABEL[host]))} remotes`)
-    if (rest.length > 0) clauses.push(`remotes on ${anyOf(rest)}`)
-  }
+  if (hosts.length > 0)
+    clauses.push(`${anyOf(hosts.map((host) => HOST_LABEL[host] ?? host))} remotes`)
 
   const agents = activates?.agent ?? []
   if (agents.length > 0) clauses.push(`${anyOf(agents.map(agentLabel))} sessions`)
@@ -134,17 +131,20 @@ export function describeActivation(activates: ExtensionActivation | undefined): 
 /** "2 panes, 1 footer" — what it adds, counted the way the row counts triggers. */
 export function describeContributions(contributes: ExtensionContributions | undefined): string {
   const parts = [
-    count(contributes?.panes?.length ?? 0, 'pane'),
-    count(contributes?.footers?.length ?? 0, 'footer'),
-    count(contributes?.linkHandlers?.length ?? 0, 'link handler')
-  ].filter((part): part is string => part !== null)
+    [contributes?.panes?.length ?? 0, 'pane'] as const,
+    [contributes?.footers?.length ?? 0, 'footer'] as const,
+    [contributes?.linkHandlers?.length ?? 0, 'link handler'] as const
+  ]
+    .filter(([n]) => n > 0)
+    .map(([n, noun]) => count(n, noun))
   return parts.join(', ')
 }
 
-/** How a pane is drawn, or how often a footer runs: the one fact per kind worth a line. */
+/** How a pane is drawn: a page it carries, a program it runs, or neither said yet. */
 export function describePaneKind(pane: { web?: string; command?: string[] }): string {
   if (pane.command && pane.command.length > 0) return `runs ${pane.command.join(' ')}`
-  return 'a page it ships'
+  if (pane.web) return 'a page it ships'
+  return 'a pane'
 }
 
 export function describeFooterInterval(seconds: number): string {
@@ -155,7 +155,7 @@ export function describeFooterInterval(seconds: number): string {
   return `every ${seconds}s`
 }
 
-function count(n: number, noun: string): string | null {
-  if (n === 0) return null
+/** "1 pane", "2 panes" — the plural rule said once, for every surface that counts something. */
+export function count(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? '' : 's'}`
 }

--- a/src/renderer/lib/pack-status.ts
+++ b/src/renderer/lib/pack-status.ts
@@ -1,4 +1,8 @@
-import type { ConnectorInstallProgress, InstalledConnectorPack } from '../../shared/types'
+import type {
+  ConnectorInstallProgress,
+  ConnectorKind,
+  InstalledConnectorPack
+} from '../../shared/types'
 import type { StatusTone } from './status-tone'
 
 /** A rejection is session state, not persisted: nothing was written to disk. */
@@ -188,8 +192,10 @@ export function describePackStatus(state: PackState): PackStatusView {
 /** Whether a connection can be added: an installed pack, a launch by name, or a catalog entry that has a pack. */
 export function canAddConnection(
   state: PackState,
-  route: { source: string; hasLegacyLaunch?: boolean }
+  route: { source: string; hasLegacyLaunch?: boolean; kind?: ConnectorKind }
 ): boolean {
+  // An extension shows on the cards its activation names; there is nothing to connect.
+  if (route.kind === 'extension') return false
   if (route.source === 'builtin') return true
   // An MCP server is a command, so there is nothing to install before connecting.
   if (route.source === 'mcp') return true

--- a/src/renderer/lib/template-requirements.ts
+++ b/src/renderer/lib/template-requirements.ts
@@ -116,7 +116,11 @@ export function requirementAction(
   const state = packStateFor({ installed: listing.pack, catalogItem: listing.catalogItem })
   // No release published a pack, so neither button would do anything.
   if (state.kind === 'not-released') return { kind: 'none' }
-  const route = { source: listing.source, hasLegacyLaunch: !!listing.catalogItem?.packageName }
+  const route = {
+    source: listing.source,
+    kind: listing.kind,
+    hasLegacyLaunch: !!listing.catalogItem?.packageName
+  }
   return canAddConnection(state, route)
     ? { kind: 'addConnection', listing }
     : { kind: 'install', listing }

--- a/tests/connection-groups-ui.test.tsx
+++ b/tests/connection-groups-ui.test.tsx
@@ -54,6 +54,45 @@ function setup(
   return { ...utils, onAdd }
 }
 
+describe('a connector on disk with nothing connected', () => {
+  it('is listed under its own heading with the way to connect it', () => {
+    const onAdd = vi.fn()
+    const pack = {
+      id: 'ado',
+      name: 'Azure DevOps',
+      version: '0.1.0',
+      kind: 'connector' as const,
+      path: '/packs/ado',
+      installedAt: 0,
+      bytes: 1,
+      triggers: [],
+      actions: [],
+      env: []
+    }
+    const { getByText } = render(
+      <ConnectionGroups
+        connections={[]}
+        listings={buildConnectorListings([], [ADO], [], [pack])}
+        manifests={{}}
+        statuses={[]}
+        workflows={[]}
+        activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
+        backfillResult={{}}
+        onAdd={onAdd}
+        onRun={vi.fn()}
+        onBackfill={vi.fn()}
+        onDelete={vi.fn()}
+        onResetWorkflow={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    )
+    expect(getByText('Installed, no connection yet')).toBeInTheDocument()
+    fireEvent.click(getByText('Add connection'))
+    expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({ id: 'ado' }))
+  })
+})
+
 describe('connections grouped by connector', () => {
   it('puts two connections under one heading with the count beside them', () => {
     // Not on a catalog card trying to sell a third — beside the things it

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -601,12 +601,41 @@ describe('what a listing is', () => {
     expect(filterConnectorListings(listings, 'checks').map((l) => l.id)).toEqual(['review'])
   })
 
+  // An extension is worth finding by what it reaches, said the way the page says it.
+  it('finds an extension by what it asks to read', () => {
+    const listings = buildConnectorListings(
+      [],
+      [
+        catalogItem('review', 'Review', {
+          kind: 'extension',
+          contributes: REVIEW,
+          permissions: ['terminal.read']
+        })
+      ],
+      []
+    )
+    expect(filterConnectorListings(listings, 'terminal output').map((l) => l.id)).toEqual([
+      'review'
+    ])
+  })
+
   // Saying "no triggers" about a thing that never has any would be a lie; it
   // says what it adds instead, and having said it, it is described.
   it('counts an extension that states its contributions as described', () => {
     const [listing] = buildConnectorListings(
       [],
       [catalogItem('review', 'Review', { kind: 'extension', contributes: REVIEW })],
+      []
+    )
+    expect(listingDetails(listing).known).toBe(true)
+  })
+
+  // Its kind is the answer; a catalog that has not listed its panes yet still
+  // describes something, and the connector's "Add it to see" is unreachable here.
+  it('counts an extension that lists nothing as described', () => {
+    const [listing] = buildConnectorListings(
+      [],
+      [catalogItem('review', 'Review', { kind: 'extension' })],
       []
     )
     expect(listingDetails(listing).known).toBe(true)

--- a/tests/connector-browse.test.ts
+++ b/tests/connector-browse.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { isImplicitConnection } from '../packages/shared/src/types'
 import {
   buildConnectorListings,
+  connectorKinds,
+  filterByKind,
   filterConnectorListings,
+  kindOf,
   groupConnections,
   connectorCategories,
   describeCatalogAge,
@@ -492,6 +495,121 @@ describe('a connection nobody asked for', () => {
     const groups = groupConnections([implicit, chosen], [])
     expect(groups).toHaveLength(1)
     expect(groups[0].connections.map((c) => c.id)).toEqual(['mine'])
+  })
+})
+
+describe('what a listing is', () => {
+  const REVIEW = {
+    panes: [{ id: 'report', title: 'Report' }],
+    footers: [{ id: 'checks', title: 'Checks', every: 30 }]
+  }
+
+  it('reads a catalog entry as what the catalog says it is', () => {
+    const [listing] = buildConnectorListings(
+      [],
+      [catalogItem('review', 'Review', { kind: 'extension', contributes: REVIEW })],
+      []
+    )
+    expect(listing.kind).toBe('extension')
+    expect(listing.contributes).toEqual(REVIEW)
+  })
+
+  it('reads a side-loaded pack as what its own manifest says', () => {
+    const installed = {
+      id: 'review',
+      name: 'Review',
+      version: '0.1.0',
+      kind: 'extension' as const,
+      path: '/packs/review',
+      installedAt: 0,
+      bytes: 1,
+      triggers: [],
+      actions: [],
+      env: [],
+      contributes: REVIEW,
+      permissions: ['git.read' as const]
+    }
+    const [listing] = buildConnectorListings([], [], [], [installed])
+    expect(listing.kind).toBe('extension')
+    expect(listing.permissions).toEqual(['git.read'])
+  })
+
+  // The files on disk are what runs, so a catalog published before a pack
+  // changed kind cannot keep describing something it no longer is.
+  it('lets the pack on disk answer over the catalog', () => {
+    const installed = {
+      id: 'review',
+      name: 'Review',
+      version: '0.2.0',
+      kind: 'extension' as const,
+      path: '/packs/review',
+      installedAt: 0,
+      bytes: 1,
+      triggers: [],
+      actions: [],
+      env: [],
+      contributes: REVIEW
+    }
+    const [listing] = buildConnectorListings(
+      [],
+      [catalogItem('review', 'Review', { kind: 'connector' })],
+      [],
+      [installed]
+    )
+    expect(listing.kind).toBe('extension')
+    expect(kindOf(listing)).toBe('extension')
+  })
+
+  it('reads anything that says nothing as a connector', () => {
+    const listings = buildConnectorListings(
+      [builtIn('github', 'GitHub')],
+      [catalogItem('kusto', 'Azure Data Explorer')],
+      [],
+      [],
+      [{ id: 'playwright', name: 'Playwright', command: 'npx', args: [] }]
+    )
+    expect(listings.every((listing) => listing.kind === 'connector')).toBe(true)
+  })
+
+  it('offers only the kinds it actually has', () => {
+    const connectorsOnly = buildConnectorListings([], [catalogItem('kusto', 'Kusto')], [])
+    expect(connectorKinds(connectorsOnly)).toEqual(['connector'])
+
+    const both = buildConnectorListings(
+      [],
+      [catalogItem('kusto', 'Kusto'), catalogItem('review', 'Review', { kind: 'extension' })],
+      []
+    )
+    expect(connectorKinds(both)).toEqual(['connector', 'extension'])
+    expect(filterByKind(both, 'extension').map((l) => l.id)).toEqual(['review'])
+    expect(filterByKind(both, undefined)).toHaveLength(2)
+  })
+
+  // An extension is worth finding by what it adds, the way a connector is by what it triggers on.
+  it('finds an extension by the name of a pane it adds', () => {
+    const listings = buildConnectorListings(
+      [],
+      [
+        catalogItem('review', 'Review', {
+          kind: 'extension',
+          description: 'Beside the terminal',
+          contributes: REVIEW
+        })
+      ],
+      []
+    )
+    expect(filterConnectorListings(listings, 'checks').map((l) => l.id)).toEqual(['review'])
+  })
+
+  // Saying "no triggers" about a thing that never has any would be a lie; it
+  // says what it adds instead, and having said it, it is described.
+  it('counts an extension that states its contributions as described', () => {
+    const [listing] = buildConnectorListings(
+      [],
+      [catalogItem('review', 'Review', { kind: 'extension', contributes: REVIEW })],
+      []
+    )
+    expect(listingDetails(listing).known).toBe(true)
   })
 })
 

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -212,7 +212,7 @@ describe('the connector list', () => {
   it('says nothing matched rather than looking empty and broken', () => {
     const { getByPlaceholderText, getByText } = setup()
     fireEvent.change(getByPlaceholderText('Search connectors'), { target: { value: 'zzz' } })
-    expect(getByText('No connectors match that.')).toBeInTheDocument()
+    expect(getByText('Nothing matches that.')).toBeInTheDocument()
   })
 
   it('says how current the list is, and offers to check again', async () => {
@@ -651,6 +651,27 @@ describe("an extension's page", () => {
     expect(getByText(/Not asked:/)).toHaveTextContent('the text selected in the terminal')
   })
 
+  // An entry that asks for nothing is a promise; one that has not said is not.
+  it('says a grant is empty only where emptiness was stated', () => {
+    const stated = buildConnectorListings([], [{ ...REVIEW, permissions: [] }], [], [])[0]
+    const { getByText } = render(
+      <ConnectorDetail listing={stated} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(getByText('Nothing. It draws what it is given.')).toBeInTheDocument()
+    expect(getByText(/Not asked:/)).toHaveTextContent("the worktree's diff and status")
+  })
+
+  it('says the catalog has not answered rather than answering for it', () => {
+    const { permissions: _permissions, ...silent } = REVIEW
+    const listings = buildConnectorListings([], [silent as ConnectorCatalogItem], [], [])
+    const { getByText, queryByText } = render(
+      <ConnectorDetail listing={listings[0]} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(getByText('The catalog does not say what it asks for yet.')).toBeInTheDocument()
+    expect(queryByText(/Not asked:/)).not.toBeInTheDocument()
+    expect(queryByText('Nothing. It draws what it is given.')).not.toBeInTheDocument()
+  })
+
   it('says it signs in with nothing rather than leaving it unanswered', () => {
     const { getByText } = render(
       <ConnectorDetail listing={listing()} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
@@ -663,8 +684,7 @@ describe("an extension's page", () => {
       <ConnectorDetail
         listing={listing(true)}
         builtIns={[]}
-        activeCards={1}
-        openCards={3}
+        cards={{ active: 1, open: 3 }}
         onAdd={vi.fn()}
         onClose={vi.fn()}
       />

--- a/tests/connector-directory-ui.test.tsx
+++ b/tests/connector-directory-ui.test.tsx
@@ -63,6 +63,44 @@ const UNRELEASED: ConnectorCatalogItem = {
   packUrl: undefined
 }
 
+/** An extension: it adds to a card rather than firing a workflow. */
+const REVIEW: ConnectorCatalogItem = {
+  id: 'review',
+  name: 'Review',
+  description: 'Read the diff beside the terminal.',
+  kind: 'extension',
+  packageName: '@vornrun/extension-review',
+  version: '0.1.0',
+  packUrl: 'https://packs.test/review-0.1.0.vorn.tgz',
+  capabilities: [],
+  category: 'Development',
+  keywords: [],
+  launch: { command: 'node', args: ['/packs/review/index.js'] },
+  contributes: {
+    panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+    footers: [{ id: 'checks', title: 'Checks', every: 30 }]
+  },
+  permissions: ['git.read', 'terminal.send'],
+  activates: { workspaceContains: ['package.json'] }
+}
+
+/** The same extension, once its files are on disk. */
+const REVIEW_PACK = {
+  id: 'review',
+  name: 'Review',
+  version: '0.1.0',
+  kind: 'extension' as const,
+  path: '/packs/review',
+  installedAt: 0,
+  bytes: 1,
+  triggers: [],
+  actions: [],
+  env: [],
+  contributes: REVIEW.contributes,
+  permissions: REVIEW.permissions,
+  activates: REVIEW.activates
+}
+
 const listings = (): ConnectorListing[] => buildConnectorListings([], [ADO, KUSTO], [])
 
 const find = (id: string) => listings().find((listing) => listing.id === id)!
@@ -518,5 +556,151 @@ describe('a connector that signs in with nothing', () => {
     expect(queryByText('Add another')).not.toBeInTheDocument()
     expect(getByText('no sign-in')).toBeInTheDocument()
     expect(getByText(/ready/)).toBeInTheDocument()
+  })
+})
+
+describe('an extension in the directory', () => {
+  const shown = () => buildConnectorListings([], [REVIEW], [])
+
+  it('marks it as an extension and counts what it adds', () => {
+    const { getByText } = render(
+      <ConnectorDirectory listings={shown()} builtIns={[]} onSelect={vi.fn()} onAdd={vi.fn()} />
+    )
+    expect(getByText('extension')).toBeInTheDocument()
+    expect(getByText('Development · 1 pane, 1 footer · v0.1.0')).toBeInTheDocument()
+  })
+
+  // Its Add button led to a form asking for a connection nothing consumes.
+  it('offers installing it and nothing to connect', () => {
+    const { getByText, queryByText } = render(
+      <ConnectorDirectory
+        listings={shown()}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+        onInstall={vi.fn()}
+      />
+    )
+    expect(getByText('Install')).toBeInTheDocument()
+    expect(queryByText('Add')).not.toBeInTheDocument()
+  })
+
+  it('says which cards it is on once it is installed', () => {
+    const { getByText } = render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [REVIEW], [], [REVIEW_PACK])}
+        builtIns={[]}
+        activeCards={{ review: 2 }}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+      />
+    )
+    expect(getByText(/on 2 cards/)).toBeInTheDocument()
+  })
+
+  it('offers no kind filter when everything listed is the same kind', () => {
+    const { queryByLabelText } = render(
+      <ConnectorDirectory listings={shown()} builtIns={[]} onSelect={vi.fn()} onAdd={vi.fn()} />
+    )
+    expect(queryByLabelText('Filter by kind')).not.toBeInTheDocument()
+  })
+
+  it('narrows to one kind when both are listed', () => {
+    const { getByLabelText, getByText, queryByText } = render(
+      <ConnectorDirectory
+        listings={buildConnectorListings([], [ADO, REVIEW], [])}
+        builtIns={[]}
+        onSelect={vi.fn()}
+        onAdd={vi.fn()}
+      />
+    )
+    expect(getByText('Azure DevOps')).toBeInTheDocument()
+    fireEvent.change(getByLabelText('Filter by kind'), { target: { value: 'extension' } })
+    expect(getByText('Review')).toBeInTheDocument()
+    expect(queryByText('Azure DevOps')).not.toBeInTheDocument()
+  })
+})
+
+describe("an extension's page", () => {
+  const listing = (installed = false) =>
+    buildConnectorListings([], [REVIEW], [], installed ? [REVIEW_PACK] : [])[0]
+
+  it('says what it adds, what it asks for, and where it shows', () => {
+    const { getByText } = render(
+      <ConnectorDetail listing={listing()} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+
+    expect(getByText('Contributes')).toBeInTheDocument()
+    expect(getByText('Report · pane')).toBeInTheDocument()
+    expect(getByText('Checks · footer')).toBeInTheDocument()
+    expect(getByText('every 30s')).toBeInTheDocument()
+
+    expect(getByText('Asks to')).toBeInTheDocument()
+    expect(getByText(/the worktree's diff and status/)).toBeInTheDocument()
+    expect(getByText(/text into the session's terminal/)).toBeInTheDocument()
+
+    expect(getByText('Shows when')).toBeInTheDocument()
+    expect(getByText('projects with package.json')).toBeInTheDocument()
+  })
+
+  // A grant reads as small only against the list it was drawn from.
+  it('names what it did not ask for', () => {
+    const { getByText } = render(
+      <ConnectorDetail listing={listing()} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(getByText(/Not asked:/)).toHaveTextContent('the text selected in the terminal')
+  })
+
+  it('says it signs in with nothing rather than leaving it unanswered', () => {
+    const { getByText } = render(
+      <ConnectorDetail listing={listing()} builtIns={[]} onAdd={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(getByText('Nothing. It only reads what the session already has.')).toBeInTheDocument()
+  })
+
+  it('counts the cards it is on against the cards this window has', () => {
+    const { getByText } = render(
+      <ConnectorDetail
+        listing={listing(true)}
+        builtIns={[]}
+        activeCards={1}
+        openCards={3}
+        onAdd={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(getByText('on 1 of 3 open cards')).toBeInTheDocument()
+  })
+
+  it('offers uninstalling it, and nothing to connect', () => {
+    const onRemove = vi.fn()
+    const { getByText, queryByText } = render(
+      <ConnectorDetail
+        listing={listing(true)}
+        builtIns={[]}
+        onAdd={vi.fn()}
+        onRemove={onRemove}
+        onClose={vi.fn()}
+      />
+    )
+    expect(queryByText('Add a connection')).not.toBeInTheDocument()
+    fireEvent.click(getByText('Uninstall'))
+    expect(onRemove).toHaveBeenCalled()
+  })
+
+  it('leaves uninstall alone while one of its own actions is running', () => {
+    const onRemove = vi.fn()
+    const { getByText } = render(
+      <ConnectorDetail
+        listing={listing(true)}
+        builtIns={[]}
+        activity={{ phrase: 'Removing…' }}
+        onAdd={vi.fn()}
+        onRemove={onRemove}
+        onClose={vi.fn()}
+      />
+    )
+    fireEvent.click(getByText('Uninstall'))
+    expect(onRemove).not.toHaveBeenCalled()
   })
 })

--- a/tests/connector-extension-cards.test.tsx
+++ b/tests/connector-extension-cards.test.tsx
@@ -96,7 +96,7 @@ describe('the cards an extension is on', () => {
       ['card-2', [drawing()]]
     ])
     render(<ConnectorSettings />)
-    expect(await screen.findByText(/on 2 cards/)).toBeInTheDocument()
+    expect(await screen.findByText(/on 2 of 2 open cards/)).toBeInTheDocument()
   })
 
   // The shell in a card's panel is drawn inside that card, so counting it would
@@ -108,7 +108,7 @@ describe('the cards an extension is on', () => {
     ])
     state.terminalsPanes = new Map([['card-1', { terminals: ['shell-1'], activeTab: 0 }]])
     render(<ConnectorSettings />)
-    expect(await screen.findByText(/on 1 card/)).toBeInTheDocument()
+    expect(await screen.findByText(/on 1 of 1 open card/)).toBeInTheDocument()
   })
 
   // Installed and drawing nowhere is a fact worth saying; silence reads as unknown.

--- a/tests/connector-extension-cards.test.tsx
+++ b/tests/connector-extension-cards.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type {
+  ConnectorCatalogItem,
+  ExtensionActivationState,
+  InstalledConnectorPack
+} from '../src/shared/types'
+
+/**
+ * How many cards an extension is actually on.
+ *
+ * The count is the one number on this page a person could check by looking, so
+ * it has to mean what it says: cards, not sessions, and only the ones this
+ * window opened. A shell inside a card's panel is a session of its own and
+ * deliberately not a card, which is the way the fraction used to overstate both
+ * of its halves.
+ */
+
+const state = {
+  config: { workflows: [], projects: [] },
+  extensionActivation: new Map<string, ExtensionActivationState[]>(),
+  terminalsPanes: new Map<string, { terminals: string[]; activeTab: number }>()
+}
+
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: Object.assign((selector: (s: typeof state) => unknown) => selector(state), {
+    getState: () => state
+  })
+}))
+
+const { ConnectorSettings } = await import('../src/renderer/components/settings/ConnectorSettings')
+
+const REVIEW: ConnectorCatalogItem = {
+  id: 'review',
+  name: 'Review',
+  description: 'Read the diff beside the terminal.',
+  kind: 'extension',
+  packageName: '@vornrun/extension-review',
+  version: '0.1.0',
+  packUrl: 'https://packs.test/review-0.1.0.vorn.tgz',
+  capabilities: [],
+  category: 'Development',
+  keywords: [],
+  launch: { command: 'node', args: ['/packs/review/index.js'] },
+  contributes: { footers: [{ id: 'checks', title: 'Checks', every: 30 }] },
+  permissions: ['terminal.read']
+}
+
+const PACK = {
+  id: 'review',
+  name: 'Review',
+  version: '0.1.0',
+  kind: 'extension' as const,
+  path: '/packs/review',
+  installedAt: 0,
+  bytes: 1,
+  triggers: [],
+  actions: [],
+  env: [],
+  contributes: REVIEW.contributes,
+  permissions: REVIEW.permissions
+} as unknown as InstalledConnectorPack
+
+/** What the host says about one session: active, and drawing something. */
+function drawing(active = true): ExtensionActivationState {
+  return {
+    extensionId: 'review',
+    extensionName: 'Review',
+    active,
+    panes: [],
+    footers: active ? ['checks'] : [],
+    linkHandlers: []
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  state.extensionActivation = new Map()
+  state.terminalsPanes = new Map()
+  ;(window as unknown as { api: unknown }).api = {
+    listConnectors: vi.fn().mockResolvedValue([]),
+    listConnections: vi.fn().mockResolvedValue([]),
+    getConnectorStatus: vi.fn().mockResolvedValue([]),
+    listConnectorCatalog: vi.fn().mockResolvedValue({ items: [REVIEW], fetchedAt: Date.now() }),
+    listConnectorPacks: vi.fn().mockResolvedValue([PACK]),
+    onConnectorInstallProgress: vi.fn().mockReturnValue(() => {})
+  }
+})
+
+describe('the cards an extension is on', () => {
+  it('counts one card per session it draws on', async () => {
+    state.extensionActivation = new Map([
+      ['card-1', [drawing()]],
+      ['card-2', [drawing()]]
+    ])
+    render(<ConnectorSettings />)
+    expect(await screen.findByText(/on 2 cards/)).toBeInTheDocument()
+  })
+
+  // The shell in a card's panel is drawn inside that card, so counting it would
+  // report two cards where a person sees one.
+  it('leaves out a shell claimed by a card panel', async () => {
+    state.extensionActivation = new Map([
+      ['card-1', [drawing()]],
+      ['shell-1', [drawing()]]
+    ])
+    state.terminalsPanes = new Map([['card-1', { terminals: ['shell-1'], activeTab: 0 }]])
+    render(<ConnectorSettings />)
+    expect(await screen.findByText(/on 1 card/)).toBeInTheDocument()
+  })
+
+  // Installed and drawing nowhere is a fact worth saying; silence reads as unknown.
+  it('says so when it is installed and on no card', async () => {
+    state.extensionActivation = new Map([['card-1', [drawing(false)]]])
+    render(<ConnectorSettings />)
+    expect(await screen.findByText(/on no open card/)).toBeInTheDocument()
+  })
+
+  // Active with nothing listed draws nothing, whatever the flag says.
+  it('does not count a card it draws nothing on', async () => {
+    const silent: ExtensionActivationState = { ...drawing(), footers: [] }
+    state.extensionActivation = new Map([['card-1', [silent]]])
+    render(<ConnectorSettings />)
+    await waitFor(() => expect(screen.getByText(/on no open card/)).toBeInTheDocument())
+  })
+})

--- a/tests/connector-install-flow.test.tsx
+++ b/tests/connector-install-flow.test.tsx
@@ -7,7 +7,7 @@ import type { ConnectorCatalogItem, ConnectorPackSummary } from '../src/shared/t
 vi.mock('../src/renderer/stores', () => ({
   useAppStore: Object.assign(
     (selector: (state: unknown) => unknown) =>
-      selector({ config: { workflows: [], projects: [] } }),
+      selector({ config: { workflows: [], projects: [] }, extensionActivation: new Map() }),
     { getState: () => ({}) }
   )
 }))

--- a/tests/connector-install-flow.test.tsx
+++ b/tests/connector-install-flow.test.tsx
@@ -122,3 +122,31 @@ describe('installing from a catalog row', () => {
     await waitFor(() => expect(screen.queryByText(/the server went away/)).toBeNull())
   })
 })
+
+describe('which tab leads', () => {
+  it('opens on the catalog when nothing is installed', async () => {
+    render(<ConnectorSettings />)
+    await screen.findByRole('button', { name: /^Install$/ })
+    expect(screen.getByRole('button', { name: 'Browse' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'Installed' })).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
+  })
+
+  it('opens on what is installed once a pack is on disk', async () => {
+    ;(window as unknown as { api: { listConnectorPacks: unknown } }).api.listConnectorPacks = vi
+      .fn()
+      .mockResolvedValue([
+        { ...PREVIEW, path: '/packs/acme', installedAt: 0, bytes: 1, kind: 'connector' }
+      ])
+    render(<ConnectorSettings />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Installed' })).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      )
+    )
+    expect(screen.getByRole('heading', { name: 'Plugins' })).toBeInTheDocument()
+  })
+})

--- a/tests/connector-install-flow.test.tsx
+++ b/tests/connector-install-flow.test.tsx
@@ -7,7 +7,11 @@ import type { ConnectorCatalogItem, ConnectorPackSummary } from '../src/shared/t
 vi.mock('../src/renderer/stores', () => ({
   useAppStore: Object.assign(
     (selector: (state: unknown) => unknown) =>
-      selector({ config: { workflows: [], projects: [] }, extensionActivation: new Map() }),
+      selector({
+        config: { workflows: [], projects: [] },
+        extensionActivation: new Map(),
+        terminalsPanes: new Map()
+      }),
     { getState: () => ({}) }
   )
 }))

--- a/tests/connector-pack-confirm.test.tsx
+++ b/tests/connector-pack-confirm.test.tsx
@@ -157,3 +157,56 @@ describe('the sheet shown before a pack is kept', () => {
     expect(queryByText('Needs')).not.toBeInTheDocument()
   })
 })
+
+describe('the sheet shown before an extension is kept', () => {
+  const EXTENSION: ConnectorPackSummary = {
+    id: 'review',
+    name: 'Review',
+    version: '0.1.0',
+    kind: 'extension',
+    token: 'staged-review',
+    triggers: [],
+    actions: [],
+    env: [],
+    contributes: {
+      panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+      footers: [{ id: 'checks', title: 'Checks', every: 30 }]
+    },
+    permissions: ['git.read', 'terminal.send', 'card.rename']
+  }
+
+  it('says what it would add to a card', () => {
+    render(<PackInstallConfirm preview={EXTENSION} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('Adds')).toBeInTheDocument()
+    expect(screen.getByText('Report pane, Checks footer')).toBeInTheDocument()
+  })
+
+  // What it may touch is the question this sheet exists to answer.
+  it('says what it would reach, under the verb it answers to', () => {
+    render(<PackInstallConfirm preview={EXTENSION} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('Reads')).toBeInTheDocument()
+    expect(screen.getByText("the worktree's diff and status")).toBeInTheDocument()
+    expect(screen.getByText('Sends')).toBeInTheDocument()
+    expect(screen.getByText("text into the session's terminal")).toBeInTheDocument()
+    expect(screen.getByText('Renames')).toBeInTheDocument()
+    expect(screen.getByText('the session card')).toBeInTheDocument()
+  })
+
+  it('stays silent about a verb it asks nothing of', () => {
+    render(
+      <PackInstallConfirm
+        preview={{ ...EXTENSION, permissions: ['git.read'] }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.queryByText('Sends')).not.toBeInTheDocument()
+    expect(screen.queryByText('Renames')).not.toBeInTheDocument()
+  })
+
+  it('shows no Adds row for a connector, which adds nothing to a card', () => {
+    render(<PackInstallConfirm preview={PREVIEW} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.queryByText('Adds')).not.toBeInTheDocument()
+    expect(screen.queryByText('Reads')).not.toBeInTheDocument()
+  })
+})

--- a/tests/extension-copy.test.ts
+++ b/tests/extension-copy.test.ts
@@ -84,11 +84,15 @@ describe('where an extension shows', () => {
   it('names a host it knows and says the rest as they are', () => {
     expect(describeActivation({ remoteHost: ['github.com'] })).toEqual(['GitHub remotes'])
     expect(describeActivation({ remoteHost: ['git.example.com'] })).toEqual([
-      'remotes on git.example.com'
+      'git.example.com remotes'
     ])
+  })
+
+  // Any one of a field's values is enough, so two of them are one clause. Two
+  // clauses would read as both being required, which is the opposite.
+  it('reads a list within one field as any of them', () => {
     expect(describeActivation({ remoteHost: ['github.com', 'git.example.com'] })).toEqual([
-      'GitHub remotes',
-      'remotes on git.example.com'
+      'GitHub or git.example.com remotes'
     ])
   })
 
@@ -130,6 +134,11 @@ describe('what an extension adds', () => {
   it('says how a pane is drawn', () => {
     expect(describePaneKind({ web: 'web/report/index.html' })).toBe('a page it ships')
     expect(describePaneKind({ command: ['top'] })).toBe('runs top')
+  })
+
+  // Claiming a page for a pane that ships none would be describing a file that is not there.
+  it('says nothing about a pane that names neither a page nor a program', () => {
+    expect(describePaneKind({})).toBe('a pane')
   })
 
   it('says an interval the way a person would', () => {

--- a/tests/extension-copy.test.ts
+++ b/tests/extension-copy.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import {
+  describeActivation,
+  describeContributions,
+  describeFooterInterval,
+  describePaneKind,
+  notAsked,
+  permissionRows
+} from '../src/renderer/lib/extension-copy'
+import type { ExtensionPermission } from '../src/shared/types'
+
+describe('what an extension asks for', () => {
+  it('groups a grant under the verb it answers to', () => {
+    expect(permissionRows(['terminal.send', 'git.read', 'card.rename'])).toEqual([
+      { label: 'Reads', items: ["the worktree's diff and status"] },
+      { label: 'Sends', items: ["text into the session's terminal"] },
+      { label: 'Renames', items: ['the session card'] }
+    ])
+  })
+
+  // Two extensions asking for the same things have to read the same, or a
+  // reordered manifest looks like a changed request.
+  it('reads the same however the manifest ordered it', () => {
+    const one: ExtensionPermission[] = ['agent.usage', 'terminal.read', 'git.read']
+    const other: ExtensionPermission[] = ['git.read', 'agent.usage', 'terminal.read']
+    expect(permissionRows(one)).toEqual(permissionRows(other))
+    expect(permissionRows(one)[0].items).toEqual([
+      "the worktree's diff and status",
+      "the session's recent terminal output",
+      "the agent's context and provider allowance"
+    ])
+  })
+
+  it('says nothing for a bucket it asked nothing of', () => {
+    expect(permissionRows(['git.read']).map((row) => row.label)).toEqual(['Reads'])
+    expect(permissionRows([])).toEqual([])
+    expect(permissionRows(undefined)).toEqual([])
+  })
+
+  // A grant reads as small only against the list it was drawn from.
+  it('names what it did not ask for, from the same closed list', () => {
+    expect(notAsked(['git.read', 'terminal.read'])).toEqual([
+      'the text selected in the terminal',
+      "the agent's context and provider allowance",
+      "text into the session's terminal",
+      'the session card'
+    ])
+    expect(notAsked(undefined)).toHaveLength(6)
+    expect(
+      notAsked([
+        'git.read',
+        'terminal.read',
+        'terminal.selection',
+        'terminal.send',
+        'card.rename',
+        'agent.usage'
+      ])
+    ).toEqual([])
+  })
+})
+
+describe('where an extension shows', () => {
+  it('says every session when it names no rule', () => {
+    expect(describeActivation(undefined)).toEqual(['every session'])
+    expect(describeActivation({})).toEqual(['every session'])
+  })
+
+  it('reads a path as the projects that have it', () => {
+    expect(describeActivation({ workspaceContains: ['package.json'] })).toEqual([
+      'projects with package.json'
+    ])
+  })
+
+  // Any one value satisfies a field, so the clause is an "or" inside.
+  it('joins the values of one field with or', () => {
+    expect(describeActivation({ workspaceContains: ['package.json', 'Cargo.toml'] })).toEqual([
+      'projects with package.json or Cargo.toml'
+    ])
+    expect(describeActivation({ platform: ['darwin', 'linux', 'win32'] })).toEqual([
+      'macOS, Linux or Windows'
+    ])
+  })
+
+  it('names a host it knows and says the rest as they are', () => {
+    expect(describeActivation({ remoteHost: ['github.com'] })).toEqual(['GitHub remotes'])
+    expect(describeActivation({ remoteHost: ['git.example.com'] })).toEqual([
+      'remotes on git.example.com'
+    ])
+    expect(describeActivation({ remoteHost: ['github.com', 'git.example.com'] })).toEqual([
+      'GitHub remotes',
+      'remotes on git.example.com'
+    ])
+  })
+
+  it('names an agent the way the rest of the app names it', () => {
+    expect(describeActivation({ agent: ['claude'] })).toEqual(['Claude Code sessions'])
+    expect(describeActivation({ agent: ['shell'] })).toEqual(['shell sessions'])
+  })
+
+  // Every declared field has to hold, so the clauses read as a list of conditions.
+  it('keeps one clause per field it declares', () => {
+    expect(
+      describeActivation({
+        workspaceContains: ['package.json'],
+        remoteHost: ['github.com'],
+        agent: ['claude'],
+        platform: ['darwin']
+      })
+    ).toEqual(['projects with package.json', 'GitHub remotes', 'Claude Code sessions', 'macOS'])
+  })
+})
+
+describe('what an extension adds', () => {
+  it('counts each kind, and leaves out a kind it has none of', () => {
+    expect(
+      describeContributions({
+        panes: [
+          { id: 'a', title: 'A' },
+          { id: 'b', title: 'B' }
+        ],
+        footers: [{ id: 'c', title: 'C', every: 30 }]
+      })
+    ).toBe('2 panes, 1 footer')
+    expect(describeContributions({ linkHandlers: [{ id: 'd', title: 'D', pattern: 'x' }] })).toBe(
+      '1 link handler'
+    )
+    expect(describeContributions(undefined)).toBe('')
+  })
+
+  it('says how a pane is drawn', () => {
+    expect(describePaneKind({ web: 'web/report/index.html' })).toBe('a page it ships')
+    expect(describePaneKind({ command: ['top'] })).toBe('runs top')
+  })
+
+  it('says an interval the way a person would', () => {
+    expect(describeFooterInterval(30)).toBe('every 30s')
+    expect(describeFooterInterval(60)).toBe('every minute')
+    expect(describeFooterInterval(300)).toBe('every 5 minutes')
+  })
+})

--- a/tests/installed-plugins.test.tsx
+++ b/tests/installed-plugins.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { InstalledPlugins } from '../src/renderer/components/settings/InstalledPlugins'
+import { buildConnectorListings, type ConnectorListing } from '../src/renderer/lib/connector-browse'
+import type { ConnectorCatalogItem, InstalledConnectorPack } from '../src/shared/types'
+import type { RowActivity } from '../src/renderer/lib/use-row-action'
+
+const REVIEW: ConnectorCatalogItem = {
+  id: 'review',
+  name: 'Review',
+  description: 'Read the diff beside the terminal.',
+  kind: 'extension',
+  packageName: '@vornrun/extension-review',
+  version: '0.1.0',
+  packUrl: 'https://packs.test/review-0.1.0.vorn.tgz',
+  capabilities: [],
+  category: 'Development',
+  keywords: [],
+  launch: { command: 'node', args: ['/packs/review/index.js'] },
+  contributes: {
+    panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+    footers: [{ id: 'checks', title: 'Checks', every: 30 }]
+  },
+  permissions: ['terminal.read'],
+  activates: { workspaceContains: ['package.json'] }
+}
+
+const ADO: ConnectorCatalogItem = {
+  id: 'ado',
+  name: 'Azure DevOps',
+  description: 'Trigger workflows from the work items a WIQL query returns.',
+  packageName: '@vornrun/connector-ado',
+  version: '0.1.0',
+  packUrl: 'https://packs.test/ado-0.1.0.vorn.tgz',
+  capabilities: ['triggers'],
+  category: 'Development',
+  keywords: [],
+  launch: { command: 'npx', args: ['-y', '@vornrun/connector-ado'] },
+  triggers: [{ type: 'workItem', label: 'Work item matches the query' }] as never,
+  actions: [],
+  env: []
+}
+
+function pack(over: Partial<InstalledConnectorPack> = {}): InstalledConnectorPack {
+  return {
+    id: 'review',
+    name: 'Review',
+    version: '0.1.0',
+    kind: 'extension',
+    path: '/packs/review',
+    installedAt: 0,
+    bytes: 1,
+    triggers: [],
+    actions: [],
+    env: [],
+    contributes: REVIEW.contributes,
+    permissions: REVIEW.permissions,
+    activates: REVIEW.activates,
+    ...over
+  } as InstalledConnectorPack
+}
+
+const ADO_PACK = pack({
+  id: 'ado',
+  name: 'Azure DevOps',
+  kind: 'connector',
+  path: '/packs/ado',
+  triggers: [{ type: 'workItem', label: 'Work item matches the query' }] as never,
+  contributes: undefined,
+  permissions: undefined,
+  activates: undefined
+})
+
+/** No action is running and none has failed: the ordinary row. */
+const idle: RowActivity = {
+  busy: {},
+  failed: {},
+  run: vi.fn(),
+  state: () => ({})
+}
+
+function listings(packs: InstalledConnectorPack[], connections = []): ConnectorListing[] {
+  return buildConnectorListings([], [REVIEW, ADO], connections, packs)
+}
+
+function setup(packs: InstalledConnectorPack[], over: Record<string, unknown> = {}) {
+  const onSelect = vi.fn()
+  const onInstall = vi.fn()
+  const onAdd = vi.fn()
+  const onRemove = vi.fn()
+  const onBrowse = vi.fn()
+  const utils = render(
+    <InstalledPlugins
+      listings={listings(packs)}
+      builtIns={[]}
+      activity={idle}
+      onSelect={onSelect}
+      onInstall={onInstall}
+      onAdd={onAdd}
+      onRemove={onRemove}
+      onBrowse={onBrowse}
+      {...over}
+    />
+  )
+  return { ...utils, onSelect, onInstall, onAdd, onRemove, onBrowse }
+}
+
+describe('what is installed', () => {
+  it('lists only what has files', () => {
+    // Only the extension is installed; the connector is a catalog row like any other.
+    const { getByText, queryByText } = setup([pack()])
+
+    expect(getByText('Review')).toBeInTheDocument()
+    // A catalog row nobody installed belongs in Browse, not here.
+    expect(queryByText('Azure DevOps')).toBeNull()
+  })
+
+  it('groups by kind, extensions first', () => {
+    const { getByText, container } = setup([pack(), ADO_PACK])
+
+    const headings = [...container.querySelectorAll('h3')].map((h) => h.textContent)
+    expect(headings).toEqual(['Extensions', 'Connectors'])
+    expect(getByText('Azure DevOps')).toBeInTheDocument()
+  })
+
+  it('says nothing is installed, and offers the catalog instead', () => {
+    const { getByText, onBrowse } = setup([])
+
+    fireEvent.click(getByText('Browse'))
+    expect(onBrowse).toHaveBeenCalled()
+  })
+
+  it('drops the headings when only one kind is installed', () => {
+    const { container } = setup([pack()])
+    expect(container.querySelectorAll('h3')).toHaveLength(0)
+  })
+
+  it('counts an extension against the cards this window has open', () => {
+    const { getByText } = setup([pack()], { activeCards: { review: 1 }, openCards: 3 })
+    expect(getByText(/on 1 of 3 open cards/)).toBeInTheDocument()
+  })
+
+  it('says so when an installed extension is on no card', () => {
+    const { getByText } = setup([pack()], { activeCards: { review: 0 }, openCards: 2 })
+    expect(getByText(/on no open card/)).toBeInTheDocument()
+  })
+
+  it('counts a connector by its connections, and offers one when it has none', () => {
+    const { getByRole, getByText, onAdd } = setup([ADO_PACK])
+
+    expect(getByText(/no connection yet/)).toBeInTheDocument()
+    fireEvent.click(getByRole('button', { name: /Add connection/ }))
+    expect(onAdd).toHaveBeenCalled()
+  })
+
+  it('never offers a connection for an extension', () => {
+    const { queryByRole } = setup([pack()])
+    expect(queryByRole('button', { name: /Add connection/ })).toBeNull()
+  })
+
+  it('offers the update only when the catalog carries a newer version', () => {
+    const current = setup([pack()])
+    expect(current.queryByRole('button', { name: 'Update' })).toBeNull()
+    current.unmount()
+
+    const behind = setup([pack({ version: '0.0.9' })])
+    expect(behind.getByRole('button', { name: 'Update' })).toBeInTheDocument()
+    expect(behind.getByText(/v0.1.0 available/)).toBeInTheDocument()
+  })
+
+  it('holds Uninstall while the row is removing, and says what it is doing', () => {
+    const removing: RowActivity = { ...idle, state: () => ({ phrase: 'Removing…' }) }
+    const { getByRole, getByText } = setup([pack()], { activity: removing })
+
+    expect(getByRole('button', { name: /Uninstall/ })).toBeDisabled()
+    expect(getByText('Removing…')).toBeInTheDocument()
+  })
+
+  it('opens the detail page from the row', () => {
+    const { getByRole, onSelect } = setup([pack()])
+    fireEvent.click(getByRole('button', { name: 'About Review' }))
+    expect(onSelect).toHaveBeenCalled()
+  })
+})

--- a/tests/mcp-connector-tools.test.ts
+++ b/tests/mcp-connector-tools.test.ts
@@ -537,6 +537,19 @@ describe('extensions over the wire', () => {
     expect(rows.find((row: { id: string }) => row.id === 'kusto').kind).toBe('connector')
   })
 
+  // An empty list is a claim; a catalog published before these fields said nothing.
+  it('says nothing about what an older entry never stated', async () => {
+    const { contributes: _c, permissions: _p, activates: _a, ...silent } = EXTENSION
+    server({ 'connector:catalog': { ...CATALOG, items: [silent] } })
+    const rows = parsed(await tools.get('list_connectors')!({}))
+    const review = rows.find((row: { id: string }) => row.id === 'review')
+
+    expect(review.kind).toBe('extension')
+    expect('contributes' in review).toBe(false)
+    expect('permissions' in review).toBe(false)
+    expect('activates' in review).toBe(false)
+  })
+
   it('narrows to one kind when asked', async () => {
     withExtension()
     const rows = parsed(await tools.get('list_connectors')!({ kind: 'extension' }))
@@ -615,6 +628,33 @@ describe('extensions over the wire', () => {
       })
     )
     expect(result.note).toContain('Ignored trigger and sync_interval_minutes')
+  })
+
+  // Every one of these configures a connection, and an extension makes none.
+  it('names each argument it had no use for', async () => {
+    withExtension({
+      'connector:installPack': {
+        ok: true,
+        pack: {
+          id: 'review',
+          name: 'Review',
+          version: '0.1.0',
+          kind: 'extension',
+          path: '/packs/review'
+        }
+      }
+    })
+
+    const result = parsed(
+      await tools.get('install_connector')!({
+        connector_id: 'review',
+        env: { REVIEW_TOKEN: 'x' },
+        name: 'mine',
+        project: 'vorn'
+      })
+    )
+    expect(result.note).toContain('Ignored env, name and project')
+    expect(result.note).toContain('which only a connection uses')
   })
 
   it('refuses an extension no release has published a pack for', async () => {

--- a/tests/mcp-connector-tools.test.ts
+++ b/tests/mcp-connector-tools.test.ts
@@ -498,3 +498,134 @@ describe('list_connector_actions', () => {
     expect(text(result)).toMatch(/discovery/i)
   })
 })
+
+describe('extensions over the wire', () => {
+  const EXTENSION = {
+    id: 'review',
+    name: 'Review',
+    description: 'Read the diff beside the terminal.',
+    kind: 'extension',
+    packageName: '@vornrun/extension-review',
+    version: '0.1.0',
+    packUrl: 'https://packs.test/review-0.1.0.vorn.tgz',
+    capabilities: [],
+    contributes: {
+      panes: [{ id: 'report', title: 'Report', web: 'web/report/index.html' }],
+      footers: [{ id: 'checks', title: 'Checks', every: 30 }]
+    },
+    permissions: ['git.read'],
+    activates: { workspaceContains: ['package.json'] },
+    launch: { command: 'node', args: ['/packs/review/index.js'] }
+  }
+
+  const withExtension = (overrides: Record<string, unknown> = {}) =>
+    server({
+      'connector:catalog': { ...CATALOG, items: [...CATALOG.items, EXTENSION] },
+      ...overrides
+    })
+
+  it('says which listings are extensions, and what each adds', async () => {
+    withExtension()
+    const rows = parsed(await tools.get('list_connectors')!({}))
+    const review = rows.find((row: { id: string }) => row.id === 'review')
+
+    expect(review.kind).toBe('extension')
+    expect(review.contributes.panes).toEqual([{ id: 'report', title: 'Report' }])
+    expect(review.contributes.footers).toEqual([{ id: 'checks', title: 'Checks' }])
+    expect(review.permissions).toEqual(['git.read'])
+    expect(review.activates).toEqual({ workspaceContains: ['package.json'] })
+    expect(rows.find((row: { id: string }) => row.id === 'kusto').kind).toBe('connector')
+  })
+
+  it('narrows to one kind when asked', async () => {
+    withExtension()
+    const rows = parsed(await tools.get('list_connectors')!({ kind: 'extension' }))
+    expect(rows.map((row: { id: string }) => row.id)).toEqual(['review'])
+  })
+
+  it('reports what is on disk, and lets the pack answer for its kind', async () => {
+    withExtension({
+      'connector:listPacks': [{ id: 'review', name: 'Review', version: '0.2.0', kind: 'extension' }]
+    })
+    const rows = parsed(await tools.get('list_connectors')!({}))
+    expect(rows.find((row: { id: string }) => row.id === 'review').installed).toBe('0.2.0')
+  })
+
+  // An extension has no connections to count, so "not set up yet" can only
+  // mean it is not installed.
+  it('counts an extension as set up once it is installed, not once it is connected', async () => {
+    withExtension()
+    const before = parsed(await tools.get('list_connectors')!({ installable_only: true }))
+    expect(before.map((row: { id: string }) => row.id)).toContain('review')
+
+    withExtension({
+      'connector:listPacks': [{ id: 'review', name: 'Review', version: '0.1.0', kind: 'extension' }]
+    })
+    const after = parsed(await tools.get('list_connectors')!({ installable_only: true }))
+    expect(after.map((row: { id: string }) => row.id)).not.toContain('review')
+  })
+
+  it('installs a catalog extension from its pack and makes no connection', async () => {
+    withExtension({
+      'connector:installPack': {
+        ok: true,
+        pack: {
+          id: 'review',
+          name: 'Review',
+          version: '0.1.0',
+          kind: 'extension',
+          path: '/packs/review',
+          contributes: EXTENSION.contributes,
+          permissions: EXTENSION.permissions,
+          activates: EXTENSION.activates
+        }
+      }
+    })
+
+    const result = parsed(await tools.get('install_connector')!({ connector_id: 'review' }))
+
+    expect(rpcCall).toHaveBeenCalledWith('connector:installPack', {
+      kind: 'url',
+      url: 'https://packs.test/review-0.1.0.vorn.tgz'
+    })
+    expect(rpcCall).not.toHaveBeenCalledWith('connection:create', expect.anything())
+    expect(result.kind).toBe('extension')
+    expect(result.path).toBe('/packs/review')
+  })
+
+  it('says it ignored what only a poll would use', async () => {
+    withExtension({
+      'connector:installPack': {
+        ok: true,
+        pack: {
+          id: 'review',
+          name: 'Review',
+          version: '0.1.0',
+          kind: 'extension',
+          path: '/packs/review'
+        }
+      }
+    })
+
+    const result = parsed(
+      await tools.get('install_connector')!({
+        connector_id: 'review',
+        trigger: 'nothing',
+        sync_interval_minutes: 5
+      })
+    )
+    expect(result.note).toContain('Ignored trigger and sync_interval_minutes')
+  })
+
+  it('refuses an extension no release has published a pack for', async () => {
+    withExtension({
+      'connector:catalog': {
+        ...CATALOG,
+        items: [{ ...EXTENSION, packUrl: undefined }]
+      }
+    })
+    const result = await tools.get('install_connector')!({ connector_id: 'review' })
+    expect(result.isError).toBe(true)
+    expect(text(result)).toContain('no release has published a pack')
+  })
+})

--- a/tests/mcp-connector-tools.test.ts
+++ b/tests/mcp-connector-tools.test.ts
@@ -71,6 +71,7 @@ function server(overrides: Record<string, unknown> = {}) {
       { id: 'mcp', name: 'MCP', capabilities: ['actions'], manifest: {} }
     ],
     'connector:catalog': CATALOG,
+    'connector:listPacks': [],
     'connection:list': [],
     'connector:status': [{ connectorId: 'github', authed: true }],
     'connector:probeSdk': { ok: true, manifest: MANIFEST },

--- a/tests/mcp-server-add.test.tsx
+++ b/tests/mcp-server-add.test.tsx
@@ -7,7 +7,11 @@ import type { ConnectorManifest, McpServerCatalogEntry } from '../src/shared/typ
 vi.mock('../src/renderer/stores', () => ({
   useAppStore: Object.assign(
     (selector: (state: unknown) => unknown) =>
-      selector({ config: { workflows: [], projects: [] }, extensionActivation: new Map() }),
+      selector({
+        config: { workflows: [], projects: [] },
+        extensionActivation: new Map(),
+        terminalsPanes: new Map()
+      }),
     { getState: () => ({}) }
   )
 }))

--- a/tests/mcp-server-add.test.tsx
+++ b/tests/mcp-server-add.test.tsx
@@ -7,7 +7,7 @@ import type { ConnectorManifest, McpServerCatalogEntry } from '../src/shared/typ
 vi.mock('../src/renderer/stores', () => ({
   useAppStore: Object.assign(
     (selector: (state: unknown) => unknown) =>
-      selector({ config: { workflows: [], projects: [] } }),
+      selector({ config: { workflows: [], projects: [] }, extensionActivation: new Map() }),
     { getState: () => ({}) }
   )
 }))

--- a/tests/pack-status.test.ts
+++ b/tests/pack-status.test.ts
@@ -206,6 +206,26 @@ describe('canAddConnection', () => {
     expect(canAddConnection({ kind: 'absent' }, { source: 'builtin' })).toBe(true)
   })
 
+  // An extension shows on the cards its activation names; the form behind an
+  // Add button would ask for a connection nothing consumes.
+  it('refuses an extension, installed or not', () => {
+    expect(
+      canAddConnection(
+        { kind: 'installed', version: '1.0.0' },
+        { source: 'catalog', kind: 'extension' }
+      )
+    ).toBe(false)
+    expect(
+      canAddConnection(
+        { kind: 'installed', version: '1.0.0' },
+        { source: 'installed', kind: 'extension' }
+      )
+    ).toBe(false)
+    expect(canAddConnection({ kind: 'absent' }, { source: 'builtin', kind: 'extension' })).toBe(
+      false
+    )
+  })
+
   it('arms a packaged connector once its files are on disk', () => {
     expect(canAddConnection({ kind: 'installed', version: '1.0.0' }, { source: 'catalog' })).toBe(
       true

--- a/tests/start-from-actions.test.tsx
+++ b/tests/start-from-actions.test.tsx
@@ -15,6 +15,7 @@ const LISTING: ConnectorListing = {
   name: 'Slack',
   capabilities: ['actions'],
   category: 'Chat',
+  kind: 'connector',
   source: 'catalog',
   keywords: [],
   connectedCount: 0

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -122,6 +122,7 @@ describe('what a requirement can do about itself', () => {
     name: 'Slack',
     capabilities: ['actions'],
     category: 'Chat',
+    kind: 'connector',
     source: 'catalog',
     keywords: [],
     connectedCount: 0,

--- a/tests/template-requirements.test.ts
+++ b/tests/template-requirements.test.ts
@@ -144,6 +144,14 @@ describe('what a requirement can do about itself', () => {
     })
   })
 
+  // It shows on the cards its activation names; the form would ask for a
+  // connection nothing consumes.
+  it('offers no connection form for an installed extension', () => {
+    const pack = { id: 'review', name: 'Review', version: '0.1.0' } as ConnectorListing['pack']
+    const extension = listing({ key: 'catalog:review', id: 'review', kind: 'extension', pack })
+    expect(requirementAction(needs('review'), [extension])).toMatchObject({ kind: 'install' })
+  })
+
   it('offers the connection straight away for a built-in', () => {
     const builtIn = listing({ key: 'github', id: 'github', name: 'GitHub', source: 'builtin' })
     expect(requirementAction(needs('github'), [builtIn])).toMatchObject({ kind: 'addConnection' })

--- a/tests/use-pack-install.test.tsx
+++ b/tests/use-pack-install.test.tsx
@@ -15,6 +15,7 @@ const LISTING: ConnectorListing = {
   name: 'Slack',
   capabilities: ['actions'],
   category: 'Chat',
+  kind: 'connector',
   source: 'catalog',
   keywords: [],
   connectedCount: 0,


### PR DESCRIPTION
Fourth sub-phase of extensions, plus a change the user's test asked for.

- The Settings section is **Plugins**: connectors and extensions are kinds of plugin, installed from the same directory. It opens on a new **Installed** tab that lists every pack on this machine by kind, with version, an Update button when the catalog is newer, Uninstall, and for a connector its connection count or an Add connection button, for an extension the open cards it is active on. Connections and Browse keep their tabs; a connector installed without a connection is listed on Connections so it can get one.
- The directory knows the kind: a kind filter beside the category and sign-in ones, an `Extension` chip on the row, contribution counts in the facts, and no Add button for an extension. The filters sit on their own row under a full-width search box.
- An extension's detail page shows **Contributes** (panes, footers, link handlers with their rules), **Asks to** (Reads / Sends / Renames in plain words, then what it is not asking for), and **Shows when**; a catalog entry that never stated its permissions says so instead of claiming it asks for nothing. Activation rules read the way the predicate means them.
- The install confirm gains Adds / Reads / Sends / Renames rows.
- Over MCP, `list_connectors` takes a kind, reports what is on disk, and says only what an entry states; `install_connector` installs a catalog extension from its pack and makes no connection.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2N3QkhPeXoLnDU1yUKBc