### PR TITLE
Tell the process a resize once, and show the live region through a window

### DIFF
--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -5,7 +5,7 @@ import { RunningCommand } from './RunningCommand'
 import { registerBlockLogView } from '../lib/block-log'
 import { useLiveTerminalRows } from '../hooks/useLiveTerminalRows'
 import { hasShellIntegration, onCommandBlocksChange } from '../lib/command-blocks'
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react'
 import { isShellSession } from '../../shared/types'
 import type { AgentType } from '../../shared/types'
 
@@ -60,6 +60,9 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
   const logClass = fullScreen ? 'hidden' : 'min-h-0'
   const liveClass = fullScreen ? 'flex-1 min-h-0 w-full' : 'shrink-0 w-full'
   const liveStyle = fullScreen ? undefined : { height: liveRows * LIVE_ROW_PX }
+  // The pane is what the grid is fitted to; the live region is only the window onto it.
+  const paneRef = useRef<HTMLDivElement>(null)
+  const fitTo = fullScreen ? undefined : paneRef
 
   // Declares that this terminal's finished commands are being drawn here, so
   // the capture path knows it is safe to take them out of the buffer.
@@ -72,7 +75,7 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
     // The 16px south-east reservation moves to the wrapper, so the resize
     // handle stays reachable while the log and terminal stack inside it.
     return (
-      <div className="absolute inset-0 right-4 bottom-4 flex flex-col justify-end">
+      <div ref={paneRef} className="absolute inset-0 right-4 bottom-4 flex flex-col justify-end">
         <BlockLog terminalId={terminalId} className={logClass} />
         {!fullScreen && <RunningCommand terminalId={terminalId} />}
         <TerminalSlot
@@ -80,6 +83,7 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
           isFocused={isFocused}
           className={liveClass}
           style={liveStyle}
+          fitTo={fitTo}
         />
       </div>
     )
@@ -114,7 +118,7 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
     return (
       // justify-end keeps the live terminal at the bottom before any command
       // has run, rather than stranded at the top above empty space.
-      <div className="flex h-full w-full flex-col justify-end">
+      <div ref={paneRef} className="flex h-full w-full flex-col justify-end">
         <BlockLog terminalId={terminalId} className={logClass} />
         {/* Blocks only exist once a command has finished, so a running one
             needs saying out loud — otherwise a command that never exits looks
@@ -127,6 +131,7 @@ export function TerminalPane({ terminalId, agentType, isFocused, flexible, domBl
           isFocused={isFocused}
           className={liveClass}
           style={liveStyle}
+          fitTo={fitTo}
         />
       </div>
     )

--- a/src/renderer/components/TerminalSlot.tsx
+++ b/src/renderer/components/TerminalSlot.tsx
@@ -8,8 +8,10 @@ interface Props {
   terminalId: string
   isFocused: boolean
   className?: string
-  /** The overlay tracks this element's rect, so sizing it here sizes the pty. */
+  /** The overlay tracks this element's rect, so sizing it here sizes the pty -- unless `fitTo` says otherwise. */
   style?: React.CSSProperties
+  /** The box the grid is fitted to; this element is then only the window onto it. */
+  fitTo?: React.RefObject<HTMLElement | null>
 }
 
 /**
@@ -18,7 +20,7 @@ interface Props {
  * and is positioned to overlay this element via fixed-position CSS. Unmounting
  * this component hides the terminal; it does not destroy or reparent it.
  */
-export function TerminalSlot({ terminalId, isFocused, className, style }: Props) {
+export function TerminalSlot({ terminalId, isFocused, className, style, fitTo }: Props) {
   const ref = useRef<HTMLDivElement>(null)
   // Registering is what builds the xterm and pulls the session's scrollback, up
   // to 256KB of it. Every card on the board mounts one of these, so a phone
@@ -38,11 +40,13 @@ export function TerminalSlot({ terminalId, isFocused, className, style }: Props)
   useEffect(() => {
     const el = ref.current
     if (!el || !onScreen) return
-    registerSlot(terminalId, el)
+    const fitEl = fitTo?.current
+    if (fitEl) registerSlot(terminalId, el, fitEl)
+    else registerSlot(terminalId, el)
     return () => {
       unregisterSlot(terminalId, el)
     }
-  }, [terminalId, onScreen])
+  }, [terminalId, onScreen, fitTo])
 
   useEffect(() => {
     if (!isFocused) return

--- a/src/renderer/hooks/useLiveTerminalRows.ts
+++ b/src/renderer/hooks/useLiveTerminalRows.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from 'react'
 import {
   getTerminalBufferMetrics,
   onTerminalReady,
-  onTerminalScroll
+  onTerminalScroll,
+  onTerminalWrite
 } from '../lib/terminal-registry'
 import { onCommandBlocksChange } from '../lib/command-blocks'
 
@@ -19,22 +20,21 @@ import { onCommandBlocksChange } from '../lib/command-blocks'
 /** An idle prompt still needs its own row plus somewhere to type. */
 export const MIN_LIVE_ROWS = 2
 
-/**
- * Past this the live region stops growing and the terminal scrolls
- * internally, so one noisy command cannot push the log off screen.
- */
+/** The live region grows to the grid, which is the pane; this is the cap for a grid not yet measured. */
 export const MAX_LIVE_ROWS = 16
 
 /** `null` means the terminal should take the whole pane. */
 export function clampLiveRows(metrics: {
   cursorLine: number
   isAlternate: boolean
+  rows?: number
 }): number | null {
   // A full-screen program draws to the whole screen and asks the pty how big
   // it is, so sizing it to the last command's height would hand `vim` or a
   // pager a two-row window.
   if (metrics.isAlternate) return null
-  return Math.min(MAX_LIVE_ROWS, Math.max(MIN_LIVE_ROWS, metrics.cursorLine + 1))
+  const cap = metrics.rows || MAX_LIVE_ROWS
+  return Math.min(cap, Math.max(MIN_LIVE_ROWS, metrics.cursorLine + 1))
 }
 
 export function useLiveTerminalRows(terminalId: string, enabled: boolean): number | null {
@@ -51,15 +51,19 @@ export function useLiveTerminalRows(terminalId: string, enabled: boolean): numbe
   useEffect(() => {
     if (!enabled) return
     let disposeScroll: (() => void) | undefined
+    let disposeWrite: (() => void) | undefined
     const disposeReady = onTerminalReady(terminalId, () => {
       measure()
       disposeScroll = onTerminalScroll(terminalId, measure)
+      // The grid holds every row now, so growth comes from output rather than from scrolling.
+      disposeWrite = onTerminalWrite(terminalId, measure)
     })
     // A finished command resets the terminal, so the live region shrinks back.
     const disposeBlocks = onCommandBlocksChange(terminalId, measure)
     return () => {
       disposeReady()
       disposeScroll?.()
+      disposeWrite?.()
       disposeBlocks()
     }
   }, [terminalId, enabled, measure])

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -21,6 +21,9 @@ interface TerminalEntry {
   lastAppliedRect: { top: number; left: number; width: number; height: number } | null
   lastSyncedCols: number
   lastSyncedRows: number
+  /** A size the pty has not been told yet, and the hold before it is. */
+  pendingSize: { cols: number; rows: number } | null
+  resizeTimer: ReturnType<typeof setTimeout> | null
   _loadRenderer?: (() => void) | null
   _gpuAddon?: { dispose(): void } | null
   _disposeCommandBlocks?: (() => void) | null
@@ -435,7 +438,9 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     activeSlot: null,
     lastAppliedRect: null,
     lastSyncedCols: 0,
-    lastSyncedRows: 0
+    lastSyncedRows: 0,
+    pendingSize: null,
+    resizeTimer: null
   }
 
   entry._loadRenderer = loadRenderer
@@ -575,6 +580,32 @@ function hideWrapper(wrapper: HTMLDivElement, entry: TerminalEntry): void {
   entry.lastAppliedRect = null
 }
 
+/** How long a size has to stand still before the process is told. */
+const RESIZE_SETTLE_MS = 50
+
+function sendSize(entry: TerminalEntry, terminalId: string, cols: number, rows: number): void {
+  if (cols === entry.lastSyncedCols && rows === entry.lastSyncedRows) return
+  entry.lastSyncedCols = cols
+  entry.lastSyncedRows = rows
+  window.api.resizeTerminal({ id: terminalId, cols, rows })
+}
+
+/** The first size goes out at once; every later one once it settles, so a drag is one SIGWINCH rather than one per frame. */
+function announceSize(entry: TerminalEntry, terminalId: string, cols: number, rows: number): void {
+  if (entry.lastSyncedCols === 0) {
+    sendSize(entry, terminalId, cols, rows)
+    return
+  }
+  entry.pendingSize = { cols, rows }
+  if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
+  entry.resizeTimer = setTimeout(() => {
+    entry.resizeTimer = null
+    const size = entry.pendingSize
+    entry.pendingSize = null
+    if (size) sendSize(entry, terminalId, size.cols, size.rows)
+  }, RESIZE_SETTLE_MS)
+}
+
 /**
  * Position the persistent wrapper to overlay the active slot. Called every
  * frame by TerminalHost, so the function is aggressively guarded:
@@ -633,11 +664,7 @@ export function syncTerminalOverlay(terminalId: string): void {
     return
   }
   const { cols, rows } = entry.term
-  if (cols !== entry.lastSyncedCols || rows !== entry.lastSyncedRows) {
-    entry.lastSyncedCols = cols
-    entry.lastSyncedRows = rows
-    window.api.resizeTerminal({ id: terminalId, cols, rows })
-  }
+  announceSize(entry, terminalId, cols, rows)
 }
 
 export function onRegistryChange(cb: () => void): () => void {
@@ -671,11 +698,7 @@ export function fitTerminal(terminalId: string): void {
     return
   }
   const { cols, rows } = entry.term
-  if (cols !== entry.lastSyncedCols || rows !== entry.lastSyncedRows) {
-    entry.lastSyncedCols = cols
-    entry.lastSyncedRows = rows
-    window.api.resizeTerminal({ id: terminalId, cols, rows })
-  }
+  announceSize(entry, terminalId, cols, rows)
 }
 
 /**
@@ -887,6 +910,9 @@ export function destroyTerminal(terminalId: string): void {
   // A seed still in flight would otherwise resolve and write into a terminal
   // that no longer exists.
   hydrating.delete(terminalId)
+  if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
+  entry.resizeTimer = null
+  entry.pendingSize = null
   entry._disposeCommandBlocks?.()
   entry._disposeCommandBlocks = null
   entry._disposeScrollAnchor?.()

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -21,7 +21,10 @@ interface TerminalEntry {
   /** When set, the grid is fitted to this box and the slot is only the window onto it. */
   fitElement: HTMLElement | null
   lastAppliedRect: { top: number; left: number; width: number; height: number } | null
-  lastMask: { top: number; height: number; offset: number } | null
+  /** The rows shown of the grid, as last written: top, rows above it, rows in it, the box under it. */
+  lastWindow: { top: number; offset: number; shown: number; boxHeight: number } | null
+  /** The cell as xterm laid it out at the last fit, for the window and the hold. */
+  cell: { width: number; height: number } | null
   lastSyncedCols: number
   lastSyncedRows: number
   /** The hold before a moved box is taken as the new size, and the deadline a box that keeps moving cannot push past. */
@@ -339,6 +342,9 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
   // Let app-level shortcuts pass through instead of being consumed by xterm
   term.attachCustomKeyEventHandler((e) => {
     if (e.type === 'keydown' && keyRedirectHandler?.(terminalId, e)) return false
+    // A held size goes before a keystroke, so what is typed reaches the program after the SIGWINCH.
+    const held = registry.get(terminalId)
+    if (e.type === 'keydown' && held?.resizeTimer) fitNow(held, terminalId)
 
     const mod = rendererIsMac ? e.metaKey : e.ctrlKey
     if (!mod) return true
@@ -429,11 +435,6 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
   // Forward keystrokes to pty
   term.onData((data) => {
     if (seeding.has(terminalId)) return
-    // A held size goes before a keystroke, so what is typed reaches the program after the SIGWINCH. Not before
-    // the terminal's own reply to a query: that is not a keystroke, and a program that asks on every redraw would
-    // otherwise resize itself in a loop for as long as the box moved.
-    const entry = registry.get(terminalId)
-    if (entry?.resizeTimer && !data.startsWith('\x1b')) fitNow(entry, terminalId)
     window.api.writeTerminal(terminalId, data)
   })
 
@@ -446,7 +447,8 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     activeSlot: null,
     fitElement: null,
     lastAppliedRect: null,
-    lastMask: null,
+    lastWindow: null,
+    cell: null,
     lastSyncedCols: 0,
     lastSyncedRows: 0,
     resizeTimer: null,
@@ -591,58 +593,69 @@ function hideWrapper(wrapper: HTMLDivElement, entry: TerminalEntry): void {
     wrapper.style.visibility = 'hidden'
     wrapper.style.pointerEvents = 'none'
   }
+  wrapper.style.clipPath = ''
   entry.lastAppliedRect = null
-  entry.lastMask = null
+  entry.lastWindow = null
 }
 
-/**
- * Show only the slot's rows of a grid fitted to a bigger box.
- *
- * Block mode sizes the live region to what the command has drawn, and used to
- * refit the grid to it -- so the shell was told `rows=2` at an idle prompt and
- * every line of output was a SIGWINCH. The grid keeps the box's rows now; the
- * slot is a window onto the rows around the cursor, the same rows the small
- * grid showed by scrolling.
- */
-function applyMask(
+/** The cell as xterm laid it out: its screen element over its grid. */
+function measureCell(entry: TerminalEntry): void {
+  const screen = entry.term.element?.querySelector('.xterm-screen')
+  if (!screen || !entry.term.cols || !entry.term.rows) return
+  const { width, height } = screen.getBoundingClientRect()
+  if (width <= 0 || height <= 0) return
+  entry.cell = { width: width / entry.term.cols, height: height / entry.term.rows }
+}
+
+/** The rows of the grid that are shown: the slot's, from the top, or a shrinking box's around the cursor while the hold runs. */
+function applyWindow(
   entry: TerminalEntry,
   wrapper: HTMLDivElement,
   box: { top: number; height: number },
-  mask: { top: number; height: number }
+  win: { top: number; height: number }
 ): void {
-  const rows = entry.term.rows || 1
-  // xterm floors its rows into the box, so the box over the rows recovers the cell.
-  const cell = Math.max(1, Math.floor(box.height / rows))
-  const maskRows = Math.max(1, Math.round(mask.height / cell))
-  const cursorY = entry.term.buffer.active.cursorY || 0
-  const offset = Math.max(0, cursorY + 1 - maskRows) * cell
-  const next = { top: mask.top - offset, height: mask.height, offset }
-  const last = entry.lastMask
-  if (last && last.top === next.top && last.height === next.height && last.offset === next.offset)
-    return
-  wrapper.style.top = `${next.top}px`
-  // clip-path clips hit-testing too, so the hidden rows take no clicks.
-  wrapper.style.clipPath = `inset(${offset}px 0 ${Math.max(0, box.height - offset - mask.height)}px 0)`
-  entry.lastMask = next
-}
-
-/** The window applied for a slot with a box, and taken off for one without. */
-function syncMask(
-  entry: TerminalEntry,
-  wrapper: HTMLDivElement,
-  box: { top: number; height: number },
-  maskRaw: DOMRect | null
-): void {
-  if (maskRaw) {
-    applyMask(entry, wrapper, box, {
-      top: Math.round(maskRaw.top),
-      height: Math.round(maskRaw.height)
-    })
-  } else if (entry.lastMask) {
-    wrapper.style.clipPath = ''
-    wrapper.style.top = `${box.top}px`
-    entry.lastMask = null
+  const cell = entry.cell
+  const rows = entry.term.rows || 0
+  let next: NonNullable<TerminalEntry['lastWindow']>
+  if (!cell || !rows) {
+    next = { top: box.top, offset: 0, shown: 0, boxHeight: box.height }
+  } else {
+    const winRows = Math.min(rows, Math.max(1, Math.round(win.height / cell.height)))
+    const above = entry.fitElement
+      ? 0
+      : Math.max(0, (entry.term.buffer.active.cursorY || 0) + 1 - winRows)
+    const offset = above * cell.height
+    next = { top: win.top - offset, offset, shown: winRows * cell.height, boxHeight: box.height }
   }
+  const last = entry.lastWindow
+  if (
+    last &&
+    last.top === next.top &&
+    last.offset === next.offset &&
+    last.shown === next.shown &&
+    last.boxHeight === next.boxHeight
+  ) {
+    return
+  }
+  wrapper.style.top = `${next.top}px`
+  // clip-path clips hit-testing too, so hidden rows take no clicks.
+  wrapper.style.clipPath = next.shown
+    ? `inset(${next.offset}px 0 ${Math.max(0, box.height - next.offset - next.shown)}px 0)`
+    : ''
+  entry.lastWindow = next
+}
+
+/** The window for the rects as they are now. */
+function syncWindow(entry: TerminalEntry, wrapper: HTMLDivElement): void {
+  const box = entry.lastAppliedRect
+  const slot = entry.activeSlot
+  if (!box || !slot) return
+  if (!entry.fitElement) {
+    applyWindow(entry, wrapper, box, box)
+    return
+  }
+  const raw = slot.getBoundingClientRect()
+  applyWindow(entry, wrapper, box, { top: Math.round(raw.top), height: Math.round(raw.height) })
 }
 
 /** How long a box has to stand still before its size is taken; a slow frame must not lapse it. */
@@ -667,6 +680,8 @@ function fitNow(entry: TerminalEntry, terminalId: string): void {
   } catch {
     return
   }
+  measureCell(entry)
+  if (entry.persistentWrapper) syncWindow(entry, entry.persistentWrapper)
   const { cols, rows } = entry.term
   if (cols === entry.lastSyncedCols && rows === entry.lastSyncedRows) return
   entry.lastSyncedCols = cols
@@ -680,26 +695,12 @@ function fitWhenSettled(entry: TerminalEntry, terminalId: string): void {
     fitNow(entry, terminalId)
     return
   }
-  // A move that would not change the grid arms nothing, and drops a hold armed for one that would have.
-  const next = entry.fitAddon.proposeDimensions()
-  if (next && next.cols === entry.lastSyncedCols && next.rows === entry.lastSyncedRows) {
-    clearHold(entry)
-    return
-  }
   if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
   entry.resizeTimer = setTimeout(() => fitNow(entry, terminalId), RESIZE_SETTLE_MS)
   entry.resizeDeadline ??= setTimeout(() => fitNow(entry, terminalId), RESIZE_MAX_WAIT_MS)
 }
 
-/**
- * Position the persistent wrapper to overlay the active slot. Called every
- * frame by TerminalHost, so the function is aggressively guarded: the rect
- * is rounded to integer pixels so subpixel jitter changes nothing, the box
- * moves every frame but the grid takes its size only once it has settled
- * (`fitWhenSettled`), and the pty hears only a size that actually changed.
- * visibility is used (not display:none) because xterm needs nonzero layout
- * metrics to fit correctly.
- */
+/** Per frame from TerminalHost: the box follows the slot at once, the grid takes its size once it settles, and the pty hears only a changed size. */
 export function syncTerminalOverlay(terminalId: string): void {
   const entry = registry.get(terminalId)
   const wrapper = entry?.persistentWrapper
@@ -709,10 +710,10 @@ export function syncTerminalOverlay(terminalId: string): void {
     hideWrapper(wrapper, entry)
     return
   }
-  // The grid's box is what it is fitted to; with a fit element the slot is only the window.
+  // The grid's box is what it is fitted to; with a fit element the slot is only the window onto it.
   const raw = (entry.fitElement ?? slot).getBoundingClientRect()
-  const maskRaw = entry.fitElement ? slot.getBoundingClientRect() : null
-  if (raw.width <= 0 || raw.height <= 0 || (maskRaw && maskRaw.height <= 0)) {
+  const winRaw = entry.fitElement ? slot.getBoundingClientRect() : raw
+  if (raw.width <= 0 || raw.height <= 0 || winRaw.height <= 0) {
     hideWrapper(wrapper, entry)
     return
   }
@@ -722,32 +723,29 @@ export function syncTerminalOverlay(terminalId: string): void {
     width: Math.round(raw.width),
     height: Math.round(raw.height)
   }
+  const win = { top: Math.round(winRaw.top), height: Math.round(winRaw.height) }
   const last = entry.lastAppliedRect
-  if (
+  const same =
     last !== null &&
     last.top === rect.top &&
     last.left === rect.left &&
     last.width === rect.width &&
     last.height === rect.height
-  ) {
-    syncMask(entry, wrapper, rect, maskRaw)
+  if (!same) {
+    const sizeChanged = last === null || last.width !== rect.width || last.height !== rect.height
+    wrapper.style.left = `${rect.left}px`
+    if (sizeChanged) {
+      wrapper.style.width = `${rect.width}px`
+      wrapper.style.height = `${rect.height}px`
+    }
+    wrapper.style.visibility = 'visible'
+    wrapper.style.pointerEvents = 'auto'
+    entry.lastAppliedRect = rect
+    applyWindow(entry, wrapper, rect, win)
+    if (sizeChanged && entry.term.element) fitWhenSettled(entry, terminalId)
     return
   }
-  // Size-changed matters for fit (cols/rows depend on width/height); position-
-  // only changes (Framer Motion springs move cards via translate) just need a
-  // style update and skip the layout-reading fitAddon.fit() call.
-  const sizeChanged = last === null || last.width !== rect.width || last.height !== rect.height
-  wrapper.style.top = `${rect.top}px`
-  wrapper.style.left = `${rect.left}px`
-  if (sizeChanged) {
-    wrapper.style.width = `${rect.width}px`
-    wrapper.style.height = `${rect.height}px`
-  }
-  wrapper.style.visibility = 'visible'
-  wrapper.style.pointerEvents = 'auto'
-  entry.lastAppliedRect = rect
-  syncMask(entry, wrapper, rect, maskRaw)
-  if (sizeChanged && entry.term.element) fitWhenSettled(entry, terminalId)
+  applyWindow(entry, wrapper, rect, win)
 }
 
 export function onRegistryChange(cb: () => void): () => void {
@@ -955,6 +953,27 @@ export function onTerminalReady(terminalId: string, callback: () => void): () =>
   readyCallbacks.get(terminalId)!.add(callback)
   return () => {
     readyCallbacks.get(terminalId)?.delete(callback)
+  }
+}
+
+/** Output as it lands, coalesced to a frame -- what the live region grows by. */
+export function onTerminalWrite(
+  terminalId: string,
+  callback: () => void
+): (() => void) | undefined {
+  const entry = registry.get(terminalId)
+  if (!entry) return undefined
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const disposable = entry.term.onWriteParsed(() => {
+    if (timer) return
+    timer = setTimeout(() => {
+      timer = null
+      callback()
+    }, 16)
+  })
+  return () => {
+    disposable.dispose()
+    if (timer) clearTimeout(timer)
   }
 }
 

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -21,8 +21,9 @@ interface TerminalEntry {
   lastAppliedRect: { top: number; left: number; width: number; height: number } | null
   lastSyncedCols: number
   lastSyncedRows: number
-  /** The hold before a moved box is taken as the new size. */
+  /** The hold before a moved box is taken as the new size, and the deadline a box that keeps moving cannot push past. */
   resizeTimer: ReturnType<typeof setTimeout> | null
+  resizeDeadline: ReturnType<typeof setTimeout> | null
   _loadRenderer?: (() => void) | null
   _gpuAddon?: { dispose(): void } | null
   _disposeCommandBlocks?: (() => void) | null
@@ -425,9 +426,11 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
   // Forward keystrokes to pty
   term.onData((data) => {
     if (seeding.has(terminalId)) return
-    // A held size goes first: what is typed must reach the program after the SIGWINCH, not before.
+    // A held size goes before a keystroke, so what is typed reaches the program after the SIGWINCH. Not before
+    // the terminal's own reply to a query: that is not a keystroke, and a program that asks on every redraw would
+    // otherwise resize itself in a loop for as long as the box moved.
     const entry = registry.get(terminalId)
-    if (entry?.resizeTimer) fitNow(entry, terminalId)
+    if (entry?.resizeTimer && !data.startsWith('\x1b')) fitNow(entry, terminalId)
     window.api.writeTerminal(terminalId, data)
   })
 
@@ -441,7 +444,8 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     lastAppliedRect: null,
     lastSyncedCols: 0,
     lastSyncedRows: 0,
-    resizeTimer: null
+    resizeTimer: null,
+    resizeDeadline: null
   }
 
   entry._loadRenderer = loadRenderer
@@ -585,11 +589,19 @@ function hideWrapper(wrapper: HTMLDivElement, entry: TerminalEntry): void {
 
 /** How long a box has to stand still before its size is taken; a slow frame must not lapse it. */
 const RESIZE_SETTLE_MS = 100
+/** A box that never stands still is fitted anyway by this, so nothing can starve the grid. */
+const RESIZE_MAX_WAIT_MS = 400
+
+function clearHold(entry: TerminalEntry): void {
+  if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
+  if (entry.resizeDeadline) clearTimeout(entry.resizeDeadline)
+  entry.resizeTimer = null
+  entry.resizeDeadline = null
+}
 
 /** Grid, pty and the server's screen model take the box's size at one moment, so none wraps differently from another. */
 function fitNow(entry: TerminalEntry, terminalId: string): void {
-  if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
-  entry.resizeTimer = null
+  clearHold(entry)
   // A hidden wrapper has no box to fit; fitting it would send a 2x1 grid.
   if (!entry.term.element || !entry.lastAppliedRect) return
   try {
@@ -610,8 +622,15 @@ function fitWhenSettled(entry: TerminalEntry, terminalId: string): void {
     fitNow(entry, terminalId)
     return
   }
+  // A move that would not change the grid arms nothing, and drops a hold armed for one that would have.
+  const next = entry.fitAddon.proposeDimensions()
+  if (next && next.cols === entry.lastSyncedCols && next.rows === entry.lastSyncedRows) {
+    clearHold(entry)
+    return
+  }
   if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
   entry.resizeTimer = setTimeout(() => fitNow(entry, terminalId), RESIZE_SETTLE_MS)
+  entry.resizeDeadline ??= setTimeout(() => fitNow(entry, terminalId), RESIZE_MAX_WAIT_MS)
 }
 
 /**
@@ -908,7 +927,7 @@ export function destroyTerminal(terminalId: string): void {
   // A seed still in flight would otherwise resolve and write into a terminal
   // that no longer exists.
   hydrating.delete(terminalId)
-  if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
+  clearHold(entry)
   entry._disposeCommandBlocks?.()
   entry._disposeCommandBlocks = null
   entry._disposeScrollAnchor?.()

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -21,8 +21,7 @@ interface TerminalEntry {
   lastAppliedRect: { top: number; left: number; width: number; height: number } | null
   lastSyncedCols: number
   lastSyncedRows: number
-  /** A size the pty has not been told yet, and the hold before it is. */
-  pendingSize: { cols: number; rows: number } | null
+  /** The hold before a moved box is taken as the new size. */
   resizeTimer: ReturnType<typeof setTimeout> | null
   _loadRenderer?: (() => void) | null
   _gpuAddon?: { dispose(): void } | null
@@ -426,6 +425,9 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
   // Forward keystrokes to pty
   term.onData((data) => {
     if (seeding.has(terminalId)) return
+    // A held size goes first: what is typed must reach the program after the SIGWINCH, not before.
+    const entry = registry.get(terminalId)
+    if (entry?.resizeTimer) fitNow(entry, terminalId)
     window.api.writeTerminal(terminalId, data)
   })
 
@@ -439,7 +441,6 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     lastAppliedRect: null,
     lastSyncedCols: 0,
     lastSyncedRows: 0,
-    pendingSize: null,
     resizeTimer: null
   }
 
@@ -502,6 +503,8 @@ function ensurePersistentWrapper(entry: TerminalEntry, terminalId: string): HTML
   wrapper.style.height = '0'
   wrapper.style.visibility = 'hidden'
   wrapper.style.pointerEvents = 'none'
+  // The grid follows the box a beat behind it, so for that beat it may be the larger of the two.
+  wrapper.style.overflow = 'hidden'
   entry.persistentWrapper = wrapper
   if (hostRoot) {
     hostRoot.appendChild(wrapper)
@@ -580,39 +583,45 @@ function hideWrapper(wrapper: HTMLDivElement, entry: TerminalEntry): void {
   entry.lastAppliedRect = null
 }
 
-/** How long a size has to stand still before the process is told. */
-const RESIZE_SETTLE_MS = 50
+/** How long a box has to stand still before its size is taken; a slow frame must not lapse it. */
+const RESIZE_SETTLE_MS = 100
 
-function sendSize(entry: TerminalEntry, terminalId: string, cols: number, rows: number): void {
+/** Grid, pty and the server's screen model take the box's size at one moment, so none wraps differently from another. */
+function fitNow(entry: TerminalEntry, terminalId: string): void {
+  if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
+  entry.resizeTimer = null
+  // A hidden wrapper has no box to fit; fitting it would send a 2x1 grid.
+  if (!entry.term.element || !entry.lastAppliedRect) return
+  try {
+    entry.fitAddon.fit()
+  } catch {
+    return
+  }
+  const { cols, rows } = entry.term
   if (cols === entry.lastSyncedCols && rows === entry.lastSyncedRows) return
   entry.lastSyncedCols = cols
   entry.lastSyncedRows = rows
   window.api.resizeTerminal({ id: terminalId, cols, rows })
 }
 
-/** The first size goes out at once; every later one once it settles, so a drag is one SIGWINCH rather than one per frame. */
-function announceSize(entry: TerminalEntry, terminalId: string, cols: number, rows: number): void {
+/** The first box is taken at once; a later one once it settles, so a drag is one refit and one SIGWINCH rather than one per frame. */
+function fitWhenSettled(entry: TerminalEntry, terminalId: string): void {
   if (entry.lastSyncedCols === 0) {
-    sendSize(entry, terminalId, cols, rows)
+    fitNow(entry, terminalId)
     return
   }
-  entry.pendingSize = { cols, rows }
   if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
-  entry.resizeTimer = setTimeout(() => {
-    entry.resizeTimer = null
-    const size = entry.pendingSize
-    entry.pendingSize = null
-    if (size) sendSize(entry, terminalId, size.cols, size.rows)
-  }, RESIZE_SETTLE_MS)
+  entry.resizeTimer = setTimeout(() => fitNow(entry, terminalId), RESIZE_SETTLE_MS)
 }
 
 /**
  * Position the persistent wrapper to overlay the active slot. Called every
- * frame by TerminalHost, so the function is aggressively guarded:
- * rect is rounded to integer pixels so subpixel spring jitter doesn't
- * trigger a fit+IPC each frame, and pty resize IPC only fires when the
- * integer cols/rows actually change. visibility is used (not display:none)
- * because xterm needs nonzero layout metrics to fit correctly.
+ * frame by TerminalHost, so the function is aggressively guarded: the rect
+ * is rounded to integer pixels so subpixel jitter changes nothing, the box
+ * moves every frame but the grid takes its size only once it has settled
+ * (`fitWhenSettled`), and the pty hears only a size that actually changed.
+ * visibility is used (not display:none) because xterm needs nonzero layout
+ * metrics to fit correctly.
  */
 export function syncTerminalOverlay(terminalId: string): void {
   const entry = registry.get(terminalId)
@@ -657,14 +666,7 @@ export function syncTerminalOverlay(terminalId: string): void {
   wrapper.style.visibility = 'visible'
   wrapper.style.pointerEvents = 'auto'
   entry.lastAppliedRect = rect
-  if (!sizeChanged || !entry.term.element) return
-  try {
-    entry.fitAddon.fit()
-  } catch {
-    return
-  }
-  const { cols, rows } = entry.term
-  announceSize(entry, terminalId, cols, rows)
+  if (sizeChanged && entry.term.element) fitWhenSettled(entry, terminalId)
 }
 
 export function onRegistryChange(cb: () => void): () => void {
@@ -689,16 +691,11 @@ export function getRegisteredTerminalIds(): string[] {
  * identical and the column count stale, and the terminal then sat with a band
  * of unused width until something resized it.
  */
-export function fitTerminal(terminalId: string): void {
+export function fitTerminal(terminalId: string, when: 'now' | 'settled' = 'now'): void {
   const entry = registry.get(terminalId)
-  if (!entry || !entry.term.element) return
-  try {
-    entry.fitAddon.fit()
-  } catch {
-    return
-  }
-  const { cols, rows } = entry.term
-  announceSize(entry, terminalId, cols, rows)
+  if (!entry) return
+  if (when === 'now') fitNow(entry, terminalId)
+  else fitWhenSettled(entry, terminalId)
 }
 
 /**
@@ -726,6 +723,7 @@ export function clearTerminalSelection(terminalId: string): void {
 export function pasteToTerminal(terminalId: string, text: string): void {
   const entry = registry.get(terminalId)
   if (!entry) return
+  if (entry.resizeTimer) fitNow(entry, terminalId)
   // xterm's paste sends the text and *then* clears its hidden textarea, which
   // only exists once the terminal is opened — so before that it throws after
   // sending, and a caller's following carriage return never runs.
@@ -911,8 +909,6 @@ export function destroyTerminal(terminalId: string): void {
   // that no longer exists.
   hydrating.delete(terminalId)
   if (entry.resizeTimer) clearTimeout(entry.resizeTimer)
-  entry.resizeTimer = null
-  entry.pendingSize = null
   entry._disposeCommandBlocks?.()
   entry._disposeCommandBlocks = null
   entry._disposeScrollAnchor?.()
@@ -946,7 +942,8 @@ export function setAllTerminalsFontSize(fontSize: number): void {
   const effective = getEffectiveFontSize(fontSize)
   for (const [id, entry] of registry) {
     entry.term.options.fontSize = effective
-    fitTerminal(id)
+    // A pinch is many steps; the pty hears where it ends.
+    fitTerminal(id, 'settled')
   }
 }
 

--- a/src/renderer/lib/terminal-registry.ts
+++ b/src/renderer/lib/terminal-registry.ts
@@ -18,7 +18,10 @@ interface TerminalEntry {
   fitAddon: FitAddon
   persistentWrapper: HTMLDivElement | null
   activeSlot: HTMLElement | null
+  /** When set, the grid is fitted to this box and the slot is only the window onto it. */
+  fitElement: HTMLElement | null
   lastAppliedRect: { top: number; left: number; width: number; height: number } | null
+  lastMask: { top: number; height: number; offset: number } | null
   lastSyncedCols: number
   lastSyncedRows: number
   /** The hold before a moved box is taken as the new size, and the deadline a box that keeps moving cannot push past. */
@@ -441,7 +444,9 @@ function createTerminalEntry(terminalId: string): TerminalEntry {
     fitAddon,
     persistentWrapper: null,
     activeSlot: null,
+    fitElement: null,
     lastAppliedRect: null,
+    lastMask: null,
     lastSyncedCols: 0,
     lastSyncedRows: 0,
     resizeTimer: null,
@@ -555,10 +560,11 @@ export function setHostRoot(root: HTMLElement | null): void {
  * and will track this slot's bounding rect via syncTerminalOverlay.
  * Last-registered slot wins if multiple slots register for the same id.
  */
-export function registerSlot(terminalId: string, slotEl: HTMLElement): void {
+export function registerSlot(terminalId: string, slotEl: HTMLElement, fitEl?: HTMLElement): void {
   let entry = registry.get(terminalId)
   if (!entry) entry = createTerminalEntry(terminalId)
   entry.activeSlot = slotEl
+  entry.fitElement = fitEl ?? null
   ensurePersistentWrapper(entry, terminalId)
   openIntoPersistentWrapper(entry, terminalId)
   syncTerminalOverlay(terminalId)
@@ -572,6 +578,7 @@ export function unregisterSlot(terminalId: string, slotEl: HTMLElement): void {
   const entry = registry.get(terminalId)
   if (!entry || entry.activeSlot !== slotEl) return
   entry.activeSlot = null
+  entry.fitElement = null
   syncTerminalOverlay(terminalId)
 }
 
@@ -585,6 +592,57 @@ function hideWrapper(wrapper: HTMLDivElement, entry: TerminalEntry): void {
     wrapper.style.pointerEvents = 'none'
   }
   entry.lastAppliedRect = null
+  entry.lastMask = null
+}
+
+/**
+ * Show only the slot's rows of a grid fitted to a bigger box.
+ *
+ * Block mode sizes the live region to what the command has drawn, and used to
+ * refit the grid to it -- so the shell was told `rows=2` at an idle prompt and
+ * every line of output was a SIGWINCH. The grid keeps the box's rows now; the
+ * slot is a window onto the rows around the cursor, the same rows the small
+ * grid showed by scrolling.
+ */
+function applyMask(
+  entry: TerminalEntry,
+  wrapper: HTMLDivElement,
+  box: { top: number; height: number },
+  mask: { top: number; height: number }
+): void {
+  const rows = entry.term.rows || 1
+  // xterm floors its rows into the box, so the box over the rows recovers the cell.
+  const cell = Math.max(1, Math.floor(box.height / rows))
+  const maskRows = Math.max(1, Math.round(mask.height / cell))
+  const cursorY = entry.term.buffer.active.cursorY || 0
+  const offset = Math.max(0, cursorY + 1 - maskRows) * cell
+  const next = { top: mask.top - offset, height: mask.height, offset }
+  const last = entry.lastMask
+  if (last && last.top === next.top && last.height === next.height && last.offset === next.offset)
+    return
+  wrapper.style.top = `${next.top}px`
+  // clip-path clips hit-testing too, so the hidden rows take no clicks.
+  wrapper.style.clipPath = `inset(${offset}px 0 ${Math.max(0, box.height - offset - mask.height)}px 0)`
+  entry.lastMask = next
+}
+
+/** The window applied for a slot with a box, and taken off for one without. */
+function syncMask(
+  entry: TerminalEntry,
+  wrapper: HTMLDivElement,
+  box: { top: number; height: number },
+  maskRaw: DOMRect | null
+): void {
+  if (maskRaw) {
+    applyMask(entry, wrapper, box, {
+      top: Math.round(maskRaw.top),
+      height: Math.round(maskRaw.height)
+    })
+  } else if (entry.lastMask) {
+    wrapper.style.clipPath = ''
+    wrapper.style.top = `${box.top}px`
+    entry.lastMask = null
+  }
 }
 
 /** How long a box has to stand still before its size is taken; a slow frame must not lapse it. */
@@ -651,8 +709,10 @@ export function syncTerminalOverlay(terminalId: string): void {
     hideWrapper(wrapper, entry)
     return
   }
-  const raw = slot.getBoundingClientRect()
-  if (raw.width <= 0 || raw.height <= 0) {
+  // The grid's box is what it is fitted to; with a fit element the slot is only the window.
+  const raw = (entry.fitElement ?? slot).getBoundingClientRect()
+  const maskRaw = entry.fitElement ? slot.getBoundingClientRect() : null
+  if (raw.width <= 0 || raw.height <= 0 || (maskRaw && maskRaw.height <= 0)) {
     hideWrapper(wrapper, entry)
     return
   }
@@ -670,6 +730,7 @@ export function syncTerminalOverlay(terminalId: string): void {
     last.width === rect.width &&
     last.height === rect.height
   ) {
+    syncMask(entry, wrapper, rect, maskRaw)
     return
   }
   // Size-changed matters for fit (cols/rows depend on width/height); position-
@@ -685,6 +746,7 @@ export function syncTerminalOverlay(terminalId: string): void {
   wrapper.style.visibility = 'visible'
   wrapper.style.pointerEvents = 'auto'
   entry.lastAppliedRect = rect
+  syncMask(entry, wrapper, rect, maskRaw)
   if (sizeChanged && entry.term.element) fitWhenSettled(entry, terminalId)
 }
 

--- a/tests/live-terminal-rows.test.ts
+++ b/tests/live-terminal-rows.test.ts
@@ -24,7 +24,11 @@ describe('clampLiveRows', () => {
     expect(clampLiveRows({ cursorLine: 4, isAlternate: false })).toBe(5)
   })
 
-  it('stops growing so one noisy command cannot push the log off screen', () => {
+  it('grows no further than the grid, whose rows the pane holds', () => {
+    expect(clampLiveRows({ cursorLine: 500, isAlternate: false, rows: 40 })).toBe(40)
+  })
+
+  it('falls back to a cap while the grid is not yet measured', () => {
     expect(clampLiveRows({ cursorLine: 500, isAlternate: false })).toBe(MAX_LIVE_ROWS)
   })
 

--- a/tests/terminal-pane-mask.test.tsx
+++ b/tests/terminal-pane-mask.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+
+// The live region is a window onto a grid fitted to the pane; a full-screen program gets the pane itself.
+const hoisted = vi.hoisted(() => ({
+  rows: 2 as number | null,
+  slots: [] as Array<{ fitTo?: { current: HTMLElement | null } }>
+}))
+
+vi.mock('../src/renderer/hooks/useLiveTerminalRows', () => ({
+  useLiveTerminalRows: () => hoisted.rows
+}))
+vi.mock('../src/renderer/lib/command-blocks', () => ({
+  hasShellIntegration: () => true,
+  onCommandBlocksChange: () => () => {}
+}))
+vi.mock('../src/renderer/lib/block-log', () => ({ registerBlockLogView: () => () => {} }))
+vi.mock('../src/renderer/components/BlockLog', () => ({ BlockLog: () => null }))
+vi.mock('../src/renderer/components/RunningCommand', () => ({ RunningCommand: () => null }))
+vi.mock('../src/renderer/components/CommandSpine', () => ({ CommandSpine: () => null }))
+vi.mock('../src/renderer/components/TerminalSlot', () => ({
+  TerminalSlot: (props: { fitTo?: { current: HTMLElement | null } }) => {
+    hoisted.slots.push(props)
+    return <div data-testid="slot" />
+  }
+}))
+
+import { TerminalPane } from '../src/renderer/components/TerminalPane'
+
+afterEach(() => {
+  cleanup()
+  hoisted.slots.length = 0
+})
+
+describe('the live region in block mode', () => {
+  it('is a window onto a grid fitted to the pane', () => {
+    hoisted.rows = 2
+    const { container } = render(
+      <TerminalPane terminalId="t" agentType="shell" isFocused={false} domBlocks />
+    )
+
+    const slot = hoisted.slots.at(-1)!
+    expect(slot.fitTo?.current).toBe(container.firstElementChild)
+  })
+
+  it('is the pane itself for a full-screen program', () => {
+    hoisted.rows = null
+    render(<TerminalPane terminalId="t" agentType="shell" isFocused={false} domBlocks />)
+
+    expect(hoisted.slots.at(-1)!.fitTo).toBeUndefined()
+  })
+})

--- a/tests/terminal-registry-slot.test.ts
+++ b/tests/terminal-registry-slot.test.ts
@@ -1,8 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// When on, the fit mock sizes the grid from the wrapper's box, 8x16 px cells, so a moved rect moves cols/rows.
-const sizer = vi.hoisted(() => ({ enabled: false }))
+// The fit mock sizes the grid from the wrapper's box, 8x16 px cells, so a moved rect moves cols/rows.
+const made = vi.hoisted(() => ({
+  terms: [] as Array<{ onData: ReturnType<typeof vi.fn> }>,
+  fits: [] as Array<ReturnType<typeof vi.fn>>
+}))
 
 vi.mock('@xterm/xterm', () => {
   class MockTerminal {
@@ -31,6 +34,9 @@ vi.mock('@xterm/xterm', () => {
     scrollToBottom = vi.fn()
     scrollToLine = vi.fn()
     refresh = vi.fn()
+    constructor() {
+      made.terms.push(this)
+    }
     open(el: HTMLElement): void {
       this.element = el
     }
@@ -58,13 +64,30 @@ vi.mock('@xterm/addon-fit', () => {
     }
     fit = vi.fn(() => {
       const el = this.term?.element
-      if (!sizer.enabled || !this.term || !el) return
+      if (!this.term || !el) return
       this.term.cols = Math.max(2, Math.floor((parseInt(el.style.width) || 0) / 8))
       this.term.rows = Math.max(1, Math.floor((parseInt(el.style.height) || 0) / 16))
     })
+    constructor() {
+      made.fits.push(this.fit)
+    }
   }
   return { FitAddon: MockFitAddon }
 })
+
+// The GPU renderers would throw on the mock terminal; a no-op keeps the swap path alive.
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: class {
+    activate(): void {}
+    dispose(): void {}
+  }
+}))
+vi.mock('@xterm/addon-canvas', () => ({
+  CanvasAddon: class {
+    activate(): void {}
+    dispose(): void {}
+  }
+}))
 
 vi.mock('@xterm/addon-web-links', () => {
   class MockWebLinksAddon {}
@@ -92,24 +115,26 @@ import {
   onRegistryChange,
   getRegisteredTerminalIds,
   destroyTerminal,
-  fitTerminal
+  fitTerminal,
+  setAllTerminalsFontSize
 } from '../src/renderer/lib/terminal-registry'
 
+/** Read lazily, so a test can move the rect it passed. */
 function makeSlot(rect: Partial<DOMRect>): HTMLDivElement {
   const el = document.createElement('div')
-  const full: DOMRect = {
-    top: 0,
-    left: 0,
-    width: 0,
-    height: 0,
-    right: 0,
-    bottom: 0,
-    x: 0,
-    y: 0,
-    toJSON: () => ({}),
-    ...rect
-  } as DOMRect
-  el.getBoundingClientRect = () => full
+  el.getBoundingClientRect = () =>
+    ({
+      top: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      right: 0,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+      ...rect
+    }) as DOMRect
   return el
 }
 
@@ -281,117 +306,104 @@ describe('terminal-registry: slot / persistent-host API', () => {
   })
 })
 
-// The pty hears a terminal's first size at once and every later one once it settles: a drag is one SIGWINCH, not one per frame.
-describe('what the pty is told about size', () => {
+// The box moves every frame; the grid, the pty and the server's model take its size together once it settles.
+describe('when a moved box becomes a size', () => {
   let host: HTMLDivElement
+  let rect: Partial<DOMRect>
   const resize = (): ReturnType<typeof vi.fn> =>
     window.api.resizeTerminal as ReturnType<typeof vi.fn>
   const sizes = (): Array<{ cols: number; rows: number }> =>
     resize().mock.calls.map((c) => ({ cols: c[0].cols, rows: c[0].rows }))
-
-  /** A slot whose rect the test can move. */
-  function movableSlot(
-    width: number,
-    height: number
-  ): { el: HTMLDivElement; resizeTo: (w: number, h: number) => void } {
-    const el = document.createElement('div')
-    let box = { width, height }
-    el.getBoundingClientRect = () =>
-      ({
-        top: 0,
-        left: 0,
-        right: box.width,
-        bottom: box.height,
-        x: 0,
-        y: 0,
-        ...box,
-        toJSON: () => ({})
-      }) as DOMRect
-    return {
-      el,
-      resizeTo: (w, h) => {
-        box = { width: w, height: h }
-      }
-    }
+  const fit = (): ReturnType<typeof vi.fn> => made.fits[made.fits.length - 1]!
+  const move = (width: number, height: number): void => {
+    rect.width = width
+    rect.height = height
+    syncTerminalOverlay('t')
   }
 
   beforeEach(() => {
     vi.useFakeTimers()
-    sizer.enabled = true
+    made.terms.length = 0
+    made.fits.length = 0
     host = document.createElement('div')
     document.body.appendChild(host)
     setHostRoot(host)
+    rect = { width: 800, height: 480 }
+    registerSlot('t', makeSlot(rect))
   })
 
   afterEach(() => {
     for (const id of getRegisteredTerminalIds()) destroyTerminal(id)
     setHostRoot(null)
     document.body.innerHTML = ''
-    sizer.enabled = false
     vi.clearAllMocks()
     vi.useRealTimers()
   })
 
-  it('tells it the first size at once', () => {
-    const slot = movableSlot(800, 480)
-    registerSlot('t', slot.el)
-
+  it('takes the first box at once', () => {
     expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
   })
 
-  it('tells it a drag once, after the last frame, with the size it ended at', () => {
-    const slot = movableSlot(800, 480)
-    registerSlot('t', slot.el)
-
+  it('lets a drag settle, then refits once and tells the pty once, at the size it ended at', () => {
+    const fitsBefore = fit().mock.calls.length
     for (let w = 808; w <= 880; w += 8) {
-      slot.resizeTo(w, 480)
-      syncTerminalOverlay('t')
+      move(w, 480)
       vi.advanceTimersByTime(16)
     }
+    expect(fit().mock.calls.length).toBe(fitsBefore)
     expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
 
-    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(100)
+    expect(fit().mock.calls.length).toBe(fitsBefore + 1)
     expect(sizes()).toEqual([
       { cols: 100, rows: 30 },
       { cols: 110, rows: 30 }
     ])
   })
 
-  it('says nothing when a drag ends where it began', () => {
-    const slot = movableSlot(800, 480)
-    registerSlot('t', slot.el)
-    slot.resizeTo(880, 480)
-    syncTerminalOverlay('t')
-    slot.resizeTo(800, 480)
-    syncTerminalOverlay('t')
+  it('says nothing to the pty when a drag ends where it began', () => {
+    move(880, 480)
+    move(800, 480)
 
-    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(100)
     expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
   })
 
   it('says nothing for a terminal destroyed during the hold', () => {
-    const slot = movableSlot(800, 480)
-    registerSlot('t', slot.el)
-    slot.resizeTo(880, 480)
-    syncTerminalOverlay('t')
+    move(880, 480)
     destroyTerminal('t')
 
-    vi.advanceTimersByTime(50)
+    vi.advanceTimersByTime(100)
     expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
   })
 
-  it('holds a refit for a font or renderer change the same way', () => {
-    const slot = movableSlot(800, 480)
-    registerSlot('t', slot.el)
-    // The box did not move; the cell did. `fitTerminal` is that path.
-    getPersistentWrapper('t')!.style.width = '880px'
-    fitTerminal('t')
-    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+  it('takes a held size before a keystroke, so what is typed follows the SIGWINCH', () => {
+    move(880, 480)
+    const onData = made.terms[made.terms.length - 1]!.onData.mock.calls[0][0] as (d: string) => void
+    onData('x')
 
-    vi.advanceTimersByTime(50)
     expect(sizes()).toEqual([
       { cols: 100, rows: 30 },
       { cols: 110, rows: 30 }
     ])
+    const write = window.api.writeTerminal as ReturnType<typeof vi.fn>
+    expect(resize().mock.invocationCallOrder[1]).toBeLessThan(write.mock.invocationCallOrder[0])
+  })
+
+  it('refits at once for a renderer or font that changed the cell, and holds a font-size gesture', () => {
+    // The box did not move; the cell did. `fitTerminal` is that path, and it is one shot.
+    getPersistentWrapper('t')!.style.width = '880px'
+    fitTerminal('t')
+    expect(sizes()).toEqual([
+      { cols: 100, rows: 30 },
+      { cols: 110, rows: 30 }
+    ])
+
+    // A pinch is many steps; the pty hears where it ends.
+    getPersistentWrapper('t')!.style.width = '960px'
+    setAllTerminalsFontSize(14)
+    expect(sizes()).toHaveLength(2)
+    vi.advanceTimersByTime(100)
+    expect(sizes()[2]).toEqual({ cols: 120, rows: 30 })
   })
 })

--- a/tests/terminal-registry-slot.test.ts
+++ b/tests/terminal-registry-slot.test.ts
@@ -62,11 +62,19 @@ vi.mock('@xterm/addon-fit', () => {
     activate(term: unknown): void {
       this.term = term as MockFitAddon['term']
     }
-    fit = vi.fn(() => {
+    proposeDimensions(): { cols: number; rows: number } | undefined {
       const el = this.term?.element
-      if (!this.term || !el) return
-      this.term.cols = Math.max(2, Math.floor((parseInt(el.style.width) || 0) / 8))
-      this.term.rows = Math.max(1, Math.floor((parseInt(el.style.height) || 0) / 16))
+      if (!el) return undefined
+      return {
+        cols: Math.max(2, Math.floor((parseInt(el.style.width) || 0) / 8)),
+        rows: Math.max(1, Math.floor((parseInt(el.style.height) || 0) / 16))
+      }
+    }
+    fit = vi.fn(() => {
+      const next = this.proposeDimensions()
+      if (!this.term || !next) return
+      this.term.cols = next.cols
+      this.term.rows = next.rows
     })
     constructor() {
       made.fits.push(this.fit)
@@ -359,6 +367,36 @@ describe('when a moved box becomes a size', () => {
       { cols: 100, rows: 30 },
       { cols: 110, rows: 30 }
     ])
+  })
+
+  it('ignores a move that would not change the grid, and drops a hold it had armed', () => {
+    move(880, 480)
+    // Back inside the same cell count before the hold lapses: nothing to take.
+    move(803, 480)
+
+    vi.advanceTimersByTime(400)
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+  })
+
+  it('fits a box that never stands still by the deadline', () => {
+    // Two pixels a frame: the grid first moves at 808px, and the deadline runs from there.
+    let w = 800
+    for (let t = 0; t < 600; t += 16) {
+      w += 2
+      move(w, 480)
+      vi.advanceTimersByTime(16)
+    }
+
+    expect(sizes()).toHaveLength(2)
+    expect(sizes()[1]!.cols).toBeGreaterThan(100)
+  })
+
+  it("does not take a held size for the terminal's own reply to a query", () => {
+    move(880, 480)
+    const onData = made.terms[made.terms.length - 1]!.onData.mock.calls[0][0] as (d: string) => void
+    onData('\x1b[24;80R')
+
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
   })
 
   it('says nothing to the pty when a drag ends where it began', () => {

--- a/tests/terminal-registry-slot.test.ts
+++ b/tests/terminal-registry-slot.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // The fit mock sizes the grid from the wrapper's box, 8x16 px cells, so a moved rect moves cols/rows.
 const made = vi.hoisted(() => ({
-  terms: [] as Array<{ onData: ReturnType<typeof vi.fn> }>,
+  terms: [] as Array<{ onData: ReturnType<typeof vi.fn>; buffer: { active: { cursorY: number } } }>,
   fits: [] as Array<ReturnType<typeof vi.fn>>
 }))
 
@@ -14,7 +14,7 @@ vi.mock('@xterm/xterm', () => {
     rows = 24
     options = { fontSize: 13 }
     buffer = {
-      active: { viewportY: 0, baseY: 0, type: 'normal' },
+      active: { viewportY: 0, baseY: 0, cursorY: 0, type: 'normal' },
       onBufferChange: vi.fn().mockReturnValue({ dispose: vi.fn() })
     }
     parser = {
@@ -443,5 +443,89 @@ describe('when a moved box becomes a size', () => {
     expect(sizes()).toHaveLength(2)
     vi.advanceTimersByTime(100)
     expect(sizes()[2]).toEqual({ cols: 120, rows: 30 })
+  })
+})
+
+// Block mode: the grid is fitted to the pane and the slot is only the window onto the rows around the cursor.
+describe('a mask over a full-size grid', () => {
+  let host: HTMLDivElement
+  let pane: { top: number; left: number; width: number; height: number }
+  let slot: { top: number; left: number; width: number; height: number }
+  const resize = (): ReturnType<typeof vi.fn> =>
+    window.api.resizeTerminal as ReturnType<typeof vi.fn>
+  const sizes = (): Array<{ cols: number; rows: number }> =>
+    resize().mock.calls.map((c) => ({ cols: c[0].cols, rows: c[0].rows }))
+  const wrapper = (): HTMLDivElement => getPersistentWrapper('t')!
+  const clip = (): string => wrapper().style.clipPath
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    made.terms.length = 0
+    made.fits.length = 0
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    setHostRoot(host)
+    // A 760px pane, 16px cells in this mock: 47 rows. The slot sits at its bottom, two rows tall.
+    pane = { top: 100, left: 0, width: 800, height: 760 }
+    slot = { top: 828, left: 0, width: 800, height: 32 }
+    registerSlot('t', makeSlot(slot), makeSlot(pane))
+  })
+
+  afterEach(() => {
+    for (const id of getRegisteredTerminalIds()) destroyTerminal(id)
+    setHostRoot(null)
+    document.body.innerHTML = ''
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it("gives the grid the pane's size and the pty the pane's rows", () => {
+    expect(wrapper().style.width).toBe('800px')
+    expect(wrapper().style.height).toBe('760px')
+    expect(sizes()).toEqual([{ cols: 100, rows: 47 }])
+  })
+
+  it('shows only the slot, starting at its top', () => {
+    expect(wrapper().style.top).toBe('828px')
+    expect(clip()).toBe('inset(0px 0 728px 0)')
+  })
+
+  it('grows the window with the output and tells the pty nothing', () => {
+    slot.height = 96
+    syncTerminalOverlay('t')
+    vi.advanceTimersByTime(500)
+
+    expect(clip()).toBe('inset(0px 0 664px 0)')
+    expect(sizes()).toEqual([{ cols: 100, rows: 47 }])
+  })
+
+  it('keeps the rows around the cursor in the window once it has drawn more than fits', () => {
+    slot.top = 604
+    slot.height = 256 // 16 rows
+    made.terms[made.terms.length - 1]!.buffer.active.cursorY = 30
+    syncTerminalOverlay('t')
+
+    // Rows 15..30 are the window; 15 rows lie above it.
+    expect(wrapper().style.top).toBe(`${604 - 15 * 16}px`)
+    expect(clip()).toBe('inset(240px 0 264px 0)')
+  })
+
+  it('still refits when the pane itself changes', () => {
+    pane.width = 960
+    syncTerminalOverlay('t')
+    vi.advanceTimersByTime(100)
+
+    expect(sizes()).toEqual([
+      { cols: 100, rows: 47 },
+      { cols: 120, rows: 47 }
+    ])
+  })
+
+  it('is no mask at all for a slot registered without a box', () => {
+    registerSlot('t', makeSlot({ top: 100, left: 0, width: 800, height: 760 }))
+    syncTerminalOverlay('t')
+
+    expect(clip()).toBe('')
+    expect(wrapper().style.top).toBe('100px')
   })
 })

--- a/tests/terminal-registry-slot.test.ts
+++ b/tests/terminal-registry-slot.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+// When on, the fit mock sizes the grid from the wrapper's box, 8x16 px cells, so a moved rect moves cols/rows.
+const sizer = vi.hoisted(() => ({ enabled: false }))
+
 vi.mock('@xterm/xterm', () => {
   class MockTerminal {
     element: HTMLElement | null = null
@@ -17,7 +20,7 @@ vi.mock('@xterm/xterm', () => {
     }
     registerMarker = vi.fn()
     registerDecoration = vi.fn()
-    loadAddon = vi.fn()
+    loadAddon = vi.fn((addon: { activate?: (t: unknown) => void }) => addon.activate?.(this))
     onData = vi.fn()
     attachCustomKeyEventHandler = vi.fn()
     dispose = vi.fn()
@@ -49,7 +52,16 @@ vi.mock('@xterm/xterm', () => {
 
 vi.mock('@xterm/addon-fit', () => {
   class MockFitAddon {
-    fit = vi.fn()
+    term: { element: HTMLElement | null; cols: number; rows: number } | null = null
+    activate(term: unknown): void {
+      this.term = term as MockFitAddon['term']
+    }
+    fit = vi.fn(() => {
+      const el = this.term?.element
+      if (!sizer.enabled || !this.term || !el) return
+      this.term.cols = Math.max(2, Math.floor((parseInt(el.style.width) || 0) / 8))
+      this.term.rows = Math.max(1, Math.floor((parseInt(el.style.height) || 0) / 16))
+    })
   }
   return { FitAddon: MockFitAddon }
 })
@@ -79,7 +91,8 @@ import {
   syncTerminalOverlay,
   onRegistryChange,
   getRegisteredTerminalIds,
-  destroyTerminal
+  destroyTerminal,
+  fitTerminal
 } from '../src/renderer/lib/terminal-registry'
 
 function makeSlot(rect: Partial<DOMRect>): HTMLDivElement {
@@ -265,5 +278,120 @@ describe('terminal-registry: slot / persistent-host API', () => {
     syncTerminalOverlay('term-round')
     expect(wrapper.style.top).toBe('50px')
     expect(wrapper.style.left).toBe('101px')
+  })
+})
+
+// The pty hears a terminal's first size at once and every later one once it settles: a drag is one SIGWINCH, not one per frame.
+describe('what the pty is told about size', () => {
+  let host: HTMLDivElement
+  const resize = (): ReturnType<typeof vi.fn> =>
+    window.api.resizeTerminal as ReturnType<typeof vi.fn>
+  const sizes = (): Array<{ cols: number; rows: number }> =>
+    resize().mock.calls.map((c) => ({ cols: c[0].cols, rows: c[0].rows }))
+
+  /** A slot whose rect the test can move. */
+  function movableSlot(
+    width: number,
+    height: number
+  ): { el: HTMLDivElement; resizeTo: (w: number, h: number) => void } {
+    const el = document.createElement('div')
+    let box = { width, height }
+    el.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        left: 0,
+        right: box.width,
+        bottom: box.height,
+        x: 0,
+        y: 0,
+        ...box,
+        toJSON: () => ({})
+      }) as DOMRect
+    return {
+      el,
+      resizeTo: (w, h) => {
+        box = { width: w, height: h }
+      }
+    }
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sizer.enabled = true
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    setHostRoot(host)
+  })
+
+  afterEach(() => {
+    for (const id of getRegisteredTerminalIds()) destroyTerminal(id)
+    setHostRoot(null)
+    document.body.innerHTML = ''
+    sizer.enabled = false
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('tells it the first size at once', () => {
+    const slot = movableSlot(800, 480)
+    registerSlot('t', slot.el)
+
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+  })
+
+  it('tells it a drag once, after the last frame, with the size it ended at', () => {
+    const slot = movableSlot(800, 480)
+    registerSlot('t', slot.el)
+
+    for (let w = 808; w <= 880; w += 8) {
+      slot.resizeTo(w, 480)
+      syncTerminalOverlay('t')
+      vi.advanceTimersByTime(16)
+    }
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+
+    vi.advanceTimersByTime(50)
+    expect(sizes()).toEqual([
+      { cols: 100, rows: 30 },
+      { cols: 110, rows: 30 }
+    ])
+  })
+
+  it('says nothing when a drag ends where it began', () => {
+    const slot = movableSlot(800, 480)
+    registerSlot('t', slot.el)
+    slot.resizeTo(880, 480)
+    syncTerminalOverlay('t')
+    slot.resizeTo(800, 480)
+    syncTerminalOverlay('t')
+
+    vi.advanceTimersByTime(50)
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+  })
+
+  it('says nothing for a terminal destroyed during the hold', () => {
+    const slot = movableSlot(800, 480)
+    registerSlot('t', slot.el)
+    slot.resizeTo(880, 480)
+    syncTerminalOverlay('t')
+    destroyTerminal('t')
+
+    vi.advanceTimersByTime(50)
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+  })
+
+  it('holds a refit for a font or renderer change the same way', () => {
+    const slot = movableSlot(800, 480)
+    registerSlot('t', slot.el)
+    // The box did not move; the cell did. `fitTerminal` is that path.
+    getPersistentWrapper('t')!.style.width = '880px'
+    fitTerminal('t')
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+
+    vi.advanceTimersByTime(50)
+    expect(sizes()).toEqual([
+      { cols: 100, rows: 30 },
+      { cols: 110, rows: 30 }
+    ])
   })
 })

--- a/tests/terminal-registry-slot.test.ts
+++ b/tests/terminal-registry-slot.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // The fit mock sizes the grid from the wrapper's box, 8x16 px cells, so a moved rect moves cols/rows.
 const made = vi.hoisted(() => ({
-  terms: [] as Array<{ onData: ReturnType<typeof vi.fn>; buffer: { active: { cursorY: number } } }>,
+  terms: [] as Array<{
+    onData: ReturnType<typeof vi.fn>
+    attachCustomKeyEventHandler: ReturnType<typeof vi.fn>
+    buffer: { active: { cursorY: number } }
+  }>,
   fits: [] as Array<ReturnType<typeof vi.fn>>
 }))
 
@@ -34,11 +38,16 @@ vi.mock('@xterm/xterm', () => {
     scrollToBottom = vi.fn()
     scrollToLine = vi.fn()
     refresh = vi.fn()
+    screen = document.createElement('div')
     constructor() {
       made.terms.push(this)
+      this.screen.className = 'xterm-screen'
+      this.screen.getBoundingClientRect = () =>
+        ({ width: this.cols * 8, height: this.rows * 16 }) as DOMRect
     }
     open(el: HTMLElement): void {
       this.element = el
+      el.appendChild(this.screen)
     }
     hasSelection(): boolean {
       return false
@@ -58,7 +67,12 @@ vi.mock('@xterm/xterm', () => {
 
 vi.mock('@xterm/addon-fit', () => {
   class MockFitAddon {
-    term: { element: HTMLElement | null; cols: number; rows: number } | null = null
+    term: {
+      element: HTMLElement | null
+      cols: number
+      rows: number
+      buffer?: { active: { cursorY: number } }
+    } | null = null
     activate(term: unknown): void {
       this.term = term as MockFitAddon['term']
     }
@@ -75,6 +89,9 @@ vi.mock('@xterm/addon-fit', () => {
       if (!this.term || !next) return
       this.term.cols = next.cols
       this.term.rows = next.rows
+      // xterm keeps the cursor on the screen when the screen shrinks.
+      const active = this.term.buffer?.active
+      if (active) active.cursorY = Math.min(active.cursorY, next.rows - 1)
     })
     constructor() {
       made.fits.push(this.fit)
@@ -391,14 +408,6 @@ describe('when a moved box becomes a size', () => {
     expect(sizes()[1]!.cols).toBeGreaterThan(100)
   })
 
-  it("does not take a held size for the terminal's own reply to a query", () => {
-    move(880, 480)
-    const onData = made.terms[made.terms.length - 1]!.onData.mock.calls[0][0] as (d: string) => void
-    onData('\x1b[24;80R')
-
-    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
-  })
-
   it('says nothing to the pty when a drag ends where it began', () => {
     move(880, 480)
     move(800, 480)
@@ -415,17 +424,38 @@ describe('when a moved box becomes a size', () => {
     expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
   })
 
-  it('takes a held size before a keystroke, so what is typed follows the SIGWINCH', () => {
+  it('takes a held size on a keystroke, so what is typed follows the SIGWINCH', () => {
     move(880, 480)
-    const onData = made.terms[made.terms.length - 1]!.onData.mock.calls[0][0] as (d: string) => void
-    onData('x')
+    const term = made.terms[made.terms.length - 1]!
+    const onKey = term.attachCustomKeyEventHandler.mock.calls[0][0] as (e: KeyboardEvent) => boolean
+    onKey({ type: 'keydown', key: 'ArrowUp', metaKey: false, ctrlKey: false } as KeyboardEvent)
 
     expect(sizes()).toEqual([
       { cols: 100, rows: 30 },
       { cols: 110, rows: 30 }
     ])
-    const write = window.api.writeTerminal as ReturnType<typeof vi.fn>
-    expect(resize().mock.invocationCallOrder[1]).toBeLessThan(write.mock.invocationCallOrder[0])
+  })
+
+  it("does not take a held size for the terminal's own reply to a query", () => {
+    move(880, 480)
+    const onData = made.terms[made.terms.length - 1]!.onData.mock.calls[0][0] as (d: string) => void
+    onData('\x1b[24;80R')
+
+    expect(sizes()).toEqual([{ cols: 100, rows: 30 }])
+  })
+
+  it('keeps the rows around the cursor in view while a shrinking box waits out the hold', () => {
+    // 30 rows of 16px; the box drops to 12 rows with the cursor on row 29.
+    made.terms[made.terms.length - 1]!.buffer.active.cursorY = 29
+    move(800, 192)
+    const box = getPersistentWrapper('t')!
+
+    expect(box.style.top).toBe(`${0 - 18 * 16}px`)
+    expect(box.style.clipPath).toBe('inset(288px 0 0px 0)')
+
+    vi.advanceTimersByTime(100)
+    expect(box.style.top).toBe('0px')
+    expect(box.style.clipPath).toBe('inset(0px 0 0px 0)')
   })
 
   it('refits at once for a renderer or font that changed the cell, and holds a font-size gesture', () => {
@@ -499,18 +529,17 @@ describe('a mask over a full-size grid', () => {
     expect(sizes()).toEqual([{ cols: 100, rows: 47 }])
   })
 
-  it('keeps the rows around the cursor in the window once it has drawn more than fits', () => {
+  it('shows the top rows of the grid, which holds every row the command has drawn', () => {
     slot.top = 604
-    slot.height = 256 // 16 rows
+    slot.height = 256
     made.terms[made.terms.length - 1]!.buffer.active.cursorY = 30
     syncTerminalOverlay('t')
 
-    // Rows 15..30 are the window; 15 rows lie above it.
-    expect(wrapper().style.top).toBe(`${604 - 15 * 16}px`)
-    expect(clip()).toBe('inset(240px 0 264px 0)')
+    expect(wrapper().style.top).toBe('604px')
+    expect(clip()).toBe('inset(0px 0 504px 0)')
   })
 
-  it('still refits when the pane itself changes', () => {
+  it('still refits when the pane itself changes, and keeps the window where the slot is', () => {
     pane.width = 960
     syncTerminalOverlay('t')
     vi.advanceTimersByTime(100)
@@ -519,13 +548,25 @@ describe('a mask over a full-size grid', () => {
       { cols: 100, rows: 47 },
       { cols: 120, rows: 47 }
     ])
+    expect(wrapper().style.top).toBe('828px')
   })
 
-  it('is no mask at all for a slot registered without a box', () => {
+  it('shows the whole pane again for a full-screen program that took the slot over', () => {
+    // vim: the pane hands the slot over without a box, through an unregister and a register.
+    const slotEl = makeSlot({ top: 100, left: 0, width: 800, height: 760 })
+    unregisterSlot('t', document.querySelector('[data-terminal-id]') as HTMLElement)
+    registerSlot('t', slotEl)
+    syncTerminalOverlay('t')
+
+    expect(clip()).toBe('inset(0px 0 8px 0)')
+    expect(wrapper().style.top).toBe('100px')
+  })
+
+  it('is no window at all for a slot registered without a box', () => {
     registerSlot('t', makeSlot({ top: 100, left: 0, width: 800, height: 760 }))
     syncTerminalOverlay('t')
 
-    expect(clip()).toBe('')
+    expect(clip()).toBe('inset(0px 0 8px 0)')
     expect(wrapper().style.top).toBe('100px')
   })
 })

--- a/tests/terminal-slot.test.tsx
+++ b/tests/terminal-slot.test.tsx
@@ -68,4 +68,11 @@ describe('TerminalSlot', () => {
     rafCallbacks.forEach((cb) => cb())
     expect(focusTerminal).not.toHaveBeenCalled()
   })
+
+  it('hands the registry the box to fit to, when given one', () => {
+    const box = document.createElement('div')
+    render(<TerminalSlot terminalId="abc" isFocused={false} fitTo={{ current: box }} />)
+
+    expect(registerSlot).toHaveBeenCalledWith('abc', expect.any(HTMLElement), box)
+  })
 })


### PR DESCRIPTION
Every frame of a size change — an animated window maximize, a card's corner being dragged, a pane maximized — refitted the terminal and sent `terminal:resize`. The server answered each with a `SIGWINCH`, a reflow of its screen model and a history frame written to disk: about fifteen per terminal per maximize. A full-screen program repainted on every one, into a box that had already moved on, so its content chased the frame and settled late. And in command-blocks mode the shell was told it had **two rows** at an idle prompt, with a SIGWINCH for every line of output that grew the live region.

Measured before deciding: xterm's own reflow with a full 2000-line scrollback is 0.3–2.4 ms. The reflow was never the cost; the fan-out was.

## What changes

**The box moves every frame; the grid, the pty and the server's model take its size together once it settles** — 100 ms after the last change, 400 ms at most for a box that never stands still. The first size a terminal ever has goes out at once, so a new pane's prompt is at the right width. A keystroke takes a held size first, so what is typed reaches the program after the SIGWINCH. Grid and model never wrap differently from each other, because they change at one moment.

**Block mode shows the live region through a window, not a grid cut to fit it.** The grid is fitted to the pane; the live region is a clip that shows its top rows, growing with the command up to the pane, and shrinking back when the block lifts into the log. Rows never change with output, so no two-row shell and no signal per line. Full-screen programs keep the whole pane as before.

## Measured and seen

Keystroke → echo through the server was already 0.8 ms after #590; this branch does not touch it. Resizes, from the dev trace: one `terminal:resize` per gesture where there were fifteen. In the dev app, with blocks on: `echo $LINES` at an idle prompt prints the pane's rows, not 2; `seq 1 30` under `trap 'print WINCH' WINCH` prints nothing; a card maximize prints one.

## Review

`/code-review high` ran twice. The first pass found the first cut refitting the grid per frame while the model waited — hence "together once it settles" — and that a keystroke could overtake a held resize. The second, on the window, found five things that would have shipped: a hidden wrapper kept its clip, so `vim` after a shell prompt was clipped to two rows; the window's `top` was overwritten on a sideways move; the cell was recovered as `floor(box / rows)`, half a pixel a row off on Retina, so the clip drifted off the cursor; ESC-prefixed keys (arrows, Delete) skipped the pre-keystroke flush; and output above the sixteen-row window was hidden and unscrollable while a command ran. All fixed: the cell is measured from xterm's screen element, the window runs in every mode (a shrinking box keeps the rows around the cursor in view during the hold), the flush is on keydown, and the live region grows to the pane — a product decision taken with Javier.

## Tests

`tests/terminal-registry-slot.test.ts` on a fit mock that sizes the grid from the box and a screen element that yields the cell: the first size at once; a drag is one send at its final size; a move that ends where it began sends nothing; a box that keeps moving is fitted by the deadline; a keystroke takes a held size, a terminal reply does not; a shrinking box shows the rows around the cursor while it waits; and the window: pane-sized grid, top rows shown, output grows the window without a send, a pane change still refits and keeps the window in place, a full-screen program that takes over the slot gets the whole pane. `tests/terminal-pane-mask.test.tsx` renders the real `TerminalPane` for the first time. `tests/live-terminal-rows.test.ts` covers the new cap.

Not in this change: `LIVE_ROW_PX = 19` is still hard-coded while the cell follows the font size — the slot is a few pixels off at other sizes, as before; the clip now uses the measured cell so no partial row is painted. Server-side coalescing of resize frames. The WebGL canvas reallocation per frame, which needs a real profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9xDZGyS3vzszATiHWYF8F
