### PR TITLE
Start the server without waiting on the login shell, and never keep a failed answer

### DIFF
--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process'
 import {
   AiAgentType,
   AgentType,
@@ -11,28 +10,21 @@ import {
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { shellEscape } from './process-utils'
 import { stripSessionSelectors } from './launch-tokens'
+import { findOnPath } from './resolve-executable'
 
-function commandExists(cmd: string, env: Record<string, string>): boolean {
-  try {
-    const bin = process.platform === 'win32' ? 'where' : 'which'
-    execFileSync(bin, [cmd], { stdio: 'pipe', timeout: 3000, env })
-    return true
-  } catch {
-    return false
-  }
-}
-
+/** The configured command, and where on `env.PATH` it lives; the name when it is not there. */
 function resolveAgentCommand(
   config: AgentCommandConfig,
   env: Record<string, string>
-): { command: string; args: string[] } {
-  if (commandExists(config.command, env)) {
-    return { command: config.command, args: config.args }
+): { command: string; args: string[]; path: string } {
+  const primary = findOnPath(config.command, env.PATH)
+  if (primary) return { command: config.command, args: config.args, path: primary }
+  if (config.fallbackCommand) {
+    const fallback = findOnPath(config.fallbackCommand, env.PATH)
+    if (fallback)
+      return { command: config.fallbackCommand, args: config.fallbackArgs ?? [], path: fallback }
   }
-  if (config.fallbackCommand && commandExists(config.fallbackCommand, env)) {
-    return { command: config.fallbackCommand, args: config.fallbackArgs ?? [] }
-  }
-  return { command: config.command, args: config.args }
+  return { command: config.command, args: config.args, path: config.command }
 }
 
 /**
@@ -245,8 +237,8 @@ export function buildHeadlessSpawnArgs(
       // `claude -p` (print mode) reads the prompt from stdin when no positional
       // prompt is given. Deliver it there so the shell never sees it.
       return prompt
-        ? { command: cmd.command, args: [...extraArgs, '-p'], stdin: prompt }
-        : { command: cmd.command, args: [...extraArgs, '-p', ''] }
+        ? { command: cmd.path, args: [...extraArgs, '-p'], stdin: prompt }
+        : { command: cmd.path, args: [...extraArgs, '-p', ''] }
     case 'copilot':
       // `copilot` reads the prompt from stdin when `-p` is absent ("Run in an
       // interactive terminal or provide a prompt with -p or via standard in").
@@ -257,8 +249,8 @@ export function buildHeadlessSpawnArgs(
       // none at all, and with no prompt it blocks on stdin producing no output
       // whatsoever: the step never finished and its run never closed.
       return prompt
-        ? { command: cmd.command, args: [...extraArgs], stdin: prompt }
-        : { command: cmd.command, args: [...extraArgs, '-p', ''] }
+        ? { command: cmd.path, args: [...extraArgs], stdin: prompt }
+        : { command: cmd.path, args: [...extraArgs, '-p', ''] }
     case 'codex':
       // `codex exec` reads its instructions from stdin when no PROMPT argument
       // is given. Passing the prompt positionally instead would also work on
@@ -267,13 +259,13 @@ export function buildHeadlessSpawnArgs(
       // passed as an argument — codex then treats stdin as a separate
       // `<stdin>` block rather than as the instructions.
       return prompt
-        ? { command: cmd.command, args: [...extraArgs, 'exec'], stdin: prompt }
-        : { command: cmd.command, args: [...extraArgs, 'exec', ''] }
+        ? { command: cmd.path, args: [...extraArgs, 'exec'], stdin: prompt }
+        : { command: cmd.path, args: [...extraArgs, 'exec', ''] }
     case 'opencode':
       // `opencode run` with no positional message reads the message from stdin.
       return prompt
-        ? { command: cmd.command, args: [...extraArgs, 'run'], stdin: prompt }
-        : { command: cmd.command, args: [...extraArgs, 'run', ''] }
+        ? { command: cmd.path, args: [...extraArgs, 'run'], stdin: prompt }
+        : { command: cmd.path, args: [...extraArgs, 'run', ''] }
     case 'gemini':
       // gemini reads stdin whenever stdin isn't a TTY and uses it as the input
       // when no `-p` is given (`input = input ? stdin + input : stdin`). Piped
@@ -284,9 +276,9 @@ export function buildHeadlessSpawnArgs(
       // re-injects it as `--prompt` on the relaunch command line — which would
       // reintroduce the newline truncation. Vorn doesn't enable that sandbox.
       return prompt
-        ? { command: cmd.command, args: [...extraArgs], stdin: prompt }
-        : { command: cmd.command, args: [...extraArgs, '-p', ''] }
+        ? { command: cmd.path, args: [...extraArgs], stdin: prompt }
+        : { command: cmd.path, args: [...extraArgs, '-p', ''] }
     default:
-      return { command: cmd.command, args: [...extraArgs, '-p', prompt] }
+      return { command: cmd.path, args: [...extraArgs, '-p', prompt] }
   }
 }

--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -17,10 +17,11 @@ function resolveAgentCommand(
   config: AgentCommandConfig,
   env: Record<string, string>
 ): { command: string; args: string[]; path: string } {
-  const primary = findOnPath(config.command, env.PATH)
+  const pathEnv = env.PATH ?? env.Path
+  const primary = findOnPath(config.command, pathEnv)
   if (primary) return { command: config.command, args: config.args, path: primary }
   if (config.fallbackCommand) {
-    const fallback = findOnPath(config.fallbackCommand, env.PATH)
+    const fallback = findOnPath(config.fallbackCommand, pathEnv)
     if (fallback)
       return { command: config.fallbackCommand, args: config.fallbackArgs ?? [], path: fallback }
   }

--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import path from 'node:path'
 import fs from 'node:fs'
 import crypto from 'node:crypto'
@@ -66,6 +66,27 @@ export function getRepoRoot(cwd: string): string | null {
   } catch {
     return null
   }
+}
+
+/** `git rev-parse <what>` without blocking the event loop; null when git says no. */
+function gitRevParse(args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      gitBin(),
+      ['rev-parse', ...args],
+      { cwd, ...EXEC_OPTS, env: getSafeEnv(), timeout: 3000 },
+      (err, stdout) => resolve(err ? null : String(stdout).trim() || null)
+    )
+  })
+}
+
+export async function getGitBranchAsync(projectPath: string): Promise<string | null> {
+  const branch = await gitRevParse(['--abbrev-ref', 'HEAD'], projectPath)
+  return branch && branch !== 'HEAD' ? branch : null
+}
+
+export function getGitHeadAsync(projectPath: string): Promise<string | null> {
+  return gitRevParse(['HEAD'], projectPath)
 }
 
 export function getGitBranch(projectPath: string, remote?: RemoteHost): string | null {

--- a/packages/server/src/git-utils.ts
+++ b/packages/server/src/git-utils.ts
@@ -1,3 +1,4 @@
+import { promisify } from 'node:util'
 import { execFile, execFileSync } from 'node:child_process'
 import path from 'node:path'
 import fs from 'node:fs'
@@ -68,21 +69,28 @@ export function getRepoRoot(cwd: string): string | null {
   }
 }
 
