### PR TITLE
Send a keystroke's echo at once

### DIFF
--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -641,8 +641,8 @@ class PtyManager extends EventEmitter {
 
   /** How long a stream is held so its many small reads go out as one flush. */
   private static readonly BUFFER_FLUSH_MS = 8
-  /** When each session last flushed, to tell a lone echo from a stream. */
-  private lastFlushAt = new Map<string, number>()
+  /** A read this small after a quiet spell is a keystroke's echo; a TUI's repaint is never this small. */
+  private static readonly ECHO_MAX_BYTES = 64
 
   /**
    * Put bytes into a session's output as though the process had written them.
@@ -668,19 +668,24 @@ class PtyManager extends EventEmitter {
   private bufferData(id: string, data: string): void {
     const existing = this.dataBuffers.get(id)
     this.dataBuffers.set(id, existing ? existing + data : data)
+    // A pending timer means a stream is in flight, and this read joins it.
     if (this.flushTimers.has(id)) return
 
-    // The first read after a quiet spell goes out at once: that is a typed character's echo, and
-    // holding it for company that never comes is what a keystroke feels as lag. Reads that follow
-    // within the hold are a stream, and those are coalesced.
-    const quietFor = Date.now() - (this.lastFlushAt.get(id) ?? 0)
-    if (quietFor >= PtyManager.BUFFER_FLUSH_MS) {
-      this.flushBuffer(id)
-      return
-    }
+    // An echo held for company that never comes is what a keystroke feels as lag.
+    if (!existing && Buffer.byteLength(data) <= PtyManager.ECHO_MAX_BYTES) this.flushBuffer(id)
+    this.armFlush(id)
+  }
+
+  /** The hold, re-armed while a stream keeps coming so quiet is the timer lapsing with nothing to send. */
+  private armFlush(id: string): void {
     this.flushTimers.set(
       id,
-      setTimeout(() => this.flushBuffer(id), PtyManager.BUFFER_FLUSH_MS)
+      setTimeout(() => {
+        this.flushTimers.delete(id)
+        if (!this.dataBuffers.has(id)) return
+        this.flushBuffer(id)
+        this.armFlush(id)
+      }, PtyManager.BUFFER_FLUSH_MS)
     )
   }
 
@@ -709,11 +714,9 @@ class PtyManager extends EventEmitter {
   private flushBuffer(id: string): void {
     const data = this.dataBuffers.get(id)
     this.dataBuffers.delete(id)
-    this.flushTimers.delete(id)
     if (data) {
       const seq = this.lastFlushSeq(id) + 1
       this.flushSeq.set(id, seq)
-      this.lastFlushAt.set(id, Date.now())
 
       // Clients first, always. What follows models the screen for nobody who is
       // waiting; this line is a person watching their terminal, and it must not
@@ -764,6 +767,8 @@ class PtyManager extends EventEmitter {
   private drainBuffer(id: string): void {
     const timer = this.flushTimers.get(id)
     if (timer) clearTimeout(timer)
+    // Forgotten as well as cleared: a timer left in the map reads as a stream in flight, and every read after it would wait for a flush that never comes.
+    this.flushTimers.delete(id)
     this.flushBuffer(id)
   }
 
@@ -883,7 +888,6 @@ class PtyManager extends EventEmitter {
       this.deleteTempKey(id)
       this.clearSessionTracking(id)
       this.flushSeq.delete(id)
-      this.lastFlushAt.delete(id)
       clearScrollback(id)
       // Beside the scrollback it belongs to: the PTY is gone and nothing will
       // draw into it again. The session record survives so the card can show an
@@ -1184,7 +1188,6 @@ class PtyManager extends EventEmitter {
       clearTimeout(timer)
     }
     this.dataBuffers.clear()
-    this.lastFlushAt.clear()
     this.flushTimers.clear()
     this.flushSeq.clear()
 

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -639,7 +639,10 @@ class PtyManager extends EventEmitter {
     return this.extensionPtys.has(id)
   }
 
+  /** How long a stream is held so its many small reads go out as one flush. */
   private static readonly BUFFER_FLUSH_MS = 8
+  /** When each session last flushed, to tell a lone echo from a stream. */
+  private lastFlushAt = new Map<string, number>()
 
   /**
    * Put bytes into a session's output as though the process had written them.
@@ -665,13 +668,20 @@ class PtyManager extends EventEmitter {
   private bufferData(id: string, data: string): void {
     const existing = this.dataBuffers.get(id)
     this.dataBuffers.set(id, existing ? existing + data : data)
+    if (this.flushTimers.has(id)) return
 
-    if (!this.flushTimers.has(id)) {
-      this.flushTimers.set(
-        id,
-        setTimeout(() => this.flushBuffer(id), PtyManager.BUFFER_FLUSH_MS)
-      )
+    // The first read after a quiet spell goes out at once: that is a typed character's echo, and
+    // holding it for company that never comes is what a keystroke feels as lag. Reads that follow
+    // within the hold are a stream, and those are coalesced.
+    const quietFor = Date.now() - (this.lastFlushAt.get(id) ?? 0)
+    if (quietFor >= PtyManager.BUFFER_FLUSH_MS) {
+      this.flushBuffer(id)
+      return
     }
+    this.flushTimers.set(
+      id,
+      setTimeout(() => this.flushBuffer(id), PtyManager.BUFFER_FLUSH_MS)
+    )
   }
 
   /**
@@ -703,6 +713,7 @@ class PtyManager extends EventEmitter {
     if (data) {
       const seq = this.lastFlushSeq(id) + 1
       this.flushSeq.set(id, seq)
+      this.lastFlushAt.set(id, Date.now())
 
       // Clients first, always. What follows models the screen for nobody who is
       // waiting; this line is a person watching their terminal, and it must not
@@ -872,6 +883,7 @@ class PtyManager extends EventEmitter {
       this.deleteTempKey(id)
       this.clearSessionTracking(id)
       this.flushSeq.delete(id)
+      this.lastFlushAt.delete(id)
       clearScrollback(id)
       // Beside the scrollback it belongs to: the PTY is gone and nothing will
       // draw into it again. The session record survives so the card can show an
@@ -1172,6 +1184,7 @@ class PtyManager extends EventEmitter {
       clearTimeout(timer)
     }
     this.dataBuffers.clear()
+    this.lastFlushAt.clear()
     this.flushTimers.clear()
     this.flushSeq.clear()
 

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -61,7 +61,7 @@ const readyCallbacks = new Map<string, Set<() => void>>()
 /** One flush of a session's output; see `PtyManager.flushSeq` for `seq`. */
 type Chunk = Pick<TerminalData, 'data' | 'seq'>
 
-/** Text is joined as it always was; bytes go in as they came, since joining them means copying them. */
+/** The chunks held behind a seed: text joined, bytes as they came, since joining bytes means copying them. */
 function writeChunks(term: Terminal, chunks: readonly Chunk[]): void {
   let text = ''
   for (const chunk of chunks) {
@@ -160,7 +160,7 @@ export function hydrateTerminal(terminalId: string): Promise<void> {
   const state: Hydration = { held: [], done: Promise.resolve() }
   hydrating.set(terminalId, state)
 
-  /** Everything held, in order, as one write. xterm queues a task per call. */
+  /** Everything held, in order, after the seed. */
   const flushHeld = (above = -1): void => {
     // A chunk whose sequence cannot be compared cannot be deduplicated, and the
     // choice is then between showing it twice and not showing it at all. Twice

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -58,7 +58,6 @@ const registry = new Map<string, TerminalEntry>()
 const seeding = new Set<string>()
 const readyCallbacks = new Map<string, Set<() => void>>()
 
-// --- Write batching: single global listener + requestAnimationFrame ---
 /** One flush of a session's output; see `PtyManager.flushSeq` for `seq`. */
 type Chunk = Pick<TerminalData, 'data' | 'seq'>
 
@@ -79,9 +78,6 @@ function writeChunks(term: Terminal, chunks: readonly Chunk[]): void {
   if (text) term.write(text)
 }
 
-const pendingWrites = new Map<string, Chunk[]>()
-let rafId: number | null = null
-
 /**
  * Sessions being seeded right now.
  *
@@ -100,51 +96,29 @@ interface Hydration {
 
 const hydrating = new Map<string, Hydration>()
 
-function scheduleFlush(): void {
-  if (rafId !== null) return
-  rafId = requestAnimationFrame(flushWrites)
-}
-
-function flushWrites(): void {
-  rafId = null
-  for (const [id, chunks] of pendingWrites) {
-    // Not `seeding`: that is a module-level Set in this file now, and a local
-    // of the same name holding something else entirely is a trap for whoever
-    // edits this next.
-    const hydration = hydrating.get(id)
-    if (hydration) {
-      for (const chunk of chunks) hydration.held.push(chunk)
-      continue
-    }
-    const entry = registry.get(id)
-    if (entry) writeChunks(entry.term, chunks)
+/** Live output goes straight to xterm, which draws on its own frame; holding it for one of ours only added a frame. */
+function receive(id: string, chunk: Chunk): void {
+  const hydration = hydrating.get(id)
+  if (hydration) {
+    hydration.held.push(chunk)
+    return
   }
-  pendingWrites.clear()
+  const entry = registry.get(id)
+  if (entry) entry.term.write(chunk.data)
 }
 
 let removeGlobalDataListener: (() => void) | null = null
 
 export function initGlobalDataListener(): void {
   if (removeGlobalDataListener) return
-  removeGlobalDataListener = window.api.onTerminalData(({ id, data, seq }) => {
-    const existing = pendingWrites.get(id)
-    if (existing) {
-      existing.push({ data, seq })
-    } else {
-      pendingWrites.set(id, [{ data, seq }])
-    }
-    scheduleFlush()
-  })
+  removeGlobalDataListener = window.api.onTerminalData(({ id, data, seq }) =>
+    receive(id, { data, seq })
+  )
 }
 
 export function disposeGlobalDataListener(): void {
   removeGlobalDataListener?.()
   removeGlobalDataListener = null
-  if (rafId !== null) {
-    cancelAnimationFrame(rafId)
-    rafId = null
-  }
-  pendingWrites.clear()
   hydrating.clear()
   seeding.clear()
 }
@@ -910,12 +884,6 @@ export function onTerminalScroll(
 export function destroyTerminal(terminalId: string): void {
   const entry = registry.get(terminalId)
   if (!entry) return
-  // Whatever is still batched goes in before the terminal goes.
-  const chunks = pendingWrites.get(terminalId)
-  if (chunks) {
-    writeChunks(entry.term, chunks)
-    pendingWrites.delete(terminalId)
-  }
   // A seed still in flight would otherwise resolve and write into a terminal
   // that no longer exists.
   hydrating.delete(terminalId)

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -320,12 +320,64 @@ describe('the terminal is recorded where it is fed', () => {
     // frames written after it, and a restore counted them twice.
     resetScrollback()
     const { session, fake } = createAgent()
+    // The first read after a quiet spell goes out at once; the second is held for the flush.
+    fake.emitData('went out at once')
     fake.emitData('printed but not yet flushed')
 
-    expect(readScrollback(session.id), 'the buffer saw it before the model did').toBe('')
+    expect(readScrollback(session.id), 'the buffer saw it before the model did').not.toContain(
+      'printed but not yet flushed'
+    )
 
     await afterFlush()
     expect(readScrollback(session.id)).toContain('printed but not yet flushed')
+  })
+
+  // What a keystroke feels: its echo is one small read after a quiet spell, and it must not wait.
+  describe('how soon output goes out', () => {
+    const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+    function flushesOf(id: string): string[] {
+      const seen: string[] = []
+      ptyManager.on('client-message', (channel: string, payload: unknown) => {
+        const p = payload as { id: string; data: string }
+        if (channel === 'terminal:data' && p.id === id) seen.push(p.data)
+      })
+      return seen
+    }
+
+    it('sends the first read after a quiet spell at once', () => {
+      const { session, fake } = createAgent()
+      const seen = flushesOf(session.id)
+
+      fake.emitData('k')
+
+      expect(seen).toEqual(['k'])
+    })
+
+    it('holds what follows within the hold, and sends it as one flush', async () => {
+      const { session, fake } = createAgent()
+      const seen = flushesOf(session.id)
+
+      fake.emitData('line 1\n')
+      fake.emitData('line 2\n')
+      fake.emitData('line 3\n')
+      expect(seen).toEqual(['line 1\n'])
+
+      await wait(20)
+      expect(seen).toEqual(['line 1\n', 'line 2\nline 3\n'])
+    })
+
+    it('is quick again once the stream has gone quiet', async () => {
+      const { session, fake } = createAgent()
+      const seen = flushesOf(session.id)
+
+      fake.emitData('a')
+      fake.emitData('b')
+      await wait(20)
+      fake.emitData('c')
+
+      expect(seen).toEqual(['a', 'b', 'c'])
+    })
   })
 
   it('opens a log when a terminal is spawned', async () => {
@@ -351,16 +403,18 @@ describe('the terminal is recorded where it is fed', () => {
   })
 
   it('records once per flush rather than once per chunk', async () => {
-    // The reason the call sits in `flushBuffer` and not in `onData`. Thirty
-    // keystrokes are one frame, not thirty -- and it is what keeps the byte
-    // buffer and the screen model seeing the same bytes at the same moment.
+    // The reason the call sits in `flushBuffer` and not in `onData`: the first read after a quiet
+    // spell goes out alone, and the twenty-nine that follow are one frame, not twenty-nine.
     const { session, fake } = createAgent()
     for (let i = 0; i < 30; i++) fake.emitData('x')
     await afterFlush()
     await settled()
 
     const output = framesFor(session.id).filter((f) => f.kind === 'output')
-    expect(output).toEqual([{ kind: 'output', data: 'x'.repeat(30) }])
+    expect(output).toEqual([
+      { kind: 'output', data: 'x' },
+      { kind: 'output', data: 'x'.repeat(29) }
+    ])
   })
 
   it('takes the history with the terminal when it is killed', async () => {

--- a/tests/pty-manager-screen.test.ts
+++ b/tests/pty-manager-screen.test.ts
@@ -168,14 +168,7 @@ function createAgent(overrides: Partial<CreateTerminalPayload> = {}): {
 
 const ESC = '\x1b'
 
-/**
- * Wait for the output coalescer.
- *
- * `emitData` only buffers; `flushBuffer` runs on an 8 ms timer and that is where
- * the screen is fed. An assertion made straight after `emitData` is made before
- * anything under test has happened -- which is how the first version of these
- * passed against a `pty-manager` deliberately rigged to write replies back.
- */
+// Past the 8 ms hold and its re-arm: a small first read goes out at once, everything else waits for this.
 const afterFlush = (): Promise<void> => new Promise((r) => setTimeout(r, 40))
 
 beforeEach(() => {
@@ -334,24 +327,44 @@ describe('the terminal is recorded where it is fed', () => {
 
   // What a keystroke feels: its echo is one small read after a quiet spell, and it must not wait.
   describe('how soon output goes out', () => {
-    const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
-
     function flushesOf(id: string): string[] {
       const seen: string[] = []
-      ptyManager.on('client-message', (channel: string, payload: unknown) => {
+      const listener = (channel: string, payload: unknown): void => {
         const p = payload as { id: string; data: string }
         if (channel === 'terminal:data' && p.id === id) seen.push(p.data)
-      })
+      }
+      ptyManager.on('client-message', listener)
+      listeners.push(listener)
       return seen
     }
+    const listeners: Array<(channel: string, payload: unknown) => void> = []
+    afterEach(() => {
+      for (const l of listeners) ptyManager.off('client-message', l)
+      listeners.length = 0
+    })
 
-    it('sends the first read after a quiet spell at once', () => {
+    it('sends a small first read after a quiet spell at once', () => {
       const { session, fake } = createAgent()
       const seen = flushesOf(session.id)
 
       fake.emitData('k')
 
       expect(seen).toEqual(['k'])
+    })
+
+    it('holds a large first read: a repaint is not an echo', async () => {
+      // A TUI clears and redraws in reads far bigger than a keystroke; sent alone, the clear
+      // would paint a blank frame before the body arrived.
+      const { session, fake } = createAgent()
+      const seen = flushesOf(session.id)
+      const clear = `${ESC}[2J${ESC}[H` + 'x'.repeat(200)
+
+      fake.emitData(clear)
+      fake.emitData('the rest of the frame')
+      expect(seen).toEqual([])
+
+      await afterFlush()
+      expect(seen).toEqual([clear + 'the rest of the frame'])
     })
 
     it('holds what follows within the hold, and sends it as one flush', async () => {
@@ -363,8 +376,22 @@ describe('the terminal is recorded where it is fed', () => {
       fake.emitData('line 3\n')
       expect(seen).toEqual(['line 1\n'])
 
-      await wait(20)
+      await afterFlush()
       expect(seen).toEqual(['line 1\n', 'line 2\nline 3\n'])
+    })
+
+    it('is quick again after a resume drained what was held', async () => {
+      // `releaseForResume` drains mid-stream; the timer must go with the drain, or the next
+      // read would wait for a flush nothing is going to schedule.
+      const { session, fake } = createAgent()
+      const seen = flushesOf(session.id)
+
+      fake.emitData('a')
+      fake.emitData('b')
+      ptyManager.releaseForResume(session.id)
+      fake.emitData('c')
+
+      expect(seen).toEqual(['a', 'b', 'c'])
     })
 
     it('is quick again once the stream has gone quiet', async () => {
@@ -373,7 +400,7 @@ describe('the terminal is recorded where it is fed', () => {
 
       fake.emitData('a')
       fake.emitData('b')
-      await wait(20)
+      await afterFlush()
       fake.emitData('c')
 
       expect(seen).toEqual(['a', 'b', 'c'])
@@ -403,8 +430,9 @@ describe('the terminal is recorded where it is fed', () => {
   })
 
   it('records once per flush rather than once per chunk', async () => {
-    // The reason the call sits in `flushBuffer` and not in `onData`: the first read after a quiet
-    // spell goes out alone, and the twenty-nine that follow are one frame, not twenty-nine.
+    // The reason the call sits in `flushBuffer` and not in `onData`: a small first read goes out
+    // alone, and the twenty-nine that follow are one frame, not twenty-nine -- one flush more per
+    // burst than before, taken so that a keystroke's echo never waits.
     const { session, fake } = createAgent()
     for (let i = 0; i < 30; i++) fake.emitData('x')
     await afterFlush()

--- a/tests/terminal-hydrate.test.ts
+++ b/tests/terminal-hydrate.test.ts
@@ -319,14 +319,13 @@ describe('output that arrives as bytes', () => {
     expect(written()).toEqual(['text:seed', 'bytes:live-1', 'bytes:live-2'])
   })
 
-  it('still joins text from a server that sends it', async () => {
+  it('writes text from a server that sends it as it came', async () => {
     attachTerminal.mockResolvedValue({ data: '', seq: 0, live: true })
     await open()
 
     emit({ id: ID, data: 'plain', seq: 1 })
     emit({ id: ID, data: ' text', seq: 2 })
-    await frame()
 
-    expect(written()).toEqual(['text:plain text'])
+    expect(written()).toEqual(['text:plain', 'text: text'])
   })
 })

--- a/tests/terminal-hydrate.test.ts
+++ b/tests/terminal-hydrate.test.ts
@@ -157,7 +157,6 @@ describe('what the seed already contains', () => {
 
     const hydrating = open()
     emit({ id: ID, data: 'already in the seed', seq: 5 })
-    await frame()
     answer({ data: 'THE SEED', seq: 5, live: true })
     await hydrating
 
@@ -171,7 +170,6 @@ describe('what the seed already contains', () => {
     const hydrating = open()
     emit({ id: ID, data: 'in the seed', seq: 5 })
     emit({ id: ID, data: 'after the seed', seq: 6 })
-    await frame()
     answer({ data: 'THE SEED', seq: 5, live: true })
     await hydrating
 
@@ -190,13 +188,10 @@ describe('what the seed already contains', () => {
     ] as const) {
       emit({ id: ID, data, seq })
     }
-    await frame()
     answer({ data: 'THE SEED', seq: 5, live: true })
     await hydrating
 
-    // One write, not three. xterm queues a task per call, and the held chunks
-    // are already in order -- joining them is the same bytes at a third of the
-    // scheduling.
+    // Held text is joined: the same bytes in one write.
     expect(writes()).toEqual(['THE SEED', 'firstsecondthird'])
   })
 })
@@ -241,7 +236,6 @@ describe('a seed that never arrives', () => {
 
     const hydrating = open()
     emit({ id: ID, data: 'happened anyway', seq: 2 })
-    await frame()
     await hydrating
     quiet.mockRestore()
 
@@ -260,7 +254,6 @@ describe('a chunk whose sequence cannot be compared', () => {
 
     const hydrating = open()
     emit({ id: ID, data: 'no sequence on this', seq: undefined as unknown as number })
-    await frame()
     answer({ data: 'THE SEED', seq: 5, live: true })
     await hydrating
 
@@ -300,8 +293,8 @@ describe('output that arrives as bytes', () => {
 
     emit({ id: ID, data: bytes('ab'), seq: 1 })
     emit({ id: ID, data: bytes('cd'), seq: 2 })
-    await frame()
 
+    // No wait: live output that sat until a frame would pass with one, and that is the regression this pins.
     expect(written()).toEqual(['bytes:ab', 'bytes:cd'])
   })
 
@@ -312,7 +305,6 @@ describe('output that arrives as bytes', () => {
 
     emit({ id: ID, data: bytes('live-1'), seq: 2 })
     emit({ id: ID, data: bytes('live-2'), seq: 3 })
-    await frame()
     seed({ data: 'seed', seq: 1, live: true })
     await hydrated
 


### PR DESCRIPTION
A typed character's echo took ten milliseconds at the median to get from the pty back to the socket, twenty at p90, where the pty itself takes a fifth of one. Then the window held it for a frame of its own. That is most of the difference between Vorn and a native terminal under the fingers.

Two buffers caused it, both tuned for streaming output rather than typing.

**Server.** Every read off the pty was held for `BUFFER_FLUSH_MS = 8` so that a stream's many small reads would go out as one flush. An echo is one small read with nothing following it, and it waited the full eight for company that never came. A read small enough to be an echo now goes out at once when nothing is in flight; anything larger, and every read that follows within the hold, is a stream and is coalesced as before. Quiet is the hold lapsing with nothing to send — the timer re-arms while a stream keeps coming — rather than a timestamp, so the flush partition does not depend on the clock between two reads.

**Renderer.** Arrived bytes were held for the next `requestAnimationFrame` before `term.write`, on the theory that one write per frame was cheaper than one per chunk. xterm parses a write when it comes and draws on a frame of its own, so the hold bought nothing and cost up to sixteen milliseconds. Output now goes to xterm as it arrives; the only thing that still holds it is a seed in flight, which must be written first.

## Measured

Sixty keystrokes into `cat`, timed from `terminal:write` to the `terminal:data` carrying the echo, over the socket on a scratch data dir.

| | p50 | p90 | p99 |
|---|---|---|---|
| bare pty | 0.2 ms | 0.4 ms | 0.8 ms |
| through the server, before | 9.9 ms | 20.4 ms | 24.1 ms |
| through the server, after | **0.8–1.3 ms** | **1.6–3.7 ms** | **3–9 ms** |

Six runs of the after case; the spread is the machine's scheduler, and the bare pty shows the same outliers. The renderer's frame cannot be timed without a window and is felt instead.

## Review

`/code-review high` ran before this opened. Its one substantive finding: the first cut sent the first read after quiet alone whatever its size, so a full-screen program's clear-screen could go out ahead of its body and paint a blank frame — hence the size gate. It also found the clock-based partition made three tests order-dependent under load; the re-arming timer removes the clock. A drain now forgets its timer as well as clearing it.

The accepted trade: a burst that fits inside the hold costs one flush more than before, its first read and then the rest. `records once per flush rather than once per chunk` now expects thirty reads to be one frame of one and one of twenty-nine.

Not changed: two BEL characters in one burst can now ring twice where they rang once. The renderer's bell has a ten-second cooldown that is checked after the sound plays (`notifications.ts:76` and `:83`); that is the place to fix it and it predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9xDZGyS3vzszATiHWYF8F
