### PR TITLE
chore(release): 0.7.0-beta.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.15",
+  "version": "0.7.0-beta.16",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Version bump for the next beta. Since beta.15: workflows run in the server so they happen with nothing open (#586), Electron 44 (#588), terminal output as bytes on the wire (#589), a keystroke's echo sent at once (#590), a resize told to the process once when it settles and the live region in block mode shown through a window over a pane-sized grid (#593).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9xDZGyS3vzszATiHWYF8F