-/** `git rev-parse <what>` without blocking the event loop; null when git says no. */
-function gitRevParse(args: string[], cwd: string): Promise<string | null> {
-  return new Promise((resolve) => {
-    execFile(
-      gitBin(),
-      ['rev-parse', ...args],
-      { cwd, ...EXEC_OPTS, env: getSafeEnv(), timeout: 3000 },
-      (err, stdout) => resolve(err ? null : String(stdout).trim() || null)
-    )
-  })
+/** A detached HEAD is no branch. */
+function branchOrNull(raw: string | null): string | null {
+  return raw && raw !== 'HEAD' ? raw : null
+}
+
+/** `git rev-parse` without blocking the event loop; null when git says no. */
+async function gitRevParse(args: string[], cwd: string): Promise<string | null> {
+  try {
+    const { stdout } = await promisify(execFile)(gitBin(), ['rev-parse', ...args], {
+      cwd,
+      ...EXEC_OPTS,
+      env: getSafeEnv(),
+      timeout: 3000
+    })
+    return String(stdout).trim() || null
+  } catch {
+    return null
+  }
 }
 
 export async function getGitBranchAsync(projectPath: string): Promise<string | null> {
-  const branch = await gitRevParse(['--abbrev-ref', 'HEAD'], projectPath)
-  return branch && branch !== 'HEAD' ? branch : null
+  return branchOrNull(await gitRevParse(['--abbrev-ref', 'HEAD'], projectPath))
 }
 
 export function getGitHeadAsync(projectPath: string): Promise<string | null> {
@@ -91,11 +99,9 @@ export function getGitHeadAsync(projectPath: string): Promise<string | null> {
 
 export function getGitBranch(projectPath: string, remote?: RemoteHost): string | null {
   try {
-    const branch = gitExec(['rev-parse', '--abbrev-ref', 'HEAD'], projectPath, {
-      timeout: 3000,
-      remote
-    }).trim()
-    return branch && branch !== 'HEAD' ? branch : null
+    return branchOrNull(
+      gitExec(['rev-parse', '--abbrev-ref', 'HEAD'], projectPath, { timeout: 3000, remote }).trim()
+    )
   } catch {
     return null
   }

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -1,7 +1,6 @@
 import { spawn, ChildProcess } from 'node:child_process'
 import crypto from 'node:crypto'
 import fs from 'node:fs'
-import path from 'node:path'
 import { EventEmitter } from 'node:events'
 import {
   AiAgentType,
@@ -21,7 +20,6 @@ import {
 } from './git-utils'
 import { getLaunchEnv, shellEscape } from './process-utils'
 import { buildHeadlessSpawnArgs } from './agent-launch'
-import { resolveExecutable } from './resolve-executable'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import log from './logger'
 import { isDraining, DRAINING_MESSAGE } from './draining'
@@ -127,17 +125,13 @@ class HeadlessManager extends EventEmitter {
     // Not truncated: this line is the first thing anyone reads when a session
     // produces no output, and the flag that explains it is as likely to be at
     // the end as the start. The prompt isn't here — it goes to stdin.
-    // By absolute path: spawn only searches the PATH it is handed, and boot may have missed it.
-    const command = path.isAbsolute(spawnArgs.command)
-      ? spawnArgs.command
-      : (resolveExecutable(spawnArgs.command) ?? spawnArgs.command)
-    const launchCommand = [command, ...spawnArgList].join(' ')
+    const launchCommand = [spawnArgs.command, ...spawnArgList].join(' ')
     log.info(
       `[headless] launching in ${effectivePath}: ${launchCommand}` +
         (spawnArgs.stdin != null ? ` (prompt on stdin, ${spawnArgs.stdin.length} chars)` : '')
     )
 
-    const child = spawn(command, spawnArgList, {
+    const child = spawn(spawnArgs.command, spawnArgList, {
       cwd: effectivePath,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -1,6 +1,7 @@
 import { spawn, ChildProcess } from 'node:child_process'
 import crypto from 'node:crypto'
 import fs from 'node:fs'
+import path from 'node:path'
 import { EventEmitter } from 'node:events'
 import {
   AiAgentType,
@@ -20,6 +21,7 @@ import {
 } from './git-utils'
 import { getLaunchEnv, shellEscape } from './process-utils'
 import { buildHeadlessSpawnArgs } from './agent-launch'
+import { resolveExecutable } from './resolve-executable'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import log from './logger'
 import { isDraining, DRAINING_MESSAGE } from './draining'
@@ -125,13 +127,17 @@ class HeadlessManager extends EventEmitter {
     // Not truncated: this line is the first thing anyone reads when a session
     // produces no output, and the flag that explains it is as likely to be at
     // the end as the start. The prompt isn't here — it goes to stdin.
-    const launchCommand = [spawnArgs.command, ...spawnArgList].join(' ')
+    // By absolute path: spawn only searches the PATH it is handed, and boot may have missed it.
+    const command = path.isAbsolute(spawnArgs.command)
+      ? spawnArgs.command
+      : (resolveExecutable(spawnArgs.command) ?? spawnArgs.command)
+    const launchCommand = [command, ...spawnArgList].join(' ')
     log.info(
       `[headless] launching in ${effectivePath}: ${launchCommand}` +
         (spawnArgs.stdin != null ? ` (prompt on stdin, ${spawnArgs.stdin.length} chars)` : '')
     )
 
-    const child = spawn(spawnArgs.command, spawnArgList, {
+    const child = spawn(command, spawnArgList, {
       cwd: effectivePath,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -125,13 +125,14 @@ class HeadlessManager extends EventEmitter {
     // Not truncated: this line is the first thing anyone reads when a session
     // produces no output, and the flag that explains it is as likely to be at
     // the end as the start. The prompt isn't here — it goes to stdin.
-    const launchCommand = [spawnArgs.command, ...spawnArgList].join(' ')
+    const command = useShell ? shellEscape(spawnArgs.command, 'cmd') : spawnArgs.command
+    const launchCommand = [command, ...spawnArgList].join(' ')
     log.info(
       `[headless] launching in ${effectivePath}: ${launchCommand}` +
         (spawnArgs.stdin != null ? ` (prompt on stdin, ${spawnArgs.stdin.length} chars)` : '')
     )
 
-    const child = spawn(spawnArgs.command, spawnArgList, {
+    const child = spawn(command, spawnArgList, {
       cwd: effectivePath,
       env,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -57,7 +57,7 @@ import { ptyManager } from './pty-manager'
 import { configureHistory, flushHistory, checkpointAll } from './history/writer'
 import { recoverHistory } from './history/recovery'
 import { seedRestored, markRecovered, verifyRestored, consumeRestored } from './restored-sessions'
-import { getGitBranch, getGitHead } from './git-utils'
+import { getGitBranchAsync, getGitHeadAsync } from './git-utils'
 import { sessionManager } from './session-persistence'
 import { headlessManager } from './headless-manager'
 import { scheduler } from './scheduler'
@@ -67,7 +67,7 @@ import { redeemCode, pollRequest, pendingRequests } from './pairing'
 import { getTailscaleStatus } from './tailscale'
 import { initRebind, checkAndRebind, getCurrentHost } from './server-rebind'
 import { isAllowedUpgrade, logRefusedUpgrade, setTrustedOriginHosts } from './ws-origin'
-import { setEnvPassthrough, setLaunchDataDir } from './process-utils'
+import { primeShellEnv, setEnvPassthrough, setLaunchDataDir } from './process-utils'
 import log from './logger'
 import { appFrameAncestors } from './extensions/frame-ancestors'
 
@@ -151,6 +151,9 @@ export async function startServer(
     adopted?: AdoptedPane[]
   } = {}
 ) {
+  const bootStarted = Date.now()
+  // First, so the shell runs while the database opens and the modules load.
+  const shellEnvReady = primeShellEnv()
   // Initialize database + config. This resolves the data directory for the whole
   // process; everything else reads it back with getDataDir() rather than
   // deriving it again, so nothing can disagree about where the files are.
@@ -404,6 +407,43 @@ export async function startServer(
 
   // Register all RPC methods
   registerAllMethods()
+
+  // Started here and awaited before the port file: history is read and the
+  // trees are checked while the socket comes up, so discovery waits on neither.
+  // After `registerAllMethods()`, so nothing here races the first debounced
+  // `saveSessions`. Adopted sessions belong in this list for both things it
+  // decides: their screens are rebuilt from the previous server's checkpoint,
+  // and a session absent from it has its history swept. Null sweeps nothing.
+  const recoverable =
+    carriedOver === null
+      ? null
+      : [
+          ...carriedOver,
+          ...adopted
+            .filter((pane) => !carriedOver.some((s) => s.id === pane.session.id))
+            .map((pane) => pane.session)
+        ]
+  if (carriedOver === null && adopted.length) {
+    log.warn(
+      '[handoff] the session list could not be read; adopted terminals start without scrollback'
+    )
+  }
+  const recovering = recoverHistory(dataDir, recoverable)
+  // The shell's PATH is worth a short wait for git; a slow shell is not worth the boot.
+  const verifying = Promise.race([shellEnvReady, new Promise((r) => setTimeout(r, 1000))]).then(
+    () =>
+      verifyRestored({
+        isDirectory: (at) => {
+          try {
+            return fs.statSync(at).isDirectory()
+          } catch {
+            return false
+          }
+        },
+        branch: getGitBranchAsync,
+        head: getGitHeadAsync
+      })
+  )
   // Connects the rung-none packs installed before installing meant connecting.
   reconcileImplicitConnections()
   scheduler.startInboxWorker()
@@ -595,45 +635,8 @@ export async function startServer(
 
   registerMethod('server:handoff', (params) => handOver(params, handoffHost))
 
-  // Only now, and for two reasons. It is after `registerAllMethods()`, so
-  // nothing here races the first debounced `saveSessions`. And it is after the
-  // endpoint claim, so a server that arrives second exits above rather than
-  // replaying every terminal on the machine and then standing down.
-  //
-  // It runs before the port file and the credential below, which closes the
-  // window the plan for this expected to have to live with: a client cannot find
-  // this server until both of those exist, so there is no moment where one can
-  // ask for history that has not been read yet. The cost is that discovery waits
-  // on it -- measured at 77ms for fifty terminals.
-  // Adopted sessions belong in this list for both things it decides: their screens
-  // are rebuilt from the previous server's checkpoint, and a session absent from it
-  // has its history swept. Null stays null, which sweeps nothing.
-  const recoverable =
-    carriedOver === null
-      ? null
-      : [
-          ...carriedOver,
-          ...adopted
-            .filter((pane) => !carriedOver.some((s) => s.id === pane.session.id))
-            .map((pane) => pane.session)
-        ]
-  if (carriedOver === null && adopted.length) {
-    log.warn(
-      '[handoff] the session list could not be read; adopted terminals start without scrollback'
-    )
-  }
-  markRecovered((await recoverHistory(dataDir, recoverable)).recovered)
-  verifyRestored({
-    isDirectory: (at) => {
-      try {
-        return fs.statSync(at).isDirectory()
-      } catch {
-        return false
-      }
-    },
-    branch: getGitBranch,
-    head: getGitHead
-  })
+  markRecovered((await recovering).recovered)
+  await verifying
 
   // After recovery, whose rebuilt screens `createScreen` would otherwise clear, and
   // before the port file, so no client can find this server and be told it is empty.
@@ -645,7 +648,7 @@ export async function startServer(
   publishLocalCredential(ownsPublished)
   writePortFile(dataDir, actualPort, ownsPublished)
 
-  log.info(`[server] listening on ${host}:${actualPort}`)
+  log.info(`[server] listening on ${host}:${actualPort} (ready in ${Date.now() - bootStarted}ms)`)
 
   // Graceful shutdown
   const { hookServer } = await import('./hook-server')

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,7 +67,12 @@ import { redeemCode, pollRequest, pendingRequests } from './pairing'
 import { getTailscaleStatus } from './tailscale'
 import { initRebind, checkAndRebind, getCurrentHost } from './server-rebind'
 import { isAllowedUpgrade, logRefusedUpgrade, setTrustedOriginHosts } from './ws-origin'
-import { primeShellEnv, setEnvPassthrough, setLaunchDataDir } from './process-utils'
+import {
+  primeShellEnv,
+  shellEnvSettled,
+  setEnvPassthrough,
+  setLaunchDataDir
+} from './process-utils'
 import log from './logger'
 import { appFrameAncestors } from './extensions/frame-ancestors'
 
@@ -152,8 +157,8 @@ export async function startServer(
   } = {}
 ) {
   const bootStarted = Date.now()
-  // First, so the shell runs while the database opens and the modules load.
-  const shellEnvReady = primeShellEnv()
+  // First, so the shell answers while the database opens and the modules load.
+  void primeShellEnv()
   // Initialize database + config. This resolves the data directory for the whole
   // process; everything else reads it back with getDataDir() rather than
   // deriving it again, so nothing can disagree about where the files are.
@@ -408,42 +413,6 @@ export async function startServer(
   // Register all RPC methods
   registerAllMethods()
 
-  // Started here and awaited before the port file: history is read and the
-  // trees are checked while the socket comes up, so discovery waits on neither.
-  // After `registerAllMethods()`, so nothing here races the first debounced
-  // `saveSessions`. Adopted sessions belong in this list for both things it
-  // decides: their screens are rebuilt from the previous server's checkpoint,
-  // and a session absent from it has its history swept. Null sweeps nothing.
-  const recoverable =
-    carriedOver === null
-      ? null
-      : [
-          ...carriedOver,
-          ...adopted
-            .filter((pane) => !carriedOver.some((s) => s.id === pane.session.id))
-            .map((pane) => pane.session)
-        ]
-  if (carriedOver === null && adopted.length) {
-    log.warn(
-      '[handoff] the session list could not be read; adopted terminals start without scrollback'
-    )
-  }
-  const recovering = recoverHistory(dataDir, recoverable)
-  // The shell's PATH is worth a short wait for git; a slow shell is not worth the boot.
-  const verifying = Promise.race([shellEnvReady, new Promise((r) => setTimeout(r, 1000))]).then(
-    () =>
-      verifyRestored({
-        isDirectory: (at) => {
-          try {
-            return fs.statSync(at).isDirectory()
-          } catch {
-            return false
-          }
-        },
-        branch: getGitBranchAsync,
-        head: getGitHeadAsync
-      })
-  )
   // Connects the rung-none packs installed before installing meant connecting.
   reconcileImplicitConnections()
   scheduler.startInboxWorker()
@@ -581,6 +550,41 @@ export async function startServer(
   // serve`, so a check that lived only there would be late or absent exactly
   // where it matters.
   if (endpoint) watchEndpoint(() => endpoint?.holds() ?? false)
+
+  // After the claim, so a server that arrives second exits above rather than
+  // replaying every terminal first; awaited before the port file, so no client
+  // can be told there is no history. Adopted sessions are rebuilt from the
+  // previous server's checkpoint, and a session absent from the list has its
+  // history swept. Null sweeps nothing.
+  const recoverable =
+    carriedOver === null
+      ? null
+      : [
+          ...carriedOver,
+          ...adopted
+            .filter((pane) => !carriedOver.some((s) => s.id === pane.session.id))
+            .map((pane) => pane.session)
+        ]
+  if (carriedOver === null && adopted.length) {
+    log.warn(
+      '[handoff] the session list could not be read; adopted terminals start without scrollback'
+    )
+  }
+  const recovering = recoverHistory(dataDir, recoverable)
+  // git is worth a short wait for the shell's PATH; a slow shell is not worth the boot.
+  const verifying = shellEnvSettled(1000).then(() =>
+    verifyRestored({
+      isDirectory: (at) => {
+        try {
+          return fs.statSync(at).isDirectory()
+        } catch {
+          return false
+        }
+      },
+      branch: getGitBranchAsync,
+      head: getGitHeadAsync
+    })
+  )
 
   /** Registered here because every closure needs the endpoint, port and file ownership. */
   const handoffHost: HandoffHost = {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -156,9 +156,9 @@ export async function startServer(
     adopted?: AdoptedPane[]
   } = {}
 ) {
-  const bootStarted = Date.now()
   // First, so the shell answers while the database opens and the modules load.
   void primeShellEnv()
+  const bootStarted = Date.now()
   // Initialize database + config. This resolves the data directory for the whole
   // process; everything else reads it back with getDataDir() rather than
   // deriving it again, so nothing can disagree about where the files are.

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -35,10 +35,16 @@ export function primeShellEnv(): Promise<void> {
   if (priming) return priming
   const run = new Promise<void>((resolve) => {
     const started = Date.now()
+    // The shell gets the filtered environment: the desktop's credential is still in process.env here.
     execFile(
       getDefaultShell(),
       ['-ilc', 'env'],
-      { encoding: 'utf-8', timeout: SHELL_ENV_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
+      {
+        encoding: 'utf-8',
+        timeout: SHELL_ENV_TIMEOUT_MS,
+        maxBuffer: 4 * 1024 * 1024,
+        env: filterEnv(process.env, new Set())
+      },
       (err, stdout) => {
         const ms = Date.now() - started
         if (err) {
@@ -60,6 +66,11 @@ export function primeShellEnv(): Promise<void> {
     if (priming === run) priming = undefined
   })
   return run
+}
+
+/** True once the login shell has answered; on Windows there is nothing to wait for. */
+export function shellEnvResolved(): boolean {
+  return process.platform === 'win32' || resolvedEnvCache !== undefined
 }
 
 /** Wait for the shell's answer, but never longer than `maxMs`. */

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -19,82 +19,70 @@ function parseEnvOutput(output: string): Record<string, string> {
 }
 
 const SHELL_ENV_TIMEOUT_MS = 15_000
-/** How long a failed probe is trusted before the next caller tries the shell again. */
+/** How long a shell that did not answer is left alone before it is asked again. */
 const SHELL_ENV_RETRY_MS = 30_000
 
 let resolvedEnvCache: Record<string, string> | undefined
-let lastProbeFailedAt = 0
 let priming: Promise<void> | undefined
-
-function loginShell(): string {
-  return process.env.SHELL || '/bin/zsh'
-}
+let retryAfter = 0
+/** Set once a server asked; a short-lived CLI never starts a shell it would then wait on. */
+let wanted = false
 
 /** Ask the login shell for its environment in the background; a failure is logged, not kept. */
 export function primeShellEnv(): Promise<void> {
+  wanted = true
   if (process.platform === 'win32' || resolvedEnvCache) return Promise.resolve()
-  priming ??= new Promise<void>((resolve) => {
+  if (priming) return priming
+  const run = new Promise<void>((resolve) => {
     const started = Date.now()
     execFile(
-      loginShell(),
+      getDefaultShell(),
       ['-ilc', 'env'],
       { encoding: 'utf-8', timeout: SHELL_ENV_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
       (err, stdout) => {
-        priming = undefined
+        const ms = Date.now() - started
         if (err) {
-          lastProbeFailedAt = Date.now()
+          retryAfter = Date.now() + SHELL_ENV_RETRY_MS
           log.warn(
-            { err: err.message, ms: Date.now() - started },
+            { err: err.message, ms },
             "[env] the login shell did not answer; child processes get this process's PATH until it does"
           )
         } else {
           resolvedEnvCache = parseEnvOutput(stdout)
-          log.info({ ms: Date.now() - started }, '[env] login shell environment resolved')
+          log.info({ ms }, '[env] login shell environment resolved')
         }
         resolve()
       }
     )
   })
-  return priming
+  priming = run
+  void run.then(() => {
+    if (priming === run) priming = undefined
+  })
+  return run
 }
 
-/** The login shell's environment, or null when it did not answer. */
-function getUserShellEnv(): Record<string, string> | null {
-  if (process.platform === 'win32') return { ...process.env } as Record<string, string>
-  const started = Date.now()
-  try {
-    const output = execFileSync(loginShell(), ['-ilc', 'env'], {
-      encoding: 'utf-8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe']
+/** Wait for the shell's answer, but never longer than `maxMs`. */
+export function shellEnvSettled(maxMs: number): Promise<void> {
+  const pending = priming
+  if (!pending) return Promise.resolve()
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, maxMs)
+    void pending.then(() => {
+      clearTimeout(timer)
+      resolve()
     })
-    log.info({ ms: Date.now() - started }, '[env] login shell environment resolved')
-    return parseEnvOutput(output)
-  } catch (err) {
-    lastProbeFailedAt = Date.now()
-    log.warn(
-      { err: (err as Error).message, ms: Date.now() - started },
-      "[env] the login shell did not answer; child processes get this process's PATH until it does"
-    )
-    return null
-  }
+  })
 }
 
 /**
- * Resolved lazily and memoized: getUserShellEnv() spawns a login shell, and
- * doing that at import time made merely importing this module — as the pure
- * helpers' unit tests do — pay for a subprocess it never uses.
+ * The login shell's environment once it has answered, this process's own until then.
  * Only a success is kept: a shell that timed out at boot must not mean "no PATH" for good.
  */
 function resolvedEnv(): Record<string, string> {
   if (resolvedEnvCache) return resolvedEnvCache
-  // Still asking, or just failed: this process's own environment, not a second shell.
-  if (priming || Date.now() - lastProbeFailedAt < SHELL_ENV_RETRY_MS) {
-    return { ...process.env } as Record<string, string>
-  }
-  const env = getUserShellEnv()
-  if (env) resolvedEnvCache = env
-  return env ?? ({ ...process.env } as Record<string, string>)
+  if (wanted && !priming && Date.now() >= retryAfter) void primeShellEnv()
+  return { ...process.env } as Record<string, string>
 }
 
 /**

--- a/packages/server/src/process-utils.ts
+++ b/packages/server/src/process-utils.ts
@@ -6,26 +6,77 @@ import type { RemoteHost } from '@vornrun/shared/types'
 // anything that reaches the database.
 import { BOOTSTRAP_ENV_VAR } from '@vornrun/shared/protocol'
 import { NEVER_BORROWED_ENV, SENSITIVE_ENV_PREFIXES } from '@vornrun/shared/types'
+import log from './logger'
 
-function getUserShellEnv(): Record<string, string> {
+/** Parse `env` output into a map. */
+function parseEnvOutput(output: string): Record<string, string> {
+  const env: Record<string, string> = {}
+  for (const line of output.split('\n')) {
+    const idx = line.indexOf('=')
+    if (idx > 0) env[line.substring(0, idx)] = line.substring(idx + 1)
+  }
+  return env
+}
+
+const SHELL_ENV_TIMEOUT_MS = 15_000
+/** How long a failed probe is trusted before the next caller tries the shell again. */
+const SHELL_ENV_RETRY_MS = 30_000
+
+let resolvedEnvCache: Record<string, string> | undefined
+let lastProbeFailedAt = 0
+let priming: Promise<void> | undefined
+
+function loginShell(): string {
+  return process.env.SHELL || '/bin/zsh'
+}
+
+/** Ask the login shell for its environment in the background; a failure is logged, not kept. */
+export function primeShellEnv(): Promise<void> {
+  if (process.platform === 'win32' || resolvedEnvCache) return Promise.resolve()
+  priming ??= new Promise<void>((resolve) => {
+    const started = Date.now()
+    execFile(
+      loginShell(),
+      ['-ilc', 'env'],
+      { encoding: 'utf-8', timeout: SHELL_ENV_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout) => {
+        priming = undefined
+        if (err) {
+          lastProbeFailedAt = Date.now()
+          log.warn(
+            { err: err.message, ms: Date.now() - started },
+            "[env] the login shell did not answer; child processes get this process's PATH until it does"
+          )
+        } else {
+          resolvedEnvCache = parseEnvOutput(stdout)
+          log.info({ ms: Date.now() - started }, '[env] login shell environment resolved')
+        }
+        resolve()
+      }
+    )
+  })
+  return priming
+}
+
+/** The login shell's environment, or null when it did not answer. */
+function getUserShellEnv(): Record<string, string> | null {
   if (process.platform === 'win32') return { ...process.env } as Record<string, string>
+  const started = Date.now()
   try {
-    const shell = process.env.SHELL || '/bin/zsh'
-    const output = execFileSync(shell, ['-ilc', 'env'], {
+    const output = execFileSync(loginShell(), ['-ilc', 'env'], {
       encoding: 'utf-8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'] as ['pipe', 'pipe', 'pipe']
     })
-    const env: Record<string, string> = {}
-    for (const line of output.split('\n')) {
-      const idx = line.indexOf('=')
-      if (idx > 0) {
-        env[line.substring(0, idx)] = line.substring(idx + 1)
-      }
-    }
-    return env
-  } catch {
-    return { ...process.env } as Record<string, string>
+    log.info({ ms: Date.now() - started }, '[env] login shell environment resolved')
+    return parseEnvOutput(output)
+  } catch (err) {
+    lastProbeFailedAt = Date.now()
+    log.warn(
+      { err: (err as Error).message, ms: Date.now() - started },
+      "[env] the login shell did not answer; child processes get this process's PATH until it does"
+    )
+    return null
   }
 }
 
@@ -33,12 +84,17 @@ function getUserShellEnv(): Record<string, string> {
  * Resolved lazily and memoized: getUserShellEnv() spawns a login shell, and
  * doing that at import time made merely importing this module — as the pure
  * helpers' unit tests do — pay for a subprocess it never uses.
+ * Only a success is kept: a shell that timed out at boot must not mean "no PATH" for good.
  */
-let resolvedEnvCache: Record<string, string> | undefined
-
 function resolvedEnv(): Record<string, string> {
-  resolvedEnvCache ??= getUserShellEnv()
-  return resolvedEnvCache
+  if (resolvedEnvCache) return resolvedEnvCache
+  // Still asking, or just failed: this process's own environment, not a second shell.
+  if (priming || Date.now() - lastProbeFailedAt < SHELL_ENV_RETRY_MS) {
+    return { ...process.env } as Record<string, string>
+  }
+  const env = getUserShellEnv()
+  if (env) resolvedEnvCache = env
+  return env ?? ({ ...process.env } as Record<string, string>)
 }
 
 /**

--- a/packages/server/src/resolve-executable.ts
+++ b/packages/server/src/resolve-executable.ts
@@ -12,9 +12,8 @@ import { getSafeEnv } from './process-utils'
 // "not found" until app restart.
 const cache = new Map<string, string>()
 
-function find(name: string): string | null {
-  const env = getSafeEnv()
-  const pathEnv = env.PATH || env.Path || process.env.PATH || ''
+/** Where `name` lives on `pathEnv`, or null. On Windows `.exe` and `.cmd` count too. */
+export function findOnPath(name: string, pathEnv: string | undefined): string | null {
   if (!pathEnv) return null
   const sep = process.platform === 'win32' ? ';' : ':'
   const candidates = process.platform === 'win32' ? [`${name}.exe`, `${name}.cmd`, name] : [name]
@@ -32,6 +31,11 @@ function find(name: string): string | null {
     }
   }
   return null
+}
+
+function find(name: string): string | null {
+  const env = getSafeEnv()
+  return findOnPath(name, env.PATH || env.Path || process.env.PATH)
 }
 
 /**

--- a/packages/server/src/resolve-executable.ts
+++ b/packages/server/src/resolve-executable.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { getSafeEnv } from './process-utils'
+import { getSafeEnv, shellEnvResolved } from './process-utils'
 
 // Packaged Electron apps on macOS don't inherit the login-shell PATH, so
 // user-installed binaries (Homebrew at /opt/homebrew/bin, /usr/local/bin)
@@ -48,7 +48,8 @@ export function resolveExecutable(name: string): string | null {
   const hit = cache.get(name)
   if (hit) return hit
   const found = find(name)
-  if (found) cache.set(name, found)
+  // A hit on the provisional PATH is not the user's answer; keep asking until the shell has spoken.
+  if (found && shellEnvResolved()) cache.set(name, found)
   return found
 }
 

--- a/packages/server/src/restore-environment.ts
+++ b/packages/server/src/restore-environment.ts
@@ -2,24 +2,27 @@ import type { RestoreEnvironment, TerminalSession } from '@vornrun/shared/types'
 
 export interface EnvironmentProbe {
   isDirectory(at: string): boolean
-  branch(cwd: string): string | null
-  head(cwd: string): string | null
+  branch(cwd: string): string | null | Promise<string | null>
+  head(cwd: string): string | null | Promise<string | null>
 }
 
 // What is there now against what the record says, so Resume is offered knowingly.
-export function probeEnvironment(
+export async function probeEnvironment(
   session: Pick<
     TerminalSession,
     'projectPath' | 'worktreePath' | 'branch' | 'headCommit' | 'remoteHostId'
   >,
   probe: EnvironmentProbe
-): RestoreEnvironment | undefined {
+): Promise<RestoreEnvironment | undefined> {
   if (session.remoteHostId) return undefined
   const cwd = session.worktreePath ?? session.projectPath
   const present = probe.isDirectory(cwd)
+  const [branch, head] = present
+    ? await Promise.all([probe.branch(cwd), probe.head(cwd)])
+    : [null, null]
   return {
     worktree: present ? 'ok' : 'missing',
-    branch: { recorded: session.branch ?? null, actual: present ? probe.branch(cwd) : null },
-    head: { recorded: session.headCommit ?? null, actual: present ? probe.head(cwd) : null }
+    branch: { recorded: session.branch ?? null, actual: branch },
+    head: { recorded: session.headCommit ?? null, actual: head }
   }
 }

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -112,13 +112,29 @@ export function markRecovered(
   }
 }
 
-/** Check each record against the tree once, so Resume is offered knowingly. One that throws is left unchecked. */
-/** Every record at once: the git calls behind the probe are what a busy boot waits on. */
+/** Every record at once, one git answer per directory; a record that throws is left unchecked. */
 export async function verifyRestored(probe: EnvironmentProbe): Promise<void> {
+  const answers = new Map<string, Promise<string | null>>()
+  const shared =
+    (ask: 'branch' | 'head') =>
+    (cwd: string): Promise<string | null> => {
+      const key = `${ask}\0${cwd}`
+      let answer = answers.get(key)
+      if (!answer) {
+        answer = Promise.resolve(probe[ask](cwd))
+        answers.set(key, answer)
+      }
+      return answer
+    }
+  const once: EnvironmentProbe = {
+    isDirectory: probe.isDirectory,
+    branch: shared('branch'),
+    head: shared('head')
+  }
   await Promise.all(
     [...held.values()].map(async (entry) => {
       try {
-        const environment = await probeEnvironment(entry.session, probe)
+        const environment = await probeEnvironment(entry.session, once)
         if (environment) entry.environment = environment
       } catch (err) {
         log.warn({ err, id: entry.session.id }, '[restored] could not verify a session')
@@ -127,7 +143,6 @@ export async function verifyRestored(probe: EnvironmentProbe): Promise<void> {
   )
 }
 
-/** What a client is offered. */
 export function listRestored(): RestoredSession[] {
   return [...held.values()]
 }

--- a/packages/server/src/restored-sessions.ts
+++ b/packages/server/src/restored-sessions.ts
@@ -113,15 +113,18 @@ export function markRecovered(
 }
 
 /** Check each record against the tree once, so Resume is offered knowingly. One that throws is left unchecked. */
-export function verifyRestored(probe: EnvironmentProbe): void {
-  for (const entry of held.values()) {
-    try {
-      const environment = probeEnvironment(entry.session, probe)
-      if (environment) entry.environment = environment
-    } catch (err) {
-      log.warn({ err, id: entry.session.id }, '[restored] could not verify a session')
-    }
-  }
+/** Every record at once: the git calls behind the probe are what a busy boot waits on. */
+export async function verifyRestored(probe: EnvironmentProbe): Promise<void> {
+  await Promise.all(
+    [...held.values()].map(async (entry) => {
+      try {
+        const environment = await probeEnvironment(entry.session, probe)
+        if (environment) entry.environment = environment
+      } catch (err) {
+        log.warn({ err, id: entry.session.id }, '[restored] could not verify a session')
+      }
+    })
+  )
 }
 
 /** What a client is offered. */

--- a/packages/server/src/ws-auth.ts
+++ b/packages/server/src/ws-auth.ts
@@ -72,9 +72,7 @@ export function initBootstrapSecret(
 
   // Remove it from the environment now that it is held in a module variable.
   // `filterEnv` strips the name, but a filter only covers the paths it is asked
-  // about — `primeShellEnv` runs the login shell with the parent environment
-  // and reads `env` back, so anything still in `process.env` is reachable. After
-  // this, no child can inherit it however it is spawned.
+  // about; after this, no child can inherit it however it is spawned.
   delete process.env[BOOTSTRAP_ENV_VAR]
 
   localTokenPath = null

--- a/packages/server/src/ws-auth.ts
+++ b/packages/server/src/ws-auth.ts
@@ -72,7 +72,7 @@ export function initBootstrapSecret(
 
   // Remove it from the environment now that it is held in a module variable.
   // `filterEnv` strips the name, but a filter only covers the paths it is asked
-  // about — `getUserShellEnv` runs the login shell with the parent environment
+  // about — `primeShellEnv` runs the login shell with the parent environment
   // and reads `env` back, so anything still in `process.env` is reachable. After
   // this, no child can inherit it however it is spawned.
   delete process.env[BOOTSTRAP_ENV_VAR]

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -12,8 +12,10 @@ const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
 // `index.cjs`, which is required rather than executed.
 const SHEBANG = '#!/usr/bin/env node'
 
+// Node keeps the bundle's compiled form on disk, so a warm start skips half its load.
+const COMPILE_CACHE = `;try { require('module').enableCompileCache() } catch (e) {}`
+
 const NATIVE_MODULE_PATCH = `
-;try { require('module').enableCompileCache() } catch (e) {}
 // Patch module resolution for Electron's utilityProcess.
 //
 // utilityProcess doesn't have the main process's ASAR require() patching,
@@ -54,7 +56,7 @@ export default defineConfig({
   target: 'node22',
   clean: true,
   banner: {
-    js: `${SHEBANG}\n${NATIVE_MODULE_PATCH}`
+    js: `${SHEBANG}\n${COMPILE_CACHE}\n${NATIVE_MODULE_PATCH}`
   },
   // What `vorn --version` answers. The bundle has no package.json to read.
   define: {

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -13,6 +13,7 @@ const { version } = JSON.parse(readFileSync('./package.json', 'utf-8'))
 const SHEBANG = '#!/usr/bin/env node'
 
 const NATIVE_MODULE_PATCH = `
+;try { require('module').enableCompileCache() } catch (e) {}
 // Patch module resolution for Electron's utilityProcess.
 //
 // utilityProcess doesn't have the main process's ASAR require() patching,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -101,6 +101,7 @@ function createWindow(): void {
   })
 
   mainWindow.once('ready-to-show', () => {
+    log.info(`[window] ready to show ${Math.round(process.uptime() * 1000)}ms after launch`)
     mainWindow?.maximize()
     mainWindow?.show()
   })

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -657,13 +657,16 @@ async function tryAdopt(
   // that reading is how a second server gets started on a live port. A socket
   // that closes before greeting has answered: nothing is there.
   const identity = await new Promise<ServerIdentity | null>((resolve) => {
-    const timer = setTimeout(() => resolve(null), ADOPT_IDENTITY_TIMEOUT_MS)
-    const settle = (found: ServerIdentity | null): void => {
+    const timer = setTimeout(() => settle(null), ADOPT_IDENTITY_TIMEOUT_MS)
+    const gone = (): void => settle(null)
+    function settle(found: ServerIdentity | null): void {
       clearTimeout(timer)
+      candidate.off('identity', settle)
+      candidate.off('disconnected', gone)
       resolve(found)
     }
     candidate.once('identity', settle)
-    candidate.once('disconnected', () => settle(null))
+    candidate.once('disconnected', gone)
   })
   log.info(`[launcher] probed ${target} in ${Date.now() - probing}ms`)
 

--- a/src/main/server/server-launcher.ts
+++ b/src/main/server/server-launcher.ts
@@ -648,19 +648,24 @@ async function tryAdopt(
   const token = readLocalToken(self.dataDir)
 
   const candidate = new ServerBridge(target, token ?? undefined)
+  const probing = Date.now()
   candidate.connect()
 
   // The greeting is the first frame on the socket and arrives before
   // authentication, so this resolves even against a server that would reject the
   // credential. A timeout means "cannot tell", which must not be read as "dead":
-  // that reading is how a second server gets started on a live port.
+  // that reading is how a second server gets started on a live port. A socket
+  // that closes before greeting has answered: nothing is there.
   const identity = await new Promise<ServerIdentity | null>((resolve) => {
     const timer = setTimeout(() => resolve(null), ADOPT_IDENTITY_TIMEOUT_MS)
-    candidate.once('identity', (found: ServerIdentity) => {
+    const settle = (found: ServerIdentity | null): void => {
       clearTimeout(timer)
       resolve(found)
-    })
+    }
+    candidate.once('identity', settle)
+    candidate.once('disconnected', () => settle(null))
   })
+  log.info(`[launcher] probed ${target} in ${Date.now() - probing}ms`)
 
   // Something answered, so this is a server rather than a leftover -- and one
   // this app cannot reach, which is a refusal rather than permission to start a

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(() => '/usr/bin/cmd') // commandExists returns true
-}))
+// Nothing is on PATH here, so every command keeps its configured name.
+vi.mock('../packages/server/src/resolve-executable', () => ({ findOnPath: () => null }))
 
 import {
   buildAgentLaunchLine,

--- a/tests/env-passthrough.test.ts
+++ b/tests/env-passthrough.test.ts
@@ -174,7 +174,7 @@ describe('normalizePassthrough', () => {
  * and `filterEnv` only strips keys, so anything it does not remove is inherited by
  * every PTY, headless agent and script node.
  *
- * This is not hypothetical on one platform only: `getUserShellEnv` falls back to
+ * This is not hypothetical on one platform only: `primeShellEnv` falls back to
  * `{ ...process.env }` on Windows and whenever the login-shell probe fails.
  */
 describe('the desktop bootstrap credential', () => {

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -16,6 +16,9 @@ vi.mock('node:child_process', async () => {
   }
 })
 
+vi.mock('../packages/server/src/resolve-executable', () => ({
+  resolveExecutable: (name: string) => (name === 'claude' ? '/opt/agents/bin/claude' : null)
+}))
 vi.mock('../packages/server/src/git-utils', () => ({
   getGitBranch: vi.fn(() => 'main'),
   checkoutBranch: vi.fn(),
@@ -51,6 +54,30 @@ describe('headlessManager.createHeadless', () => {
     expect(idx).toBeGreaterThanOrEqual(0)
     expect(args[idx + 1]).toBe(session.agentSessionId)
 
+    headlessManager.killHeadless(session.id)
+  })
+
+  it('spawns the agent by its absolute path, so a poor PATH cannot lose it', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'claude',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: 'go',
+      headless: true
+    })
+    expect(spawnMock.mock.calls[0][0]).toBe('/opt/agents/bin/claude')
+    headlessManager.killHeadless(session.id)
+  })
+
+  it('keeps a bare name when nothing on PATH answers to it', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'codex',
+      projectName: 'p',
+      projectPath: '/p',
+      initialPrompt: 'go',
+      headless: true
+    })
+    expect(spawnMock.mock.calls[0][0]).toBe('codex')
     headlessManager.killHeadless(session.id)
   })
 

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:child_process', async () => {
 })
 
 vi.mock('../packages/server/src/resolve-executable', () => ({
-  resolveExecutable: (name: string) => (name === 'claude' ? '/opt/agents/bin/claude' : null)
+  findOnPath: (name: string) => (name === 'claude' ? '/opt/agents/bin/claude' : null)
 }))
 vi.mock('../packages/server/src/git-utils', () => ({
   getGitBranch: vi.fn(() => 'main'),

--- a/tests/process-utils.test.ts
+++ b/tests/process-utils.test.ts
@@ -287,3 +287,59 @@ describe('the data directory handed to spawned processes', () => {
     expect(mod.getLaunchEnv().VORN_DATA_DIR).toBe('/tmp/some-other-vorn')
   })
 })
+
+describe('the login-shell environment', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    mockExecFile.mockReset()
+    process.env = { HOME: '/home/user', PATH: '/usr/bin', SHELL: '/bin/zsh' }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.useRealTimers()
+  })
+
+  it('primes in the background and hands the answer to every later caller', async () => {
+    mockExecFile.mockImplementation((_bin, _args, _opts, cb) =>
+      cb(null, 'PATH=/opt/homebrew/bin:/usr/bin\nEDITOR=vim\n')
+    )
+    const mod = await import('../packages/server/src/process-utils')
+    await mod.primeShellEnv()
+    expect(mod.getSafeEnv().PATH).toBe('/opt/homebrew/bin:/usr/bin')
+    expect(mockExecFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('answers with its own environment while the shell is still being asked', async () => {
+    let finish: (() => void) | undefined
+    mockExecFile.mockImplementation((_bin, _args, _opts, cb) => {
+      finish = () => cb(null, 'PATH=/from/shell\n')
+    })
+    const mod = await import('../packages/server/src/process-utils')
+    const priming = mod.primeShellEnv()
+    expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+    finish?.()
+    await priming
+    expect(mod.getSafeEnv().PATH).toBe('/from/shell')
+  })
+
+  it('does not remember a shell that failed to answer', async () => {
+    vi.useFakeTimers()
+    const { execFileSync } = await import('node:child_process')
+    const sync = execFileSync as unknown as ReturnType<typeof vi.fn>
+    sync.mockImplementationOnce(() => {
+      throw new Error('ETIMEDOUT')
+    })
+    const mod = await import('../packages/server/src/process-utils')
+    expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+
+    sync.mockImplementationOnce(() => 'PATH=/late/but/right\n')
+    // Inside the retry window the failure still stands, without asking again.
+    expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+    vi.advanceTimersByTime(31_000)
+    expect(mod.getSafeEnv().PATH).toBe('/late/but/right')
+    expect(mod.getSafeEnv().PATH).toBe('/late/but/right')
+  })
+})

--- a/tests/process-utils.test.ts
+++ b/tests/process-utils.test.ts
@@ -320,26 +320,38 @@ describe('the login-shell environment', () => {
     const mod = await import('../packages/server/src/process-utils')
     const priming = mod.primeShellEnv()
     expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+    expect(mockExecFile).toHaveBeenCalledTimes(1)
     finish?.()
     await priming
     expect(mod.getSafeEnv().PATH).toBe('/from/shell')
   })
 
-  it('does not remember a shell that failed to answer', async () => {
+  it('asks the shell again after a failure, but not right away', async () => {
     vi.useFakeTimers()
-    const { execFileSync } = await import('node:child_process')
-    const sync = execFileSync as unknown as ReturnType<typeof vi.fn>
-    sync.mockImplementationOnce(() => {
-      throw new Error('ETIMEDOUT')
-    })
+    mockExecFile.mockImplementationOnce((_bin, _args, _opts, cb) => cb(new Error('ETIMEDOUT')))
     const mod = await import('../packages/server/src/process-utils')
+    await mod.primeShellEnv()
     expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+    // Inside the retry window the failure stands, without asking again.
+    expect(mockExecFile).toHaveBeenCalledTimes(1)
 
-    sync.mockImplementationOnce(() => 'PATH=/late/but/right\n')
-    // Inside the retry window the failure still stands, without asking again.
-    expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+    mockExecFile.mockImplementationOnce((_bin, _args, _opts, cb) =>
+      cb(null, 'PATH=/late/but/right\n')
+    )
     vi.advanceTimersByTime(31_000)
+    expect(mod.getSafeEnv().PATH).toBe('/usr/bin')
+    await mod.shellEnvSettled(1000)
     expect(mod.getSafeEnv().PATH).toBe('/late/but/right')
-    expect(mod.getSafeEnv().PATH).toBe('/late/but/right')
+    expect(mockExecFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('waits for the shell only as long as it is told to', async () => {
+    vi.useFakeTimers()
+    mockExecFile.mockImplementation(() => {})
+    const mod = await import('../packages/server/src/process-utils')
+    void mod.primeShellEnv()
+    const settled = mod.shellEnvSettled(1000).then(() => 'done')
+    vi.advanceTimersByTime(1000)
+    await expect(settled).resolves.toBe('done')
   })
 })

--- a/tests/process-utils.test.ts
+++ b/tests/process-utils.test.ts
@@ -312,6 +312,16 @@ describe('the login-shell environment', () => {
     expect(mockExecFile).toHaveBeenCalledTimes(1)
   })
 
+  it('does not hand the desktop credential to the login shell', async () => {
+    process.env.SECRET_VORN_BOOTSTRAP_TOKEN = 'owner-token'
+    mockExecFile.mockImplementation((_bin, _args, _opts, cb) => cb(null, 'PATH=/x\n'))
+    const mod = await import('../packages/server/src/process-utils')
+    await mod.primeShellEnv()
+    const spawnEnv = mockExecFile.mock.calls[0][2].env as Record<string, string>
+    expect(spawnEnv.SECRET_VORN_BOOTSTRAP_TOKEN).toBeUndefined()
+    expect(spawnEnv.HOME).toBe('/home/user')
+  })
+
   it('answers with its own environment while the shell is still being asked', async () => {
     let finish: (() => void) | undefined
     mockExecFile.mockImplementation((_bin, _args, _opts, cb) => {

--- a/tests/resolve-executable.test.ts
+++ b/tests/resolve-executable.test.ts
@@ -3,8 +3,10 @@ import fs from 'node:fs'
 
 // We swap in a custom safe-env per test so we can drive the PATH search.
 const safeEnvMock = vi.fn()
+const shellAnswered = { value: true }
 vi.mock('../packages/server/src/process-utils', () => ({
-  getSafeEnv: () => safeEnvMock()
+  getSafeEnv: () => safeEnvMock(),
+  shellEnvResolved: () => shellAnswered.value
 }))
 
 const importResolver = async () => {
@@ -19,6 +21,7 @@ function setPlatform(p: NodeJS.Platform): void {
 }
 
 beforeEach(() => {
+  shellAnswered.value = true
   safeEnvMock.mockReset()
 })
 
@@ -53,6 +56,26 @@ describe('resolveExecutable()', () => {
     expect(second).toBe(first)
     // No additional probes on the second call.
     expect(accessSpy.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it('does not keep a hit made before the login shell answered', async () => {
+    safeEnvMock.mockReturnValue({ PATH: '/usr/bin' })
+    const accessSpy = vi.spyOn(fs, 'accessSync').mockImplementation((p) => {
+      if (String(p).endsWith('/usr/bin/git')) return undefined
+      throw new Error('ENOENT')
+    })
+    shellAnswered.value = false
+    const { resolveExecutable } = await importResolver()
+    resolveExecutable('git')
+    const probesBeforeAnswer = accessSpy.mock.calls.length
+    resolveExecutable('git')
+    // Still asked: the provisional PATH's git may not be the user's.
+    expect(accessSpy.mock.calls.length).toBeGreaterThan(probesBeforeAnswer)
+    shellAnswered.value = true
+    resolveExecutable('git')
+    const probesAfterAnswer = accessSpy.mock.calls.length
+    expect(resolveExecutable('git')).toBe('/usr/bin/git')
+    expect(accessSpy.mock.calls.length).toBe(probesAfterAnswer)
   })
 
   it('returns null when PATH is empty', async () => {

--- a/tests/restore-environment.test.ts
+++ b/tests/restore-environment.test.ts
@@ -16,45 +16,45 @@ const agent = {
 }
 
 describe('checking a record against the tree before offering Resume', () => {
-  it('reports the ordinary case: everything where it was left', () => {
-    expect(probeEnvironment(agent, tree())).toEqual({
+  it('reports the ordinary case: everything where it was left', async () => {
+    expect(await probeEnvironment(agent, tree())).toEqual({
       worktree: 'ok',
       branch: { recorded: 'feature', actual: 'feature' },
       head: { recorded: 'aaaa1111', actual: 'aaaa1111' }
     })
   })
 
-  it('names both commits when HEAD moved', () => {
-    const env = probeEnvironment(agent, tree({ head: 'bbbb2222' }))
+  it('names both commits when HEAD moved', async () => {
+    const env = await probeEnvironment(agent, tree({ head: 'bbbb2222' }))
     expect(env?.head).toEqual({ recorded: 'aaaa1111', actual: 'bbbb2222' })
     expect(headMoved(env)).toBe(true)
   })
 
-  it('says the worktree is missing and asks git nothing about it', () => {
+  it('says the worktree is missing and asks git nothing about it', async () => {
     const probe = tree({ dirs: ['/repo'] })
-    const env = probeEnvironment(agent, probe)
+    const env = await probeEnvironment(agent, probe)
     expect(env?.worktree).toBe('missing')
     expect(env?.head.actual).toBeNull()
     expect(probe.head).not.toHaveBeenCalled()
     expect(probe.branch).not.toHaveBeenCalled()
   })
 
-  it('checks the project when there is no worktree', () => {
+  it('checks the project when there is no worktree', async () => {
     const probe = tree()
-    probeEnvironment({ projectPath: '/repo' }, probe)
+    await probeEnvironment({ projectPath: '/repo' }, probe)
     expect(probe.head).toHaveBeenCalledWith('/repo')
   })
 
-  it('does not call an unknown commit a move', () => {
+  it('does not call an unknown commit a move', async () => {
     // Records written before HEAD was recorded have nothing to compare.
-    expect(headMoved(probeEnvironment({ projectPath: '/repo' }, tree()))).toBe(false)
-    expect(headMoved(probeEnvironment(agent, tree({ head: null })))).toBe(false)
+    expect(headMoved(await probeEnvironment({ projectPath: '/repo' }, tree()))).toBe(false)
+    expect(headMoved(await probeEnvironment(agent, tree({ head: null })))).toBe(false)
     expect(headMoved(undefined)).toBe(false)
   })
 
-  it('leaves a remote session unchecked rather than probing this machine', () => {
+  it('leaves a remote session unchecked rather than probing this machine', async () => {
     const probe = tree()
-    expect(probeEnvironment({ ...agent, remoteHostId: 'box' }, probe)).toBeUndefined()
+    expect(await probeEnvironment({ ...agent, remoteHostId: 'box' }, probe)).toBeUndefined()
     expect(probe.head).not.toHaveBeenCalled()
   })
 })

--- a/tests/restored-sessions.test.ts
+++ b/tests/restored-sessions.test.ts
@@ -162,9 +162,9 @@ describe('checking each record against the tree', () => {
     head: () => 'cafe0000'
   }
 
-  it('records what it found beside the record', () => {
+  it('records what it found beside the record', async () => {
     seedRestored([session({ headCommit: 'cafe0000', branch: 'main' })], NOW)
-    verifyRestored(probe)
+    await verifyRestored(probe)
     expect(listRestored()[0].environment).toEqual({
       worktree: 'ok',
       branch: { recorded: 'main', actual: 'main' },
@@ -172,15 +172,15 @@ describe('checking each record against the tree', () => {
     })
   })
 
-  it('marks a worktree that is no longer there', () => {
+  it('marks a worktree that is no longer there', async () => {
     seedRestored([session({ worktreePath: '/gone' })], NOW)
-    verifyRestored(probe)
+    await verifyRestored(probe)
     expect(listRestored()[0].environment?.worktree).toBe('missing')
   })
 
-  it('does not let one record that throws take the launch down with it', () => {
+  it('does not let one record that throws take the launch down with it', async () => {
     seedRestored([session({ id: 'bad', projectPath: '/boom' }), session({ id: 'good' })], NOW)
-    verifyRestored({
+    await verifyRestored({
       ...probe,
       isDirectory: (at) => {
         if (at === '/boom') throw new Error('EACCES')

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -25,6 +25,8 @@ const published = {
   pidAlive: true,
   /** Whether the running server closes the socket after greeting us. */
   rejectsCredential: false,
+  /** Whether the name refuses the connection outright: a socket nobody holds. */
+  refused: false,
   /** Set once the fake spawned server has "published" its port file. */
   spawnedPid: null as number | null
 }
@@ -62,6 +64,12 @@ class FakeBridge extends EventEmitter {
   }
   connect(): void {
     setImmediate(() => {
+      if (published.refused) {
+        // Once: the server this launch then spawns must be reachable.
+        published.refused = false
+        this.emit('disconnected')
+        return
+      }
       // Mirrors the real ordering: the socket opens and `connected` fires first,
       // then frames arrive. So `isConnected` is already true when the greeting
       // lands, and cannot be used as proof the credential was accepted.
@@ -197,6 +205,7 @@ beforeEach(() => {
   published.protocolVersion = RUNTIME_PROTOCOL_VERSION
   published.pidAlive = true
   published.rejectsCredential = false
+  published.refused = false
   published.spawnedPid = null
   hostSettings.value = { mode: 'local', url: '', token: undefined }
 })
@@ -320,6 +329,23 @@ describe('declining a server that is running', () => {
     await launchServer()
 
     expect(spawned).toHaveLength(1)
+  })
+
+  it('gives up at once on a name that refuses the connection', async () => {
+    // The state after an update: the old server is gone and its socket with it.
+    // Waiting out the greeting deadline here is what made every update slow.
+    published.port = 50091
+    published.token = null
+    published.identity = null
+    published.protocolVersion = undefined as unknown as number
+    published.refused = true
+    const { launchServer } = await import('../src/main/server/server-launcher')
+
+    const started = Date.now()
+    await launchServer()
+
+    expect(spawned).toHaveLength(1)
+    expect(Date.now() - started).toBeLessThan(1000)
   })
 
   it('spawns when nothing is published at all', async () => {

--- a/tests/server-launcher-adoption.test.ts
+++ b/tests/server-launcher-adoption.test.ts
@@ -332,8 +332,7 @@ describe('declining a server that is running', () => {
   })
 
   it('gives up at once on a name that refuses the connection', async () => {
-    // The state after an update: the old server is gone and its socket with it.
-    // Waiting out the greeting deadline here is what made every update slow.
+    // After an update the old server and its socket are gone; the greeting deadline is not owed.
     published.port = 50091
     published.token = null
     published.identity = null


### PR DESCRIPTION
## The bug

Today's 16:50 server start took 9.7 s and every headless agent launched after it failed with `spawn claude ENOENT` (`spawn copilot ENOENT` too). Cause: the server asks the login shell for its environment once, synchronously, at the first terminal restore, under a 5 s cap. At a busy boot the shell missed the cap, and the fallback — the bare `PATH` launchd gave the app — was memoized for the life of the server. Nothing logged it.

## What changes

- `primeShellEnv()` asks the shell in the background from the first line of `startServer`; a failure is logged (`[env] the login shell did not answer…`) and retried after 30 s instead of kept. While the answer is pending, callers get the process's own environment rather than a second blocking shell.
- Headless spawns resolve the agent to an absolute path (`resolveExecutable`), so a poor `PATH` cannot lose it.
- History recovery and the git verification of restored terminals run concurrently with `listen` and the endpoint claim; verification is async and parallel across sessions, and waits at most 1 s for the shell.
- The bundle enables Node's compile cache (`module.enableCompileCache()`), cutting module load of the 3.4 MB bundle roughly in half on warm starts.
- The launcher's adoption probe settles when the socket closes without greeting instead of waiting the 3 s identity deadline — that was 3 s of every update handover.
- Logs: `[server] listening … (ready in Nms)`, `[launcher] probed <target> in Nms`, and `[window] ready to show Nms after launch` in the desktop.

## Measured

Packaged bundle, on a copy of the real data dir (11 workflows, 4 restored terminals), launchd-style environment, alternating baseline/fix:

| Scenario | Before | After |
|---|---|---|
| Idle, warm caches | 0.47–0.50 s | 0.34 s |
| Idle, cold | 0.69–1.03 s | 0.34–0.56 s |
| Login shell takes 6 s | 7.1 s, PATH poisoned | 1.3 s, PATH correct once the shell answers |
| CPU + disk stress | 16.5 s | 1.8–2.9 s |
| Update handover probe on a dead socket | 3 s | < 10 ms |

Idle time is now runtime start (0.13 s) + module load (0.10 s) + boot (0.09 s).

Tests: new cases for the background prime, the un-memoized failure, absolute-path spawns, the refused-socket probe, and the async environment probe. Full suite passes locally except the known ambient-env case inside a Vorn session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE