### PR TITLE
Remember the worktree a step made, so a gate answered later still runs in it

### DIFF
--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -463,6 +463,9 @@ function createSchema(): void {
       output TEXT,
       structured_output TEXT,
       iteration INTEGER,
+      worktree_path TEXT,
+      worktree_name TEXT,
+      worktree_origin TEXT,
       FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
     );
 
@@ -1065,6 +1068,24 @@ function migrateSchema(d: Database.Database): void {
       ).run()
     })()
     log.info('[database] migrated schema to version 18 (session groups)')
+  }
+
+  if (version < 19) {
+    d.transaction(() => {
+      const cols = d.prepare('PRAGMA table_info(workflow_run_nodes)').all() as Array<{
+        name: string
+      }>
+      for (const column of ['worktree_path', 'worktree_name', 'worktree_origin']) {
+        if (!cols.some((c) => c.name === column)) {
+          d.exec(`ALTER TABLE workflow_run_nodes ADD COLUMN ${column} TEXT`)
+        }
+      }
+
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '19')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 19 (worktrees on run steps)')
   }
 }
 
@@ -3512,8 +3533,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
 
     const insertNode = d.prepare(
-      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics, output, structured_output, iteration)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics, output, structured_output, iteration, worktree_path, worktree_name, worktree_origin)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const ns of execution.nodeStates) {
       insertNode.run(
@@ -3536,7 +3557,10 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
         // Stored as JSON text: the parsed shape is whatever the step's
         // outputSchema declared, so there is nothing narrower to store it as.
         ns.structuredOutput ? JSON.stringify(ns.structuredOutput) : null,
-        ns.iteration ?? null
+        ns.iteration ?? null,
+        ns.worktreePath ?? null,
+        ns.worktreeName ?? null,
+        ns.worktreeOrigin ?? null
       )
     }
 
@@ -3591,6 +3615,9 @@ type WorkflowRunNodeRow = {
   output: string | null
   structured_output: string | null
   iteration: number | null
+  worktree_path: string | null
+  worktree_name: string | null
+  worktree_origin: string | null
 }
 
 function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
@@ -3617,7 +3644,12 @@ function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
     ...(n.diagnostics != null && { diagnostics: n.diagnostics }),
     ...(n.output != null && { output: n.output }),
     ...(structured !== undefined && { structuredOutput: structured }),
-    ...(n.iteration != null && { iteration: n.iteration })
+    ...(n.iteration != null && { iteration: n.iteration }),
+    ...(n.worktree_path != null && { worktreePath: n.worktree_path }),
+    ...(n.worktree_name != null && { worktreeName: n.worktree_name }),
+    ...((n.worktree_origin === 'created' || n.worktree_origin === 'inherited') && {
+      worktreeOrigin: n.worktree_origin
+    })
   }
 }
 

--- a/tests/database-workflow-run.test.ts
+++ b/tests/database-workflow-run.test.ts
@@ -60,6 +60,33 @@ describe('workflow run persistence', () => {
     expect(state.approvedAt).toBe('2026-04-20T10:00:04Z')
   })
 
+  it('round-trips the worktree a step made, which a gate answered later runs in', () => {
+    const exec: WorkflowExecution = {
+      workflowId: 'wf-1',
+      runId: 'wf-1:2026-09-10T10:00:00Z',
+      startedAt: '2026-09-10T10:00:00Z',
+      status: 'running',
+      nodeStates: [
+        {
+          nodeId: 'research',
+          status: 'success',
+          worktreePath: '/repos/.vorn-worktrees/app/silver-madrigal-d4dc9209',
+          worktreeName: 'silver-madrigal',
+          worktreeOrigin: 'created'
+        },
+        { nodeId: 'approve', status: 'waiting' }
+      ]
+    }
+    saveWorkflowRun(exec)
+    const [loaded] = listWorkflowRuns('wf-1')
+    expect(loaded.nodeStates[0]).toMatchObject({
+      worktreePath: '/repos/.vorn-worktrees/app/silver-madrigal-d4dc9209',
+      worktreeName: 'silver-madrigal',
+      worktreeOrigin: 'created'
+    })
+    expect(loaded.nodeStates[1]).not.toHaveProperty('worktreePath')
+  })
+
   it('round-trips step diagnostics, which outlive the window that made them', () => {
     // The timeline matters most for a run you come back to later, so it has to
     // survive the reload rather than living only in renderer memory.


### PR DESCRIPTION
Since #586 a run parked on an approval gate leaves `activeRuns` and is read back from the database when the gate is answered. `workflow_run_nodes` never stored `worktreePath` / `worktreeName` / `worktreeOrigin`, so after the gate `{{steps.research.worktreePath}}` resolved to `''`, the Push script ran with no cwd and failed with `fatal: not a git repository` — seen on both factory runs this morning (x and ollama), whose Research/Develop/Review had all passed.

Schema 19 adds the three columns to `workflow_run_nodes`; the insert and the row mapping carry them; `worktreeOrigin` is only restored when it is one of the two known values. Test: a saved run's step round-trips its worktree, and a step without one stays without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE