### PR TITLE
Let a launch name its model, in the launcher, the intent bar and a workflow step

### DIFF
--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -66,8 +66,9 @@ export function buildAgentLaunchLine(
   // Per-step args override settings-level args; escape each for shell safety
   const escape = (value: string) => shellEscape(value, payload.remoteHostId ? 'posix' : 'auto')
   const effectiveArgs = withModel(payload, cmd.command, payload.args ?? cmd.args)
+  // Only a path with spaces that names one file is quoted; `~/bin/claude` keeps its expansion.
   const commandLine =
-    commandShape(cmd.command, !payload.remoteHostId) === 'executable'
+    /\s/.test(cmd.command) && commandShape(cmd.command, !payload.remoteHostId) === 'executable'
       ? escape(cmd.command)
       : cmd.command
   let launchLine = [commandLine, ...effectiveArgs.map(escape)].join(' ')

--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -10,7 +10,7 @@ import {
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { shellEscape } from './process-utils'
 import { stripSessionSelectors } from './launch-tokens'
-import { applyModelArguments, assertModelCommand } from './model-arguments'
+import { applyModelArguments, assertModelCommand, commandShape } from './model-arguments'
 import { findOnPath } from './resolve-executable'
 
 /** The configured command, and where on `env.PATH` it lives; the name when it is not there. */
@@ -42,6 +42,13 @@ function resolveHeadlessArgs(
   return baseArgs
 }
 
+/** The arguments with the chosen model as their one model selector, or as they are. */
+function withModel(payload: CreateTerminalPayload, command: string, args: string[]): string[] {
+  if (payload.model === undefined) return args
+  assertModelCommand(command, !payload.remoteHostId)
+  return applyModelArguments(payload.agentType, args, payload.model)
+}
+
 /**
  * Builds the interactive launch command (for PTY/terminal sessions).
  * This starts the agent's TUI/interactive mode.
@@ -58,12 +65,11 @@ export function buildAgentLaunchLine(
   const cmd = resolveAgentCommand(cmdConfig, env)
   // Per-step args override settings-level args; escape each for shell safety
   const escape = (value: string) => shellEscape(value, payload.remoteHostId ? 'posix' : 'auto')
-  let effectiveArgs = payload.args !== undefined ? payload.args : cmd.args
-  if (payload.model !== undefined) {
-    assertModelCommand(cmd.command)
-    effectiveArgs = applyModelArguments(payload.agentType, effectiveArgs, payload.model)
-  }
-  const commandLine = payload.model !== undefined ? escape(cmd.command) : cmd.command
+  const effectiveArgs = withModel(payload, cmd.command, payload.args ?? cmd.args)
+  const commandLine =
+    commandShape(cmd.command, !payload.remoteHostId) === 'executable'
+      ? escape(cmd.command)
+      : cmd.command
   let launchLine = [commandLine, ...effectiveArgs.map(escape)].join(' ')
 
   // Where the configured command ends and its arguments begin. Known exactly
@@ -144,59 +150,6 @@ export function buildAgentLaunchLine(
   return launchLine
 }
 
-/**
- * Builds the non-interactive launch command (for headless/background execution).
- * Uses each agent's native non-interactive mode:
- *   claude  -> claude -p 'prompt'
- *   copilot -> copilot -p 'prompt'
- *   codex   -> codex exec 'prompt'
- *   opencode -> opencode run 'prompt'
- *   gemini  -> gemini -p 'prompt'
- */
-export function buildHeadlessLaunchLine(
-  payload: CreateTerminalPayload,
-  agentCommands: Record<AiAgentType, AgentCommandConfig>,
-  env: Record<string, string>
-): string {
-  if ((payload.agentType as AgentType) === 'shell') {
-    throw new Error('buildHeadlessLaunchLine called for shell session')
-  }
-  const cmdConfig = agentCommands[payload.agentType] || DEFAULT_AGENT_COMMANDS[payload.agentType]
-  const cmd = resolveAgentCommand(cmdConfig, env)
-  const baseCmd = payload.model !== undefined ? shellEscape(cmd.command) : cmd.command
-  let extraArgs = resolveHeadlessArgs(payload, cmdConfig, cmd.args)
-  if (payload.model !== undefined) {
-    assertModelCommand(cmd.command)
-    extraArgs = applyModelArguments(payload.agentType, extraArgs, payload.model)
-  }
-  const renderedArgs =
-    payload.model !== undefined ? extraArgs.map((a) => shellEscape(a)) : extraArgs
-  const argsStr = renderedArgs.length > 0 ? renderedArgs.join(' ') + ' ' : ''
-
-  const emptyStr = process.platform === 'win32' ? '""' : "''"
-  const prompt = payload.initialPrompt ? shellEscape(payload.initialPrompt) : emptyStr
-
-  switch (payload.agentType) {
-    case 'claude':
-      return `${baseCmd} ${argsStr}-p ${prompt}`
-
-    case 'copilot':
-      return `${baseCmd} ${argsStr}-p ${prompt}`
-
-    case 'codex':
-      return `${baseCmd} ${argsStr}exec ${payload.resumeSessionId ? `resume ${shellEscape(payload.resumeSessionId)} ` : ''}${prompt}`
-
-    case 'opencode':
-      return `${baseCmd} ${argsStr}run ${prompt}`
-
-    case 'gemini':
-      return `${baseCmd} ${argsStr}-p ${prompt}`
-
-    default:
-      return `${baseCmd} ${argsStr}-p ${prompt}`
-  }
-}
-
 export interface HeadlessSpawnArgs {
   command: string
   args: string[]
@@ -234,11 +187,9 @@ export function buildHeadlessSpawnArgs(
   const cmdConfig = agentCommands[payload.agentType] || DEFAULT_AGENT_COMMANDS[payload.agentType]
   const cmd = resolveAgentCommand(cmdConfig, env)
   const prompt = payload.initialPrompt || ''
-  let extraArgs = [...resolveHeadlessArgs(payload, cmdConfig, cmd.args)]
-  if (payload.model !== undefined) {
-    assertModelCommand(cmd.command)
-    extraArgs = applyModelArguments(payload.agentType, extraArgs, payload.model)
-  }
+  const extraArgs = [
+    ...withModel(payload, cmd.command, resolveHeadlessArgs(payload, cmdConfig, cmd.args))
+  ]
 
   if (
     payload.resumeSessionId &&

--- a/packages/server/src/agent-launch.ts
+++ b/packages/server/src/agent-launch.ts
@@ -10,6 +10,7 @@ import {
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { shellEscape } from './process-utils'
 import { stripSessionSelectors } from './launch-tokens'
+import { applyModelArguments, assertModelCommand } from './model-arguments'
 import { findOnPath } from './resolve-executable'
 
 /** The configured command, and where on `env.PATH` it lives; the name when it is not there. */
@@ -56,14 +57,20 @@ export function buildAgentLaunchLine(
   const cmdConfig = agentCommands[payload.agentType] || DEFAULT_AGENT_COMMANDS[payload.agentType]
   const cmd = resolveAgentCommand(cmdConfig, env)
   // Per-step args override settings-level args; escape each for shell safety
-  const effectiveArgs = payload.args !== undefined ? payload.args : cmd.args
-  let launchLine = [cmd.command, ...effectiveArgs.map((a) => shellEscape(a))].join(' ')
+  const escape = (value: string) => shellEscape(value, payload.remoteHostId ? 'posix' : 'auto')
+  let effectiveArgs = payload.args !== undefined ? payload.args : cmd.args
+  if (payload.model !== undefined) {
+    assertModelCommand(cmd.command)
+    effectiveArgs = applyModelArguments(payload.agentType, effectiveArgs, payload.model)
+  }
+  const commandLine = payload.model !== undefined ? escape(cmd.command) : cmd.command
+  let launchLine = [commandLine, ...effectiveArgs.map(escape)].join(' ')
 
   // Where the configured command ends and its arguments begin. Known exactly
   // rather than guessed, because this line was just composed here -- which is
   // what lets `npx -y @anthropic-ai/claude-code` be a command and an argument
   // that merely ends in `/claude` be left alone.
-  const argsFrom = cmd.command.length
+  const argsFrom = commandLine.length
 
   const exactResume = Boolean(
     payload.resumeSessionId && supportsExactSessionResume(payload.agentType)
@@ -82,7 +89,7 @@ export function buildAgentLaunchLine(
   }
 
   if (exactResume && payload.resumeSessionId) {
-    const escapedResumeId = shellEscape(payload.resumeSessionId)
+    const escapedResumeId = escape(payload.resumeSessionId)
     switch (payload.agentType) {
       case 'claude':
         launchLine += ` --resume ${escapedResumeId}`
@@ -113,11 +120,11 @@ export function buildAgentLaunchLine(
     payload.sessionId &&
     supportsSessionIdPinning(payload.agentType)
   ) {
-    launchLine += ` ${getSessionIdPinningFlag(payload.agentType)} ${shellEscape(payload.sessionId)}`
+    launchLine += ` ${getSessionIdPinningFlag(payload.agentType)} ${escape(payload.sessionId)}`
   }
 
   if (payload.initialPrompt) {
-    const escaped = shellEscape(payload.initialPrompt)
+    const escaped = escape(payload.initialPrompt)
     switch (payload.agentType) {
       case 'copilot':
         launchLine += ` -i ${escaped}`
@@ -156,9 +163,15 @@ export function buildHeadlessLaunchLine(
   }
   const cmdConfig = agentCommands[payload.agentType] || DEFAULT_AGENT_COMMANDS[payload.agentType]
   const cmd = resolveAgentCommand(cmdConfig, env)
-  const baseCmd = cmd.command
-  const extraArgs = resolveHeadlessArgs(payload, cmdConfig, cmd.args)
-  const argsStr = extraArgs.length > 0 ? extraArgs.join(' ') + ' ' : ''
+  const baseCmd = payload.model !== undefined ? shellEscape(cmd.command) : cmd.command
+  let extraArgs = resolveHeadlessArgs(payload, cmdConfig, cmd.args)
+  if (payload.model !== undefined) {
+    assertModelCommand(cmd.command)
+    extraArgs = applyModelArguments(payload.agentType, extraArgs, payload.model)
+  }
+  const renderedArgs =
+    payload.model !== undefined ? extraArgs.map((a) => shellEscape(a)) : extraArgs
+  const argsStr = renderedArgs.length > 0 ? renderedArgs.join(' ') + ' ' : ''
 
   const emptyStr = process.platform === 'win32' ? '""' : "''"
   const prompt = payload.initialPrompt ? shellEscape(payload.initialPrompt) : emptyStr
@@ -171,7 +184,7 @@ export function buildHeadlessLaunchLine(
       return `${baseCmd} ${argsStr}-p ${prompt}`
 
     case 'codex':
-      return `${baseCmd} ${argsStr}exec ${prompt}`
+      return `${baseCmd} ${argsStr}exec ${payload.resumeSessionId ? `resume ${shellEscape(payload.resumeSessionId)} ` : ''}${prompt}`
 
     case 'opencode':
       return `${baseCmd} ${argsStr}run ${prompt}`
@@ -221,7 +234,11 @@ export function buildHeadlessSpawnArgs(
   const cmdConfig = agentCommands[payload.agentType] || DEFAULT_AGENT_COMMANDS[payload.agentType]
   const cmd = resolveAgentCommand(cmdConfig, env)
   const prompt = payload.initialPrompt || ''
-  const extraArgs = [...resolveHeadlessArgs(payload, cmdConfig, cmd.args)]
+  let extraArgs = [...resolveHeadlessArgs(payload, cmdConfig, cmd.args)]
+  if (payload.model !== undefined) {
+    assertModelCommand(cmd.command)
+    extraArgs = applyModelArguments(payload.agentType, extraArgs, payload.model)
+  }
 
   if (
     payload.resumeSessionId &&
@@ -259,6 +276,13 @@ export function buildHeadlessSpawnArgs(
       // truncates it at the first newline. Note the prompt must NOT also be
       // passed as an argument — codex then treats stdin as a separate
       // `<stdin>` block rather than as the instructions.
+      if (payload.resumeSessionId) {
+        return {
+          command: cmd.path,
+          args: [...extraArgs, 'exec', 'resume', payload.resumeSessionId, '-'],
+          stdin: prompt
+        }
+      }
       return prompt
         ? { command: cmd.path, args: [...extraArgs, 'exec'], stdin: prompt }
         : { command: cmd.path, args: [...extraArgs, 'exec', ''] }

--- a/packages/server/src/agent-model-catalog.ts
+++ b/packages/server/src/agent-model-catalog.ts
@@ -5,7 +5,7 @@ import type {
   AgentModelChoice,
   AgentModelRequest
 } from '@vornrun/shared/agent-models'
-import { CURATED_MODELS, supportsModelSelection } from '@vornrun/shared/agent-models'
+import { supportsModelSelection } from '@vornrun/shared/agent-models'
 import type { AiAgentType, AgentCommandConfig } from '@vornrun/shared/types'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import { configManager } from './config-manager'
@@ -25,7 +25,15 @@ const asObject = (value: unknown): Json =>
 function idOf(agent: AiAgentType, entry: Json): unknown {
   if (agent === 'claude') return entry.value
   if (agent === 'codex') return entry.model ?? entry.id
+  if (agent === 'copilot') return entry.modelId
   return entry.id
+}
+
+/** Copilot says what a model costs against the plan; that is the hint worth showing. */
+function descriptionOf(entry: Json): string | undefined {
+  const usage = asObject(entry._meta).copilotUsage
+  if (typeof usage === 'string' && usage) return `${usage} usage`
+  return typeof entry.description === 'string' ? entry.description : undefined
 }
 
 /** The agents' own answers, normalised to one shape; hidden and disabled entries dropped. */
@@ -43,13 +51,16 @@ export function parseModelChoices(agent: AiAgentType, value: unknown): AgentMode
   for (const item of value) {
     const entry = asObject(item)
     if (entry.hidden === true || asObject(entry.policy).state === 'disabled') continue
+    const enablement = asObject(entry._meta).copilotEnablement
+    if (enablement !== undefined && enablement !== 'enabled') continue
     const id = idOf(agent, entry)
     if (typeof id !== 'string' || !id) continue
     const label = entry.displayName ?? entry.name
+    const description = descriptionOf(entry)
     byId.set(id, {
       id,
       label: typeof label === 'string' ? label : id,
-      ...(typeof entry.description === 'string' && { description: entry.description })
+      ...(description && { description })
     })
   }
   return [...byId.values()]
@@ -62,7 +73,7 @@ export interface ProbeContext {
   env: Record<string, string>
 }
 
-type ProbedAgent = 'claude' | 'codex' | 'opencode'
+type ProbedAgent = 'claude' | 'codex' | 'copilot' | 'opencode'
 
 /** The one invocation of each CLI that lists models without starting a conversation. */
 function probeArguments(agent: ProbedAgent, configured: string[]): string[] {
@@ -84,6 +95,8 @@ function probeArguments(agent: ProbedAgent, configured: string[]): string[] {
       ]
     case 'codex':
       return [...configured, 'app-server', '--stdio']
+    case 'copilot':
+      return ['--acp', '--no-remote', '--no-remote-export']
     case 'opencode':
       return ['models']
   }
@@ -162,6 +175,23 @@ export function probeProcess(
       if (response.subtype !== 'success') throw new Error('Initialization failed')
       finish(undefined, parseModelChoices('claude', asObject(response.response).models))
     }
+    // Copilot lists models on session/new; the session is never prompted.
+    const readCopilot = (msg: Json): void => {
+      if (msg.id === 1) {
+        if (msg.error) throw new Error('Initialization failed')
+        send({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'session/new',
+          params: { cwd: context.cwd, mcpServers: [] }
+        })
+        return
+      }
+      if (msg.id !== 2) return
+      if (msg.error) throw new Error('Session failed')
+      const models = asObject(asObject(msg.result).models).availableModels
+      finish(undefined, parseModelChoices('copilot', models))
+    }
     const readCodex = (msg: Json): void => {
       if (msg.id === 1) {
         if (msg.error) throw new Error('Initialization failed')
@@ -200,6 +230,7 @@ export function probeProcess(
         try {
           const msg = asObject(JSON.parse(line))
           if (agent === 'claude') readClaude(msg)
+          else if (agent === 'copilot') readCopilot(msg)
           else readCodex(msg)
         } catch {
           finish(new Error(UNSUPPORTED_ANSWER))
@@ -218,6 +249,16 @@ export function probeProcess(
         id: 1,
         method: 'initialize',
         params: { clientInfo: { name: 'vorn_model_catalog', version: '1.0.0' } }
+      })
+    } else if (agent === 'copilot') {
+      send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: 1,
+          clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } }
+        }
       })
     } else {
       child.stdin.end()
@@ -261,9 +302,6 @@ export function createModelCatalogService(discover: Discover, now: () => number 
     if (!request.projectPath || request.projectPath.includes('{{')) {
       return unavailable('Choose a project to list models, or type a model id.')
     }
-    const curated = CURATED_MODELS[request.agentType]
-    if (curated) return { choices: curated, status: 'ready', source: 'built-in' }
-
     const key = JSON.stringify([request.agentType, path.resolve(request.projectPath), config])
     const entry = cache.get(key) ?? { fetchedAt: 0 }
     cache.set(key, entry)
@@ -272,7 +310,6 @@ export function createModelCatalogService(discover: Discover, now: () => number 
       return {
         choices: entry.choices!,
         status: 'ready',
-        source: 'agent',
         fetchedAt: entry.fetchedAt
       }
     }
@@ -281,7 +318,7 @@ export function createModelCatalogService(discover: Discover, now: () => number 
         entry.choices = choices
         entry.fetchedAt = now()
         entry.error = undefined
-        return { choices, status: 'ready', source: 'agent', fetchedAt: entry.fetchedAt }
+        return { choices, status: 'ready', fetchedAt: entry.fetchedAt }
       })
       .catch((error: unknown): AgentModelCatalog => {
         entry.error =
@@ -292,7 +329,6 @@ export function createModelCatalogService(discover: Discover, now: () => number 
         return {
           choices: entry.choices,
           status: 'stale',
-          source: 'agent',
           fetchedAt: entry.fetchedAt,
           error: entry.error
         }
@@ -304,7 +340,6 @@ export function createModelCatalogService(discover: Discover, now: () => number 
       return {
         choices: entry.choices,
         status: 'stale',
-        source: 'agent',
         fetchedAt: entry.fetchedAt,
         error: entry.error
       }

--- a/packages/server/src/agent-model-catalog.ts
+++ b/packages/server/src/agent-model-catalog.ts
@@ -30,8 +30,8 @@ function idOf(agent: AiAgentType, entry: Json): unknown {
 }
 
 /** Copilot says what a model costs against the plan; that is the hint worth showing. */
-function descriptionOf(entry: Json): string | undefined {
-  const usage = asObject(entry._meta).copilotUsage
+function descriptionOf(agent: AiAgentType, entry: Json): string | undefined {
+  const usage = agent === 'copilot' ? asObject(entry._meta).copilotUsage : undefined
   if (typeof usage === 'string' && usage) return `${usage} usage`
   return typeof entry.description === 'string' ? entry.description : undefined
 }
@@ -51,12 +51,12 @@ export function parseModelChoices(agent: AiAgentType, value: unknown): AgentMode
   for (const item of value) {
     const entry = asObject(item)
     if (entry.hidden === true || asObject(entry.policy).state === 'disabled') continue
-    const enablement = asObject(entry._meta).copilotEnablement
+    const enablement = agent === 'copilot' ? asObject(entry._meta).copilotEnablement : undefined
     if (enablement !== undefined && enablement !== 'enabled') continue
     const id = idOf(agent, entry)
     if (typeof id !== 'string' || !id) continue
     const label = entry.displayName ?? entry.name
-    const description = descriptionOf(entry)
+    const description = descriptionOf(agent, entry)
     byId.set(id, {
       id,
       label: typeof label === 'string' ? label : id,
@@ -96,7 +96,7 @@ function probeArguments(agent: ProbedAgent, configured: string[]): string[] {
     case 'codex':
       return [...configured, 'app-server', '--stdio']
     case 'copilot':
-      return ['--acp', '--no-remote', '--no-remote-export']
+      return [...configured, '--acp', '--no-remote', '--no-remote-export']
     case 'opencode':
       return ['models']
   }

--- a/packages/server/src/agent-model-catalog.ts
+++ b/packages/server/src/agent-model-catalog.ts
@@ -21,6 +21,13 @@ type Json = Record<string, unknown>
 const asObject = (value: unknown): Json =>
   typeof value === 'object' && value !== null ? (value as Json) : {}
 
+/** Each CLI names the model id differently. */
+function idOf(agent: AiAgentType, entry: Json): unknown {
+  if (agent === 'claude') return entry.value
+  if (agent === 'codex') return entry.model ?? entry.id
+  return entry.id
+}
+
 /** The agents' own answers, normalised to one shape; hidden and disabled entries dropped. */
 export function parseModelChoices(agent: AiAgentType, value: unknown): AgentModelChoice[] {
   if (agent === 'opencode') {
@@ -36,8 +43,7 @@ export function parseModelChoices(agent: AiAgentType, value: unknown): AgentMode
   for (const item of value) {
     const entry = asObject(item)
     if (entry.hidden === true || asObject(entry.policy).state === 'disabled') continue
-    const id =
-      agent === 'claude' ? entry.value : agent === 'codex' ? (entry.model ?? entry.id) : entry.id
+    const id = idOf(agent, entry)
     if (typeof id !== 'string' || !id) continue
     const label = entry.displayName ?? entry.name
     byId.set(id, {
@@ -282,11 +288,12 @@ export function createModelCatalogService(discover: Discover, now: () => number 
           error instanceof Error
             ? error.message
             : 'Could not list models. Check the agent installation and sign-in, then refresh or type a model id.'
+        if (!entry.choices) return unavailable(entry.error)
         return {
-          choices: entry.choices ?? [],
-          status: entry.choices ? 'stale' : 'unavailable',
-          source: entry.choices ? 'agent' : undefined,
-          fetchedAt: entry.choices ? entry.fetchedAt : undefined,
+          choices: entry.choices,
+          status: 'stale',
+          source: 'agent',
+          fetchedAt: entry.fetchedAt,
           error: entry.error
         }
       })

--- a/packages/server/src/agent-model-catalog.ts
+++ b/packages/server/src/agent-model-catalog.ts
@@ -1,0 +1,346 @@
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import type {
+  AgentModelCatalog,
+  AgentModelChoice,
+  AgentModelRequest
+} from '@vornrun/shared/agent-models'
+import { CURATED_MODELS, supportsModelSelection } from '@vornrun/shared/agent-models'
+import type { AiAgentType, AgentCommandConfig } from '@vornrun/shared/types'
+import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
+import { configManager } from './config-manager'
+import { getLaunchEnv, shellEscape } from './process-utils'
+import { findOnPath } from './resolve-executable'
+import { assertModelCommand } from './model-arguments'
+
+const PROBE_TIMEOUT_MS = 15_000
+const CACHE_TTL_MS = 5 * 60_000
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024
+
+type Json = Record<string, unknown>
+const asObject = (value: unknown): Json =>
+  typeof value === 'object' && value !== null ? (value as Json) : {}
+
+/** The agents' own answers, normalised to one shape; hidden and disabled entries dropped. */
+export function parseModelChoices(agent: AiAgentType, value: unknown): AgentModelChoice[] {
+  if (agent === 'opencode') {
+    if (typeof value !== 'string') throw new Error('Invalid OpenCode model catalog.')
+    const ids = value
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => /^[^\s/]+\/\S+$/.test(line))
+    return [...new Set(ids)].map((id) => ({ id, label: id }))
+  }
+  if (!Array.isArray(value)) throw new Error('Invalid model catalog.')
+  const byId = new Map<string, AgentModelChoice>()
+  for (const item of value) {
+    const entry = asObject(item)
+    if (entry.hidden === true || asObject(entry.policy).state === 'disabled') continue
+    const id =
+      agent === 'claude' ? entry.value : agent === 'codex' ? (entry.model ?? entry.id) : entry.id
+    if (typeof id !== 'string' || !id) continue
+    const label = entry.displayName ?? entry.name
+    byId.set(id, {
+      id,
+      label: typeof label === 'string' ? label : id,
+      ...(typeof entry.description === 'string' && { description: entry.description })
+    })
+  }
+  return [...byId.values()]
+}
+
+export interface ProbeContext {
+  command: string
+  args: string[]
+  cwd: string
+  env: Record<string, string>
+}
+
+type ProbedAgent = 'claude' | 'codex' | 'opencode'
+
+/** The one invocation of each CLI that lists models without starting a conversation. */
+function probeArguments(agent: ProbedAgent, configured: string[]): string[] {
+  switch (agent) {
+    case 'claude':
+      return [
+        ...configured,
+        '-p',
+        '--input-format',
+        'stream-json',
+        '--output-format',
+        'stream-json',
+        '--verbose',
+        '--no-session-persistence',
+        '--safe-mode',
+        '--strict-mcp-config',
+        '--tools',
+        ''
+      ]
+    case 'codex':
+      return [...configured, 'app-server', '--stdio']
+    case 'opencode':
+      return ['models']
+  }
+}
+
+const UNSUPPORTED_ANSWER =
+  'The agent returned an unsupported model response. Update the CLI or type a model id.'
+
+/** Ask an installed CLI for its models; the process is bounded in output, time and what it may do. */
+export function probeProcess(
+  context: ProbeContext,
+  agent: ProbedAgent
+): Promise<AgentModelChoice[]> {
+  return new Promise((resolve, reject) => {
+    const args = probeArguments(agent, context.args)
+    const viaShell = process.platform === 'win32' && /\.(cmd|bat)$/i.test(context.command)
+    const child = spawn(
+      viaShell ? shellEscape(context.command, 'cmd') : context.command,
+      viaShell ? args.map((arg) => shellEscape(arg, 'cmd')) : args,
+      {
+        cwd: context.cwd,
+        env: context.env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+        shell: viaShell
+      }
+    )
+
+    let settled = false
+    let buffered = ''
+    let bytes = 0
+    let nextId = 2
+    const collected: AgentModelChoice[] = []
+    const cursors = new Set<string>()
+
+    const finish = (error?: Error, result?: AgentModelChoice[]): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(deadline)
+      child.stdin.destroy()
+      child.kill()
+      setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+      }, 1000).unref()
+      if (error) reject(error)
+      else resolve(result ?? [])
+    }
+    const deadline = setTimeout(
+      () => finish(new Error('Model discovery timed out. Refresh to retry or type a model id.')),
+      PROBE_TIMEOUT_MS
+    )
+    const send = (message: unknown): void => {
+      if (!settled) child.stdin.write(JSON.stringify(message) + '\n')
+    }
+
+    child.stdin.on('error', () => finish(new Error('Agent discovery connection closed.')))
+    child.on('error', () =>
+      finish(new Error('Could not start the configured agent. Check its executable.'))
+    )
+    // Drained, never returned: stderr can carry credentials.
+    child.stderr.on('data', () => {})
+    child.on('close', (code) => {
+      if (settled) return
+      if (agent === 'opencode' && code === 0) finish(undefined, parseModelChoices(agent, buffered))
+      else
+        finish(
+          new Error(
+            'Agent model discovery failed. Check the CLI installation and sign-in, then refresh.'
+          )
+        )
+    })
+
+    const readClaude = (msg: Json): void => {
+      if (msg.type !== 'control_response') return
+      const response = asObject(msg.response)
+      if (response.subtype !== 'success') throw new Error('Initialization failed')
+      finish(undefined, parseModelChoices('claude', asObject(response.response).models))
+    }
+    const readCodex = (msg: Json): void => {
+      if (msg.id === 1) {
+        if (msg.error) throw new Error('Initialization failed')
+        send({ method: 'initialized' })
+        send({ id: nextId, method: 'model/list', params: { limit: 100, includeHidden: false } })
+        return
+      }
+      if (msg.id !== nextId) return
+      if (msg.error) throw new Error('Model listing failed')
+      const result = asObject(msg.result)
+      collected.push(...parseModelChoices('codex', result.data))
+      const cursor = result.nextCursor
+      if (typeof cursor === 'string' && cursor) {
+        if (cursors.has(cursor)) throw new Error('Repeated pagination cursor')
+        cursors.add(cursor)
+        send({
+          id: ++nextId,
+          method: 'model/list',
+          params: { limit: 100, includeHidden: false, cursor }
+        })
+        return
+      }
+      finish(undefined, [...new Map(collected.map((choice) => [choice.id, choice])).values()])
+    }
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      bytes += chunk.length
+      if (bytes > MAX_OUTPUT_BYTES)
+        return finish(new Error('Model catalog exceeded the output limit.'))
+      buffered += chunk.toString()
+      if (agent === 'opencode') return
+      let end: number
+      while (!settled && (end = buffered.indexOf('\n')) !== -1) {
+        const line = buffered.slice(0, end)
+        buffered = buffered.slice(end + 1)
+        try {
+          const msg = asObject(JSON.parse(line))
+          if (agent === 'claude') readClaude(msg)
+          else readCodex(msg)
+        } catch {
+          finish(new Error(UNSUPPORTED_ANSWER))
+        }
+      }
+    })
+
+    if (agent === 'claude') {
+      send({
+        type: 'control_request',
+        request_id: 'vorn-models',
+        request: { subtype: 'initialize' }
+      })
+    } else if (agent === 'codex') {
+      send({
+        id: 1,
+        method: 'initialize',
+        params: { clientInfo: { name: 'vorn_model_catalog', version: '1.0.0' } }
+      })
+    } else {
+      child.stdin.end()
+    }
+  })
+}
+
+interface CacheEntry {
+  choices?: AgentModelChoice[]
+  fetchedAt: number
+  pending?: Promise<AgentModelCatalog>
+  error?: string
+}
+
+type Discover = (
+  request: AgentModelRequest,
+  config: AgentCommandConfig
+) => Promise<AgentModelChoice[]>
+
+const unavailable = (error: string): AgentModelCatalog => ({
+  choices: [],
+  status: 'unavailable',
+  error
+})
+
+/** One list per agent, command configuration and project, kept for five minutes; the stale list stands in while a refresh runs. */
+export function createModelCatalogService(discover: Discover, now: () => number = Date.now) {
+  const cache = new Map<string, CacheEntry>()
+  return async (
+    request: AgentModelRequest,
+    config: AgentCommandConfig
+  ): Promise<AgentModelCatalog> => {
+    if (!supportsModelSelection(request.agentType)) {
+      return unavailable('Model selection is unavailable for this agent.')
+    }
+    if (request.remoteHostId) {
+      return unavailable(
+        'Models on a remote host cannot be listed; use the default or type a model id.'
+      )
+    }
+    if (!request.projectPath || request.projectPath.includes('{{')) {
+      return unavailable('Choose a project to list models, or type a model id.')
+    }
+    const curated = CURATED_MODELS[request.agentType]
+    if (curated) return { choices: curated, status: 'ready', source: 'built-in' }
+
+    const key = JSON.stringify([request.agentType, path.resolve(request.projectPath), config])
+    const entry = cache.get(key) ?? { fetchedAt: 0 }
+    cache.set(key, entry)
+    const fresh = entry.choices && now() - entry.fetchedAt < CACHE_TTL_MS
+    if (!request.refresh && fresh) {
+      return {
+        choices: entry.choices!,
+        status: 'ready',
+        source: 'agent',
+        fetchedAt: entry.fetchedAt
+      }
+    }
+    entry.pending ??= discover(request, config)
+      .then((choices): AgentModelCatalog => {
+        entry.choices = choices
+        entry.fetchedAt = now()
+        entry.error = undefined
+        return { choices, status: 'ready', source: 'agent', fetchedAt: entry.fetchedAt }
+      })
+      .catch((error: unknown): AgentModelCatalog => {
+        entry.error =
+          error instanceof Error
+            ? error.message
+            : 'Could not list models. Check the agent installation and sign-in, then refresh or type a model id.'
+        return {
+          choices: entry.choices ?? [],
+          status: entry.choices ? 'stale' : 'unavailable',
+          source: entry.choices ? 'agent' : undefined,
+          fetchedAt: entry.choices ? entry.fetchedAt : undefined,
+          error: entry.error
+        }
+      })
+      .finally(() => {
+        entry.pending = undefined
+      })
+    if (!request.refresh && entry.choices) {
+      return {
+        choices: entry.choices,
+        status: 'stale',
+        source: 'agent',
+        fetchedAt: entry.fetchedAt,
+        error: entry.error
+      }
+    }
+    return entry.pending
+  }
+}
+
+/** Only the selectors that shape which models a CLI can see; a prompt or a mode would start work. */
+function discoveryArguments(agent: AiAgentType, configured: string[]): string[] {
+  if (agent !== 'codex') return []
+  const paired = ['-c', '--config', '-p', '--profile', '--local-provider']
+  const args: string[] = []
+  for (let i = 0; i < configured.length; i++) {
+    const arg = configured[i]!
+    if (paired.includes(arg) && configured[i + 1]) args.push(arg, configured[++i]!)
+    else if (paired.some((flag) => arg.startsWith(flag + '='))) args.push(arg)
+    else if (arg === '--oss') args.push(arg)
+  }
+  return args
+}
+
+const catalog = createModelCatalogService(async (request, config) => {
+  const env = getLaunchEnv()
+  assertModelCommand(config.command)
+  const command = path.isAbsolute(config.command)
+    ? config.command
+    : findOnPath(config.command, env.PATH ?? env.Path)
+  if (!command) throw new Error(`${config.command} is not installed on this machine.`)
+  return probeProcess(
+    {
+      command,
+      args: discoveryArguments(request.agentType, config.args),
+      cwd: request.projectPath,
+      env
+    },
+    request.agentType as ProbedAgent
+  )
+})
+
+export function listAgentModels(request: AgentModelRequest): Promise<AgentModelCatalog> {
+  const config =
+    configManager.loadConfig().agentCommands?.[request.agentType] ??
+    DEFAULT_AGENT_COMMANDS[request.agentType]
+  return catalog(request, config)
+}

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -60,9 +60,20 @@ class HeadlessManager extends EventEmitter {
     // nobody would ever see it. Existing sessions are untouched -- their clients
     // hold a descriptor, not a name.
     if (isDraining()) throw new Error(DRAINING_MESSAGE)
-    if (payload.model !== undefined)
-      buildHeadlessSpawnArgs(payload, this.agentCommands, getLaunchEnv())
     const id = crypto.randomUUID()
+    // Pinned before the arguments are built, so a fresh launch carries the id it will resume by.
+    let agentSessionId = payload.agentType === 'codex' ? payload.resumeSessionId : undefined
+    if (supportsSessionIdPinning(payload.agentType)) {
+      if (payload.resumeSessionId) {
+        agentSessionId = payload.resumeSessionId
+      } else {
+        agentSessionId = crypto.randomUUID()
+        payload.sessionId = agentSessionId
+      }
+    }
+    const env = getLaunchEnv()
+    // Built before a worktree exists, so arguments that cannot be built create nothing.
+    const spawnArgs = buildHeadlessSpawnArgs(payload, this.agentCommands, env)
     let effectivePath = payload.projectPath
     let effectiveBranch: string | undefined
     let worktreeName: string | undefined
@@ -92,23 +103,6 @@ class HeadlessManager extends EventEmitter {
         effectiveBranch = payload.branch
       }
     }
-
-    // Pre-generate the session id before buildHeadlessSpawnArgs so the --session-id
-    // flag can be injected; keeps parity with the interactive PTY path.
-    // Codex can resume headlessly without supporting fresh ID pinning.
-    // OpenCode's headless builder does not yet implement exact resume.
-    let agentSessionId = payload.agentType === 'codex' ? payload.resumeSessionId : undefined
-    if (supportsSessionIdPinning(payload.agentType)) {
-      if (payload.resumeSessionId) {
-        agentSessionId = payload.resumeSessionId
-      } else {
-        agentSessionId = crypto.randomUUID()
-        payload.sessionId = agentSessionId
-      }
-    }
-
-    const env = getLaunchEnv()
-    const spawnArgs = buildHeadlessSpawnArgs(payload, this.agentCommands, env)
 
     // Windows needs `shell: true` to run the `.cmd`/`.ps1` shims that
     // npm-installed agents ship as. Under `shell: true`, Node concatenates argv

--- a/packages/server/src/headless-manager.ts
+++ b/packages/server/src/headless-manager.ts
@@ -60,6 +60,8 @@ class HeadlessManager extends EventEmitter {
     // nobody would ever see it. Existing sessions are untouched -- their clients
     // hold a descriptor, not a name.
     if (isDraining()) throw new Error(DRAINING_MESSAGE)
+    if (payload.model !== undefined)
+      buildHeadlessSpawnArgs(payload, this.agentCommands, getLaunchEnv())
     const id = crypto.randomUUID()
     let effectivePath = payload.projectPath
     let effectiveBranch: string | undefined
@@ -93,7 +95,9 @@ class HeadlessManager extends EventEmitter {
 
     // Pre-generate the session id before buildHeadlessSpawnArgs so the --session-id
     // flag can be injected; keeps parity with the interactive PTY path.
-    let agentSessionId: string | undefined
+    // Codex can resume headlessly without supporting fresh ID pinning.
+    // OpenCode's headless builder does not yet implement exact resume.
+    let agentSessionId = payload.agentType === 'codex' ? payload.resumeSessionId : undefined
     if (supportsSessionIdPinning(payload.agentType)) {
       if (payload.resumeSessionId) {
         agentSessionId = payload.resumeSessionId

--- a/packages/server/src/model-arguments.ts
+++ b/packages/server/src/model-arguments.ts
@@ -47,23 +47,21 @@ export function applyModelArguments(agent: AiAgentType, args: string[], model: s
   return [...kept, '--model', id, ...args.slice(i)]
 }
 
-/** A model can be added only to a command that is one executable; a shell wrapper is left alone. */
-export function assertModelCommand(command: string): void {
-  if (/[;&|<>`\n\r]/.test(command) || command.includes('$(')) {
-    throw new Error(
-      'A model cannot be added to this shell wrapper. Configure an executable with its arguments separately, or use the configured default.'
-    )
-  }
+/** One executable the shell can be handed quoted, or a wrapper it must read as written. */
+export function commandShape(command: string, onThisMachine = true): 'executable' | 'wrapper' {
+  if (/[;&|<>`\n\r]/.test(command) || command.includes('$(')) return 'wrapper'
   const tokens = tokenize(command)
+  if (!tokens) return 'wrapper'
+  if (tokens.length === 1) return 'executable'
   // A path with spaces tokenizes into several words yet names one file.
-  if (!tokens || (tokens.length > 1 && !existsSync(command))) {
+  return onThisMachine && existsSync(command) ? 'executable' : 'wrapper'
+}
+
+/** A model rides the arguments, so the command must be one executable. */
+export function assertModelCommand(command: string, onThisMachine = true): void {
+  if (commandShape(command, onThisMachine) === 'wrapper') {
     throw new Error(
-      'A model needs an executable with its arguments configured separately. Use the configured default for this wrapper.'
-    )
-  }
-  if (tokens.length > 1 && tokens.some((t) => t.value.startsWith('-'))) {
-    throw new Error(
-      'Move flags out of the agent command into its arguments before choosing a model.'
+      'A model needs a command that is one executable. Move the wrapper and its flags into agent arguments, or use the configured default.'
     )
   }
 }

--- a/packages/server/src/model-arguments.ts
+++ b/packages/server/src/model-arguments.ts
@@ -1,0 +1,69 @@
+import type { AiAgentType } from '@vornrun/shared/types'
+import { supportsModelSelection, validateModelId } from '@vornrun/shared/agent-models'
+import { tokenize } from './launch-tokens'
+import { existsSync } from 'node:fs'
+
+/** Every agent takes `--model`; the others also take `-m`, and codex `-c model=`. */
+function takesShortFlag(agent: AiAgentType): boolean {
+  return agent !== 'claude'
+}
+
+function isCodexModelConfig(value: string | undefined): boolean {
+  return /^model\s*=/.test(value ?? '')
+}
+
+/** How many arguments the model selector starting at `args[i]` spans, or 0 when it is not one. */
+function modelSelectorLength(agent: AiAgentType, args: string[], i: number): number {
+  const arg = args[i]!
+  const next = args[i + 1]
+  if (arg === '--model' || (takesShortFlag(agent) && arg === '-m')) {
+    if (!next || next.startsWith('-')) {
+      throw new Error('Fix the incomplete model flag in agent arguments.')
+    }
+    return 2
+  }
+  if (arg.startsWith('--model=')) return 1
+  if (takesShortFlag(agent) && arg.startsWith('-m') && arg.length > 2) return 1
+  if (agent === 'codex') {
+    if ((arg === '-c' || arg === '--config') && isCodexModelConfig(next)) return 2
+    if (/^(?:-c=?|--config=)model\s*=/.test(arg)) return 1
+  }
+  return 0
+}
+
+/** The configured arguments with `model` as their one model selector; nothing past `--` is touched. */
+export function applyModelArguments(agent: AiAgentType, args: string[], model: string): string[] {
+  if (!supportsModelSelection(agent)) {
+    throw new Error(`Model selection is not supported for ${agent}.`)
+  }
+  const id = validateModelId(model)
+  const kept: string[] = []
+  let i = 0
+  while (i < args.length && args[i] !== '--') {
+    const span = modelSelectorLength(agent, args, i)
+    if (span === 0) kept.push(args[i]!)
+    i += span || 1
+  }
+  return [...kept, '--model', id, ...args.slice(i)]
+}
+
+/** A model can be added only to a command that is one executable; a shell wrapper is left alone. */
+export function assertModelCommand(command: string): void {
+  if (/[;&|<>`\n\r]/.test(command) || command.includes('$(')) {
+    throw new Error(
+      'A model cannot be added to this shell wrapper. Configure an executable with its arguments separately, or use the configured default.'
+    )
+  }
+  const tokens = tokenize(command)
+  // A path with spaces tokenizes into several words yet names one file.
+  if (!tokens || (tokens.length > 1 && !existsSync(command))) {
+    throw new Error(
+      'A model needs an executable with its arguments configured separately. Use the configured default for this wrapper.'
+    )
+  }
+  if (tokens.length > 1 && tokens.some((t) => t.value.startsWith('-'))) {
+    throw new Error(
+      'Move flags out of the agent command into its arguments before choosing a model.'
+    )
+  }
+}

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -239,8 +239,6 @@ class PtyManager extends EventEmitter {
     if (isDraining()) throw new Error(DRAINING_MESSAGE)
     // A pane created now would be in neither the manifest nor the replacement.
     if (isHandingOver()) throw new Error(HANDOVER_MESSAGE)
-    // Validate model overrides before allocating a PTY or changing worktrees.
-    if (payload.model !== undefined) this.buildAgentLaunchLine(payload)
     const id = reuseId ?? crypto.randomUUID()
     const shell = getDefaultShell(configManager.loadConfig().defaults.shell)
 
@@ -262,6 +260,23 @@ class PtyManager extends EventEmitter {
     shell: string,
     payload: CreateTerminalPayload
   ): TerminalSession {
+    // Session ID pinning: agents that support it (supportsSessionIdPinning) get a
+    // UUID assigned on fresh launch via --session-id, enabling exact --resume later.
+    // Other agents rely on history-based fallback for resume.
+    let agentSessionId = supportsExactSessionResume(payload.agentType)
+      ? payload.resumeSessionId
+      : undefined
+    if (supportsSessionIdPinning(payload.agentType)) {
+      if (payload.resumeSessionId) {
+        agentSessionId = payload.resumeSessionId
+      } else {
+        agentSessionId = crypto.randomUUID()
+        payload.sessionId = agentSessionId
+      }
+    }
+    // Built before a worktree or PTY exists, so a line that cannot be built creates nothing.
+    const launchLine = this.buildAgentLaunchLine(payload)
+
     let effectivePath = payload.projectPath
     let worktreePath: string | undefined
     let worktreeName: string | undefined
@@ -321,22 +336,6 @@ class PtyManager extends EventEmitter {
       env: { ...getLaunchEnv(), VORN_SESSION_ID: id }
     })
 
-    // Session ID pinning: agents that support it (supportsSessionIdPinning) get a
-    // UUID assigned on fresh launch via --session-id, enabling exact --resume later.
-    // Other agents rely on history-based fallback for resume.
-    let agentSessionId = supportsExactSessionResume(payload.agentType)
-      ? payload.resumeSessionId
-      : undefined
-    if (supportsSessionIdPinning(payload.agentType)) {
-      if (payload.resumeSessionId) {
-        agentSessionId = payload.resumeSessionId
-      } else {
-        agentSessionId = crypto.randomUUID()
-        payload.sessionId = agentSessionId
-      }
-    }
-
-    const launchLine = this.buildAgentLaunchLine(payload)
     setTimeout(() => ptyProcess.write(launchLine + '\r'), 300)
 
     this.setupPtyEvents(id, ptyProcess, INITIAL_COLS, INITIAL_ROWS)
@@ -380,6 +379,7 @@ class PtyManager extends EventEmitter {
     payload: CreateTerminalPayload,
     host: RemoteHost
   ): TerminalSession {
+    const agentLine = this.buildAgentLaunchLine(payload)
     const ptyProcess = pty.spawn(shell, getShellArgs(), {
       name: 'xterm-256color',
       cols: INITIAL_COLS,
@@ -424,7 +424,6 @@ class PtyManager extends EventEmitter {
     sshParts.push(`'echo ${marker} && exec $SHELL -l'`)
 
     // Build remote command: cd to project path then launch agent
-    const agentLine = this.buildAgentLaunchLine(payload)
     const remoteCmd = `cd ${shellEscape(payload.projectPath, 'posix')} && ${agentLine}`
 
     // Write SSH command after local shell is ready

--- a/packages/server/src/pty-manager.ts
+++ b/packages/server/src/pty-manager.ts
@@ -14,7 +14,8 @@ import {
   IPC,
   TerminalSession,
   RemoteHost,
-  supportsSessionIdPinning
+  supportsSessionIdPinning,
+  supportsExactSessionResume
 } from '@vornrun/shared/types'
 import { displayNameFromPrompt } from '@vornrun/shared/string-utils'
 import {
@@ -238,6 +239,8 @@ class PtyManager extends EventEmitter {
     if (isDraining()) throw new Error(DRAINING_MESSAGE)
     // A pane created now would be in neither the manifest nor the replacement.
     if (isHandingOver()) throw new Error(HANDOVER_MESSAGE)
+    // Validate model overrides before allocating a PTY or changing worktrees.
+    if (payload.model !== undefined) this.buildAgentLaunchLine(payload)
     const id = reuseId ?? crypto.randomUUID()
     const shell = getDefaultShell(configManager.loadConfig().defaults.shell)
 
@@ -321,7 +324,9 @@ class PtyManager extends EventEmitter {
     // Session ID pinning: agents that support it (supportsSessionIdPinning) get a
     // UUID assigned on fresh launch via --session-id, enabling exact --resume later.
     // Other agents rely on history-based fallback for resume.
-    let agentSessionId: string | undefined
+    let agentSessionId = supportsExactSessionResume(payload.agentType)
+      ? payload.resumeSessionId
+      : undefined
     if (supportsSessionIdPinning(payload.agentType)) {
       if (payload.resumeSessionId) {
         agentSessionId = payload.resumeSessionId
@@ -529,6 +534,9 @@ class PtyManager extends EventEmitter {
       pid: ptyProcess.pid,
       remoteHostId: host.id,
       remoteHostLabel: host.label,
+      ...(payload.resumeSessionId && supportsExactSessionResume(payload.agentType)
+        ? { agentSessionId: payload.resumeSessionId }
+        : {}),
       ...(payload.displayName
         ? { displayName: payload.displayName }
         : payload.initialPrompt

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -2271,10 +2271,7 @@ export function registerAllMethods(): void {
       // (e.g. the agent CLI doesn't support hooks.json).
     }
 
-    // Fresh local Codex/OpenCode sessions cannot pin an ID. Their local DB
-    // supplies a best-effort fallback; directory/timestamp matching remains
-    // ambiguous when several conversations share a directory. Known resume
-    // IDs and remote sessions must never be replaced by this local lookup.
+    // A local lookup for agents that cannot pin an id; a known id or a remote session is never replaced.
     if (
       supportsExactSessionResume(payload.agentType) &&
       !supportsSessionIdPinning(payload.agentType) &&

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -209,6 +209,7 @@ import {
 import { disconnectToken } from './ws-handler'
 import { testSshConnection } from './process-utils'
 import { captureAgentSessionId } from './agent-session-capture'
+import { listAgentModels } from './agent-model-catalog'
 import { supportsExactSessionResume, supportsSessionIdPinning } from '@vornrun/shared/types'
 import log from './logger'
 
@@ -1502,6 +1503,7 @@ export function registerAllMethods(): void {
 
   // Agent/IDE detection
   registerMethod('agent:detectInstalled', () => detectInstalledAgents())
+  registerMethod('agent:listModels', (request) => listAgentModels(request))
   registerMethod('ide:detect', () => detectIDEs())
   registerMethod('project:detectMobile', ({ projectPath }) => detectMobileProject(projectPath))
   registerMethod('ide:open', ({ ideId, projectPath }) => openInIDE(ideId, projectPath))
@@ -2269,12 +2271,15 @@ export function registerAllMethods(): void {
       // (e.g. the agent CLI doesn't support hooks.json).
     }
 
-    // For agents without session ID pinning (copilot, codex, opencode), read
-    // the agent's own DB after it starts to capture the real session ID.
-    // This enables reliable --resume on next app restart.
+    // Fresh local Codex/OpenCode sessions cannot pin an ID. Their local DB
+    // supplies a best-effort fallback; directory/timestamp matching remains
+    // ambiguous when several conversations share a directory. Known resume
+    // IDs and remote sessions must never be replaced by this local lookup.
     if (
       supportsExactSessionResume(payload.agentType) &&
-      !supportsSessionIdPinning(payload.agentType)
+      !supportsSessionIdPinning(payload.agentType) &&
+      !session.agentSessionId &&
+      !session.remoteHostId
     ) {
       const captureSessionId = session.id
       // Asked more than once: an agent slow to write its own history used to be

--- a/packages/server/src/workflows/engine.ts
+++ b/packages/server/src/workflows/engine.ts
@@ -895,6 +895,11 @@ async function executeNode(
     }
   }
 
+  if (config.agentType === 'fromTask' && config.model !== undefined) {
+    throw new Error(
+      'A model needs a concrete agent. Clear the model or choose an agent for this step.'
+    )
+  }
   const effectiveAgent = resolveEffectiveAgent(config, context, resolvedTask)
 
   // Resolve project name/path from the triggering task when the node config
@@ -1058,7 +1063,8 @@ async function executeNode(
         headless: true,
         workflowId: workflow.id,
         workflowName: workflow.name,
-        args: config.args
+        args: config.args,
+        model: config.model
       })
 
       sessionId = headlessSession.id
@@ -1217,6 +1223,7 @@ async function executeNode(
       initialPrompt,
       promptDelayMs: config.promptDelayMs,
       args: config.args,
+      model: config.model,
       remoteHostId
     })
 

--- a/packages/server/src/workflows/engine.ts
+++ b/packages/server/src/workflows/engine.ts
@@ -387,6 +387,11 @@ export function resolveEffectiveAgent(
   resolvedTask: TaskConfig | undefined
 ): AiAgentType {
   if (config.agentType !== 'fromTask') return config.agentType
+  if (config.model !== undefined) {
+    throw new Error(
+      'A model needs a concrete agent. Clear the model or choose an agent for this step.'
+    )
+  }
   return (
     context?.task?.assignedAgent ??
     resolvedTask?.assignedAgent ??
@@ -895,11 +900,6 @@ async function executeNode(
     }
   }
 
-  if (config.agentType === 'fromTask' && config.model !== undefined) {
-    throw new Error(
-      'A model needs a concrete agent. Clear the model or choose an agent for this step.'
-    )
-  }
   const effectiveAgent = resolveEffectiveAgent(config, context, resolvedTask)
 
   // Resolve project name/path from the triggering task when the node config

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     ".": "./src/index.ts",
     "./types": "./src/types.ts",
     "./agent-defaults": "./src/agent-defaults.ts",
+    "./agent-models": "./src/agent-models.ts",
     "./prompt-builder": "./src/prompt-builder.ts",
     "./protocol": "./src/protocol.ts",
     "./string-utils": "./src/string-utils.ts",

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -1,0 +1,50 @@
+import type { AiAgentType } from './types'
+
+export interface AgentModelChoice {
+  id: string
+  label: string
+  description?: string
+}
+
+export interface AgentModelRequest {
+  agentType: AiAgentType
+  projectPath: string
+  remoteHostId?: string
+  refresh?: boolean
+}
+
+export interface AgentModelCatalog {
+  choices: AgentModelChoice[]
+  status: 'ready' | 'stale' | 'unavailable'
+  /** Where a ready or stale list came from, for the menu's footer. */
+  source?: 'agent' | 'built-in'
+  fetchedAt?: number
+  error?: string
+}
+
+const MODEL_AGENTS: readonly string[] = ['claude', 'copilot', 'opencode', 'codex']
+
+export function supportsModelSelection(agent: string): boolean {
+  return MODEL_AGENTS.includes(agent)
+}
+
+/** Copilot's CLI takes `--model` but cannot list models, so the menu offers these. */
+export const CURATED_MODELS: Partial<Record<AiAgentType, AgentModelChoice[]>> = {
+  copilot: [
+    { id: 'auto', label: 'Auto', description: 'Let Copilot pick' },
+    { id: 'gpt-5.4', label: 'GPT-5.4' },
+    { id: 'gpt-5-mini', label: 'GPT-5 mini' },
+    { id: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5' },
+    { id: 'claude-opus-4.5', label: 'Claude Opus 4.5' }
+  ]
+}
+
+/** A model id goes on a command line as one argument, so it must read as one. */
+export function validateModelId(value: string): string {
+  const model = value.trim()
+  const unprintable = [...model].some((c) => c.charCodeAt(0) < 32 || c.charCodeAt(0) === 127)
+  if (!model || model.startsWith('-') || /\s/.test(model) || unprintable) {
+    throw new Error('Enter a model id without spaces, control characters, or a leading dash.')
+  }
+  return model
+}

--- a/packages/shared/src/agent-models.ts
+++ b/packages/shared/src/agent-models.ts
@@ -16,8 +16,6 @@ export interface AgentModelRequest {
 export interface AgentModelCatalog {
   choices: AgentModelChoice[]
   status: 'ready' | 'stale' | 'unavailable'
-  /** Where a ready or stale list came from, for the menu's footer. */
-  source?: 'agent' | 'built-in'
   fetchedAt?: number
   error?: string
 }
@@ -26,17 +24,6 @@ const MODEL_AGENTS: readonly string[] = ['claude', 'copilot', 'opencode', 'codex
 
 export function supportsModelSelection(agent: string): boolean {
   return MODEL_AGENTS.includes(agent)
-}
-
-/** Copilot's CLI takes `--model` but cannot list models, so the menu offers these. */
-export const CURATED_MODELS: Partial<Record<AiAgentType, AgentModelChoice[]>> = {
-  copilot: [
-    { id: 'auto', label: 'Auto', description: 'Let Copilot pick' },
-    { id: 'gpt-5.4', label: 'GPT-5.4' },
-    { id: 'gpt-5-mini', label: 'GPT-5 mini' },
-    { id: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5' },
-    { id: 'claude-opus-4.5', label: 'Claude Opus 4.5' }
-  ]
 }
 
 /** A model id goes on a command line as one argument, so it must read as one. */

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,3 +1,4 @@
+import type { AgentModelRequest, AgentModelCatalog } from './agent-models'
 import type {
   AuthProbeReport,
   CreateTerminalPayload,
@@ -782,6 +783,7 @@ export interface RequestMethods {
     params: void
     result: Record<string, boolean>
   }
+  'agent:listModels': { params: AgentModelRequest; result: AgentModelCatalog }
   'ide:detect': { params: void; result: Array<{ id: string; name: string }> }
   /**
    * Whether a project looks like a mobile app, so the device control can be

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -877,6 +877,8 @@ export type UseWorktreeOption = boolean | 'fromContext'
 // Launch Agent action config
 export interface LaunchAgentConfig {
   agentType: LaunchAgentType
+  /** Literal CLI model override; requires a concrete agent. */
+  model?: string
   projectName: string
   projectPath: string
   args?: string[]
@@ -1426,6 +1428,8 @@ export interface RecentSession {
 
 export interface CreateTerminalPayload {
   agentType: AiAgentType
+  /** Omitted means preserve the agent's configured default. */
+  model?: string
   projectName: string
   projectPath: string
   resumeSessionId?: string
@@ -1853,6 +1857,7 @@ export const IPC = {
   SESSION_EVENT_LIST: 'sessionEvent:list',
   SESSION_EVENT_LIST_BY_SESSION: 'sessionEvent:listBySession',
   AGENT_DETECT_INSTALLED: 'agent:detectInstalled',
+  AGENT_LIST_MODELS: 'agent:listModels',
   TAILSCALE_STATUS: 'tailscale:status',
   SERVER_REACHABLE_URLS: 'server:reachableUrls',
   PAIRING_START: 'pairing:start',

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -521,6 +521,8 @@ export function createApiShim(wsUrl: string) {
     // ── IDE Detection & Launch ──
     detectIDEs: () => rpc.invoke('ide:detect'),
     detectInstalledAgents: () => rpc.invoke('agent:detectInstalled'),
+    listAgentModels: (request: import('@vornrun/shared/agent-models').AgentModelRequest) =>
+      rpc.invoke('agent:listModels', request),
     openInIDE: (ideId: string, projectPath: string) =>
       rpc.invoke('ide:open', { ideId, projectPath }),
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -283,6 +283,9 @@ export function registerIpcHandlers(): void {
     requireBridge().request(IPC.PROJECT_DETECT_MOBILE, params)
   )
   safeHandle(IPC.AGENT_DETECT_INSTALLED, () => requireBridge().request(IPC.AGENT_DETECT_INSTALLED))
+  safeHandle(IPC.AGENT_LIST_MODELS, (_event, request) =>
+    requireBridge().request(IPC.AGENT_LIST_MODELS, request)
+  )
   safeHandle(IPC.IDE_OPEN, (_, params) => requireBridge().request(IPC.IDE_OPEN, params))
 
   // ─── Credential vault (requires safeStorage in main process) ───

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import type { AgentModelRequest, AgentModelCatalog } from '@vornrun/shared/agent-models'
 import {
   LOCAL_SERVER_RUNNING_CHANNEL,
   SERVER_REPLACED_CHANNEL,
@@ -224,6 +225,9 @@ const api = {
 
   detectInstalledAgents: (): Promise<Record<AiAgentType, boolean>> =>
     ipcRenderer.invoke(IPC.AGENT_DETECT_INSTALLED),
+
+  listAgentModels: (request: AgentModelRequest): Promise<AgentModelCatalog> =>
+    ipcRenderer.invoke(IPC.AGENT_LIST_MODELS, request),
 
   openInIDE: (ideId: string, projectPath: string): Promise<void> =>
     ipcRenderer.invoke(IPC.IDE_OPEN, { ideId, projectPath }),

--- a/src/renderer/components/AgentPicker.tsx
+++ b/src/renderer/components/AgentPicker.tsx
@@ -1,15 +1,12 @@
-import { useState, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Check, ChevronDown, Bot, ClipboardList } from 'lucide-react'
 import { AiAgentType, LaunchAgentType } from '../../shared/types'
 import { AgentIcon } from './AgentIcon'
+import { useAnchoredMenu } from '../hooks/useAnchoredMenu'
 
-/** Only used to choose a direction; the flipped menu is anchored by its edge. */
 const MENU_ITEM_PX = 28
 const MENU_PADDING_PX = 8
-const MENU_GAP_PX = 4
-const VIEWPORT_MARGIN_PX = 8
 
 const AGENT_LABELS: Record<AiAgentType, string> = {
   claude: 'Claude',
@@ -34,41 +31,11 @@ export function AgentPicker({
   allowNone?: boolean
   allowFromTask?: boolean
 }) {
-  const [open, setOpen] = useState(false)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
-  const [position, setPosition] = useState<{
-    top?: number
-    bottom?: number
-    left: number
-    width: number
-  }>({ top: 0, left: 0, width: 0 })
-
-  const handleTrigger = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (open) {
-      setOpen(false)
-      return
-    }
-    const rect = triggerRef.current?.getBoundingClientRect()
-    if (rect) {
-      // The picker sits at the bottom of the intent bar, so a menu that only
-      // ever drops downward opens off the bottom of the window. Anchoring the
-      // flipped menu by its bottom edge means the exact height never has to be
-      // known — the estimate below only decides which way to go.
-      const estimated = itemCount * MENU_ITEM_PX + MENU_PADDING_PX
-      const flipUp =
-        rect.bottom + MENU_GAP_PX + estimated > window.innerHeight - VIEWPORT_MARGIN_PX &&
-        rect.top - MENU_GAP_PX - estimated > VIEWPORT_MARGIN_PX
-      setPosition({
-        top: flipUp ? undefined : rect.bottom + MENU_GAP_PX,
-        bottom: flipUp ? window.innerHeight - rect.top + MENU_GAP_PX : undefined,
-        left: rect.left,
-        width: rect.width
-      })
-    }
-    setOpen(true)
-  }
+  const agents = Object.keys(AGENT_LABELS) as AiAgentType[]
+  const itemCount = agents.length + (allowNone ? 1 : 0) + (allowFromTask ? 1 : 0)
+  const { open, setOpen, toggle, triggerRef, menuRef, position } = useAnchoredMenu({
+    estimateHeight: () => itemCount * MENU_ITEM_PX + MENU_PADDING_PX
+  })
 
   const handleSelect = (agent: LaunchAgentType | null) => {
     if (agent && agent !== 'fromTask' && !installStatus[agent]) return
@@ -78,32 +45,11 @@ export function AgentPicker({
     }
   }
 
-  useEffect(() => {
-    if (!open) return
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as Node
-      if (triggerRef.current?.contains(target)) return
-      if (menuRef.current && !menuRef.current.contains(target)) setOpen(false)
-    }
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', handleClick)
-    document.addEventListener('keydown', handleKey)
-    return () => {
-      document.removeEventListener('mousedown', handleClick)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [open])
-
-  const agents = Object.keys(AGENT_LABELS) as AiAgentType[]
-  const itemCount = agents.length + (allowNone ? 1 : 0) + (allowFromTask ? 1 : 0)
-
   return (
     <>
       <button
         ref={triggerRef}
-        onClick={handleTrigger}
+        onClick={toggle}
         className={
           variant === 'form'
             ? 'w-full flex items-center gap-2 px-3 py-2 text-[13px] bg-white/[0.06] border border-white/[0.1] rounded-md text-white hover:border-white/[0.2] transition-colors'

--- a/src/renderer/components/IntentBar.tsx
+++ b/src/renderer/components/IntentBar.tsx
@@ -39,6 +39,8 @@ import { resolveIntentMode, SHELL_BUILTINS, type IntentMode } from '../lib/inten
 import { getPreferredAgent, setPreferredAgent } from '../lib/launch-prefs'
 import { getDisplayPathBasename, launchAgentFromShell } from '../lib/session-utils'
 import { AgentPicker } from './AgentPicker'
+import { ModelPicker } from './ModelPicker'
+import { usePreferredModel } from '../hooks/usePreferredModel'
 import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import type { AiAgentType, LaunchAgentType } from '../../shared/types'
 
@@ -169,6 +171,7 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
 
   const defaultAgent = useAppStore((s) => s.config?.defaults.defaultAgent)
   const [agent, setAgent] = useState<AiAgentType>(() => getPreferredAgent(defaultAgent ?? 'claude'))
+  const modelPreference = usePreferredModel(agent, session?.remoteHostId)
   const { status: installStatus } = useAgentInstallStatus()
 
   const isShell = isShellSession(session?.agentType)
@@ -376,7 +379,7 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
       if (isPrompt) {
         if (isLaunching.current || !session) return
         isLaunching.current = true
-        void launchAgentFromShell(session, agent, trimmed).finally(() => {
+        void launchAgentFromShell(session, agent, trimmed, modelPreference.model).finally(() => {
           isLaunching.current = false
         })
       } else {
@@ -392,7 +395,7 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
       setPinnedMode(null)
       closeDropdown()
     },
-    [terminalId, kind, projectPath, closeDropdown, isPrompt, session, agent]
+    [terminalId, kind, projectPath, closeDropdown, isPrompt, session, agent, modelPreference.model]
   )
 
   const refreshForValue = useCallback(
@@ -751,12 +754,20 @@ export function IntentBar({ terminalId, compact, indentPx = 16 }: Props) {
               starts is part of the action, so it stays visible rather than
               fading with the shortcut hints. */}
           {isPrompt && (
-            <div className="shrink-0 -mt-[1px]">
+            <div className="shrink-0 -mt-[1px] flex items-center gap-1">
               <AgentPicker
                 currentAgent={agent}
                 onChange={handleAgentChange}
                 installStatus={installStatus}
                 variant="compact"
+              />
+              <ModelPicker
+                variant="bordered"
+                agentType={agent}
+                projectPath={cwd ?? undefined}
+                remoteHostId={session?.remoteHostId}
+                value={modelPreference.model}
+                onChange={modelPreference.setModel}
               />
             </div>
           )}

--- a/src/renderer/components/ModelPicker.tsx
+++ b/src/renderer/components/ModelPicker.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Check, ChevronDown, Cpu, Loader2, RefreshCw } from 'lucide-react'
-import type { AiAgentType, LaunchAgentType } from '../../shared/types'
+import type { LaunchAgentType } from '../../shared/types'
 import {
   supportsModelSelection,
   validateModelId,
@@ -11,6 +11,7 @@ import {
 } from '@vornrun/shared/agent-models'
 import { Tooltip } from './Tooltip'
 import { useAnchoredMenu } from '../hooks/useAnchoredMenu'
+import { useAgentModelCatalog } from '../hooks/useAgentModelCatalog'
 
 const MENU_ROW_PX = 28
 const MENU_CHROME_PX = 84
@@ -26,6 +27,8 @@ interface Props {
   onChange: (model: string | undefined) => void
   /** `compact` is the launcher chip; `bordered` the intent bar's; `form` a full-width field. */
   variant?: Variant
+  /** Ask for the list as soon as the agent and project are known, not only when opened. */
+  prefetch?: boolean
 }
 
 const TRIGGER_CLASS: Record<Variant, string> = {
@@ -60,7 +63,8 @@ function footerFor(
   loading: boolean,
   openedAt: number
 ): { text: string; spinner: boolean } {
-  if (loading) return { text: `Asking ${agent}…`, spinner: true }
+  if (loading)
+    return catalog ? { text: `Asking ${agent}…`, spinner: true } : { text: '', spinner: false }
   if (!catalog) return { text: '', spinner: false }
   if (catalog.status === 'unavailable') {
     return { text: catalog.error ?? 'Could not list models — type an id', spinner: false }
@@ -78,63 +82,31 @@ export function ModelPicker({
   remoteHostId,
   value,
   onChange,
-  variant = 'compact'
+  variant = 'compact',
+  prefetch = false
 }: Props) {
   const [query, setQuery] = useState('')
   const [invalid, setInvalid] = useState('')
-  const [fetched, setFetched] = useState<{ key: string; catalog: AgentModelCatalog } | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [refreshes, setRefreshes] = useState(0)
   const [openedAt, setOpenedAt] = useState(0)
 
   const followsTask = agentType === 'fromTask'
   const supported = followsTask || supportsModelSelection(agentType)
-  const key = `${agentType}\u0000${projectPath ?? ''}\u0000${remoteHostId ?? ''}`
-  const catalog = fetched?.key === key ? fetched.catalog : null
+
+  const { open, setOpen, toggle, triggerRef, menuRef, position } = useAnchoredMenu({
+    estimateHeight: () =>
+      Math.min(8, (catalog?.choices.length ?? 0) + 1) * MENU_ROW_PX + MENU_CHROME_PX,
+    menuWidth: (trigger) => Math.max(MENU_WIDTH_PX, variant === 'form' ? trigger : 0)
+  })
+  // A remote host cannot be asked, so only an opened menu learns that and says so.
+  const wanted =
+    supported && !followsTask && (open || (prefetch && Boolean(projectPath) && !remoteHostId))
+  const { catalog, loading, refresh } = useAgentModelCatalog(
+    { agentType, projectPath, remoteHostId },
+    wanted
+  )
   const choices = catalog?.choices ?? []
   const selected = choices.find((choice) => choice.id === value)
   const label = selected?.label ?? value
-
-  const { open, setOpen, toggle, triggerRef, menuRef, position } = useAnchoredMenu({
-    estimateHeight: () => Math.min(8, choices.length + 1) * MENU_ROW_PX + MENU_CHROME_PX,
-    menuWidth: (trigger) => Math.max(MENU_WIDTH_PX, variant === 'form' ? trigger : 0)
-  })
-
-  // The one launcher and form ask as soon as they know the agent; a chip on every card waits to be opened.
-  const eager = variant !== 'bordered' && Boolean(projectPath)
-
-  useEffect(() => {
-    if (!supported || agentType === 'fromTask' || (!open && !eager)) return
-    let cancelled = false
-    const request = {
-      agentType: agentType as AiAgentType,
-      projectPath: projectPath ?? '',
-      remoteHostId
-    }
-    const list = window.api?.listAgentModels
-    const settle = (catalog: AgentModelCatalog) => {
-      if (!cancelled) setFetched({ key, catalog })
-    }
-    void (async () => {
-      await Promise.resolve()
-      if (cancelled) return
-      if (!list) {
-        settle({ choices: [], status: 'unavailable', error: 'This server cannot list models.' })
-        return
-      }
-      setLoading(true)
-      try {
-        settle(await list({ ...request, refresh: refreshes > 0 }))
-      } catch {
-        settle({ choices: [], status: 'unavailable', error: 'Could not list models.' })
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [open, eager, supported, key, agentType, projectPath, remoteHostId, refreshes])
 
   if (!supported) return null
 
@@ -143,7 +115,6 @@ export function ModelPicker({
     if (!open) {
       setQuery('')
       setInvalid('')
-      setRefreshes(0)
       setOpenedAt(Date.now())
     }
     toggle(e)
@@ -169,10 +140,8 @@ export function ModelPicker({
     : choices
   const exact = shown.find((c) => c.id.toLowerCase() === needle)
   const groupedByProvider = agentType === 'opencode'
-  const asking = loading && choices.length === 0
-  const footer = asking
-    ? { text: '', spinner: false }
-    : footerFor(agentType, catalog, loading, openedAt)
+  const asking = loading && !catalog
+  const footer = footerFor(agentType, catalog, loading, openedAt)
 
   const triggerText = followsTask ? "Follows the task's agent" : (label ?? DEFAULT_TEXT[variant])
   const formTone = followsTask
@@ -357,7 +326,7 @@ export function ModelPicker({
               onMouseDown={(e) => {
                 e.preventDefault()
                 e.stopPropagation()
-                setRefreshes((n) => n + 1)
+                refresh()
               }}
               className="w-5 h-5 grid place-items-center rounded text-gray-500 hover:text-gray-300 hover:bg-white/[0.06]"
             >

--- a/src/renderer/components/ModelPicker.tsx
+++ b/src/renderer/components/ModelPicker.tsx
@@ -65,9 +65,6 @@ function footerFor(
   if (catalog.status === 'unavailable') {
     return { text: catalog.error ?? 'Could not list models — type an id', spinner: false }
   }
-  if (catalog.source === 'built-in') {
-    return { text: 'Known ids — others can be typed', spinner: false }
-  }
   const failed = catalog.status === 'stale' ? ' · refreshing failed' : ''
   return {
     text: `From ${agent} · ${agoLabel(catalog.fetchedAt, openedAt)}${failed}`,
@@ -85,13 +82,15 @@ export function ModelPicker({
 }: Props) {
   const [query, setQuery] = useState('')
   const [invalid, setInvalid] = useState('')
-  const [catalog, setCatalog] = useState<AgentModelCatalog | null>(null)
+  const [fetched, setFetched] = useState<{ key: string; catalog: AgentModelCatalog } | null>(null)
   const [loading, setLoading] = useState(false)
   const [refreshes, setRefreshes] = useState(0)
   const [openedAt, setOpenedAt] = useState(0)
 
   const followsTask = agentType === 'fromTask'
   const supported = followsTask || supportsModelSelection(agentType)
+  const key = `${agentType}\u0000${projectPath ?? ''}\u0000${remoteHostId ?? ''}`
+  const catalog = fetched?.key === key ? fetched.catalog : null
   const choices = catalog?.choices ?? []
   const selected = choices.find((choice) => choice.id === value)
   const label = selected?.label ?? value
@@ -101,9 +100,11 @@ export function ModelPicker({
     menuWidth: (trigger) => Math.max(MENU_WIDTH_PX, variant === 'form' ? trigger : 0)
   })
 
-  // Asked when the menu opens, and again on refresh; the list belongs to this agent and project.
+  // The one launcher and form ask as soon as they know the agent; a chip on every card waits to be opened.
+  const eager = variant !== 'bordered' && Boolean(projectPath)
+
   useEffect(() => {
-    if (!open || !supported) return
+    if (!supported || agentType === 'fromTask' || (!open && !eager)) return
     let cancelled = false
     const request = {
       agentType: agentType as AiAgentType,
@@ -111,20 +112,21 @@ export function ModelPicker({
       remoteHostId
     }
     const list = window.api?.listAgentModels
+    const settle = (catalog: AgentModelCatalog) => {
+      if (!cancelled) setFetched({ key, catalog })
+    }
     void (async () => {
       await Promise.resolve()
       if (cancelled) return
       if (!list) {
-        setCatalog({ choices: [], status: 'unavailable', error: 'This server cannot list models.' })
+        settle({ choices: [], status: 'unavailable', error: 'This server cannot list models.' })
         return
       }
       setLoading(true)
       try {
-        const result = await list({ ...request, refresh: refreshes > 0 })
-        if (!cancelled) setCatalog(result)
+        settle(await list({ ...request, refresh: refreshes > 0 }))
       } catch {
-        if (!cancelled)
-          setCatalog({ choices: [], status: 'unavailable', error: 'Could not list models.' })
+        settle({ choices: [], status: 'unavailable', error: 'Could not list models.' })
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -132,7 +134,7 @@ export function ModelPicker({
     return () => {
       cancelled = true
     }
-  }, [open, supported, agentType, projectPath, remoteHostId, refreshes])
+  }, [open, eager, supported, key, agentType, projectPath, remoteHostId, refreshes])
 
   if (!supported) return null
 
@@ -167,7 +169,10 @@ export function ModelPicker({
     : choices
   const exact = shown.find((c) => c.id.toLowerCase() === needle)
   const groupedByProvider = agentType === 'opencode'
-  const footer = footerFor(agentType, catalog, loading, openedAt)
+  const asking = loading && choices.length === 0
+  const footer = asking
+    ? { text: '', spinner: false }
+    : footerFor(agentType, catalog, loading, openedAt)
 
   const triggerText = followsTask ? "Follows the task's agent" : (label ?? DEFAULT_TEXT[variant])
   const formTone = followsTask
@@ -281,6 +286,15 @@ export function ModelPicker({
       }}
     >
       <div className="overflow-y-auto py-1 max-h-60">
+        {asking && (
+          <p
+            role="status"
+            className="flex items-center gap-2 px-3 py-1.5 text-[12px] text-gray-500"
+          >
+            <Loader2 size={11} className="animate-spin shrink-0" />
+            Asking {agentType} for its models…
+          </p>
+        )}
         {!needle && (
           <button
             type="button"
@@ -335,7 +349,7 @@ export function ModelPicker({
       <div className="flex items-center gap-2 px-3 pb-2 text-[10px] text-gray-600">
         {footer.spinner && <Loader2 size={10} className="animate-spin shrink-0" />}
         <span className="flex-1 truncate">{footer.text}</span>
-        {catalog?.source === 'agent' && !loading && (
+        {catalog && catalog.status !== 'unavailable' && !loading && (
           <Tooltip label={`Ask ${agentType} again`}>
             <button
               type="button"

--- a/src/renderer/components/ModelPicker.tsx
+++ b/src/renderer/components/ModelPicker.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Check, ChevronDown, Cpu, Loader2, RefreshCw } from 'lucide-react'
-import type { AiAgentType } from '../../shared/types'
+import type { AiAgentType, LaunchAgentType } from '../../shared/types'
 import {
   supportsModelSelection,
   validateModelId,
@@ -10,30 +10,36 @@ import {
   type AgentModelChoice
 } from '@vornrun/shared/agent-models'
 import { Tooltip } from './Tooltip'
+import { useAnchoredMenu } from '../hooks/useAnchoredMenu'
 
-/** Only used to choose a direction; the flipped menu is anchored by its edge. */
 const MENU_ROW_PX = 28
 const MENU_CHROME_PX = 84
-const MENU_GAP_PX = 4
-const VIEWPORT_MARGIN_PX = 8
 const MENU_WIDTH_PX = 288
 
-const AGENT_NAMES: Record<string, string> = {
-  claude: 'claude',
-  copilot: 'copilot',
-  codex: 'codex',
-  opencode: 'opencode'
-}
+type Variant = 'compact' | 'bordered' | 'form'
 
 interface Props {
-  agentType: AiAgentType | string
+  agentType: LaunchAgentType | string
   projectPath?: string
   remoteHostId?: string
   value?: string
   onChange: (model: string | undefined) => void
   /** `compact` is the launcher chip; `bordered` the intent bar's; `form` a full-width field. */
-  variant?: 'compact' | 'bordered' | 'form'
-  disabled?: boolean
+  variant?: Variant
+}
+
+const TRIGGER_CLASS: Record<Variant, string> = {
+  form: 'w-full flex items-center gap-2 px-3 py-2 text-[13px] bg-white/[0.06] border border-white/[0.1] rounded-md transition-colors',
+  bordered:
+    'flex items-center gap-1.5 rounded-[4px] border border-white/[0.12] px-1.5 py-0.5 text-[12px] text-gray-300 transition-colors hover:border-white/25 hover:bg-white/[0.04]',
+  compact:
+    'flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-white/[0.06] transition-colors text-xs text-gray-400'
+}
+
+const DEFAULT_TEXT: Record<Variant, string> = {
+  form: 'Agent default',
+  bordered: '',
+  compact: 'Default'
 }
 
 function agoLabel(fetchedAt: number | undefined, now: number): string {
@@ -48,36 +54,52 @@ function providerOf(id: string): string | undefined {
   return slash > 0 ? id.slice(0, slash) : undefined
 }
 
+function footerFor(
+  agent: string,
+  catalog: AgentModelCatalog | null,
+  loading: boolean,
+  openedAt: number
+): { text: string; spinner: boolean } {
+  if (loading) return { text: `Asking ${agent}…`, spinner: true }
+  if (!catalog) return { text: '', spinner: false }
+  if (catalog.status === 'unavailable') {
+    return { text: catalog.error ?? 'Could not list models — type an id', spinner: false }
+  }
+  if (catalog.source === 'built-in') {
+    return { text: 'Known ids — others can be typed', spinner: false }
+  }
+  const failed = catalog.status === 'stale' ? ' · refreshing failed' : ''
+  return {
+    text: `From ${agent} · ${agoLabel(catalog.fetchedAt, openedAt)}${failed}`,
+    spinner: false
+  }
+}
+
 export function ModelPicker({
   agentType,
   projectPath,
   remoteHostId,
   value,
   onChange,
-  variant = 'compact',
-  disabled = false
+  variant = 'compact'
 }: Props) {
-  const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
   const [invalid, setInvalid] = useState('')
   const [catalog, setCatalog] = useState<AgentModelCatalog | null>(null)
   const [loading, setLoading] = useState(false)
   const [refreshes, setRefreshes] = useState(0)
   const [openedAt, setOpenedAt] = useState(0)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
-  const [position, setPosition] = useState<{
-    top?: number
-    bottom?: number
-    left: number
-    width: number
-  }>({ top: 0, left: 0, width: MENU_WIDTH_PX })
 
-  const supported = supportsModelSelection(agentType)
-  const agentName = AGENT_NAMES[agentType] ?? agentType
+  const followsTask = agentType === 'fromTask'
+  const supported = followsTask || supportsModelSelection(agentType)
   const choices = catalog?.choices ?? []
   const selected = choices.find((choice) => choice.id === value)
   const label = selected?.label ?? value
+
+  const { open, setOpen, toggle, triggerRef, menuRef, position } = useAnchoredMenu({
+    estimateHeight: () => Math.min(8, choices.length + 1) * MENU_ROW_PX + MENU_CHROME_PX,
+    menuWidth: (trigger) => Math.max(MENU_WIDTH_PX, variant === 'form' ? trigger : 0)
+  })
 
   // Asked when the menu opens, and again on refresh; the list belongs to this agent and project.
   useEffect(() => {
@@ -112,61 +134,16 @@ export function ModelPicker({
     }
   }, [open, supported, agentType, projectPath, remoteHostId, refreshes])
 
-  useEffect(() => {
-    if (!open) return
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as Node
-      if (triggerRef.current?.contains(target)) return
-      if (menuRef.current && !menuRef.current.contains(target)) setOpen(false)
-    }
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation()
-        setOpen(false)
-        triggerRef.current?.focus()
-      }
-    }
-    document.addEventListener('mousedown', handleClick)
-    document.addEventListener('keydown', handleKey)
-    return () => {
-      document.removeEventListener('mousedown', handleClick)
-      document.removeEventListener('keydown', handleKey)
-    }
-  }, [open])
-
   if (!supported) return null
 
   const handleTrigger = (e: React.MouseEvent) => {
-    e.stopPropagation()
-    if (disabled) return
-    if (open) {
-      setOpen(false)
-      return
+    if (followsTask) return
+    if (!open) {
+      setQuery('')
+      setInvalid('')
+      setOpenedAt(Date.now())
     }
-    const rect = triggerRef.current?.getBoundingClientRect()
-    if (rect) {
-      const width = Math.min(
-        Math.max(MENU_WIDTH_PX, variant === 'form' ? rect.width : 0),
-        window.innerWidth - 16
-      )
-      const estimated = Math.min(8, choices.length + 1) * MENU_ROW_PX + MENU_CHROME_PX
-      const flipUp =
-        rect.bottom + MENU_GAP_PX + estimated > window.innerHeight - VIEWPORT_MARGIN_PX &&
-        rect.top - MENU_GAP_PX - estimated > VIEWPORT_MARGIN_PX
-      setPosition({
-        top: flipUp ? undefined : rect.bottom + MENU_GAP_PX,
-        bottom: flipUp ? window.innerHeight - rect.top + MENU_GAP_PX : undefined,
-        left: Math.max(
-          VIEWPORT_MARGIN_PX,
-          Math.min(rect.left, window.innerWidth - width - VIEWPORT_MARGIN_PX)
-        ),
-        width
-      })
-    }
-    setQuery('')
-    setInvalid('')
-    setOpenedAt(Date.now())
-    setOpen(true)
+    toggle(e)
   }
 
   const select = (model: string | undefined) => {
@@ -187,60 +164,39 @@ export function ModelPicker({
   const shown = needle
     ? choices.filter((c) => `${c.label} ${c.id}`.toLowerCase().includes(needle))
     : choices
-  const exact = shown.find((c) => c.id === needle || c.id.toLowerCase() === needle)
+  const exact = shown.find((c) => c.id.toLowerCase() === needle)
   const groupedByProvider = agentType === 'opencode'
+  const footer = footerFor(agentType, catalog, loading, openedAt)
 
-  const footer = loading
-    ? { text: `Asking ${agentName}…`, spinner: true }
-    : catalog?.status === 'unavailable'
-      ? { text: catalog.error ?? 'Could not list models — type an id', spinner: false }
-      : catalog?.source === 'built-in'
-        ? { text: 'Known ids — others can be typed', spinner: false }
-        : catalog
-          ? {
-              text: `From ${agentName} · ${agoLabel(catalog.fetchedAt, openedAt)}${catalog.status === 'stale' ? ' · refreshing failed' : ''}`,
-              spinner: false
-            }
-          : { text: '', spinner: false }
-
-  const triggerClass =
-    variant === 'form'
-      ? `w-full flex items-center gap-2 px-3 py-2 text-[13px] bg-white/[0.06] border border-white/[0.1] rounded-md transition-colors ${
-          disabled ? 'text-gray-600 cursor-default' : 'text-white hover:border-white/[0.2]'
-        }`
-      : variant === 'bordered'
-        ? 'flex items-center gap-1.5 rounded-[4px] border border-white/[0.12] px-1.5 py-0.5 text-[12px] text-gray-300 transition-colors hover:border-white/25 hover:bg-white/[0.04]'
-        : 'flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-white/[0.06] transition-colors text-xs text-gray-400'
-
-  const triggerText = disabled
-    ? "Follows the task's agent"
-    : (label ?? (variant === 'form' ? 'Agent default' : 'Default'))
-  const showText = variant !== 'bordered' || label !== undefined
+  const triggerText = followsTask ? "Follows the task's agent" : (label ?? DEFAULT_TEXT[variant])
+  const formTone = followsTask
+    ? 'text-gray-600 cursor-default'
+    : 'text-white hover:border-white/[0.2]'
 
   const trigger = (
     <button
       ref={triggerRef}
       type="button"
       onClick={handleTrigger}
-      disabled={disabled}
+      disabled={followsTask}
       aria-haspopup="listbox"
       aria-expanded={open}
       aria-label={label ? `Model: ${label}` : 'Model: agent default'}
-      className={triggerClass}
+      className={variant === 'form' ? `${TRIGGER_CLASS.form} ${formTone}` : TRIGGER_CLASS[variant]}
     >
       <Cpu
         size={variant === 'form' ? 14 : 13}
         className={label ? 'text-gray-300' : 'text-gray-500'}
         strokeWidth={1.75}
       />
-      {showText && (
+      {triggerText && (
         <span
-          className={`flex-1 text-left truncate max-w-[170px] ${label || disabled ? '' : 'text-gray-500'}`}
+          className={`flex-1 text-left truncate max-w-[170px] ${label || followsTask ? '' : 'text-gray-500'}`}
         >
           {triggerText}
         </span>
       )}
-      {!disabled && showText && (
+      {!followsTask && triggerText && (
         <ChevronDown size={variant === 'form' ? 12 : 10} className="shrink-0 text-gray-500" />
       )}
     </button>
@@ -379,7 +335,7 @@ export function ModelPicker({
         {footer.spinner && <Loader2 size={10} className="animate-spin shrink-0" />}
         <span className="flex-1 truncate">{footer.text}</span>
         {catalog?.source === 'agent' && !loading && (
-          <Tooltip label={`Ask ${agentName} again`}>
+          <Tooltip label={`Ask ${agentType} again`}>
             <button
               type="button"
               aria-label="Refresh models"

--- a/src/renderer/components/ModelPicker.tsx
+++ b/src/renderer/components/ModelPicker.tsx
@@ -141,6 +141,7 @@ export function ModelPicker({
     if (!open) {
       setQuery('')
       setInvalid('')
+      setRefreshes(0)
       setOpenedAt(Date.now())
     }
     toggle(e)

--- a/src/renderer/components/ModelPicker.tsx
+++ b/src/renderer/components/ModelPicker.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Check, ChevronDown, Cpu, Loader2, RefreshCw } from 'lucide-react'
+import type { AiAgentType } from '../../shared/types'
+import {
+  supportsModelSelection,
+  validateModelId,
+  type AgentModelCatalog,
+  type AgentModelChoice
+} from '@vornrun/shared/agent-models'
+import { Tooltip } from './Tooltip'
+
+/** Only used to choose a direction; the flipped menu is anchored by its edge. */
+const MENU_ROW_PX = 28
+const MENU_CHROME_PX = 84
+const MENU_GAP_PX = 4
+const VIEWPORT_MARGIN_PX = 8
+const MENU_WIDTH_PX = 288
+
+const AGENT_NAMES: Record<string, string> = {
+  claude: 'claude',
+  copilot: 'copilot',
+  codex: 'codex',
+  opencode: 'opencode'
+}
+
+interface Props {
+  agentType: AiAgentType | string
+  projectPath?: string
+  remoteHostId?: string
+  value?: string
+  onChange: (model: string | undefined) => void
+  /** `compact` is the launcher chip; `bordered` the intent bar's; `form` a full-width field. */
+  variant?: 'compact' | 'bordered' | 'form'
+  disabled?: boolean
+}
+
+function agoLabel(fetchedAt: number | undefined, now: number): string {
+  if (!fetchedAt) return ''
+  const minutes = Math.round((now - fetchedAt) / 60_000)
+  return minutes < 1 ? 'just now' : `${minutes} min ago`
+}
+
+/** OpenCode ids are `provider/model`; the provider becomes a section header. */
+function providerOf(id: string): string | undefined {
+  const slash = id.indexOf('/')
+  return slash > 0 ? id.slice(0, slash) : undefined
+}
+
+export function ModelPicker({
+  agentType,
+  projectPath,
+  remoteHostId,
+  value,
+  onChange,
+  variant = 'compact',
+  disabled = false
+}: Props) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [invalid, setInvalid] = useState('')
+  const [catalog, setCatalog] = useState<AgentModelCatalog | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [refreshes, setRefreshes] = useState(0)
+  const [openedAt, setOpenedAt] = useState(0)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<{
+    top?: number
+    bottom?: number
+    left: number
+    width: number
+  }>({ top: 0, left: 0, width: MENU_WIDTH_PX })
+
+  const supported = supportsModelSelection(agentType)
+  const agentName = AGENT_NAMES[agentType] ?? agentType
+  const choices = catalog?.choices ?? []
+  const selected = choices.find((choice) => choice.id === value)
+  const label = selected?.label ?? value
+
+  // Asked when the menu opens, and again on refresh; the list belongs to this agent and project.
+  useEffect(() => {
+    if (!open || !supported) return
+    let cancelled = false
+    const request = {
+      agentType: agentType as AiAgentType,
+      projectPath: projectPath ?? '',
+      remoteHostId
+    }
+    const list = window.api?.listAgentModels
+    void (async () => {
+      await Promise.resolve()
+      if (cancelled) return
+      if (!list) {
+        setCatalog({ choices: [], status: 'unavailable', error: 'This server cannot list models.' })
+        return
+      }
+      setLoading(true)
+      try {
+        const result = await list({ ...request, refresh: refreshes > 0 })
+        if (!cancelled) setCatalog(result)
+      } catch {
+        if (!cancelled)
+          setCatalog({ choices: [], status: 'unavailable', error: 'Could not list models.' })
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, supported, agentType, projectPath, remoteHostId, refreshes])
+
+  useEffect(() => {
+    if (!open) return
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target)) return
+      if (menuRef.current && !menuRef.current.contains(target)) setOpen(false)
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  if (!supported) return null
+
+  const handleTrigger = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (disabled) return
+    if (open) {
+      setOpen(false)
+      return
+    }
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (rect) {
+      const width = Math.min(
+        Math.max(MENU_WIDTH_PX, variant === 'form' ? rect.width : 0),
+        window.innerWidth - 16
+      )
+      const estimated = Math.min(8, choices.length + 1) * MENU_ROW_PX + MENU_CHROME_PX
+      const flipUp =
+        rect.bottom + MENU_GAP_PX + estimated > window.innerHeight - VIEWPORT_MARGIN_PX &&
+        rect.top - MENU_GAP_PX - estimated > VIEWPORT_MARGIN_PX
+      setPosition({
+        top: flipUp ? undefined : rect.bottom + MENU_GAP_PX,
+        bottom: flipUp ? window.innerHeight - rect.top + MENU_GAP_PX : undefined,
+        left: Math.max(
+          VIEWPORT_MARGIN_PX,
+          Math.min(rect.left, window.innerWidth - width - VIEWPORT_MARGIN_PX)
+        ),
+        width
+      })
+    }
+    setQuery('')
+    setInvalid('')
+    setOpenedAt(Date.now())
+    setOpen(true)
+  }
+
+  const select = (model: string | undefined) => {
+    setOpen(false)
+    if (model !== value) onChange(model)
+    triggerRef.current?.focus()
+  }
+
+  const chooseTypedId = () => {
+    try {
+      select(validateModelId(query))
+    } catch (err) {
+      setInvalid((err as Error).message)
+    }
+  }
+
+  const needle = query.trim().toLowerCase()
+  const shown = needle
+    ? choices.filter((c) => `${c.label} ${c.id}`.toLowerCase().includes(needle))
+    : choices
+  const exact = shown.find((c) => c.id === needle || c.id.toLowerCase() === needle)
+  const groupedByProvider = agentType === 'opencode'
+
+  const footer = loading
+    ? { text: `Asking ${agentName}…`, spinner: true }
+    : catalog?.status === 'unavailable'
+      ? { text: catalog.error ?? 'Could not list models — type an id', spinner: false }
+      : catalog?.source === 'built-in'
+        ? { text: 'Known ids — others can be typed', spinner: false }
+        : catalog
+          ? {
+              text: `From ${agentName} · ${agoLabel(catalog.fetchedAt, openedAt)}${catalog.status === 'stale' ? ' · refreshing failed' : ''}`,
+              spinner: false
+            }
+          : { text: '', spinner: false }
+
+  const triggerClass =
+    variant === 'form'
+      ? `w-full flex items-center gap-2 px-3 py-2 text-[13px] bg-white/[0.06] border border-white/[0.1] rounded-md transition-colors ${
+          disabled ? 'text-gray-600 cursor-default' : 'text-white hover:border-white/[0.2]'
+        }`
+      : variant === 'bordered'
+        ? 'flex items-center gap-1.5 rounded-[4px] border border-white/[0.12] px-1.5 py-0.5 text-[12px] text-gray-300 transition-colors hover:border-white/25 hover:bg-white/[0.04]'
+        : 'flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-white/[0.06] transition-colors text-xs text-gray-400'
+
+  const triggerText = disabled
+    ? "Follows the task's agent"
+    : (label ?? (variant === 'form' ? 'Agent default' : 'Default'))
+  const showText = variant !== 'bordered' || label !== undefined
+
+  const trigger = (
+    <button
+      ref={triggerRef}
+      type="button"
+      onClick={handleTrigger}
+      disabled={disabled}
+      aria-haspopup="listbox"
+      aria-expanded={open}
+      aria-label={label ? `Model: ${label}` : 'Model: agent default'}
+      className={triggerClass}
+    >
+      <Cpu
+        size={variant === 'form' ? 14 : 13}
+        className={label ? 'text-gray-300' : 'text-gray-500'}
+        strokeWidth={1.75}
+      />
+      {showText && (
+        <span
+          className={`flex-1 text-left truncate max-w-[170px] ${label || disabled ? '' : 'text-gray-500'}`}
+        >
+          {triggerText}
+        </span>
+      )}
+      {!disabled && showText && (
+        <ChevronDown size={variant === 'form' ? 12 : 10} className="shrink-0 text-gray-500" />
+      )}
+    </button>
+  )
+
+  const rowClass = (current: boolean) =>
+    `w-full flex items-center gap-2 px-3 py-1.5 text-[12px] text-left transition-colors ${
+      current
+        ? 'text-white bg-white/[0.06]'
+        : 'text-gray-300 hover:text-white hover:bg-white/[0.04]'
+    }`
+  const checkCell = (current: boolean) =>
+    current ? (
+      <Check size={11} strokeWidth={3} className="shrink-0" />
+    ) : (
+      <span className="w-[11px] shrink-0" />
+    )
+
+  const row = (choice: AgentModelChoice) => {
+    const current = choice.id === value
+    return (
+      <button
+        key={choice.id}
+        type="button"
+        role="option"
+        aria-selected={current}
+        title={choice.description}
+        onMouseDown={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          select(choice.id)
+        }}
+        className={rowClass(current)}
+      >
+        {checkCell(current)}
+        <span className="flex-1 min-w-0 truncate">{choice.label}</span>
+        {choice.label !== choice.id && (
+          <span className="text-[10px] text-gray-600 font-mono shrink-0 truncate max-w-[120px]">
+            {choice.id}
+          </span>
+        )}
+      </button>
+    )
+  }
+
+  const rows: React.ReactNode[] = []
+  let lastProvider: string | undefined
+  for (const choice of shown) {
+    const provider = groupedByProvider ? providerOf(choice.id) : undefined
+    if (provider && provider !== lastProvider) {
+      rows.push(
+        <div
+          key={`p:${provider}`}
+          className="px-3 pt-2 pb-0.5 text-[10px] uppercase tracking-wide text-gray-600"
+        >
+          {provider}
+        </div>
+      )
+      lastProvider = provider
+    }
+    rows.push(row(choice))
+  }
+
+  const menu = (
+    <motion.div
+      ref={menuRef}
+      role="listbox"
+      aria-label="Model"
+      initial={{ opacity: 0, scale: 0.96, y: -4 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      exit={{ opacity: 0, scale: 0.96, y: -4 }}
+      transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+      className="fixed z-[200] border border-white/[0.08] rounded-lg shadow-xl overflow-hidden flex flex-col"
+      style={{
+        background: 'var(--color-surface-overlay)',
+        top: position.top,
+        bottom: position.bottom,
+        left: position.left,
+        width: position.width,
+        maxHeight: 'calc(100vh - 32px)'
+      }}
+    >
+      <div className="overflow-y-auto py-1 max-h-60">
+        {!needle && (
+          <button
+            type="button"
+            role="option"
+            aria-selected={value === undefined}
+            onMouseDown={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              select(undefined)
+            }}
+            className={rowClass(value === undefined)}
+          >
+            {checkCell(value === undefined)}
+            <span className="flex-1">Agent default</span>
+          </button>
+        )}
+        {value && !selected && !needle && row({ id: value, label: value })}
+        {rows}
+        {needle && shown.length === 0 && (
+          <p className="px-3 py-1.5 text-[12px] text-gray-600">No listed model matches</p>
+        )}
+      </div>
+      <div className="border-t border-white/[0.06] px-3 py-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-wide text-gray-600 shrink-0">id</span>
+          <input
+            autoFocus
+            value={query}
+            spellCheck={false}
+            aria-label="Model id"
+            placeholder="type a model id"
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setInvalid('')
+            }}
+            onKeyDown={(e) => {
+              if (e.key !== 'Enter') return
+              e.preventDefault()
+              e.stopPropagation()
+              if (exact) select(exact.id)
+              else if (needle) chooseTypedId()
+            }}
+            className={`flex-1 min-w-0 bg-white/[0.04] border rounded px-2 py-0.5 text-[11px] font-mono text-gray-200 placeholder:text-gray-700 focus:outline-none ${
+              invalid
+                ? 'border-[var(--color-danger)]'
+                : 'border-white/[0.08] focus:border-white/[0.2]'
+            }`}
+          />
+        </div>
+        {invalid && <p className="mt-1 text-[11px] text-[var(--color-danger)]">{invalid}</p>}
+      </div>
+      <div className="flex items-center gap-2 px-3 pb-2 text-[10px] text-gray-600">
+        {footer.spinner && <Loader2 size={10} className="animate-spin shrink-0" />}
+        <span className="flex-1 truncate">{footer.text}</span>
+        {catalog?.source === 'agent' && !loading && (
+          <Tooltip label={`Ask ${agentName} again`}>
+            <button
+              type="button"
+              aria-label="Refresh models"
+              onMouseDown={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setRefreshes((n) => n + 1)
+              }}
+              className="w-5 h-5 grid place-items-center rounded text-gray-500 hover:text-gray-300 hover:bg-white/[0.06]"
+            >
+              <RefreshCw size={11} />
+            </button>
+          </Tooltip>
+        )}
+      </div>
+    </motion.div>
+  )
+
+  return (
+    <>
+      {variant === 'bordered' && !label ? (
+        <Tooltip label="Model · agent default">{trigger}</Tooltip>
+      ) : (
+        trigger
+      )}
+      {createPortal(<AnimatePresence>{open && menu}</AnimatePresence>, document.body)}
+    </>
+  )
+}

--- a/src/renderer/components/PromptLauncher.tsx
+++ b/src/renderer/components/PromptLauncher.tsx
@@ -320,6 +320,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
 
       {/* Model, between the agent and where it runs */}
       <ModelPicker
+        prefetch
         agentType={settings.selectedAgent}
         projectPath={settings.selectedWorktreePath ?? selectedProjectConfig?.path}
         remoteHostId={

--- a/src/renderer/components/PromptLauncher.tsx
+++ b/src/renderer/components/PromptLauncher.tsx
@@ -5,6 +5,8 @@ import { AiAgentType, ProjectConfig, getProjectRemoteHostId } from '../../shared
 import { AGENT_LIST } from '../lib/agent-definitions'
 import { AgentIcon } from './AgentIcon'
 import { useLaunchSettings } from '../hooks/useLaunchSettings'
+import { usePreferredModel } from '../hooks/usePreferredModel'
+import { ModelPicker } from './ModelPicker'
 import { BranchPicker } from './BranchPicker'
 import { useAgentInstallStatus } from '../hooks/useAgentInstallStatus'
 import { getRandomTips } from '../lib/tips-data'
@@ -79,6 +81,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
 
   const [prompt, setPrompt] = useState('')
   const [launching, setLaunching] = useState(false)
+  const [launchError, setLaunchError] = useState('')
   const [showAgentPicker, setShowAgentPicker] = useState(false)
   const [showProjectPicker, setShowProjectPicker] = useState(false)
   const [showWorktreePicker, setShowWorktreePicker] = useState(false)
@@ -90,6 +93,10 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
 
   const settings = useLaunchSettings()
   const selectedProjectConfig = config?.projects.find((p) => p.name === settings.selectedProject)
+  const modelPreference = usePreferredModel(
+    settings.selectedAgent,
+    selectedProjectConfig ? getProjectRemoteHostId(selectedProjectConfig) : undefined
+  )
   const tip = useMemo(() => getRandomTips(1)[0], [])
   const { status: installStatus } = useAgentInstallStatus()
 
@@ -131,6 +138,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
     if (!project) return
 
     setLaunching(true)
+    setLaunchError('')
 
     try {
       const remoteHostId = getProjectRemoteHostId(project)
@@ -166,6 +174,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
 
       const session = await window.api.createTerminal({
         agentType: settings.selectedAgent,
+        ...(modelPreference.model ? { model: modelPreference.model } : {}),
         projectName: project.name,
         projectPath: project.path,
         branch,
@@ -182,6 +191,7 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
       onClose?.()
     } catch (err) {
       console.error('[PromptLauncher] launch failed:', err)
+      setLaunchError(err instanceof Error ? err.message : 'Could not start the agent.')
     } finally {
       setLaunching(false)
     }
@@ -307,6 +317,17 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
           </div>
         )}
       </div>
+
+      {/* Model, between the agent and where it runs */}
+      <ModelPicker
+        agentType={settings.selectedAgent}
+        projectPath={settings.selectedWorktreePath ?? selectedProjectConfig?.path}
+        remoteHostId={
+          selectedProjectConfig ? getProjectRemoteHostId(selectedProjectConfig) : undefined
+        }
+        value={modelPreference.model}
+        onChange={modelPreference.setModel}
+      />
 
       {/* Worktree picker — worktree-first, before branch */}
       {settings.activeProjectPath && settings.isGitRepo && (
@@ -496,6 +517,10 @@ export function PromptLauncher({ mode, onClose }: PromptLauncherProps) {
       {!canLaunch ? (
         <p className="text-[11px] text-gray-600 mt-2 text-center">
           Select a project to get started
+        </p>
+      ) : launchError ? (
+        <p role="alert" className="text-xs text-red-400 mt-2">
+          {launchError}
         </p>
       ) : (
         <p className="text-[11px] text-gray-600 mt-2 text-center flex items-center justify-center gap-1.5">

--- a/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
+++ b/src/renderer/components/workflow-editor/nodes/LaunchAgentNode.tsx
@@ -44,6 +44,12 @@ export function LaunchAgentNode({ label, config, selected, executionStatus, onCl
         <>
           {config.projectName || 'No project'}
           {!remoteHost && config.branch && ` · ${config.branch}`}
+          {config.model && (
+            <>
+              {' · '}
+              <span className="font-mono">{config.model}</span>
+            </>
+          )}
         </>
       }
       meta={

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -21,6 +21,7 @@ import { useAgentInstallStatus } from '../../../hooks/useAgentInstallStatus'
 import { VariableAutocomplete } from './VariableAutocomplete'
 import { ProjectPicker } from '../../ProjectPicker'
 import { AgentPicker } from '../../AgentPicker'
+import { ModelPicker } from '../../ModelPicker'
 import { SelectPicker } from '../../SelectPicker'
 import { Tooltip } from '../../Tooltip'
 import { RichMarkdownEditor } from '../../rich-editor/RichMarkdownEditor'
@@ -166,10 +167,25 @@ export function LaunchAgentConfigForm({
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Agent</label>
         <AgentPicker
           currentAgent={config.agentType}
-          onChange={(agent) => agent && onChange({ ...config, agentType: agent })}
+          onChange={(agent) => agent && onChange({ ...config, agentType: agent, model: undefined })}
           installStatus={installStatus}
           variant="form"
           allowFromTask={canUseFromTask}
+        />
+      </div>
+
+      <div>
+        <label className="text-[13px] text-gray-400 font-medium block mb-2">Model</label>
+        <ModelPicker
+          variant="form"
+          agentType={config.agentType === 'fromTask' ? 'claude' : config.agentType}
+          disabled={config.agentType === 'fromTask'}
+          projectPath={projectIsFromContext ? undefined : config.projectPath}
+          remoteHostId={
+            selectedProject ? getProjectRemoteHostId(selectedProject) : config.remoteHostId
+          }
+          value={config.model}
+          onChange={(model) => onChange({ ...config, model })}
         />
       </div>
 

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -177,6 +177,7 @@ export function LaunchAgentConfigForm({
       <div>
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Model</label>
         <ModelPicker
+          prefetch
           variant="form"
           agentType={config.agentType}
           projectPath={projectIsFromContext ? undefined : config.projectPath}

--- a/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
+++ b/src/renderer/components/workflow-editor/panels/LaunchAgentConfigForm.tsx
@@ -178,8 +178,7 @@ export function LaunchAgentConfigForm({
         <label className="text-[13px] text-gray-400 font-medium block mb-2">Model</label>
         <ModelPicker
           variant="form"
-          agentType={config.agentType === 'fromTask' ? 'claude' : config.agentType}
-          disabled={config.agentType === 'fromTask'}
+          agentType={config.agentType}
           projectPath={projectIsFromContext ? undefined : config.projectPath}
           remoteHostId={
             selectedProject ? getProjectRemoteHostId(selectedProject) : config.remoteHostId

--- a/src/renderer/hooks/useAgentModelCatalog.ts
+++ b/src/renderer/hooks/useAgentModelCatalog.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AiAgentType } from '../../shared/types'
+import type { AgentModelCatalog } from '@vornrun/shared/agent-models'
+
+interface Request {
+  agentType: string
+  projectPath?: string
+  remoteHostId?: string
+}
+
+const unavailable = (error: string): AgentModelCatalog => ({
+  choices: [],
+  status: 'unavailable',
+  error
+})
+
+/** The models an agent can run in a project, asked once while wanted; `refresh` asks again. */
+export function useAgentModelCatalog(request: Request, wanted: boolean) {
+  const { agentType, projectPath = '', remoteHostId } = request
+  const key = JSON.stringify([agentType, projectPath, remoteHostId ?? ''])
+  const [fetched, setFetched] = useState<{ key: string; catalog: AgentModelCatalog } | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+  const turn = useRef(0)
+  const have = fetched?.key === key
+
+  const load = useCallback(
+    async (refresh: boolean) => {
+      const mine = ++turn.current
+      const list = window.api?.listAgentModels
+      let catalog: AgentModelCatalog
+      try {
+        catalog = list
+          ? await list({ agentType: agentType as AiAgentType, projectPath, remoteHostId, refresh })
+          : unavailable('This server cannot list models.')
+      } catch {
+        catalog = unavailable('Could not list models.')
+      }
+      await Promise.resolve()
+      if (mine === turn.current) setFetched({ key, catalog })
+    },
+    [key, agentType, projectPath, remoteHostId]
+  )
+
+  useEffect(() => {
+    if (wanted && !have) void load(false)
+  }, [wanted, have, load])
+
+  const refresh = () => {
+    setRefreshing(true)
+    void load(true).finally(() => setRefreshing(false))
+  }
+
+  return {
+    catalog: have ? fetched.catalog : null,
+    loading: (wanted && !have) || refreshing,
+    refresh
+  }
+}

--- a/src/renderer/hooks/useAnchoredMenu.ts
+++ b/src/renderer/hooks/useAnchoredMenu.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react'
+
+/** Only used to choose a direction; the flipped menu is anchored by its edge. */
+const MENU_GAP_PX = 4
+const VIEWPORT_MARGIN_PX = 8
+
+export interface AnchoredMenuPosition {
+  top?: number
+  bottom?: number
+  left: number
+  width: number
+}
+
+interface Options {
+  /** A guess at the open menu's height, deciding whether it drops down or flips up. */
+  estimateHeight: () => number
+  /** The menu's width for a trigger of this width; the trigger's own by default. */
+  menuWidth?: (triggerWidth: number) => number
+}
+
+/** A portal menu anchored to its trigger: flips up near the bottom, stays on screen, closes on outside click or Escape. */
+export function useAnchoredMenu({ estimateHeight, menuWidth }: Options) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<AnchoredMenuPosition>({ top: 0, left: 0, width: 0 })
+
+  const toggle = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (open) {
+      setOpen(false)
+      return
+    }
+    const rect = triggerRef.current?.getBoundingClientRect()
+    if (rect) {
+      const width = Math.min(menuWidth?.(rect.width) ?? rect.width, window.innerWidth - 16)
+      const estimated = estimateHeight()
+      const flipUp =
+        rect.bottom + MENU_GAP_PX + estimated > window.innerHeight - VIEWPORT_MARGIN_PX &&
+        rect.top - MENU_GAP_PX - estimated > VIEWPORT_MARGIN_PX
+      setPosition({
+        top: flipUp ? undefined : rect.bottom + MENU_GAP_PX,
+        bottom: flipUp ? window.innerHeight - rect.top + MENU_GAP_PX : undefined,
+        left: Math.max(
+          VIEWPORT_MARGIN_PX,
+          Math.min(rect.left, window.innerWidth - width - VIEWPORT_MARGIN_PX)
+        ),
+        width
+      })
+    }
+    setOpen(true)
+  }
+
+  useEffect(() => {
+    if (!open) return
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (triggerRef.current?.contains(target)) return
+      if (menuRef.current && !menuRef.current.contains(target)) setOpen(false)
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  return { open, setOpen, toggle, triggerRef, menuRef, position }
+}

--- a/src/renderer/hooks/usePreferredModel.ts
+++ b/src/renderer/hooks/usePreferredModel.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from 'react'
+import type { AiAgentType } from '../../shared/types'
+import { getPreferredModel, setPreferredModel } from '../lib/launch-prefs'
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener('vorn:launch-preferences', onChange)
+  window.addEventListener('storage', onChange)
+  return () => {
+    window.removeEventListener('vorn:launch-preferences', onChange)
+    window.removeEventListener('storage', onChange)
+  }
+}
+
+export function usePreferredModel(agent: AiAgentType, host?: string) {
+  const model = useSyncExternalStore(subscribe, () => getPreferredModel(agent, host))
+  return { model, setModel: (value: string | undefined) => setPreferredModel(agent, value, host) }
+}

--- a/src/renderer/lib/launch-prefs.ts
+++ b/src/renderer/lib/launch-prefs.ts
@@ -11,6 +11,7 @@ const STORAGE_KEY = 'vorn:lastLaunchSettings'
 export interface SavedLaunchSettings {
   project?: string
   agent?: AiAgentType
+  models?: Record<string, Partial<Record<AiAgentType, string>>>
 }
 
 export function loadLaunchSettings(): SavedLaunchSettings {
@@ -30,11 +31,29 @@ export function loadLaunchSettings(): SavedLaunchSettings {
 
 export function persistLaunchSettings(settings: SavedLaunchSettings): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...loadLaunchSettings(), ...settings }))
+    window.dispatchEvent?.(new Event('vorn:launch-preferences'))
   } catch {
     // Storage unavailable (private mode, quota). The preference is a
     // convenience, so losing it is not worth surfacing.
   }
+}
+
+export function getPreferredModel(agent: AiAgentType, host?: string): string | undefined {
+  const value = loadLaunchSettings().models?.[host ?? 'local']?.[agent]
+  return typeof value === 'string' ? value : undefined
+}
+
+export function setPreferredModel(
+  agent: AiAgentType,
+  model: string | undefined,
+  host?: string
+): void {
+  const saved = loadLaunchSettings()
+  const key = host ?? 'local'
+  persistLaunchSettings({
+    models: { ...saved.models, [key]: { ...saved.models?.[key], [agent]: model } }
+  })
 }
 
 export function getPreferredAgent(fallback: AiAgentType = 'claude'): AiAgentType {

--- a/src/renderer/lib/launch-prefs.ts
+++ b/src/renderer/lib/launch-prefs.ts
@@ -29,6 +29,7 @@ export function loadLaunchSettings(): SavedLaunchSettings {
   }
 }
 
+/** Merged, not replaced: the launcher writes project and agent, the pickers write models. */
 export function persistLaunchSettings(settings: SavedLaunchSettings): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...loadLaunchSettings(), ...settings }))
@@ -61,5 +62,5 @@ export function getPreferredAgent(fallback: AiAgentType = 'claude'): AiAgentType
 }
 
 export function setPreferredAgent(agent: AiAgentType): void {
-  persistLaunchSettings({ ...loadLaunchSettings(), agent })
+  persistLaunchSettings({ agent })
 }

--- a/src/renderer/lib/session-utils.ts
+++ b/src/renderer/lib/session-utils.ts
@@ -225,7 +225,8 @@ export async function createShellInProject(
 export async function launchAgentFromShell(
   shellSession: TerminalSession,
   agentType: AiAgentType,
-  prompt: string
+  prompt: string,
+  model?: string
 ): Promise<void> {
   const cwd = shellSession.shellCwd ?? shellSession.worktreePath ?? shellSession.projectPath
   try {
@@ -238,6 +239,7 @@ export async function launchAgentFromShell(
       projectName: shellSession.projectName,
       projectPath: cwd,
       initialPrompt: prompt,
+      ...(model ? { model } : {}),
       remoteHostId: shellSession.remoteHostId,
       worktreeName: shellSession.worktreeName
     })

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -3,11 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Nothing is on PATH here, so every command keeps its configured name.
 vi.mock('../packages/server/src/resolve-executable', () => ({ findOnPath: () => null }))
 
-import {
-  buildAgentLaunchLine,
-  buildHeadlessLaunchLine,
-  buildHeadlessSpawnArgs
-} from '../packages/server/src/agent-launch'
+import { buildAgentLaunchLine, buildHeadlessSpawnArgs } from '../packages/server/src/agent-launch'
 import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
 import type { AiAgentType, CreateTerminalPayload } from '@vornrun/shared/types'
 
@@ -125,65 +121,6 @@ describe('buildAgentLaunchLine', () => {
     )
     expect(result).not.toContain('--session-id')
     expect(result).not.toContain('--resume')
-  })
-})
-
-describe('buildHeadlessLaunchLine', () => {
-  it('builds claude with -p and headlessArgs', () => {
-    const result = buildHeadlessLaunchLine(makePayload({ initialPrompt: 'do it' }), cmds, env)
-    expect(result).toContain('claude')
-    expect(result).toContain('--dangerously-skip-permissions')
-    expect(result).toContain('-p')
-  })
-
-  it('builds copilot with --allow-all', () => {
-    const result = buildHeadlessLaunchLine(
-      makePayload({ agentType: 'copilot', initialPrompt: 'do it' }),
-      cmds,
-      env
-    )
-    expect(result).toContain('--allow-all')
-    expect(result).toContain('-p')
-  })
-
-  it('builds codex with exec subcommand', () => {
-    const result = buildHeadlessLaunchLine(
-      makePayload({ agentType: 'codex', initialPrompt: 'do it' }),
-      cmds,
-      env
-    )
-    expect(result).toContain('exec')
-    expect(result).toContain('-a never')
-  })
-
-  it('builds opencode with run subcommand', () => {
-    const result = buildHeadlessLaunchLine(
-      makePayload({ agentType: 'opencode', initialPrompt: 'do it' }),
-      cmds,
-      env
-    )
-    expect(result).toContain('run')
-  })
-
-  it('builds gemini with -y flag', () => {
-    const result = buildHeadlessLaunchLine(
-      makePayload({ agentType: 'gemini', initialPrompt: 'do it' }),
-      cmds,
-      env
-    )
-    expect(result).toContain('-y')
-    expect(result).toContain('-p')
-  })
-
-  it('uses empty quoted string when no prompt', () => {
-    const result = buildHeadlessLaunchLine(makePayload(), cmds, env)
-    expect(result).toContain("''")
-  })
-
-  it('per-step args override headlessArgs', () => {
-    const result = buildHeadlessLaunchLine(makePayload({ args: ['--custom'] }), cmds, env)
-    expect(result).toContain('--custom')
-    expect(result).not.toContain('--dangerously-skip-permissions')
   })
 })
 
@@ -414,12 +351,6 @@ describe('agent-launch guards against shell sessions', () => {
     )
   })
 
-  it('buildHeadlessLaunchLine throws for shell payloads', () => {
-    expect(() => buildHeadlessLaunchLine(shellPayload, cmds, env)).toThrow(
-      /buildHeadlessLaunchLine called for shell session/
-    )
-  })
-
   it('buildHeadlessSpawnArgs throws for shell payloads', () => {
     expect(() => buildHeadlessSpawnArgs(shellPayload, cmds, env)).toThrow(
       /buildHeadlessSpawnArgs called for shell session/
@@ -520,7 +451,7 @@ describe('a chosen model reaches the agent', () => {
   it('refuses a model on a shell wrapper command', () => {
     const commands = { ...cmds, claude: { ...cmds.claude, command: 'nvm use 20 && claude' } }
     expect(() => buildAgentLaunchLine(makePayload({ model: 'x' }), commands, env)).toThrow(
-      /shell wrapper/
+      /one executable/
     )
   })
 })

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -448,6 +448,14 @@ describe('a chosen model reaches the agent', () => {
     ])
   })
 
+  it('leaves a command the shell must expand as configured', () => {
+    const commands = { ...cmds, claude: { ...cmds.claude, command: '~/bin/claude' } }
+    expect(buildAgentLaunchLine(makePayload({ model: 'x' }), commands, env)).toBe(
+      '~/bin/claude --model x'
+    )
+    expect(buildAgentLaunchLine(makePayload(), commands, env)).toBe('~/bin/claude')
+  })
+
   it('refuses a model on a shell wrapper command', () => {
     const commands = { ...cmds, claude: { ...cmds.claude, command: 'nvm use 20 && claude' } }
     expect(() => buildAgentLaunchLine(makePayload({ model: 'x' }), commands, env)).toThrow(

--- a/tests/agent-launch.test.ts
+++ b/tests/agent-launch.test.ts
@@ -497,3 +497,30 @@ describe('exactly one selector reaches the agent', () => {
     expect(line).toContain('--resume wanted')
   })
 })
+
+describe('a chosen model reaches the agent', () => {
+  it('replaces a configured --model on the interactive line', () => {
+    const commands = {
+      ...cmds,
+      claude: { ...cmds.claude, args: ['--model', 'opus', '--verbose'] }
+    }
+    const line = buildAgentLaunchLine(makePayload({ model: 'claude-sonnet-5' }), commands, env)
+    expect(line).toBe('claude --verbose --model claude-sonnet-5')
+  })
+
+  it('is one argument on a headless spawn, after the configured ones', () => {
+    const args = buildHeadlessSpawnArgs(makePayload({ model: 'claude-sonnet-5' }), cmds, env)
+    expect(args.args.slice(0, 3)).toEqual([
+      '--dangerously-skip-permissions',
+      '--model',
+      'claude-sonnet-5'
+    ])
+  })
+
+  it('refuses a model on a shell wrapper command', () => {
+    const commands = { ...cmds, claude: { ...cmds.claude, command: 'nvm use 20 && claude' } }
+    expect(() => buildAgentLaunchLine(makePayload({ model: 'x' }), commands, env)).toThrow(
+      /shell wrapper/
+    )
+  })
+})

--- a/tests/agent-model-catalog.test.ts
+++ b/tests/agent-model-catalog.test.ts
@@ -37,10 +37,18 @@ describe('model catalogs', () => {
     ).toEqual([{ id: 'cli-id', label: 'Model' }])
     expect(
       parseModelChoices('copilot', [
-        { id: 'auto' },
-        { id: 'blocked', policy: { state: 'disabled' } }
+        { modelId: 'auto', name: 'Auto', description: 'Let Copilot pick' },
+        {
+          modelId: 'opus',
+          name: 'Opus',
+          _meta: { copilotUsage: '15x', copilotEnablement: 'enabled' }
+        },
+        { modelId: 'blocked', name: 'Blocked', _meta: { copilotEnablement: 'policy_disabled' } }
       ])
-    ).toEqual([{ id: 'auto', label: 'auto' }])
+    ).toEqual([
+      { id: 'auto', label: 'Auto', description: 'Let Copilot pick' },
+      { id: 'opus', label: 'Opus', description: '15x usage' }
+    ])
     expect(
       parseModelChoices('opencode', 'provider/model\r\nprovider/model\nother/model\nnoise')
     ).toEqual([
@@ -152,6 +160,28 @@ describe('discovery process protocol', () => {
       expect.arrayContaining(['--no-session-persistence', '--safe-mode', '--strict-mcp-config']),
       expect.anything()
     )
+  })
+
+  it('reads Copilot models from a new session over the agent protocol', async () => {
+    const { child, sent, reply } = childFixture()
+    const result = probeProcess(context, 'copilot')
+    reply({ jsonrpc: '2.0', id: 1, result: { protocolVersion: 1 } })
+    reply({
+      jsonrpc: '2.0',
+      id: 2,
+      result: { sessionId: 's', models: { availableModels: [{ modelId: 'auto', name: 'Auto' }] } }
+    })
+    expect(await result).toEqual([{ id: 'auto', label: 'Auto' }])
+    expect(sent.map((value) => (value as { method: string }).method)).toEqual([
+      'initialize',
+      'session/new'
+    ])
+    expect(spawn).toHaveBeenCalledWith(
+      'agent',
+      ['--acp', '--no-remote', '--no-remote-export'],
+      expect.anything()
+    )
+    expect(child.kill).toHaveBeenCalled()
   })
 
   it('rejects malformed responses and kills timed-out children', async () => {

--- a/tests/agent-model-catalog.test.ts
+++ b/tests/agent-model-catalog.test.ts
@@ -1,0 +1,171 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentModelRequest } from '@vornrun/shared/agent-models'
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn(), execFileSync: vi.fn() }))
+vi.mock('../packages/server/src/config-manager', () => ({
+  configManager: { loadConfig: () => ({}) }
+}))
+import { spawn } from 'node:child_process'
+import {
+  createModelCatalogService,
+  parseModelChoices,
+  probeProcess
+} from '../packages/server/src/agent-model-catalog'
+
+const request: AgentModelRequest = { agentType: 'codex', projectPath: '/project' }
+const config = { command: 'codex', args: [] }
+const choices = [{ id: 'm', label: 'Model' }]
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('model catalogs', () => {
+  it('normalizes aliases, model IDs, provider IDs, and disabled choices', () => {
+    expect(
+      parseModelChoices('claude', [
+        { value: 'opus[1m]', resolvedModel: 'versioned', displayName: 'Opus' }
+      ])
+    ).toEqual([{ id: 'opus[1m]', label: 'Opus' }])
+    expect(
+      parseModelChoices('codex', [
+        { id: 'internal', model: 'cli-id', displayName: 'Model' },
+        { id: 'hidden', hidden: true }
+      ])
+    ).toEqual([{ id: 'cli-id', label: 'Model' }])
+    expect(
+      parseModelChoices('copilot', [
+        { id: 'auto' },
+        { id: 'blocked', policy: { state: 'disabled' } }
+      ])
+    ).toEqual([{ id: 'auto', label: 'auto' }])
+    expect(
+      parseModelChoices('opencode', 'provider/model\r\nprovider/model\nother/model\nnoise')
+    ).toEqual([
+      { id: 'provider/model', label: 'provider/model' },
+      { id: 'other/model', label: 'other/model' }
+    ])
+    expect(() => parseModelChoices('claude', {})).toThrow('Invalid')
+  })
+
+  it('deduplicates simultaneous requests, caches, and refreshes explicitly', async () => {
+    const discover = vi.fn(async () => choices)
+    const service = createModelCatalogService(discover)
+    await Promise.all([service(request, config), service(request, config)])
+    await service(request, config)
+    expect(discover).toHaveBeenCalledTimes(1)
+    await service({ ...request, refresh: true }, config)
+    expect(discover).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns stale choices while refreshing and preserves them on failure', async () => {
+    let now = 0
+    const discover = vi.fn(async () => choices)
+    const service = createModelCatalogService(discover, () => now)
+    await service(request, config)
+    now = 300_001
+    discover.mockRejectedValueOnce(new Error('Sign in to the agent'))
+    expect(await service(request, config)).toMatchObject({ choices, status: 'stale' })
+    await Promise.resolve()
+    expect(discover).toHaveBeenCalledTimes(2)
+  })
+
+  it('separates projects and command settings and never probes remotes', async () => {
+    const discover = vi.fn(async () => choices)
+    const service = createModelCatalogService(discover)
+    expect(await service({ ...request, remoteHostId: 'remote' }, config)).toMatchObject({
+      choices: [],
+      status: 'unavailable'
+    })
+    expect(await service({ ...request, agentType: 'gemini' }, config)).toMatchObject({
+      status: 'unavailable'
+    })
+    expect(await service({ ...request, projectPath: '{{context.path}}' }, config)).toMatchObject({
+      status: 'unavailable'
+    })
+    expect(discover).not.toHaveBeenCalled()
+    await service(request, config)
+    await service({ ...request, projectPath: '/another' }, config)
+    await service(request, { ...config, args: ['--profile', 'work'] })
+    expect(discover).toHaveBeenCalledTimes(3)
+  })
+})
+
+function childFixture() {
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: vi.fn(),
+    exitCode: null,
+    signalCode: null
+  })
+  vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>)
+  const sent: unknown[] = []
+  child.stdin.on('data', (chunk) => sent.push(JSON.parse(String(chunk))))
+  return {
+    child,
+    sent,
+    reply: (value: unknown) => child.stdout.write(JSON.stringify(value) + '\n')
+  }
+}
+const context = { command: 'agent', args: [], cwd: '/project', env: {} }
+
+describe('discovery process protocol', () => {
+  it('initializes Codex, follows pagination, and stops without starting a thread', async () => {
+    const { child, sent, reply } = childFixture()
+    const result = probeProcess(context, 'codex')
+    reply({ id: 1, result: {} })
+    reply({ id: 2, result: { data: [{ model: 'first' }], nextCursor: 'next' } })
+    reply({ id: 3, result: { data: [{ model: 'second' }], nextCursor: null } })
+    expect(await result).toEqual([
+      { id: 'first', label: 'first' },
+      { id: 'second', label: 'second' }
+    ])
+    expect(sent).toContainEqual({
+      id: 3,
+      method: 'model/list',
+      params: { limit: 100, includeHidden: false, cursor: 'next' }
+    })
+    expect(sent.map((value) => (value as { method: string }).method)).toEqual([
+      'initialize',
+      'initialized',
+      'model/list',
+      'model/list'
+    ])
+    expect(child.kill).toHaveBeenCalled()
+  })
+
+  it('reads Claude initialization models without sending a user message', async () => {
+    const { sent, reply } = childFixture()
+    const result = probeProcess(context, 'claude')
+    reply({
+      type: 'control_response',
+      response: { subtype: 'success', response: { models: [{ value: 'sonnet' }] } }
+    })
+    expect(await result).toEqual([{ id: 'sonnet', label: 'sonnet' }])
+    expect(sent).toHaveLength(1)
+    expect(spawn).toHaveBeenCalledWith(
+      'agent',
+      expect.arrayContaining(['--no-session-persistence', '--safe-mode', '--strict-mcp-config']),
+      expect.anything()
+    )
+  })
+
+  it('rejects malformed responses and kills timed-out children', async () => {
+    vi.useFakeTimers()
+    const first = childFixture()
+    const malformed = probeProcess(context, 'codex')
+    first.child.stdout.write('not JSON\n')
+    await expect(malformed).rejects.toThrow('unsupported model response')
+    const second = childFixture()
+    const pending = probeProcess(context, 'codex')
+    await Promise.all([
+      expect(pending).rejects.toThrow('timed out'),
+      vi.advanceTimersByTimeAsync(15_000)
+    ])
+    expect(second.child.kill).toHaveBeenCalled()
+  })
+})

--- a/tests/agent-model-catalog.test.ts
+++ b/tests/agent-model-catalog.test.ts
@@ -178,7 +178,7 @@ describe('discovery process protocol', () => {
     ])
     expect(spawn).toHaveBeenCalledWith(
       'agent',
-      ['--acp', '--no-remote', '--no-remote-export'],
+      expect.arrayContaining(['--acp', '--no-remote', '--no-remote-export']),
       expect.anything()
     )
     expect(child.kill).toHaveBeenCalled()

--- a/tests/headless-manager.test.ts
+++ b/tests/headless-manager.test.ts
@@ -33,6 +33,25 @@ import { headlessManager } from '../packages/server/src/headless-manager'
 const spawnMock = spawnImport as unknown as ReturnType<typeof vi.fn>
 
 describe('headlessManager.createHeadless', () => {
+  it('preserves the requested Codex UUID and emits exec resume', () => {
+    const session = headlessManager.createHeadless({
+      agentType: 'codex',
+      projectName: 'p',
+      projectPath: '/p',
+      resumeSessionId: 'known-id',
+      initialPrompt: 'continue'
+    })
+    expect(session.agentSessionId).toBe('known-id')
+    expect(spawnMock.mock.calls.at(-1)?.[1]).toEqual([
+      '-a',
+      'never',
+      'exec',
+      'resume',
+      'known-id',
+      '-'
+    ])
+    headlessManager.killHeadless(session.id)
+  })
   beforeEach(() => {
     spawnMock.mockClear()
   })

--- a/tests/launch-agent-config-form.test.tsx
+++ b/tests/launch-agent-config-form.test.tsx
@@ -101,6 +101,25 @@ function baseConfig(overrides: Partial<LaunchAgentConfig> = {}): LaunchAgentConf
 }
 
 describe('LaunchAgentConfigForm — canUseFromTask visibility', () => {
+  it('clears the model when changing agent, including From task', () => {
+    const onChange = vi.fn()
+    render(
+      <LaunchAgentConfigForm
+        config={baseConfig({ model: 'opus' })}
+        onChange={onChange}
+        triggerType="taskCreated"
+      />
+    )
+    const changeAgent = agentPickerProps.at(-1)!.onChange as (agent: string) => void
+    changeAgent('fromTask')
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ agentType: 'fromTask', model: undefined })
+    )
+    changeAgent('codex')
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ agentType: 'codex', model: undefined })
+    )
+  })
   it('passes allowFromTask=true when trigger is taskStatusChanged', () => {
     render(
       <LaunchAgentConfigForm

--- a/tests/launch-agent-from-shell.test.ts
+++ b/tests/launch-agent-from-shell.test.ts
@@ -43,6 +43,11 @@ beforeEach(() => {
 })
 
 describe('launchAgentFromShell', () => {
+  it('forwards a model override without replacing advanced arguments', async () => {
+    await launchAgentFromShell(shell(), 'codex', 'go', 'chosen')
+    expect(lastPayload().model).toBe('chosen')
+    expect(lastPayload().args).toBeUndefined()
+  })
   it('starts the agent in the shell’s current directory', async () => {
     // A `cd` before the prompt must be honoured, which is the whole point of
     // tracking shellCwd.

--- a/tests/launch-prefs.test.ts
+++ b/tests/launch-prefs.test.ts
@@ -24,10 +24,27 @@ import {
   loadLaunchSettings,
   setPreferredAgent
 } from '../src/renderer/lib/launch-prefs'
+import {
+  getPreferredModel,
+  setPreferredModel,
+  persistLaunchSettings
+} from '../src/renderer/lib/launch-prefs'
 
 const KEY = 'vorn:lastLaunchSettings'
 
 describe('launch-prefs', () => {
+  it('keeps models separate by agent and host and preserves them on launcher saves', () => {
+    setPreferredModel('claude', 'opus')
+    setPreferredModel('codex', 'local-model')
+    setPreferredModel('codex', 'remote-model', 'host')
+    persistLaunchSettings({ agent: 'copilot', project: 'p' })
+    expect(getPreferredModel('claude')).toBe('opus')
+    expect(getPreferredModel('codex')).toBe('local-model')
+    expect(getPreferredModel('codex', 'host')).toBe('remote-model')
+    setPreferredModel('codex', undefined)
+    expect(getPreferredModel('codex')).toBeUndefined()
+    expect(getPreferredModel('codex', 'host')).toBe('remote-model')
+  })
   beforeEach(() => localStorage.clear())
 
   it('round-trips the preferred agent', () => {

--- a/tests/model-arguments.test.ts
+++ b/tests/model-arguments.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn(() => '/bin/agent') }))
+import { buildAgentLaunchLine, buildHeadlessSpawnArgs } from '../packages/server/src/agent-launch'
+import { applyModelArguments, assertModelCommand } from '../packages/server/src/model-arguments'
+import { DEFAULT_AGENT_COMMANDS } from '@vornrun/shared/agent-defaults'
+import { validateModelId } from '@vornrun/shared/agent-models'
+import type { AiAgentType } from '@vornrun/shared/types'
+
+describe('model overrides', () => {
+  it('quotes remote model IDs for the remote POSIX shell even on Windows', () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    try {
+      const line = buildAgentLaunchLine(
+        {
+          agentType: 'claude',
+          projectName: 'p',
+          projectPath: '/p',
+          remoteHostId: 'host',
+          model: 'opus[1m]'
+        },
+        DEFAULT_AGENT_COMMANDS,
+        {}
+      )
+      expect(line).toBe("claude --model 'opus[1m]'")
+    } finally {
+      platform.mockRestore()
+    }
+  })
+  it.each<AiAgentType>(['claude', 'copilot', 'opencode', 'codex'])(
+    'preserves advanced args and selects a model for %s',
+    (agentType) => {
+      const payload = {
+        agentType,
+        projectName: 'p',
+        projectPath: '/p',
+        model: 'provider/model',
+        args: ['--model=old', '--verbose'],
+        initialPrompt: 'hello world'
+      }
+      const line = buildAgentLaunchLine(payload, DEFAULT_AGENT_COMMANDS, {})
+      expect(line).toContain('--model provider/model')
+      expect(line).toContain('--verbose')
+      expect(line).not.toContain('old')
+      const headless = buildHeadlessSpawnArgs(payload, DEFAULT_AGENT_COMMANDS, {})
+      expect(headless.args).toContain('provider/model')
+      expect(headless.args).toContain('--verbose')
+      expect(headless.stdin).toBe('hello world')
+    }
+  )
+  it('removes Codex direct model config overrides but preserves sandbox settings', () => {
+    expect(
+      applyModelArguments(
+        'codex',
+        ['-mold', '-c', 'model="old"', '--config=model="other"', '-a', 'never', '-s', 'read-only'],
+        'new'
+      )
+    ).toEqual(['-a', 'never', '-s', 'read-only', '--model', 'new'])
+  })
+  it('does not interpret positional arguments after the delimiter', () => {
+    expect(applyModelArguments('codex', ['--', '--model', 'prompt'], 'new')).toEqual([
+      '--model',
+      'new',
+      '--',
+      '--model',
+      'prompt'
+    ])
+  })
+  it('rejects unsafe IDs, incomplete flags, and shell wrappers', () => {
+    for (const id of ['', '-flag', 'bad\nmodel']) expect(() => validateModelId(id)).toThrow()
+    expect(validateModelId(' opus[1m] ')).toBe('opus[1m]')
+    expect(() => applyModelArguments('codex', ['--model', '--sandbox'], 'new')).toThrow(
+      'incomplete'
+    )
+    expect(() => assertModelCommand('npx -y codex')).toThrow()
+    expect(() => assertModelCommand('/bin/env codex')).toThrow()
+    expect(() => assertModelCommand('echo x && codex')).toThrow()
+  })
+  it('retains legacy defaults and builds exact Codex headless resume', () => {
+    const payload = {
+      agentType: 'codex' as const,
+      projectName: 'p',
+      projectPath: '/p',
+      resumeSessionId: 'uuid',
+      initialPrompt: 'continue',
+      model: 'chosen'
+    }
+    expect(buildHeadlessSpawnArgs(payload, DEFAULT_AGENT_COMMANDS, {})).toEqual({
+      command: 'codex',
+      args: ['-a', 'never', '--model', 'chosen', 'exec', 'resume', 'uuid', '-'],
+      stdin: 'continue'
+    })
+    expect(buildAgentLaunchLine({ ...payload, model: undefined }, DEFAULT_AGENT_COMMANDS, {})).toBe(
+      'codex resume uuid continue'
+    )
+  })
+})

--- a/tests/model-picker.test.tsx
+++ b/tests/model-picker.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import type { AgentModelCatalog } from '@vornrun/shared/agent-models'
+import { ModelPicker } from '../src/renderer/components/ModelPicker'
+
+afterEach(cleanup)
+
+const listed: AgentModelCatalog = {
+  choices: [
+    { id: 'claude-sonnet-5', label: 'Sonnet 5' },
+    { id: 'claude-opus-5', label: 'Opus 5' }
+  ],
+  status: 'ready',
+  source: 'agent',
+  fetchedAt: Date.now()
+}
+
+function api(list = vi.fn().mockResolvedValue(listed)) {
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    writable: true,
+    value: { listAgentModels: list }
+  })
+  return list
+}
+
+const trigger = () => screen.getByRole('button', { name: /^Model:/ })
+const open = () => fireEvent.click(trigger())
+const choose = (name: string) =>
+  fireEvent.mouseDown(screen.getByRole('option', { name: new RegExp(name) }))
+
+describe('ModelPicker', () => {
+  it('renders nothing for an agent that takes no model', () => {
+    api()
+    const { container } = render(<ModelPicker agentType="gemini" onChange={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('asks for models only when opened, and lists them with the default first', async () => {
+    const list = api()
+    const onChange = vi.fn()
+    render(<ModelPicker agentType="claude" projectPath="/p" onChange={onChange} />)
+    expect(list).not.toHaveBeenCalled()
+    expect(trigger()).toHaveTextContent('Default')
+
+    open()
+    await screen.findByRole('option', { name: /Sonnet 5/ })
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveTextContent('Agent default')
+    expect(options[1]).toHaveTextContent('claude-sonnet-5')
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ agentType: 'claude', projectPath: '/p', refresh: false })
+    )
+    expect(screen.getByText(/From claude/)).toBeInTheDocument()
+
+    choose('Opus 5')
+    expect(onChange).toHaveBeenCalledWith('claude-opus-5')
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+  })
+
+  it('shows the chosen label on the trigger, and the default row clears it', async () => {
+    api()
+    const onChange = vi.fn()
+    render(
+      <ModelPicker agentType="claude" projectPath="/p" value="claude-opus-5" onChange={onChange} />
+    )
+    open()
+    await screen.findByRole('option', { name: /Opus 5/ })
+    expect(trigger()).toHaveTextContent('Opus 5')
+    choose('Agent default')
+    expect(onChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it('takes a typed id on Enter, and refuses one that cannot be an argument', async () => {
+    api()
+    const onChange = vi.fn()
+    render(<ModelPicker agentType="claude" projectPath="/p" onChange={onChange} />)
+    open()
+    await screen.findByRole('option', { name: /Sonnet 5/ })
+    const field = screen.getByRole('textbox', { name: 'Model id' })
+
+    fireEvent.change(field, { target: { value: '--bad' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByText(/leading dash/)).toBeInTheDocument()
+
+    fireEvent.change(field, { target: { value: 'claude-sonnet-5[1m]' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+    expect(onChange).toHaveBeenLastCalledWith('claude-sonnet-5[1m]')
+  })
+
+  it('filters the rows as an id is typed, and picks the exact match on Enter', async () => {
+    api()
+    const onChange = vi.fn()
+    render(<ModelPicker agentType="claude" projectPath="/p" onChange={onChange} />)
+    open()
+    await screen.findByRole('option', { name: /Sonnet 5/ })
+    const field = screen.getByRole('textbox', { name: 'Model id' })
+    fireEvent.change(field, { target: { value: 'opus' } })
+    expect(screen.queryByRole('option', { name: /Sonnet 5/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Agent default/ })).not.toBeInTheDocument()
+    fireEvent.change(field, { target: { value: 'claude-opus-5' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+    expect(onChange).toHaveBeenLastCalledWith('claude-opus-5')
+  })
+
+  it('keeps a saved id that the list does not know, and says when the list is unavailable', async () => {
+    api(vi.fn().mockRejectedValue(new Error('offline')))
+    render(<ModelPicker agentType="claude" projectPath="/p" value="saved-id" onChange={vi.fn()} />)
+    open()
+    await screen.findByText('Could not list models.')
+    expect(screen.getByRole('option', { name: /saved-id/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Refresh models' })).not.toBeInTheDocument()
+  })
+
+  it('asks again on refresh', async () => {
+    const list = api()
+    render(<ModelPicker agentType="claude" projectPath="/p" onChange={vi.fn()} />)
+    open()
+    await screen.findByRole('button', { name: 'Refresh models' })
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Refresh models' }))
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(2))
+    expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ refresh: true }))
+  })
+
+  it('groups OpenCode models by provider', async () => {
+    api(
+      vi.fn().mockResolvedValue({
+        choices: [
+          { id: 'anthropic/claude-sonnet-5', label: 'anthropic/claude-sonnet-5' },
+          { id: 'openai/gpt-5.4', label: 'openai/gpt-5.4' }
+        ],
+        status: 'ready',
+        source: 'agent',
+        fetchedAt: Date.now()
+      })
+    )
+    render(<ModelPicker agentType="opencode" projectPath="/p" onChange={vi.fn()} />)
+    open()
+    await screen.findByRole('option', { name: /gpt-5.4/ })
+    expect(screen.getByText('anthropic')).toBeInTheDocument()
+    expect(screen.getByText('openai')).toBeInTheDocument()
+  })
+
+  it('says where a built-in list came from, without a refresh', async () => {
+    api(
+      vi.fn().mockResolvedValue({
+        choices: [{ id: 'auto', label: 'Auto' }],
+        status: 'ready',
+        source: 'built-in'
+      })
+    )
+    render(<ModelPicker agentType="copilot" projectPath="/p" onChange={vi.fn()} />)
+    open()
+    await screen.findByRole('option', { name: /Auto/ })
+    expect(screen.getByText(/Known ids/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Refresh models' })).not.toBeInTheDocument()
+  })
+
+  it('is settled, not hidden, when the step follows the task', () => {
+    api()
+    render(<ModelPicker variant="form" agentType="claude" disabled onChange={vi.fn()} />)
+    expect(trigger()).toBeDisabled()
+    expect(trigger()).toHaveTextContent("Follows the task's agent")
+  })
+
+  it('shows only the icon in the bordered variant until a model is chosen', () => {
+    api()
+    const { rerender } = render(
+      <ModelPicker variant="bordered" agentType="claude" onChange={vi.fn()} />
+    )
+    expect(trigger()).not.toHaveTextContent('Default')
+    rerender(<ModelPicker variant="bordered" agentType="claude" value="haiku" onChange={vi.fn()} />)
+    expect(trigger()).toHaveTextContent('haiku')
+  })
+})

--- a/tests/model-picker.test.tsx
+++ b/tests/model-picker.test.tsx
@@ -113,7 +113,7 @@ describe('ModelPicker', () => {
     expect(screen.queryByRole('button', { name: 'Refresh models' })).not.toBeInTheDocument()
   })
 
-  it('asks again on refresh, and plainly on the next open', async () => {
+  it('asks again only on refresh, and keeps the list across a close and reopen', async () => {
     const list = api()
     render(<ModelPicker agentType="claude" projectPath="/p" onChange={vi.fn()} />)
     open()
@@ -124,8 +124,8 @@ describe('ModelPicker', () => {
     fireEvent.click(trigger())
     await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
     open()
-    await waitFor(() => expect(list).toHaveBeenCalledTimes(3))
-    expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ refresh: false }))
+    await screen.findByRole('option', { name: /Sonnet 5/ })
+    expect(list).toHaveBeenCalledTimes(2)
   })
 
   it('groups OpenCode models by provider', async () => {
@@ -146,10 +146,10 @@ describe('ModelPicker', () => {
     expect(screen.getByText('openai')).toBeInTheDocument()
   })
 
-  it('says it is asking while the list is empty, and a card chip asks only when opened', async () => {
+  it('says it is asking while the list is empty, and asks only when opened unless told to prefetch', async () => {
     let resolve!: (value: AgentModelCatalog) => void
     const list = api(vi.fn().mockReturnValue(new Promise<AgentModelCatalog>((r) => (resolve = r))))
-    render(<ModelPicker agentType="claude" projectPath="/p" onChange={vi.fn()} />)
+    render(<ModelPicker prefetch agentType="claude" projectPath="/p" onChange={vi.fn()} />)
     await waitFor(() => expect(list).toHaveBeenCalledTimes(1))
     open()
     expect(screen.getByRole('status')).toHaveTextContent('Asking claude')
@@ -158,13 +158,11 @@ describe('ModelPicker', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
     cleanup()
 
-    const bordered = api()
-    render(
-      <ModelPicker variant="bordered" agentType="claude" projectPath="/p" onChange={vi.fn()} />
-    )
-    expect(bordered).not.toHaveBeenCalled()
+    const lazy = api()
+    render(<ModelPicker agentType="claude" projectPath="/p" onChange={vi.fn()} />)
+    expect(lazy).not.toHaveBeenCalled()
     open()
-    await waitFor(() => expect(bordered).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(lazy).toHaveBeenCalledTimes(1))
   })
 
   it('is settled, not hidden, when the step follows the task', () => {

--- a/tests/model-picker.test.tsx
+++ b/tests/model-picker.test.tsx
@@ -13,7 +13,6 @@ const listed: AgentModelCatalog = {
     { id: 'claude-opus-5', label: 'Opus 5' }
   ],
   status: 'ready',
-  source: 'agent',
   fetchedAt: Date.now()
 }
 
@@ -38,11 +37,10 @@ describe('ModelPicker', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('asks for models only when opened, and lists them with the default first', async () => {
+  it('asks for models once it knows the agent, and lists them with the default first', async () => {
     const list = api()
     const onChange = vi.fn()
     render(<ModelPicker agentType="claude" projectPath="/p" onChange={onChange} />)
-    expect(list).not.toHaveBeenCalled()
     expect(trigger()).toHaveTextContent('Default')
 
     open()
@@ -138,7 +136,6 @@ describe('ModelPicker', () => {
           { id: 'openai/gpt-5.4', label: 'openai/gpt-5.4' }
         ],
         status: 'ready',
-        source: 'agent',
         fetchedAt: Date.now()
       })
     )
@@ -149,19 +146,25 @@ describe('ModelPicker', () => {
     expect(screen.getByText('openai')).toBeInTheDocument()
   })
 
-  it('says where a built-in list came from, without a refresh', async () => {
-    api(
-      vi.fn().mockResolvedValue({
-        choices: [{ id: 'auto', label: 'Auto' }],
-        status: 'ready',
-        source: 'built-in'
-      })
-    )
-    render(<ModelPicker agentType="copilot" projectPath="/p" onChange={vi.fn()} />)
+  it('says it is asking while the list is empty, and a card chip asks only when opened', async () => {
+    let resolve!: (value: AgentModelCatalog) => void
+    const list = api(vi.fn().mockReturnValue(new Promise<AgentModelCatalog>((r) => (resolve = r))))
+    render(<ModelPicker agentType="claude" projectPath="/p" onChange={vi.fn()} />)
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(1))
     open()
-    await screen.findByRole('option', { name: /Auto/ })
-    expect(screen.getByText(/Known ids/)).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Refresh models' })).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('Asking claude')
+    resolve(listed)
+    await screen.findByRole('option', { name: /Sonnet 5/ })
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    cleanup()
+
+    const bordered = api()
+    render(
+      <ModelPicker variant="bordered" agentType="claude" projectPath="/p" onChange={vi.fn()} />
+    )
+    expect(bordered).not.toHaveBeenCalled()
+    open()
+    await waitFor(() => expect(bordered).toHaveBeenCalledTimes(1))
   })
 
   it('is settled, not hidden, when the step follows the task', () => {

--- a/tests/model-picker.test.tsx
+++ b/tests/model-picker.test.tsx
@@ -115,7 +115,7 @@ describe('ModelPicker', () => {
     expect(screen.queryByRole('button', { name: 'Refresh models' })).not.toBeInTheDocument()
   })
 
-  it('asks again on refresh', async () => {
+  it('asks again on refresh, and plainly on the next open', async () => {
     const list = api()
     render(<ModelPicker agentType="claude" projectPath="/p" onChange={vi.fn()} />)
     open()
@@ -123,6 +123,11 @@ describe('ModelPicker', () => {
     fireEvent.mouseDown(screen.getByRole('button', { name: 'Refresh models' }))
     await waitFor(() => expect(list).toHaveBeenCalledTimes(2))
     expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ refresh: true }))
+    fireEvent.click(trigger())
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument())
+    open()
+    await waitFor(() => expect(list).toHaveBeenCalledTimes(3))
+    expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ refresh: false }))
   })
 
   it('groups OpenCode models by provider', async () => {

--- a/tests/model-picker.test.tsx
+++ b/tests/model-picker.test.tsx
@@ -161,7 +161,7 @@ describe('ModelPicker', () => {
 
   it('is settled, not hidden, when the step follows the task', () => {
     api()
-    render(<ModelPicker variant="form" agentType="claude" disabled onChange={vi.fn()} />)
+    render(<ModelPicker variant="form" agentType="fromTask" onChange={vi.fn()} />)
     expect(trigger()).toBeDisabled()
     expect(trigger()).toHaveTextContent("Follows the task's agent")
   })

--- a/tests/prompt-launcher-model.test.tsx
+++ b/tests/prompt-launcher-model.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+const state = vi.hoisted(() => ({
+  config: { projects: [{ name: 'Project', path: '/project' }] },
+  addTerminal: vi.fn(),
+  isNewAgentDialogOpen: false
+}))
+vi.mock('../src/renderer/stores', () => ({
+  useAppStore: (select: (value: typeof state) => unknown) => select(state)
+}))
+vi.mock('../src/renderer/hooks/useAgentInstallStatus', () => ({
+  useAgentInstallStatus: () => ({ status: { codex: true } })
+}))
+vi.mock('../src/renderer/hooks/useLaunchSettings', () => ({
+  useLaunchSettings: () => ({
+    selectedProject: 'Project',
+    selectedAgent: 'codex',
+    worktreeMode: 'project-root',
+    selectedBranch: '',
+    activeProjectPath: '',
+    filteredProjects: [],
+    persist: vi.fn(),
+    reset: vi.fn()
+  })
+}))
+vi.mock('../src/renderer/hooks/usePreferredModel', () => ({
+  usePreferredModel: () => ({ model: 'chosen', setModel: vi.fn() })
+}))
+import { PromptLauncher } from '../src/renderer/components/PromptLauncher'
+
+beforeEach(() => {
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    writable: true,
+    value: { createTerminal: vi.fn().mockResolvedValue({ id: 'new-session' }) }
+  })
+})
+afterEach(cleanup)
+
+it('launches the selected model without overriding advanced arguments', async () => {
+  render(<PromptLauncher mode="inline" />)
+  const input = screen.getByPlaceholderText('Describe your task...')
+  fireEvent.change(input, { target: { value: 'hello' } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+  await waitFor(() =>
+    expect(window.api.createTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'chosen', agentType: 'codex', initialPrompt: 'hello' })
+    )
+  )
+  expect(vi.mocked(window.api.createTerminal).mock.calls[0][0].args).toBeUndefined()
+})
+
+it('shows an actionable model launch error', async () => {
+  vi.mocked(window.api.createTerminal).mockRejectedValue(
+    new Error('Move flags out of the agent command')
+  )
+  render(<PromptLauncher mode="inline" />)
+  fireEvent.keyDown(screen.getByPlaceholderText('Describe your task...'), { key: 'Enter' })
+  expect(await screen.findByRole('alert')).toHaveTextContent('Move flags out of the agent command')
+})

--- a/tests/pty-manager-recovery.test.ts
+++ b/tests/pty-manager-recovery.test.ts
@@ -120,6 +120,7 @@ vi.mock('../packages/server/src/process-utils', async () => {
 
 import { ptyManager } from '../packages/server/src/pty-manager'
 import { createWorktree, isGitRepo } from '../packages/server/src/git-utils'
+import { buildAgentLaunchLine } from '../packages/server/src/agent-launch'
 
 const createWorktreeMock = vi.mocked(createWorktree)
 const isGitRepoMock = vi.mocked(isGitRepo)
@@ -154,6 +155,29 @@ function createAgent(overrides: Partial<CreateTerminalPayload> = {}): {
   })
   return { session, fake: lastPty() }
 }
+
+it('records the exact Codex resume ID immediately', () => {
+  const { session } = createAgent({ agentType: 'codex', resumeSessionId: 'known-id' })
+  expect(session.agentSessionId).toBe('known-id')
+})
+
+it('records a remote Codex resume ID without local discovery', () => {
+  const { session } = createAgent({
+    agentType: 'codex',
+    resumeSessionId: 'remote-id',
+    remoteHostId: REMOTE_HOST.id
+  })
+  expect(session.agentSessionId).toBe('remote-id')
+  expect(session.remoteHostId).toBe(REMOTE_HOST.id)
+})
+
+it('rejects invalid model selection before spawning a PTY', () => {
+  vi.mocked(buildAgentLaunchLine).mockImplementationOnce(() => {
+    throw new Error('Invalid model')
+  })
+  expect(() => createAgent({ model: '-invalid' })).toThrow()
+  expect(spawnMock).not.toHaveBeenCalled()
+})
 
 function messagesOn(channel: string): Record<string, unknown>[] {
   return messages.filter((m) => m.channel === channel).map((m) => m.payload)

--- a/tests/workflow-partial-and-retry.test.ts
+++ b/tests/workflow-partial-and-retry.test.ts
@@ -37,6 +37,7 @@ const releaseWorkflowRun = vi.fn(
 const launchedPrompts = new Map<string, string>()
 let onSessionCreated: ((id: string) => void) | null = null
 
+const createTerminal = vi.fn(() => Promise.resolve({ id: 'terminal' }))
 const createHeadlessSession = vi.fn((opts: { initialPrompt?: string }) => {
   const id = `sess-${++sessionSeq}`
   launchedPrompts.set(id, opts.initialPrompt ?? '')
@@ -145,6 +146,7 @@ function nextSession(): Promise<string> {
 }
 
 beforeEach(() => {
+  createHeadlessSession.mockClear()
   vi.useFakeTimers()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(globalThis as any).Notification = { permission: 'denied' }
@@ -160,6 +162,7 @@ beforeEach(() => {
     claimWorkflowRun,
     releaseWorkflowRun,
     createHeadlessSession,
+    createTerminal,
     killHeadlessSession: vi.fn(() => Promise.resolve()),
     saveWorkflowRun: vi.fn(() => Promise.resolve()),
     reportWorkflowComplete: vi.fn(() => Promise.resolve()),
@@ -178,6 +181,31 @@ afterEach(() => {
 })
 
 describe('running up to one step', () => {
+  it('passes a literal model override to headless launch', async () => {
+    const wf = makeChain()
+    Object.assign(wf.nodes[1].config, { model: 'opus[1m]' })
+    const run = executeWorkflow(wf, undefined, { targetNodeId: 'a' })
+    emitExit(await nextSession(), 0)
+    expect((await run).status).toBe('success')
+    expect(createHeadlessSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({ model: 'opus[1m]' })
+    )
+  })
+
+  it('passes a model to interactive launch without interactive preferences', async () => {
+    const wf = makeChain()
+    Object.assign(wf.nodes[1].config, { model: 'opus[1m]', headless: false })
+    const result = await executeWorkflow(wf, undefined, { targetNodeId: 'a' })
+    expect(result.status).toBe('success')
+    expect(createTerminal).toHaveBeenCalledWith(expect.objectContaining({ model: 'opus[1m]' }))
+  })
+
+  it('rejects imported From task nodes containing model overrides', async () => {
+    const wf = makeChain()
+    Object.assign(wf.nodes[1].config, { model: 'opus', agentType: 'fromTask' })
+    const result = await executeWorkflow(wf, undefined, { targetNodeId: 'a' })
+    expect(result.nodeStates.find((n) => n.nodeId === 'a')?.error).toContain('concrete agent')
+  })
   it('executes only the target and its upstream slice', async () => {
     const wf = makeChain()
     const runPromise = executeWorkflow(wf, undefined, { targetNodeId: 'b' })

--- a/tests/workflow-portability.test.ts
+++ b/tests/workflow-portability.test.ts
@@ -49,6 +49,7 @@ function workflow(overrides: Partial<WorkflowDefinition> = {}): WorkflowDefiniti
         label: 'Write',
         config: {
           agentType: 'claude',
+          model: 'opus[1m]',
           projectName: 'Novum',
           projectPath: PROJECT,
           existingWorktreePath: `${PROJECT}/wt/draft`,
@@ -140,6 +141,7 @@ describe('round trip', () => {
 
     const agent = imported.nodes.find((n) => n.id === 'write-1')!.config as Record<string, unknown>
     expect(agent.existingWorktreePath).toBe('/Users/other/code/novum2/wt/draft')
+    expect(agent.model).toBe('opus[1m]')
   })
 
   it('gives the same id on every machine, so re-import updates in place', () => {


### PR DESCRIPTION
## What

A model picker for agent launches. A person can choose the model an agent runs with in three places: the prompt launcher, a shell card's intent bar, and a workflow's Launch Agent step.

- **Shared** `agent-models.ts`: catalog types, `supportsModelSelection`, `validateModelId`. `model?: string` on `CreateTerminalPayload` and `LaunchAgentConfig`; `agent:listModels` RPC.
- **Server** `model-arguments.ts` rewrites an agent's arguments with the chosen model as their one model selector (strips `--model`, `-m`, `--model=`, codex `-c model=`; nothing past `--` is touched) and refuses a model on a shell-wrapper command. `agent-model-catalog.ts` asks each CLI for its models with its own login: Claude over stream-json initialize, Codex over `app-server model/list`, Copilot over `--acp session/new`, OpenCode from `opencode models`. Five-minute cache per agent, project and command, stale list while a refresh runs.
- **Launch** Both managers build the launch line before a worktree or PTY exists, so a line that cannot be built creates nothing. The workflow engine passes the model through and refuses a model on a From Task step.
- **Renderer** One `ModelPicker` with `compact`, `bordered` and `form` variants: "Agent default" first, listed rows with the id as a hint, provider sections for OpenCode, a bottom id field that filters and takes a typed id on Enter, a footer with where the list came from and an icon-only refresh. Fetching lives in `useAgentModelCatalog`; the launcher and the form prefetch, a card's chip waits to be opened. The anchored menu is a shared `useAnchoredMenu` hook, also used by `AgentPicker`. The choice is remembered per agent and host.

Also carried: Codex headless `exec resume <id>`, and the session-id capture guard (a known id or a remote session is never replaced by the local lookup).

## Notes

- A Copilot probe leaves one small session folder under `~/.copilot/session-state`; at most once per five minutes per project. `--no-remote --no-remote-export` keep it off github.com.
- A command like `~/bin/claude` is written as configured; only a path with spaces that names one file is quoted.

## Tests

525 files, 6752 tests green. New suites: `model-arguments`, `agent-model-catalog`, `model-picker`, `prompt-launcher-model`, `launch-prefs`; cases added to `agent-launch`, `headless-manager`, `pty-manager-recovery`, `workflow-partial-and-retry`, `launch-agent-config-form`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE
