### PR TITLE
Let the hook registration pass to the server that outlives its holder

### DIFF
--- a/packages/server/src/hook-server.ts
+++ b/packages/server/src/hook-server.ts
@@ -71,6 +71,7 @@ export class HookServer extends EventEmitter {
    * instance the person is using.
    */
   private owner = false
+  private ownerWatch: NodeJS.Timeout | null = null
   private authToken: string
 
   constructor() {
@@ -98,6 +99,8 @@ export class HookServer extends EventEmitter {
   // restarts (Claude sessions read the URL once and keep using it).
   // Falls back to an OS-assigned port if the preferred one is taken.
   private static readonly PREFERRED_PORT = 56432
+  /** How often a server that found the registration held looks again. */
+  static OWNER_POLL_MS = 1000
 
   /** Verify bearer token from Authorization header */
   private authenticate(req: http.IncomingMessage, res: http.ServerResponse): boolean {
@@ -335,20 +338,40 @@ export class HookServer extends EventEmitter {
    * while another Vorn is running is what silently redirected its hooks here.
    */
   private claim(): void {
+    if (this.tryClaim()) return
+    // The holder may be a server on its way out, as on an update; take over when it is gone.
+    this.ownerWatch = setInterval(() => {
+      if (this.tryClaim()) this.stopWatchingOwner()
+    }, HookServer.OWNER_POLL_MS)
+    this.ownerWatch.unref?.()
+  }
+
+  /** Claims the registration when nobody live holds it; true once this server owns it. */
+  private tryClaim(): boolean {
+    if (this.owner) return true
     const owner = readHookOwnerFile()
-    this.owner = mayClaimHooks({ owner, selfPid: process.pid, isAlive: pidIsAlive })
-
-    if (!this.owner) {
-      log.info(
-        `[hooks] another Vorn (pid ${owner?.pid}) owns the hook registration on port ` +
-          `${owner?.port}, so this server listens on ${this.port} without claiming it`
-      )
-      return
+    if (!mayClaimHooks({ owner, selfPid: process.pid, isAlive: pidIsAlive })) {
+      if (!this.ownerWatch) {
+        log.info(
+          `[hooks] another Vorn (pid ${owner?.pid}) owns the hook registration on port ` +
+            `${owner?.port}, so this server listens on ${this.port} without claiming it`
+        )
+      }
+      return false
     }
-
+    this.owner = true
     this.writeOwnerFile()
     this.writePortFile()
     this.writeTokenFile()
+    if (this.ownerWatch)
+      log.info(`[hooks] the registration is free; claimed it on port ${this.port}`)
+    this.emit('claimed', this.port)
+    return true
+  }
+
+  private stopWatchingOwner(): void {
+    if (this.ownerWatch) clearInterval(this.ownerWatch)
+    this.ownerWatch = null
   }
 
   private writeOwnerFile(): void {
@@ -386,6 +409,7 @@ export class HookServer extends EventEmitter {
 
     this.server?.close()
     this.server = null
+    this.stopWatchingOwner()
 
     // Only what we wrote, confirmed against the record rather than against a flag
     // we set at startup. These files name one live server, and deleting another

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -634,7 +634,13 @@ export async function startServer(
       return listening && again.kind === 'held'
     },
     // Not `shutdown()`: that kills every PTY, which is the one thing a handoff must not do.
-    exit: () => process.exit(0)
+    exit: () => {
+      // Release the hook registration so the replacement can claim it at once.
+      void import('./hook-server').then(({ hookServer }) => {
+        hookServer.stop()
+        process.exit(0)
+      })
+    }
   }
 
   registerMethod('server:handoff', (params) => handOver(params, handoffHost))

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -2346,6 +2346,7 @@ export function registerAllMethods(): void {
           installHooks(port, hookServer.getAuthToken())
         } else {
           log.info('[hooks] another Vorn owns the registration; leaving it alone')
+          hookServer.once('claimed', () => installHooks(port, hookServer.getAuthToken()))
         }
       } catch (err) {
         log.error({ err }, '[hooks] failed to install hooks:')

--- a/tests/hook-ownership-handover.test.ts
+++ b/tests/hook-ownership-handover.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+// The same isolation as hook-payload.test.ts: a real HookServer writes to a home.
+vi.mock('node-pty', () => ({ default: { spawn: vi.fn() }, spawn: vi.fn() }))
+
+const holderAlive = { value: true }
+vi.mock('../packages/server/src/hook-ownership', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../packages/server/src/hook-ownership')>()),
+  pidIsAlive: (pid: number) => (pid === 4242 ? holderAlive.value : pid === process.pid)
+}))
+
+let home: string | null = null
+let realHome: string | undefined
+let realProfile: string | undefined
+
+beforeAll(() => {
+  realHome = process.env.HOME
+  realProfile = process.env.USERPROFILE
+  home = fs.mkdtempSync(path.join(os.tmpdir(), 'vorn-hook-owner-'))
+  process.env.HOME = home
+  process.env.USERPROFILE = home
+  fs.mkdirSync(path.join(home, '.vorn'))
+})
+
+function restore(name: 'HOME' | 'USERPROFILE', value: string | undefined): void {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+afterAll(() => {
+  restore('HOME', realHome)
+  restore('USERPROFILE', realProfile)
+  if (home) fs.rmSync(home, { recursive: true, force: true })
+})
+
+const started: Array<{ stop: () => void }> = []
+afterEach(() => {
+  for (const s of started.splice(0)) s.stop()
+  holderAlive.value = true
+})
+
+const ownerFile = (): string => path.join(home!, '.vorn', 'hook-owner')
+
+describe('a server that found the registration held', () => {
+  it('claims it once the holder is gone, and says so', async () => {
+    fs.writeFileSync(ownerFile(), JSON.stringify({ port: 1, pid: 4242 }))
+    const { HookServer } = await import('../packages/server/src/hook-server')
+    HookServer.OWNER_POLL_MS = 20
+    const server = new HookServer()
+    started.push(server)
+    const claimed = new Promise<number>((resolve) => server.once('claimed', resolve))
+
+    const port = await server.start(0)
+    expect(server.ownsRegistration()).toBe(false)
+    expect(JSON.parse(fs.readFileSync(ownerFile(), 'utf-8')).pid).toBe(4242)
+
+    holderAlive.value = false
+    expect(await claimed).toBe(port)
+    expect(server.ownsRegistration()).toBe(true)
+    expect(JSON.parse(fs.readFileSync(ownerFile(), 'utf-8'))).toEqual({ port, pid: process.pid })
+    expect(fs.readFileSync(path.join(home!, '.vorn', 'port'), 'utf-8')).toBe(String(port))
+    expect(fs.readFileSync(path.join(home!, '.vorn', 'token'), 'utf-8')).toBe(server.getAuthToken())
+  })
+
+  it('stops looking when it is stopped first', async () => {
+    fs.writeFileSync(ownerFile(), JSON.stringify({ port: 1, pid: 4242 }))
+    const { HookServer } = await import('../packages/server/src/hook-server')
+    HookServer.OWNER_POLL_MS = 20
+    const server = new HookServer()
+    const onClaimed = vi.fn()
+    server.on('claimed', onClaimed)
+    await server.start(0)
+    server.stop()
+    holderAlive.value = false
+    await new Promise((r) => setTimeout(r, 80))
+    expect(onClaimed).not.toHaveBeenCalled()
+    expect(JSON.parse(fs.readFileSync(ownerFile(), 'utf-8')).pid).toBe(4242)
+  })
+})


### PR DESCRIPTION
Seen on the beta.15 → beta.16 update at 19:51: the new server (70227) started while the old one (1352) still held `~/.vorn/hook-owner`, so it listened on 57466 without claiming; the handover moved the terminals and the old server exited via `process.exit(0)` without releasing. Result: the owner file named a dead pid, `~/.claude/settings.json` pointed every hook at 56432 with the old token, nothing listened there, and status detection was dead for every session until a restart. The new server's token was never written to `~/.vorn/token`, so it could not be repaired by hand.

Fix, at the mechanism rather than the update path:
- `HookServer` that finds the registration held keeps looking (every 1 s, unref'd) and claims it the moment `mayClaimHooks` says the holder is gone — owner, port and token files are written then, and a `claimed` event fires. `register-methods` installs the settings entry on that event when it could not at start. This covers a crashed holder too, not only a handover.
- The outgoing server's stand-down (`handoffHost.exit`) stops its hook server first, which releases the shared files, so the replacement claims within a second rather than waiting on the pid probe.

Test: `tests/hook-ownership-handover.test.ts` — a server started against a live holder does not claim; when the holder dies it claims, rewrites owner/port/token, and emits `claimed`; a server stopped first stops looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE