### PR TITLE
Encrypt the cookies Vorn keeps on disk

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -46,6 +46,10 @@ linux:
   category: Development
   icon: resources/icon.png
 
+electronFuses:
+  # One-way: once on, turning it off corrupts every cookie Vorn has stored.
+  enableCookieEncryption: true
+
 npmRebuild: true
 afterPack: scripts/afterPack.cjs
 files:

--- a/tests/electron-builder-fuses.test.ts
+++ b/tests/electron-builder-fuses.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+/** The keys set under `electronFuses:`, read as text so the test needs no YAML parser. */
+function fuseSettings(): Record<string, string> {
+  const lines = readFileSync(path.resolve(__dirname, '../electron-builder.yml'), 'utf8').split('\n')
+  const start = lines.findIndex((line) => line.trim() === 'electronFuses:')
+  if (start === -1) return {}
+  const settings: Record<string, string> = {}
+  for (const line of lines.slice(start + 1)) {
+    if (!/^\s/.test(line) && line.trim()) break
+    const setting = line.match(/^\s+([A-Za-z]+):\s*(\S+)/)
+    if (setting) settings[setting[1]!] = setting[2]!
+  }
+  return settings
+}
+
+describe('the fuses the packaged app is built with', () => {
+  it('encrypts the cookie store, which cannot be turned off again without corrupting it', () => {
+    expect(fuseSettings().enableCookieEncryption).toBe('true')
+  })
+
+  it('leaves every other fuse alone, since the server runs through ELECTRON_RUN_AS_NODE', () => {
+    expect(Object.keys(fuseSettings())).toEqual(['enableCookieEncryption'])
+  })
+})


### PR DESCRIPTION
## Summary

Turns on Electron's `enableCookieEncryption` fuse in `electron-builder.yml`, so cookies Vorn stores on disk are encrypted with the OS keychain key. This matters now because connectors that sign in through a Vorn window keep their login in a browser profile on disk.

- One-way: once a build ships with the fuse on, turning it off later corrupts every stored cookie, so the config carries a one-line warning.
- Packaged builds only; `yarn dev` is unaffected.
- A test pins the `electronFuses` block to this one key, so no other fuse flips by accident.

## Testing

- `npx @electron/fuses read --app dist/mac-arm64/Vorn.app` on a local pack: `EnableCookieEncryption is Enabled`, every other fuse unchanged.
- `tests/electron-builder-fuses.test.ts` passes.
- Not yet checked by hand: a browser-pane login made on a build without the fuse surviving the upgrade. Chromium reads cookies stored before encryption was on and encrypts them when next written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE