### PR TITLE
Let a connector sign in through a Vorn window

### DIFF
--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -202,6 +202,25 @@ Two rules make a pull trigger reliable, and the SDK enforces both:
    it. Use `>=` when filtering on `since` and sort ascending; returning a few
    items again is free, because the SDK drops anything already delivered.
 
+## Act through a signed-in window
+
+A service with no API to key can still be reached as the person using it. Declare the `browser` rung with the page to sign in on, the origins the connector may act on, and a check that answers 2xx only while someone is signed in:
+
+```ts
+auth: {
+  rung: 'browser',
+  browser: {
+    signInUrl: 'https://example.com/login',
+    origins: ['https://example.com', 'https://*.example.com'],
+    check: { url: 'https://example.com/api/me', identity: ['name', 'handle'] }
+  }
+}
+```
+
+Vorn opens a window on a browser profile that belongs to one connection, and the person signs in there. The connector's code then gets `ctx.session.fetch` beside `ctx.fetch`. A call through `ctx.session.fetch` runs inside that signed-in window as a same-origin request, so the service sees its own page asking and no cookie reaches the connector. Calls outside `origins` are refused. `ctx.fetch` stays a plain fetch for public reads, such as a feed, which work before anyone signs in. A `browser` connector's declared `request` actions go through the window.
+
+`--mock` serves signed-in calls from the same routes as every other call. A `--live` run from a terminal has no window, so it skips them.
+
 ## Dedupe strategies
 
 `dedupe` tells the SDK how to recognize new items, and it then owns the cursor

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -1,3 +1,4 @@
+import { SessionUnavailableError } from './session'
 import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { resolve, sep } from 'node:path'
@@ -351,7 +352,9 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
       try {
         await runAction(connector, action.type, args, {
           config,
-          ...(options.now && { now: options.now })
+          ...(options.now && { now: options.now }),
+          // Looked up per call, so the stub installed for this run serves the signed-in calls too.
+          sessionFetchImpl: (input, init) => globalThis.fetch(input, init)
         })
         return undefined
       } catch (error) {
@@ -604,6 +607,13 @@ export function liveExamines(connector: Connector): boolean {
  * leave real issues behind, and one of `closeIssue('check')` would only prove
  * that no such issue exists.
  */
+function needsWindow(error: unknown): boolean {
+  return (
+    error instanceof SessionUnavailableError ||
+    (error instanceof Error && error.cause instanceof SessionUnavailableError)
+  )
+}
+
 async function liveFindings(connector: Connector, options: CheckOptions): Promise<CheckFinding[]> {
   if (!options.live) return []
   const found: CheckFinding[] = []
@@ -638,6 +648,8 @@ async function liveFindings(connector: Connector, options: CheckOptions): Promis
         ...(options.now && { now: options.now })
       })
     } catch (error) {
+      // A signed-in call needs a Vorn window, which a live check run from a terminal does not have.
+      if (needsWindow(error)) continue
       const reason = error instanceof Error ? error.message : String(error)
       // A service can refuse for reasons that are not the connector's fault —
       // an empty sandbox, a rate limit — so only a refusal to let it in at all

--- a/packages/connector-sdk/src/check.ts
+++ b/packages/connector-sdk/src/check.ts
@@ -353,8 +353,7 @@ async function mockFindings(connector: Connector, options: CheckOptions): Promis
         await runAction(connector, action.type, args, {
           config,
           ...(options.now && { now: options.now }),
-          // Looked up per call, so the stub installed for this run serves the signed-in calls too.
-          sessionFetchImpl: (input, init) => globalThis.fetch(input, init)
+          sessionFetchImpl: globalThis.fetch
         })
         return undefined
       } catch (error) {
@@ -598,6 +597,13 @@ export function liveExamines(connector: Connector): boolean {
   return connector.preflight !== undefined || connector.actions.some(liveRunnable)
 }
 
+function needsWindow(error: unknown): boolean {
+  return (
+    error instanceof SessionUnavailableError ||
+    (error instanceof Error && error.cause instanceof SessionUnavailableError)
+  )
+}
+
 /**
  * Ask the connector, against the real service, the questions only it can answer.
  *
@@ -607,13 +613,6 @@ export function liveExamines(connector: Connector): boolean {
  * leave real issues behind, and one of `closeIssue('check')` would only prove
  * that no such issue exists.
  */
-function needsWindow(error: unknown): boolean {
-  return (
-    error instanceof SessionUnavailableError ||
-    (error instanceof Error && error.cause instanceof SessionUnavailableError)
-  )
-}
-
 async function liveFindings(connector: Connector, options: CheckOptions): Promise<CheckFinding[]> {
   if (!options.live) return []
   const found: CheckFinding[] = []

--- a/packages/connector-sdk/src/dedupe.ts
+++ b/packages/connector-sdk/src/dedupe.ts
@@ -198,7 +198,8 @@ export async function pollWithDedupe(
       ...(state && { lastItemId: state.id }),
       ...(context.limit !== undefined && { limit: context.limit }),
       now: context.now,
-      fetch: context.fetch
+      fetch: context.fetch,
+      ...(context.session && { session: context.session })
     })
     return lastItemPoll(fetched, state, context, polledAt)
   }
@@ -212,7 +213,8 @@ export async function pollWithDedupe(
     ...(since !== undefined && { since }),
     ...(context.limit !== undefined && { limit: context.limit }),
     now: context.now,
-    fetch: context.fetch
+    fetch: context.fetch,
+    ...(context.session && { session: context.session })
   })
   return timestampPoll(fetched, state, context, polledAt)
 }

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -14,7 +14,7 @@ import type {
   ExtensionPlatform,
   PaneContribution
 } from './types'
-import { ORIGIN_PATTERN, withinOrigins } from './session'
+import { ORIGIN_PATTERN, withinOrigins } from './origins'
 
 const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -1,6 +1,7 @@
 import type {
   ActivationPredicate,
   AuthRung,
+  BrowserSignIn,
   Connector,
   ConnectorConfig,
   ConnectorDefinition,
@@ -13,6 +14,7 @@ import type {
   ExtensionPlatform,
   PaneContribution
 } from './types'
+import { ORIGIN_PATTERN, withinOrigins } from './session'
 
 const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 
@@ -27,7 +29,7 @@ const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 const PATH_DATA_PATTERN = /^[MmZzLlHhVvCcSsQqTtAa0-9\s,.\-+eE]+$/
 const VIEW_BOX_PATTERN = /^-?[\d.]+\s+-?[\d.]+\s+-?[\d.]+\s+-?[\d.]+$/
 const DEDUPE_STRATEGIES: DedupeStrategy[] = ['timestamp', 'lastItem']
-const AUTH_RUNGS: AuthRung[] = ['none', 'cli', 'key', 'oauth']
+const AUTH_RUNGS: AuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
 
 /** Everything an extension may ask the host for; anything else is not grantable. */
 export const EXTENSION_PERMISSIONS: ExtensionPermission[] = [
@@ -178,13 +180,51 @@ function assertAuth(definition: ConnectorDefinition): void {
     }
   }
 
-  if (auth.rung === 'none') {
+  if (auth.rung === 'browser') assertBrowserSignIn(id, auth.browser)
+
+  if (auth.rung === 'none' || auth.rung === 'browser') {
     const secret = (definition.config ?? []).find((field) => field.secret === true)
     if (secret) {
+      const claim = auth.rung === 'none' ? 'needs no sign-in' : 'signs in through a Vorn window'
       throw new Error(
-        `Connector ${id} claims it needs no sign-in but declares secret field "${secret.key}"`
+        `Connector ${id} claims it ${claim} but declares secret field "${secret.key}"`
       )
     }
+  }
+}
+
+/** The window, the origins it may act on, and the check that says who is signed in. */
+function assertBrowserSignIn(id: string, browser: BrowserSignIn | undefined): void {
+  if (!browser) {
+    throw new Error(
+      `Connector ${id} signs in through a Vorn window but declares no browser sign-in`
+    )
+  }
+  const origins = Array.isArray(browser.origins) ? browser.origins : []
+  const bad = origins.find((origin) => typeof origin !== 'string' || !ORIGIN_PATTERN.test(origin))
+  if (origins.length === 0 || bad !== undefined) {
+    throw new Error(
+      `Connector ${id} must name its origins as https://host or https://*.host` +
+        (bad !== undefined ? `; ${JSON.stringify(bad)} is neither` : '')
+    )
+  }
+  const places: Array<[string, unknown]> = [
+    ['sign-in page', browser.signInUrl],
+    ['signed-in check', browser.check?.url]
+  ]
+  for (const [what, url] of places) {
+    if (typeof url !== 'string' || !withinOrigins(origins, url)) {
+      throw new Error(
+        `Connector ${id} puts its ${what} ${JSON.stringify(url ?? '')} outside its origins`
+      )
+    }
+  }
+  const identity = browser.check?.identity
+  if (
+    !Array.isArray(identity) ||
+    identity.some((path) => typeof path !== 'string' || !path.trim())
+  ) {
+    throw new Error(`Connector ${id} must name its identity fields as non-empty strings`)
   }
 }
 

--- a/packages/connector-sdk/src/harness.ts
+++ b/packages/connector-sdk/src/harness.ts
@@ -17,6 +17,8 @@ export interface HarnessOptions {
   now?: () => string
   /** Answer the connector's calls from the test rather than the network. */
   fetchImpl?: typeof fetch
+  /** Answer its signed-in calls; defaults to `fetchImpl`, so one stub serves both. */
+  sessionFetchImpl?: typeof fetch
   /** Fake clock for backoff, so a retry test costs no real time. */
   sleep?: (ms: number) => Promise<void>
 }
@@ -182,10 +184,12 @@ export function createConnectorHarness(
   connector: Connector,
   harnessOptions: HarnessOptions = {}
 ): ConnectorHarness {
+  const signedIn = harnessOptions.sessionFetchImpl ?? harnessOptions.fetchImpl
   const defaults = (options: RunPollOptions = {}): RunPollOptions => ({
     ...(harnessOptions.config && { config: harnessOptions.config }),
     ...(harnessOptions.now && { now: harnessOptions.now }),
     ...(harnessOptions.fetchImpl && { fetchImpl: harnessOptions.fetchImpl }),
+    ...(signedIn && { sessionFetchImpl: signedIn }),
     ...(harnessOptions.sleep && { sleep: harnessOptions.sleep }),
     ...options
   })
@@ -198,6 +202,7 @@ export function createConnectorHarness(
         ...(harnessOptions.config && { config: harnessOptions.config }),
         ...(harnessOptions.now && { now: harnessOptions.now }),
         ...(harnessOptions.fetchImpl && { fetchImpl: harnessOptions.fetchImpl }),
+        ...(signedIn && { sessionFetchImpl: signedIn }),
         ...(harnessOptions.sleep && { sleep: harnessOptions.sleep })
       }),
     manifest: () => connectorManifest(connector),

--- a/packages/connector-sdk/src/host.ts
+++ b/packages/connector-sdk/src/host.ts
@@ -1,3 +1,4 @@
+import { loopbackEndpoint } from './loopback'
 import type { ExtensionHost, ExtensionHostMethod, ExtensionUsage } from './types'
 
 /**
@@ -41,31 +42,13 @@ export interface HostBridgeOptions {
 /** Long enough for a git read on a large tree, short enough to fail a wedged host. */
 const HOST_TIMEOUT_MS = 15_000
 
-/** The bridge is served on this machine, so a token never leaves it; a URL keeps IPv6 in brackets. */
-const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '[::1]']
-
 function endpoint(env: NodeJS.ProcessEnv): { url: string; token: string } {
-  const url = env[HOST_URL_ENV]?.trim()
-  const token = env[HOST_TOKEN_ENV]?.trim()
-  if (!url || !token) {
-    throw new Error(
-      `This extension was started without a host bridge; ${HOST_URL_ENV} and ${HOST_TOKEN_ENV} are set by Vorn`
-    )
-  }
-  // Checked before the token is sent: a bridge address that is not this machine
-  // would hand the grant to whoever set the variable.
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    throw new Error(`${HOST_URL_ENV} is ${JSON.stringify(url)}, which is not a URL`)
-  }
-  if (parsed.protocol !== 'http:' || !LOOPBACK_HOSTS.includes(parsed.hostname)) {
-    throw new Error(
-      `${HOST_URL_ENV} is ${JSON.stringify(url)}; the bridge is served on this machine, over http on ${LOOPBACK_HOSTS.join(', ')}`
-    )
-  }
-  return { url: url.replace(/\/$/, ''), token }
+  return loopbackEndpoint(env, {
+    urlVar: HOST_URL_ENV,
+    tokenVar: HOST_TOKEN_ENV,
+    missing: `This extension was started without a host bridge; ${HOST_URL_ENV} and ${HOST_TOKEN_ENV} are set by Vorn`,
+    served: 'the bridge is served on this machine'
+  })
 }
 
 /** The host as an extension process reaches it, over the bridge Vorn served it. */

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -7,6 +7,15 @@ export {
   HOST_PERMISSIONS
 } from './define'
 export { createExtensionHost, PermissionDeniedError, HOST_URL_ENV, HOST_TOKEN_ENV } from './host'
+export {
+  createSessionFetch,
+  SessionUnavailableError,
+  SESSION_HOST_ENV,
+  SESSION_TOKEN_ENV,
+  ORIGIN_PATTERN,
+  withinOrigins
+} from './session'
+export type { SessionFetchOptions } from './session'
 export type { HostBridgeOptions } from './host'
 export { checkConnector, formatFindings, runConformance, CHECK_OWNERS } from './check'
 export type {
@@ -83,6 +92,8 @@ export type {
   ActionOutputField,
   ActionRequest,
   AuthRung,
+  BrowserSignIn,
+  SessionContext,
   PaginationStrategy,
   PostReceiveOp,
   Connector,

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -10,11 +10,11 @@ export { createExtensionHost, PermissionDeniedError, HOST_URL_ENV, HOST_TOKEN_EN
 export {
   createSessionFetch,
   SessionUnavailableError,
-  SESSION_HOST_ENV,
-  SESSION_TOKEN_ENV,
-  ORIGIN_PATTERN,
-  withinOrigins
+  SessionRefusedError,
+  BROWSER_HOST_ENV,
+  BROWSER_TOKEN_ENV
 } from './session'
+export { ORIGIN_PATTERN, withinOrigins } from './origins'
 export type { SessionFetchOptions } from './session'
 export type { HostBridgeOptions } from './host'
 export { checkConnector, formatFindings, runConformance, CHECK_OWNERS } from './check'

--- a/packages/connector-sdk/src/index.ts
+++ b/packages/connector-sdk/src/index.ts
@@ -12,7 +12,9 @@ export {
   SessionUnavailableError,
   SessionRefusedError,
   BROWSER_HOST_ENV,
-  BROWSER_TOKEN_ENV
+  BROWSER_TOKEN_ENV,
+  SESSION_CALL_HEADER,
+  SESSION_CALL_META
 } from './session'
 export { ORIGIN_PATTERN, withinOrigins } from './origins'
 export type { SessionFetchOptions } from './session'

--- a/packages/connector-sdk/src/loopback.ts
+++ b/packages/connector-sdk/src/loopback.ts
@@ -1,0 +1,35 @@
+/** Where a Vorn endpoint for this process is served; a URL keeps IPv6 in brackets. */
+export const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '[::1]']
+
+export interface LoopbackNames {
+  urlVar: string
+  tokenVar: string
+  /** Said when either variable is missing. */
+  missing: string
+  /** Names what is served, as in "the bridge is served on this machine". */
+  served: string
+}
+
+/** Read an endpoint Vorn set in the environment, refusing one that is not on this machine. */
+export function loopbackEndpoint(
+  env: NodeJS.ProcessEnv,
+  names: LoopbackNames,
+  fail: (message: string) => Error = (message) => new Error(message)
+): { url: string; token: string } {
+  const url = env[names.urlVar]?.trim()
+  const token = env[names.tokenVar]?.trim()
+  if (!url || !token) throw fail(names.missing)
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw fail(`${names.urlVar} is ${JSON.stringify(url)}, which is not a URL`)
+  }
+  // Checked before the token is sent, so a variable pointing elsewhere cannot collect it.
+  if (parsed.protocol !== 'http:' || !LOOPBACK_HOSTS.includes(parsed.hostname)) {
+    throw fail(
+      `${names.urlVar} is ${JSON.stringify(url)}; ${names.served}, over http on ${LOOPBACK_HOSTS.join(', ')}`
+    )
+  }
+  return { url: url.replace(/\/$/, ''), token }
+}

--- a/packages/connector-sdk/src/origins.ts
+++ b/packages/connector-sdk/src/origins.ts
@@ -1,0 +1,20 @@
+/** An origin a connector may act on: `https://host`, or `https://*.host` for every subdomain. */
+export const ORIGIN_PATTERN = /^https:\/\/(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/i
+
+/** Whether `url` is on one of the declared origins. */
+export function withinOrigins(origins: readonly string[], url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:' || parsed.port !== '') return false
+  const target = parsed.hostname.toLowerCase()
+  return origins.some((origin) => {
+    if (!ORIGIN_PATTERN.test(origin)) return false
+    const wildcard = origin.startsWith('https://*.')
+    const host = origin.slice(wildcard ? 'https://*.'.length : 'https://'.length).toLowerCase()
+    return wildcard ? target.endsWith(`.${host}`) : target === host
+  })
+}

--- a/packages/connector-sdk/src/resilience.ts
+++ b/packages/connector-sdk/src/resilience.ts
@@ -87,6 +87,11 @@ export function backoffMs(attempt: number, policy: RetryPolicy = {}): number {
  * The wrapper is the value handed to actions as `context.fetch`, so a
  * hand-written action and a declared request are equally protected.
  */
+/** An error that says asking again cannot help, such as a closed Vorn window. */
+function isFinal(error: unknown): boolean {
+  return (error as { retryable?: unknown } | null)?.retryable === false
+}
+
 export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
   const attempts = Math.min(MAX_ATTEMPTS, Math.max(1, options.retry?.attempts ?? DEFAULT_ATTEMPTS))
   const sleep = options.sleep ?? wait
@@ -120,7 +125,7 @@ export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
       } catch (error) {
         // A thrown fetch is the network failing rather than the server
         // answering, which is exactly the case a retry exists for.
-        if (!options.retryable || last) throw error
+        if (!options.retryable || last || isFinal(error)) throw error
         if (!(await pause(backoffMs(attempt, options.retry)))) throw error
       }
     }

--- a/packages/connector-sdk/src/resilience.ts
+++ b/packages/connector-sdk/src/resilience.ts
@@ -81,16 +81,17 @@ export function backoffMs(attempt: number, policy: RetryPolicy = {}): number {
   return Math.min(max, base * 2 ** attempt)
 }
 
+/** An error that says asking again cannot help, such as a closed Vorn window. */
+function isFinal(error: unknown): boolean {
+  return (error as { retryable?: unknown } | null)?.retryable === false
+}
+
 /**
  * Wrap a fetch so it retries what is worth retrying.
  *
  * The wrapper is the value handed to actions as `context.fetch`, so a
  * hand-written action and a declared request are equally protected.
  */
-/** An error that says asking again cannot help, such as a closed Vorn window. */
-function isFinal(error: unknown): boolean {
-  return (error as { retryable?: unknown } | null)?.retryable === false
-}
 
 export function resilientFetch(options: ResilientFetchOptions): typeof fetch {
   const attempts = Math.min(MAX_ATTEMPTS, Math.max(1, options.retry?.attempts ?? DEFAULT_ATTEMPTS))

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -35,6 +35,20 @@ export interface RunPollOptions {
 
 type SessionOptions = Pick<RunPollOptions, 'sessionFetchImpl' | 'retry' | 'sleep'>
 
+/** Wrap a fetch with the SDK's retries, as far as the caller says a repeat is safe. */
+function wrap(
+  fetchImpl: typeof fetch,
+  options: Pick<RunPollOptions, 'retry' | 'sleep'>,
+  retryable: boolean
+): typeof fetch {
+  return resilientFetch({
+    fetchImpl,
+    retryable,
+    ...(options.retry !== undefined && { retry: options.retry }),
+    ...(options.sleep !== undefined && { sleep: options.sleep })
+  })
+}
+
 /** The signed-in window, handed only to a connector that signs in through one. */
 function sessionFor(
   connector: Connector,
@@ -42,14 +56,7 @@ function sessionFor(
   retryable: boolean
 ): SessionContext | undefined {
   if (connector.auth?.rung !== 'browser') return undefined
-  return {
-    fetch: resilientFetch({
-      fetchImpl: options.sessionFetchImpl ?? createSessionFetch(),
-      retryable,
-      ...(options.retry !== undefined && { retry: options.retry }),
-      ...(options.sleep !== undefined && { sleep: options.sleep })
-    })
-  }
+  return { fetch: wrap(options.sessionFetchImpl ?? createSessionFetch(), options, retryable) }
 }
 
 /** Longest chain of pages `drainPoll` will follow before calling it a bug. */
@@ -79,12 +86,7 @@ export async function runPoll(
     ...(options.limit !== undefined && { limit: options.limit }),
     now,
     // A poll only reads, so every failure it meets is worth trying again.
-    fetch: resilientFetch({
-      fetchImpl: options.fetchImpl ?? globalThis.fetch,
-      retryable: true,
-      ...(options.retry !== undefined && { retry: options.retry }),
-      ...(options.sleep !== undefined && { sleep: options.sleep })
-    }),
+    fetch: wrap(options.fetchImpl ?? globalThis.fetch, options, true),
     ...(session && { session })
   }
 
@@ -168,12 +170,7 @@ export async function runOptions(
   const loaded = await loader({
     config: options.config ?? {},
     now: options.now ?? (() => new Date().toISOString()),
-    fetch: resilientFetch({
-      fetchImpl: options.fetchImpl ?? globalThis.fetch,
-      retryable: true,
-      ...(options.retry !== undefined && { retry: options.retry }),
-      ...(options.sleep !== undefined && { sleep: options.sleep })
-    }),
+    fetch: wrap(options.fetchImpl ?? globalThis.fetch, options, true),
     ...(session && { session })
   })
 
@@ -258,12 +255,7 @@ export async function runAction(
   const method = (action.request?.method ?? 'GET').toUpperCase()
   const retryable =
     action.idempotent === true || (action.request !== undefined && SAFE_METHODS.has(method))
-  const fetchImpl = resilientFetch({
-    fetchImpl: options.fetchImpl ?? globalThis.fetch,
-    retryable,
-    ...(options.retry !== undefined && { retry: options.retry }),
-    ...(options.sleep !== undefined && { sleep: options.sleep })
-  })
+  const fetchImpl = wrap(options.fetchImpl ?? globalThis.fetch, options, retryable)
   const session = sessionFor(connector, options, retryable)
 
   if (action.request !== undefined) {

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -33,7 +33,9 @@ export interface RunPollOptions {
   sleep?: (ms: number) => Promise<void>
 }
 
-type SessionOptions = Pick<RunPollOptions, 'sessionFetchImpl' | 'retry' | 'sleep'>
+type SessionOptions = Pick<RunPollOptions, 'sessionFetchImpl' | 'retry' | 'sleep'> & {
+  sessionCall?: string
+}
 
 /** Wrap a fetch with the SDK's retries, as far as the caller says a repeat is safe. */
 function wrap(
@@ -56,7 +58,10 @@ function sessionFor(
   retryable: boolean
 ): SessionContext | undefined {
   if (connector.auth?.rung !== 'browser') return undefined
-  return { fetch: wrap(options.sessionFetchImpl ?? createSessionFetch(), options, retryable) }
+  const fetchImpl =
+    options.sessionFetchImpl ??
+    createSessionFetch(options.sessionCall ? { call: options.sessionCall } : {})
+  return { fetch: wrap(fetchImpl, options, retryable) }
 }
 
 /** Longest chain of pages `drainPoll` will follow before calling it a bug. */
@@ -142,6 +147,8 @@ export interface RunActionOptions {
   fetchImpl?: typeof fetch
   /** Replaced by the harness and by tests; defaults to the signed-in window Vorn serves. */
   sessionFetchImpl?: typeof fetch
+  /** The key Vorn gave this tool call, carried on each request through the window. */
+  sessionCall?: string
   retry?: RetryPolicy
   /** Replaced in tests so backoff costs no real time. */
   sleep?: (ms: number) => Promise<void>

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -2,12 +2,14 @@ import { pollWithDedupe } from './dedupe'
 import { normalizeItems } from './normalize'
 import { executeRequest } from './request'
 import { resilientFetch, type RetryPolicy } from './resilience'
+import { createSessionFetch } from './session'
 import type {
   ActionInputOption,
   Connector,
   ConnectorConfig,
   NormalizedItem,
-  PollContext
+  PollContext,
+  SessionContext
 } from './types'
 
 export interface PollPage {
@@ -24,9 +26,30 @@ export interface RunPollOptions {
   now?: () => string
   /** Replaced by the harness and by tests; defaults to the global fetch. */
   fetchImpl?: typeof fetch
+  /** Replaced by the harness and by tests; defaults to the signed-in window Vorn serves. */
+  sessionFetchImpl?: typeof fetch
   retry?: RetryPolicy
   /** Replaced in tests so backoff costs no real time. */
   sleep?: (ms: number) => Promise<void>
+}
+
+type SessionOptions = Pick<RunPollOptions, 'sessionFetchImpl' | 'retry' | 'sleep'>
+
+/** The signed-in window, handed only to a connector that signs in through one. */
+function sessionFor(
+  connector: Connector,
+  options: SessionOptions,
+  retryable: boolean
+): SessionContext | undefined {
+  if (connector.auth?.rung !== 'browser') return undefined
+  return {
+    fetch: resilientFetch({
+      fetchImpl: options.sessionFetchImpl ?? createSessionFetch(),
+      retryable,
+      ...(options.retry !== undefined && { retry: options.retry }),
+      ...(options.sleep !== undefined && { sleep: options.sleep })
+    })
+  }
 }
 
 /** Longest chain of pages `drainPoll` will follow before calling it a bug. */
@@ -48,6 +71,7 @@ export async function runPoll(
 
   const now = options.now ?? (() => new Date().toISOString())
   const polledAt = now()
+  const session = sessionFor(connector, options, true)
   const context: PollContext = {
     config: options.config ?? {},
     ...(options.since !== undefined && { since: options.since }),
@@ -60,7 +84,8 @@ export async function runPoll(
       retryable: true,
       ...(options.retry !== undefined && { retry: options.retry }),
       ...(options.sleep !== undefined && { sleep: options.sleep })
-    })
+    }),
+    ...(session && { session })
   }
 
   const outcome =
@@ -113,6 +138,8 @@ export interface RunActionOptions {
   now?: () => string
   /** Replaced by the harness and by tests; defaults to the global fetch. */
   fetchImpl?: typeof fetch
+  /** Replaced by the harness and by tests; defaults to the signed-in window Vorn serves. */
+  sessionFetchImpl?: typeof fetch
   retry?: RetryPolicy
   /** Replaced in tests so backoff costs no real time. */
   sleep?: (ms: number) => Promise<void>
@@ -137,6 +164,7 @@ export async function runOptions(
     throw new Error(`Connector ${connector.id} serves no options set "${name}"`)
   }
 
+  const session = sessionFor(connector, options, true)
   const loaded = await loader({
     config: options.config ?? {},
     now: options.now ?? (() => new Date().toISOString()),
@@ -145,7 +173,8 @@ export async function runOptions(
       retryable: true,
       ...(options.retry !== undefined && { retry: options.retry }),
       ...(options.sleep !== undefined && { sleep: options.sleep })
-    })
+    }),
+    ...(session && { session })
   })
 
   if (!Array.isArray(loaded)) {
@@ -235,14 +264,16 @@ export async function runAction(
     ...(options.retry !== undefined && { retry: options.retry }),
     ...(options.sleep !== undefined && { sleep: options.sleep })
   })
+  const session = sessionFor(connector, options, retryable)
 
   if (action.request !== undefined) {
     try {
+      // A declared call of a browser connector is one to its signed-in service.
       return await executeRequest(
         action.request,
         action.postReceive,
         { args: coerced, config },
-        { fetchImpl }
+        { fetchImpl: session?.fetch ?? fetchImpl }
       )
     } catch (error) {
       // Which action failed is the first thing a reader needs; the message
@@ -262,7 +293,8 @@ export async function runAction(
   const output = await action.run(coerced, {
     config,
     now: options.now ?? (() => new Date().toISOString()),
-    fetch: fetchImpl
+    fetch: fetchImpl,
+    ...(session && { session })
   })
   return output ?? {}
 }

--- a/packages/connector-sdk/src/runtime.ts
+++ b/packages/connector-sdk/src/runtime.ts
@@ -28,14 +28,14 @@ export interface RunPollOptions {
   fetchImpl?: typeof fetch
   /** Replaced by the harness and by tests; defaults to the signed-in window Vorn serves. */
   sessionFetchImpl?: typeof fetch
+  /** The key Vorn gave this tool call, carried on each request through the window. */
+  sessionCall?: string
   retry?: RetryPolicy
   /** Replaced in tests so backoff costs no real time. */
   sleep?: (ms: number) => Promise<void>
 }
 
-type SessionOptions = Pick<RunPollOptions, 'sessionFetchImpl' | 'retry' | 'sleep'> & {
-  sessionCall?: string
-}
+type SessionOptions = Pick<RunPollOptions, 'sessionFetchImpl' | 'sessionCall' | 'retry' | 'sleep'>
 
 /** Wrap a fetch with the SDK's retries, as far as the caller says a repeat is safe. */
 function wrap(

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -5,6 +5,12 @@ import { EXTENSION_AGENTS, resolveConfig } from './define'
 import { createExtensionHost } from './host'
 import { runAction, runOptions, runPoll } from './runtime'
 import { SESSION_CALL_META } from './session'
+
+/** The key Vorn gave a tool call, so its window requests are told apart from another step's. */
+function sessionCallOf(extra: { _meta?: Record<string, unknown> }): { sessionCall?: string } {
+  const key = extra._meta?.[SESSION_CALL_META]
+  return typeof key === 'string' ? { sessionCall: key } : {}
+}
 import {
   MANIFEST_TOOL,
   OPTIONS_TOOL,
@@ -194,12 +200,13 @@ export function createConnectorServer(
             .describe('The choices, each a value to send and words to show')
         })
       },
-      async (args) => {
+      async (args, extra) => {
         try {
           return json({
             options: await runOptions(connector, args.name, {
               config: config(),
-              ...(options.now && { now: options.now })
+              ...(options.now && { now: options.now }),
+              ...sessionCallOf(extra)
             })
           })
         } catch (error) {
@@ -228,7 +235,7 @@ export function createConnectorServer(
           hasMore: z.boolean().describe('Whether another page is immediately available')
         })
       },
-      async (args) => {
+      async (args, extra) => {
         try {
           const limit = args.limit === undefined ? undefined : Number(args.limit)
           if (limit !== undefined && !Number.isFinite(limit)) {
@@ -240,7 +247,8 @@ export function createConnectorServer(
               ...(args.since !== undefined && { since: args.since }),
               ...(args.cursor !== undefined && { cursor: args.cursor }),
               ...(limit !== undefined && { limit }),
-              ...(options.now && { now: options.now })
+              ...(options.now && { now: options.now }),
+              ...sessionCallOf(extra)
             })) as unknown as Record<string, unknown>
           )
         } catch (error) {
@@ -342,13 +350,12 @@ export function createConnectorServer(
         outputSchema: outputSchema(action.outputs ?? [])
       },
       async (args, extra) => {
-        const sessionCall = extra._meta?.[SESSION_CALL_META]
         try {
           return json(
             await runAction(connector, action.type, args as Record<string, unknown>, {
               config: config(),
               ...(options.now && { now: options.now }),
-              ...(typeof sessionCall === 'string' && { sessionCall })
+              ...sessionCallOf(extra)
             })
           )
         } catch (error) {

--- a/packages/connector-sdk/src/server.ts
+++ b/packages/connector-sdk/src/server.ts
@@ -4,6 +4,7 @@ import { z, type ZodTypeAny } from 'zod'
 import { EXTENSION_AGENTS, resolveConfig } from './define'
 import { createExtensionHost } from './host'
 import { runAction, runOptions, runPoll } from './runtime'
+import { SESSION_CALL_META } from './session'
 import {
   MANIFEST_TOOL,
   OPTIONS_TOOL,
@@ -340,12 +341,14 @@ export function createConnectorServer(
         inputSchema: inputShape(action.inputs ?? []),
         outputSchema: outputSchema(action.outputs ?? [])
       },
-      async (args) => {
+      async (args, extra) => {
+        const sessionCall = extra._meta?.[SESSION_CALL_META]
         try {
           return json(
             await runAction(connector, action.type, args as Record<string, unknown>, {
               config: config(),
-              ...(options.now && { now: options.now })
+              ...(options.now && { now: options.now }),
+              ...(typeof sessionCall === 'string' && { sessionCall })
             })
           )
         } catch (error) {

--- a/packages/connector-sdk/src/session.ts
+++ b/packages/connector-sdk/src/session.ts
@@ -1,12 +1,25 @@
+import { loopbackEndpoint } from './loopback'
+
 /** Where Vorn serves a browser-sign-in connector the window it signed in through. */
-export const SESSION_HOST_ENV = 'VORN_SESSION_HOST'
-export const SESSION_TOKEN_ENV = 'VORN_SESSION_TOKEN'
+export const BROWSER_HOST_ENV = 'VORN_BROWSER_HOST'
+export const BROWSER_TOKEN_ENV = 'VORN_BROWSER_TOKEN'
 
 /** The signed-in window could not make the call: Vorn is closed, too old, or not the caller. */
 export class SessionUnavailableError extends Error {
+  /** Asking again cannot bring the window back, so the SDK's retries let this through at once. */
+  readonly retryable = false
   constructor(message: string) {
     super(message)
     this.name = 'SessionUnavailableError'
+  }
+}
+
+/** Vorn refused the call itself, for instance because it is off the connector's origins. */
+export class SessionRefusedError extends Error {
+  readonly retryable = false
+  constructor(message: string) {
+    super(message)
+    this.name = 'SessionRefusedError'
   }
 }
 
@@ -19,57 +32,8 @@ export interface SessionFetchOptions {
 /** Long enough for a window to load its origin the first time, short enough to fail a wedged app. */
 const SESSION_TIMEOUT_MS = 45_000
 
-/** The endpoint is served on this machine, so the token never leaves it. */
-const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '[::1]']
-
-/** An origin a connector may act on: `https://host`, or `https://*.host` for every subdomain. */
-export const ORIGIN_PATTERN = /^https:\/\/(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/i
-
 /** Statuses a Response must carry with no body. */
-const NULL_BODY_STATUSES = new Set([101, 204, 205, 304])
-
-/** Whether `url` is on one of the declared origins. */
-export function withinOrigins(origins: readonly string[], url: string): boolean {
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    return false
-  }
-  if (parsed.protocol !== 'https:' || parsed.port !== '') return false
-  const target = parsed.hostname.toLowerCase()
-  return origins.some((origin) => {
-    if (!ORIGIN_PATTERN.test(origin)) return false
-    const wildcard = origin.startsWith('https://*.')
-    const host = origin.slice(wildcard ? 'https://*.'.length : 'https://'.length).toLowerCase()
-    return wildcard ? target.endsWith(`.${host}`) : target === host
-  })
-}
-
-function endpoint(env: NodeJS.ProcessEnv): { url: string; token: string } {
-  const url = env[SESSION_HOST_ENV]?.trim()
-  const token = env[SESSION_TOKEN_ENV]?.trim()
-  if (!url || !token) {
-    throw new SessionUnavailableError(
-      `This connector acts through a signed-in Vorn window; run it from Vorn, which sets ${SESSION_HOST_ENV}`
-    )
-  }
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    throw new SessionUnavailableError(
-      `${SESSION_HOST_ENV} is ${JSON.stringify(url)}, which is not a URL`
-    )
-  }
-  // Checked before the token is sent, so a variable pointing elsewhere cannot collect it.
-  if (parsed.protocol !== 'http:' || !LOOPBACK_HOSTS.includes(parsed.hostname)) {
-    throw new SessionUnavailableError(
-      `${SESSION_HOST_ENV} is ${JSON.stringify(url)}; the endpoint is served on this machine, over http on ${LOOPBACK_HOSTS.join(', ')}`
-    )
-  }
-  return { url: url.replace(/\/$/, ''), token }
-}
+const NULL_BODY_STATUSES = new Set([204, 205, 304])
 
 interface SessionReply {
   status: number
@@ -105,8 +69,18 @@ export function createSessionFetch(options: SessionFetchOptions = {}): typeof fe
   const env = options.env ?? process.env
   const call = options.fetchImpl ?? fetch
   return (async (input: string | URL | Request, init?: RequestInit) => {
-    const { url, token } = endpoint(env)
+    const { url, token } = loopbackEndpoint(
+      env,
+      {
+        urlVar: BROWSER_HOST_ENV,
+        tokenVar: BROWSER_TOKEN_ENV,
+        missing: `This connector acts through a signed-in Vorn window; run it from Vorn, which sets ${BROWSER_HOST_ENV}`,
+        served: 'the endpoint is served on this machine'
+      },
+      (message) => new SessionUnavailableError(message)
+    )
     const request = new Request(input, init)
+    // Carried as text both ways: signed-in calls are JSON and form posts, not uploads.
     const body = request.body ? await request.text() : undefined
     const answer = await call(`${url}/fetch`, {
       method: 'POST',
@@ -117,7 +91,7 @@ export function createSessionFetch(options: SessionFetchOptions = {}): typeof fe
         headers: Object.fromEntries(request.headers),
         ...(body !== undefined && { body })
       }),
-      signal: AbortSignal.timeout(SESSION_TIMEOUT_MS)
+      signal: AbortSignal.any([request.signal, AbortSignal.timeout(SESSION_TIMEOUT_MS)])
     })
     const text = await answer.text()
     if (answer.status === 503) {
@@ -126,7 +100,7 @@ export function createSessionFetch(options: SessionFetchOptions = {}): typeof fe
       )
     }
     if (!answer.ok) {
-      throw new Error(
+      throw new SessionRefusedError(
         refusal(text) ?? `The signed-in window refused the call with HTTP ${answer.status}`
       )
     }

--- a/packages/connector-sdk/src/session.ts
+++ b/packages/connector-sdk/src/session.ts
@@ -1,0 +1,139 @@
+/** Where Vorn serves a browser-sign-in connector the window it signed in through. */
+export const SESSION_HOST_ENV = 'VORN_SESSION_HOST'
+export const SESSION_TOKEN_ENV = 'VORN_SESSION_TOKEN'
+
+/** The signed-in window could not make the call: Vorn is closed, too old, or not the caller. */
+export class SessionUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SessionUnavailableError'
+  }
+}
+
+export interface SessionFetchOptions {
+  env?: NodeJS.ProcessEnv
+  /** Replaced in tests so nothing opens a socket. */
+  fetchImpl?: typeof fetch
+}
+
+/** Long enough for a window to load its origin the first time, short enough to fail a wedged app. */
+const SESSION_TIMEOUT_MS = 45_000
+
+/** The endpoint is served on this machine, so the token never leaves it. */
+const LOOPBACK_HOSTS = ['127.0.0.1', 'localhost', '[::1]']
+
+/** An origin a connector may act on: `https://host`, or `https://*.host` for every subdomain. */
+export const ORIGIN_PATTERN = /^https:\/\/(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/i
+
+/** Statuses a Response must carry with no body. */
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304])
+
+/** Whether `url` is on one of the declared origins. */
+export function withinOrigins(origins: readonly string[], url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:' || parsed.port !== '') return false
+  const target = parsed.hostname.toLowerCase()
+  return origins.some((origin) => {
+    if (!ORIGIN_PATTERN.test(origin)) return false
+    const wildcard = origin.startsWith('https://*.')
+    const host = origin.slice(wildcard ? 'https://*.'.length : 'https://'.length).toLowerCase()
+    return wildcard ? target.endsWith(`.${host}`) : target === host
+  })
+}
+
+function endpoint(env: NodeJS.ProcessEnv): { url: string; token: string } {
+  const url = env[SESSION_HOST_ENV]?.trim()
+  const token = env[SESSION_TOKEN_ENV]?.trim()
+  if (!url || !token) {
+    throw new SessionUnavailableError(
+      `This connector acts through a signed-in Vorn window; run it from Vorn, which sets ${SESSION_HOST_ENV}`
+    )
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new SessionUnavailableError(
+      `${SESSION_HOST_ENV} is ${JSON.stringify(url)}, which is not a URL`
+    )
+  }
+  // Checked before the token is sent, so a variable pointing elsewhere cannot collect it.
+  if (parsed.protocol !== 'http:' || !LOOPBACK_HOSTS.includes(parsed.hostname)) {
+    throw new SessionUnavailableError(
+      `${SESSION_HOST_ENV} is ${JSON.stringify(url)}; the endpoint is served on this machine, over http on ${LOOPBACK_HOSTS.join(', ')}`
+    )
+  }
+  return { url: url.replace(/\/$/, ''), token }
+}
+
+interface SessionReply {
+  status: number
+  headers?: Record<string, string>
+  body?: string
+}
+
+function readReply(text: string): SessionReply {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error('The signed-in window answered with a body that is not JSON')
+  }
+  const reply = parsed as Partial<SessionReply>
+  if (!parsed || typeof parsed !== 'object' || typeof reply.status !== 'number') {
+    throw new Error('The signed-in window answered without a status')
+  }
+  return reply as SessionReply
+}
+
+function refusal(text: string): string | undefined {
+  try {
+    const error = (JSON.parse(text) as { error?: unknown }).error
+    return typeof error === 'string' && error ? error : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** A fetch whose requests run inside the connection's signed-in Vorn window, so no cookie reaches this process. */
+export function createSessionFetch(options: SessionFetchOptions = {}): typeof fetch {
+  const env = options.env ?? process.env
+  const call = options.fetchImpl ?? fetch
+  return (async (input: string | URL | Request, init?: RequestInit) => {
+    const { url, token } = endpoint(env)
+    const request = new Request(input, init)
+    const body = request.body ? await request.text() : undefined
+    const answer = await call(`${url}/fetch`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        url: request.url,
+        method: request.method,
+        headers: Object.fromEntries(request.headers),
+        ...(body !== undefined && { body })
+      }),
+      signal: AbortSignal.timeout(SESSION_TIMEOUT_MS)
+    })
+    const text = await answer.text()
+    if (answer.status === 503) {
+      throw new SessionUnavailableError(
+        refusal(text) ?? 'Vorn could not reach the signed-in window'
+      )
+    }
+    if (!answer.ok) {
+      throw new Error(
+        refusal(text) ?? `The signed-in window refused the call with HTTP ${answer.status}`
+      )
+    }
+    const reply = readReply(text)
+    return new Response(NULL_BODY_STATUSES.has(reply.status) ? null : (reply.body ?? ''), {
+      status: reply.status,
+      ...(reply.headers && { headers: reply.headers })
+    })
+  }) as typeof fetch
+}

--- a/packages/connector-sdk/src/session.ts
+++ b/packages/connector-sdk/src/session.ts
@@ -3,6 +3,9 @@ import { loopbackEndpoint } from './loopback'
 /** Where Vorn serves a browser-sign-in connector the window it signed in through. */
 export const BROWSER_HOST_ENV = 'VORN_BROWSER_HOST'
 export const BROWSER_TOKEN_ENV = 'VORN_BROWSER_TOKEN'
+/** The tool call a window request belongs to, so Vorn can tell a step's own requests from another's. */
+export const SESSION_CALL_META = 'vorn/sessionCall'
+export const SESSION_CALL_HEADER = 'x-vorn-session-call'
 
 /** The signed-in window could not make the call: Vorn is closed, too old, or not the caller. */
 export class SessionUnavailableError extends Error {
@@ -27,6 +30,8 @@ export interface SessionFetchOptions {
   env?: NodeJS.ProcessEnv
   /** Replaced in tests so nothing opens a socket. */
   fetchImpl?: typeof fetch
+  /** The key of the tool call these requests belong to, from its MCP metadata. */
+  call?: string
 }
 
 /** Long enough for a window to load its origin the first time, short enough to fail a wedged app. */
@@ -55,14 +60,7 @@ function readReply(text: string): SessionReply {
   return reply as SessionReply
 }
 
-function refusal(text: string): string | undefined {
-  try {
-    const error = (JSON.parse(text) as { error?: unknown }).error
-    return typeof error === 'string' && error ? error : undefined
-  } catch {
-    return undefined
-  }
-}
+const refusal = (text: string): string | undefined => text.trim() || undefined
 
 /** A fetch whose requests run inside the connection's signed-in Vorn window, so no cookie reaches this process. */
 export function createSessionFetch(options: SessionFetchOptions = {}): typeof fetch {
@@ -84,7 +82,11 @@ export function createSessionFetch(options: SessionFetchOptions = {}): typeof fe
     const body = request.body ? await request.text() : undefined
     const answer = await call(`${url}/fetch`, {
       method: 'POST',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        ...(options.call && { [SESSION_CALL_HEADER]: options.call })
+      },
       body: JSON.stringify({
         url: request.url,
         method: request.method,

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -78,6 +78,8 @@ export interface PollContext {
   now(): string
   /** Fetch with the SDK's retry and backoff applied. A poll is always a read. */
   fetch: typeof fetch
+  /** Present only when the connector signs in through a Vorn window. */
+  session?: SessionContext
 }
 
 export interface PollOutcome {
@@ -122,6 +124,8 @@ export interface FetchContext {
   now(): string
   /** Fetch with the SDK's retry and backoff applied. A fetch is always a read. */
   fetch: typeof fetch
+  /** Present only when the connector signs in through a Vorn window. */
+  session?: SessionContext
 }
 
 /**
@@ -248,6 +252,8 @@ export interface ActionContext {
    * same resilience a declared request does, and tests can replace it.
    */
   fetch: typeof fetch
+  /** Present only when the connector signs in through a Vorn window. */
+  session?: SessionContext
 }
 
 /**
@@ -372,9 +378,26 @@ export interface PreflightResult {
  * `none` needs nothing — installing it is the whole setup. `cli` borrows a
  * login that already works on the machine, which is the rung to prefer
  * whenever a mature tool is signed in anyway. `key` asks for a credential.
+ * `browser` signs in through a Vorn window for a service with no API to key.
  * `oauth` is declared but not yet carried by the host.
  */
-export type AuthRung = 'none' | 'cli' | 'key' | 'oauth'
+export type AuthRung = 'none' | 'cli' | 'key' | 'browser' | 'oauth'
+
+/** How a `browser` connector signs in, and the only origins its calls may reach. */
+export interface BrowserSignIn {
+  /** The page the Vorn window opens for signing in. */
+  signInUrl: string
+  /** `https://host` or `https://*.host`; the sign-in page and the check must sit inside them. */
+  origins: string[]
+  /** Answers 2xx only when signed in; `identity` names the fields of its JSON that say who. */
+  check: { url: string; identity: string[] }
+}
+
+/** The signed-in window, offered to a `browser` connector's code. */
+export interface SessionContext {
+  /** Runs the request inside the connection's signed-in window; cookies never reach the connector. */
+  fetch: typeof fetch
+}
 
 /**
  * What a connector needs before it can talk to anything.
@@ -405,6 +428,8 @@ export interface ConnectorAuth {
   borrow?: { env?: string[]; tokenArgs?: string[]; tokenEnv?: string }
   /** Config field keys holding the credential. Required for `key`. */
   keys?: string[]
+  /** Required for `browser`. */
+  browser?: BrowserSignIn
 }
 
 /** What an options set is given to work out its choices. */
@@ -413,6 +438,8 @@ export interface OptionsContext {
   now(): string
   /** Fetch with the SDK's retry and backoff applied. Listing choices is a read. */
   fetch: typeof fetch
+  /** Present only when the connector signs in through a Vorn window. */
+  session?: SessionContext
 }
 
 /**

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto'
+import { isSignInWait } from '@vornrun/shared/workflow-graph'
 import { z } from 'zod'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { V } from '../validation'
@@ -489,7 +490,7 @@ export function annotateWaitingGates<T extends WorkflowExecution>(
       ...run,
       nodeStates: run.nodeStates.map((state) => {
         if (state.status !== 'waiting') return state
-        if (state.waitingFor === 'signIn') {
+        if (isSignInWait(state)) {
           return {
             ...state,
             asks: 'Sign in to its connection in the Vorn app, and this step runs again'
@@ -519,7 +520,7 @@ export function resolveGateTarget(
 ): { nodeId: string } | { error: string } {
   const parked = run.nodeStates.filter((n) => n.status === 'waiting')
   // Rejecting a sign-in wait ends the run; approving one would skip the step it waits to run.
-  const answerable = parked.filter((n) => decision === 'reject' || n.waitingFor !== 'signIn')
+  const answerable = parked.filter((n) => decision === 'reject' || !isSignInWait(n))
   const waiting = answerable.map((n) => n.nodeId)
   const signIns = parked.filter((n) => !answerable.includes(n)).map((n) => n.nodeId)
   if (nodeId) {

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -489,6 +489,12 @@ export function annotateWaitingGates<T extends WorkflowExecution>(
       ...run,
       nodeStates: run.nodeStates.map((state) => {
         if (state.status !== 'waiting') return state
+        if (state.waitingFor === 'signIn') {
+          return {
+            ...state,
+            asks: 'Sign in to its connection in the Vorn app, and this step runs again'
+          }
+        }
         const asks = gateMessage(workflow, state.nodeId)
         return asks ? { ...state, asks } : state
       })
@@ -510,8 +516,18 @@ export function resolveGateTarget(
   run: Pick<WorkflowExecution, 'nodeStates'>,
   nodeId?: string
 ): { nodeId: string } | { error: string } {
-  const waiting = run.nodeStates.filter((n) => n.status === 'waiting').map((n) => n.nodeId)
+  const signIns = run.nodeStates
+    .filter((n) => n.status === 'waiting' && n.waitingFor === 'signIn')
+    .map((n) => n.nodeId)
+  const waiting = run.nodeStates
+    .filter((n) => n.status === 'waiting' && n.waitingFor !== 'signIn')
+    .map((n) => n.nodeId)
   if (nodeId) {
+    if (signIns.includes(nodeId)) {
+      return {
+        error: `node "${nodeId}" is waiting for a sign-in in the Vorn app, not for an approval`
+      }
+    }
     if (waiting.includes(nodeId)) return { nodeId }
     return {
       error: waiting.length
@@ -520,7 +536,13 @@ export function resolveGateTarget(
     }
   }
   if (waiting.length === 1) return { nodeId: waiting[0] }
-  if (waiting.length === 0) return { error: 'no node in this run is waiting on a gate' }
+  if (waiting.length === 0) {
+    return {
+      error: signIns.length
+        ? 'this run is waiting for a sign-in in the Vorn app, not for an approval'
+        : 'no node in this run is waiting on a gate'
+    }
+  }
   return { error: `${waiting.length} nodes are waiting — pass node_id: ${waiting.join(', ')}` }
 }
 

--- a/packages/mcp/src/tools/workflows.ts
+++ b/packages/mcp/src/tools/workflows.ts
@@ -514,14 +514,14 @@ async function runById(
 // Which gate a decision answers: one waiting node needs no naming, several would make picking a guess.
 export function resolveGateTarget(
   run: Pick<WorkflowExecution, 'nodeStates'>,
-  nodeId?: string
+  nodeId?: string,
+  decision: 'approve' | 'reject' = 'approve'
 ): { nodeId: string } | { error: string } {
-  const signIns = run.nodeStates
-    .filter((n) => n.status === 'waiting' && n.waitingFor === 'signIn')
-    .map((n) => n.nodeId)
-  const waiting = run.nodeStates
-    .filter((n) => n.status === 'waiting' && n.waitingFor !== 'signIn')
-    .map((n) => n.nodeId)
+  const parked = run.nodeStates.filter((n) => n.status === 'waiting')
+  // Rejecting a sign-in wait ends the run; approving one would skip the step it waits to run.
+  const answerable = parked.filter((n) => decision === 'reject' || n.waitingFor !== 'signIn')
+  const waiting = answerable.map((n) => n.nodeId)
+  const signIns = parked.filter((n) => !answerable.includes(n)).map((n) => n.nodeId)
   if (nodeId) {
     if (signIns.includes(nodeId)) {
       return {
@@ -859,7 +859,7 @@ export function registerWorkflowTools(server: McpServer): void {
         }
       }
 
-      const target = resolveGateTarget(run, args.node_id)
+      const target = resolveGateTarget(run, args.node_id, args.decision)
       if ('error' in target) {
         return {
           content: [{ type: 'text', text: `Error: ${target.error}` }],

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -62,7 +62,6 @@ const FETCH_TIMEOUT_MS = 5000
 const CACHE_PATH = join(os.homedir(), '.vorn', 'connector-catalog.json')
 
 /** Rungs this build knows how to describe; anything else is dropped on read. */
-const AUTH_RUNGS = CONNECTOR_AUTH_RUNGS
 
 /** The one receipt format this build will show a verified mark for. */
 const VERIFICATION_SCHEMA = 1
@@ -289,7 +288,7 @@ function normalizeEntry(raw: unknown): ConnectorCatalogEntry | undefined {
     activates,
     ...rest
   } = entry
-  const rung = AUTH_RUNGS.includes(authRung as ConnectorAuthRung)
+  const rung = CONNECTOR_AUTH_RUNGS.includes(authRung as ConnectorAuthRung)
     ? (authRung as ConnectorAuthRung)
     : undefined
   const receipt = normalizeVerification(verified)

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -18,6 +18,7 @@
  * needs is still read by probing the installed package, so nothing here is
  * trusted once a connector is actually being set up.
  */
+import { CONNECTOR_AUTH_RUNGS } from '@vornrun/shared/types'
 import { EventEmitter } from 'node:events'
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
 import { join, dirname } from 'path'
@@ -61,7 +62,7 @@ const FETCH_TIMEOUT_MS = 5000
 const CACHE_PATH = join(os.homedir(), '.vorn', 'connector-catalog.json')
 
 /** Rungs this build knows how to describe; anything else is dropped on read. */
-const AUTH_RUNGS: ConnectorAuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
+const AUTH_RUNGS = CONNECTOR_AUTH_RUNGS
 
 /** The one receipt format this build will show a verified mark for. */
 const VERIFICATION_SCHEMA = 1

--- a/packages/server/src/connectors/catalog.ts
+++ b/packages/server/src/connectors/catalog.ts
@@ -61,7 +61,7 @@ const FETCH_TIMEOUT_MS = 5000
 const CACHE_PATH = join(os.homedir(), '.vorn', 'connector-catalog.json')
 
 /** Rungs this build knows how to describe; anything else is dropped on read. */
-const AUTH_RUNGS: ConnectorAuthRung[] = ['none', 'cli', 'key', 'oauth']
+const AUTH_RUNGS: ConnectorAuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
 
 /** The one receipt format this build will show a verified mark for. */
 const VERIFICATION_SCHEMA = 1

--- a/packages/server/src/connectors/mcp-clients.ts
+++ b/packages/server/src/connectors/mcp-clients.ts
@@ -66,7 +66,7 @@ function installedPackLaunch(id: string): { command: string; args: string[] } | 
 }
 
 /** The connector a connection runs, when it names a packaged one. */
-function sdkIdOf(conn: SourceConnection): string {
+export function sdkIdOf(conn: SourceConnection): string {
   return String(conn.filters[SDK_FILTER_KEYS.connectorId] ?? '').trim()
 }
 

--- a/packages/server/src/connectors/mcp-clients.ts
+++ b/packages/server/src/connectors/mcp-clients.ts
@@ -11,6 +11,7 @@
  * never sees the encrypted ciphertext, only the plaintext the main process
  * pushes via `credentials:setDecrypted`.
  */
+import { forgetSessionGrant, sessionEnvFor } from './session-bridge'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import {
   SDK_FILTER_KEYS,
@@ -93,7 +94,10 @@ export async function buildSpawnConfig(conn: SourceConnection): Promise<SpawnCon
   const secretEnv = parseJsonObject(decrypted.secretEnv)
   const source = await resolveConnectorAuth(sdkIdOf(conn))
   const borrowed = source ? await borrowedSecrets(source) : {}
-  return { command, args, env: { ...borrowed, ...env, ...secretEnv } }
+  const browser = source?.auth?.rung === 'browser' ? source.auth.browser : undefined
+  // The window this connection signed in through, reached with a token minted for this child alone.
+  const signedIn = browser ? sessionEnvFor(conn.id, browser) : {}
+  return { command, args, env: { ...borrowed, ...env, ...secretEnv, ...signedIn } }
 }
 
 export async function getOrStartClient(conn: SourceConnection): Promise<Client> {
@@ -106,6 +110,7 @@ export async function getOrStartClient(conn: SourceConnection): Promise<Client> 
 }
 
 export async function stopClient(connectionId: string): Promise<void> {
+  forgetSessionGrant(connectionId)
   await clients.stop(connectionId)
 }
 

--- a/packages/server/src/connectors/mcp-clients.ts
+++ b/packages/server/src/connectors/mcp-clients.ts
@@ -11,11 +11,12 @@
  * never sees the encrypted ciphertext, only the plaintext the main process
  * pushes via `credentials:setDecrypted`.
  */
-import { forgetSessionGrant, sessionEnvFor } from './session-bridge'
+import { mintSessionGrant, type SessionGrant } from './session-bridge'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import {
   SDK_FILTER_KEYS,
   connectionConnectorId,
+  type SdkBrowserSignIn,
   type SourceConnection
 } from '@vornrun/shared/types'
 import { dbListSourceConnections } from '../database'
@@ -26,7 +27,9 @@ import { borrowedSecrets } from './auth-rung'
 import { resolveConnectorAuth } from './connector-auth'
 import { createStdioClientCache } from './stdio-clients'
 
-const clients = createStdioClientCache<{ connectionId: string }>('mcp-clients')
+const clients = createStdioClientCache<{ connectionId: string; grant?: SessionGrant }>(
+  'mcp-clients'
+)
 
 function tryParseJson<T>(raw: unknown, guard: (v: unknown) => v is T, fallback: T): T {
   if (typeof raw !== 'string' || raw === '') return fallback
@@ -83,6 +86,8 @@ interface SpawnConfig {
   command: string
   args: string[]
   env: Record<string, string>
+  /** Set when the connection acts through a signed-in window. */
+  browser?: SdkBrowserSignIn
 }
 
 // A borrowed token is fetched fresh at spawn, never stored, and sits under anything entered by hand.
@@ -95,22 +100,29 @@ export async function buildSpawnConfig(conn: SourceConnection): Promise<SpawnCon
   const source = await resolveConnectorAuth(sdkIdOf(conn))
   const borrowed = source ? await borrowedSecrets(source) : {}
   const browser = source?.auth?.rung === 'browser' ? source.auth.browser : undefined
-  // The window this connection signed in through, reached with a token minted for this child alone.
-  const signedIn = browser ? sessionEnvFor(conn.id, browser) : {}
-  return { command, args, env: { ...borrowed, ...env, ...secretEnv, ...signedIn } }
+  return { command, args, env: { ...borrowed, ...env, ...secretEnv }, ...(browser && { browser }) }
 }
 
 export async function getOrStartClient(conn: SourceConnection): Promise<Client> {
   return clients.getOrStart(conn.id, async () => {
     // The spawn config carries the connection's own environment, which wins over
     // the sanitized base every child starts from.
-    const { command, args, env } = await buildSpawnConfig(conn)
-    return { config: { command, args, env }, meta: { connectionId: conn.id } }
+    const { command, args, env, browser } = await buildSpawnConfig(conn)
+    // The window this connection signed in through, reached with a token minted for this child alone.
+    const session = browser && mintSessionGrant(conn.id, browser)
+    return {
+      config: { command, args, env: { ...env, ...session?.env } },
+      meta: { connectionId: conn.id, ...(session && { grant: session.grant }) }
+    }
   })
 }
 
+/** The signed-in window grant of a connection's running child, if it has one. */
+export function sessionGrantFor(connectionId: string): SessionGrant | undefined {
+  return clients.find((meta) => meta.connectionId === connectionId)?.grant
+}
+
 export async function stopClient(connectionId: string): Promise<void> {
-  forgetSessionGrant(connectionId)
   await clients.stop(connectionId)
 }
 

--- a/packages/server/src/connectors/mcp-clients.ts
+++ b/packages/server/src/connectors/mcp-clients.ts
@@ -119,7 +119,7 @@ export async function getOrStartClient(conn: SourceConnection): Promise<Client> 
 
 /** The signed-in window grant of a connection's running child, if it has one. */
 export function sessionGrantFor(connectionId: string): SessionGrant | undefined {
-  return clients.find((meta) => meta.connectionId === connectionId)?.grant
+  return clients.get(connectionId)?.grant
 }
 
 export async function stopClient(connectionId: string): Promise<void> {

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -14,6 +14,8 @@
  * token.
  * The decrypted values are merged in at spawn time via `getOrStartClient`.
  */
+import { browserSignInFor, sessionCallsSince, stillSignedIn } from './session-bridge'
+import { dbSetConnectionSignIn, dbSignalChange } from '../database'
 import type {
   VornConnector,
   ConnectorManifest,
@@ -251,6 +253,7 @@ export async function invokeMcpTool(
   toolName: string,
   args: Record<string, unknown>
 ): Promise<ActionResult> {
+  const started = Date.now()
   try {
     const client = await getOrStartClient(conn)
     // Look up this tool's discovered inputSchema so we can coerce string form
@@ -260,7 +263,12 @@ export async function invokeMcpTool(
       ? (tools as McpDiscoveredTool[]).find((t) => t.name === toolName)
       : undefined
     const callArgs = coerceMcpArgs(tool?.inputSchema, args)
-    const result = await client.callTool({ name: toolName, arguments: callArgs })
+    const browser = browserSignInFor(conn.id) !== undefined
+    // A signed-in tool may make several calls through its window, each up to twenty seconds.
+    const params = { name: toolName, arguments: callArgs }
+    const result = browser
+      ? await client.callTool(params, undefined, { timeout: BROWSER_TOOL_TIMEOUT_MS })
+      : await client.callTool(params)
     // When the tool declared an outputSchema, MCP returns the typed payload
     // under `structuredContent`. Surface that as `output` so downstream
     // workflow steps can reference the declared fields directly
@@ -273,16 +281,52 @@ export async function invokeMcpTool(
       unknown
     >
     if (result.isError) {
-      return {
+      return await withSessionOutcome(conn, started, {
         success: false,
         error: extractTextError(result.content) ?? `MCP tool ${toolName} reported an error`,
         output
-      }
+      })
     }
-    return { success: true, output }
+    return await withSessionOutcome(conn, started, { success: true, output })
   } catch (err) {
-    return { success: false, error: err instanceof Error ? err.message : String(err) }
+    return await withSessionOutcome(conn, started, {
+      success: false,
+      error: err instanceof Error ? err.message : String(err)
+    })
   }
+}
+
+/** A tool may make several calls through its window, each up to twenty seconds. */
+const BROWSER_TOOL_TIMEOUT_MS = 120_000
+
+/** A browser connection's result, with its window calls attached and a failure told apart: Vorn closed, or the site signed it out. */
+async function withSessionOutcome(
+  conn: SourceConnection,
+  since: number,
+  result: ActionResult
+): Promise<ActionResult> {
+  if (browserSignInFor(conn.id) === undefined) return result
+  const sessionCalls = sessionCallsSince(conn.id, since)
+  const withCalls = sessionCalls.length > 0 ? { ...result, sessionCalls } : result
+  if (result.success) return withCalls
+  if (sessionCalls.some((call) => call.status === 'app-offline')) {
+    return {
+      ...withCalls,
+      errorKind: 'app-offline',
+      error: `Open Vorn on the desktop ${conn.name} signed in on, then run this step again.`
+    }
+  }
+  const refused = sessionCalls.some((call) => call.status === 401 || call.status === 403)
+  if (refused && (await stillSignedIn(conn.id)) === false) {
+    dbSetConnectionSignIn(conn.id, null, null)
+    dbSignalChange()
+    return {
+      ...withCalls,
+      errorKind: 'needs-sign-in',
+      error: `${conn.name} was signed out. Sign in again, and this step runs again.`
+    }
+  }
+  return withCalls
 }
 
 // --- Poll / trigger support -------------------------------------------------

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -14,8 +14,7 @@
  * token.
  * The decrypted values are merged in at spawn time via `getOrStartClient`.
  */
-import { browserSignInFor, sessionCallsSince, stillSignedIn } from './session-bridge'
-import { dbSetConnectionSignIn, dbSignalChange } from '../database'
+import { openSessionCall, sessionOutcome, type SessionGrant } from './session-bridge'
 import type {
   VornConnector,
   ConnectorManifest,
@@ -27,9 +26,9 @@ import type {
   ExternalItem,
   SourceConnection
 } from '@vornrun/shared/types'
-import { SDK_FILTER_KEYS } from '@vornrun/shared/types'
+import { SDK_FILTER_KEYS, SESSION_CALL_META } from '@vornrun/shared/types'
 import { schemaProperties, schemaTypeHint, schemaRequired } from '@vornrun/shared/json-schema-utils'
-import { getOrStartClient } from './mcp-clients'
+import { getOrStartClient, sessionGrantFor } from './mcp-clients'
 import { PREFLIGHT_TOOL, isReservedSdkTool } from './sdk-tools'
 import { describePack } from './packs'
 
@@ -253,21 +252,25 @@ export async function invokeMcpTool(
   toolName: string,
   args: Record<string, unknown>
 ): Promise<ActionResult> {
-  const started = Date.now()
+  let session: { grant: SessionGrant; key: string } | undefined
+  let outcome: ActionResult
   try {
     const client = await getOrStartClient(conn)
+    const grant = sessionGrantFor(conn.id)
+    if (grant) session = { grant, key: openSessionCall(grant) }
     // Look up this tool's discovered inputSchema so we can coerce string form
     // values back to the types the tool actually expects.
     const tools = conn.filters.discoveredTools
     const tool = Array.isArray(tools)
       ? (tools as McpDiscoveredTool[]).find((t) => t.name === toolName)
       : undefined
-    const callArgs = coerceMcpArgs(tool?.inputSchema, args)
-    const browser = browserSignInFor(conn.id) !== undefined
-    // A signed-in tool may make several calls through its window, each up to twenty seconds.
-    const params = { name: toolName, arguments: callArgs }
-    const result = browser
-      ? await client.callTool(params, undefined, { timeout: BROWSER_TOOL_TIMEOUT_MS })
+    const params = { name: toolName, arguments: coerceMcpArgs(tool?.inputSchema, args) }
+    const result = session
+      ? await client.callTool(
+          { ...params, _meta: { [SESSION_CALL_META]: session.key } },
+          undefined,
+          { timeout: BROWSER_TOOL_TIMEOUT_MS }
+        )
       : await client.callTool(params)
     // When the tool declared an outputSchema, MCP returns the typed payload
     // under `structuredContent`. Surface that as `output` so downstream
@@ -280,54 +283,21 @@ export async function invokeMcpTool(
       string,
       unknown
     >
-    if (result.isError) {
-      return await withSessionOutcome(conn, started, {
-        success: false,
-        error: extractTextError(result.content) ?? `MCP tool ${toolName} reported an error`,
-        output
-      })
-    }
-    return await withSessionOutcome(conn, started, { success: true, output })
+    outcome = result.isError
+      ? {
+          success: false,
+          error: extractTextError(result.content) ?? `MCP tool ${toolName} reported an error`,
+          output
+        }
+      : { success: true, output }
   } catch (err) {
-    return await withSessionOutcome(conn, started, {
-      success: false,
-      error: err instanceof Error ? err.message : String(err)
-    })
+    outcome = { success: false, error: err instanceof Error ? err.message : String(err) }
   }
+  return session ? await sessionOutcome(conn, session.grant, session.key, outcome) : outcome
 }
 
 /** A tool may make several calls through its window, each up to twenty seconds. */
 const BROWSER_TOOL_TIMEOUT_MS = 120_000
-
-/** A browser connection's result, with its window calls attached and a failure told apart: Vorn closed, or the site signed it out. */
-async function withSessionOutcome(
-  conn: SourceConnection,
-  since: number,
-  result: ActionResult
-): Promise<ActionResult> {
-  if (browserSignInFor(conn.id) === undefined) return result
-  const sessionCalls = sessionCallsSince(conn.id, since)
-  const withCalls = sessionCalls.length > 0 ? { ...result, sessionCalls } : result
-  if (result.success) return withCalls
-  if (sessionCalls.some((call) => call.status === 'app-offline')) {
-    return {
-      ...withCalls,
-      errorKind: 'app-offline',
-      error: `Open Vorn on the desktop ${conn.name} signed in on, then run this step again.`
-    }
-  }
-  const refused = sessionCalls.some((call) => call.status === 401 || call.status === 403)
-  if (refused && (await stillSignedIn(conn.id)) === false) {
-    dbSetConnectionSignIn(conn.id, null, null)
-    dbSignalChange()
-    return {
-      ...withCalls,
-      errorKind: 'needs-sign-in',
-      error: `${conn.name} was signed out. Sign in again, and this step runs again.`
-    }
-  }
-  return withCalls
-}
 
 // --- Poll / trigger support -------------------------------------------------
 

--- a/packages/server/src/connectors/mcp.ts
+++ b/packages/server/src/connectors/mcp.ts
@@ -14,7 +14,7 @@
  * token.
  * The decrypted values are merged in at spawn time via `getOrStartClient`.
  */
-import { openSessionCall, sessionOutcome, type SessionGrant } from './session-bridge'
+import { openSessionCall, sessionOutcome, type OpenSessionCall } from './session-bridge'
 import type {
   VornConnector,
   ConnectorManifest,
@@ -252,12 +252,12 @@ export async function invokeMcpTool(
   toolName: string,
   args: Record<string, unknown>
 ): Promise<ActionResult> {
-  let session: { grant: SessionGrant; key: string } | undefined
+  let call: OpenSessionCall | undefined
   let outcome: ActionResult
   try {
     const client = await getOrStartClient(conn)
     const grant = sessionGrantFor(conn.id)
-    if (grant) session = { grant, key: openSessionCall(grant) }
+    if (grant) call = openSessionCall(grant)
     // Look up this tool's discovered inputSchema so we can coerce string form
     // values back to the types the tool actually expects.
     const tools = conn.filters.discoveredTools
@@ -265,12 +265,10 @@ export async function invokeMcpTool(
       ? (tools as McpDiscoveredTool[]).find((t) => t.name === toolName)
       : undefined
     const params = { name: toolName, arguments: coerceMcpArgs(tool?.inputSchema, args) }
-    const result = session
-      ? await client.callTool(
-          { ...params, _meta: { [SESSION_CALL_META]: session.key } },
-          undefined,
-          { timeout: BROWSER_TOOL_TIMEOUT_MS }
-        )
+    const result = call
+      ? await client.callTool({ ...params, _meta: { [SESSION_CALL_META]: call.key } }, undefined, {
+          timeout: BROWSER_TOOL_TIMEOUT_MS
+        })
       : await client.callTool(params)
     // When the tool declared an outputSchema, MCP returns the typed payload
     // under `structuredContent`. Surface that as `output` so downstream
@@ -293,7 +291,7 @@ export async function invokeMcpTool(
   } catch (err) {
     outcome = { success: false, error: err instanceof Error ? err.message : String(err) }
   }
-  return session ? await sessionOutcome(conn, session.grant, session.key, outcome) : outcome
+  return call ? await sessionOutcome(conn, call, outcome) : outcome
 }
 
 /** A tool may make several calls through its window, each up to twenty seconds. */

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -13,6 +13,7 @@
  * right for polling and wrong for a probe of something the user may not
  * install. This spawns, asks, and exits.
  */
+import { ORIGIN_PATTERN, withinOrigins } from '@vornrun/shared/connector-origins'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type {
@@ -26,6 +27,7 @@ import type {
   ExtensionPaneContribution,
   ExtensionPermission,
   SdkActionInput,
+  SdkBrowserSignIn,
   SdkConnectorAuth,
   SdkConnectorIcon,
   SdkConnectorManifest,
@@ -195,7 +197,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const str = (value: unknown, fallback = ''): string =>
   typeof value === 'string' ? value : fallback
 
-const AUTH_RUNGS: ConnectorAuthRung[] = ['none', 'cli', 'key', 'oauth']
+const AUTH_RUNGS: ConnectorAuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
 
 /**
  * A bare executable name, which is all a probe command is allowed to be.
@@ -267,6 +269,16 @@ function toActionOptions(value: unknown): Array<{ value: string; label?: string 
     }))
 }
 
+/** A browser sign-in whose pages all sit inside origins this build accepts, or nothing. */
+function toBrowserSignIn(value: unknown): SdkBrowserSignIn | undefined {
+  if (!isRecord(value) || !isRecord(value.check)) return undefined
+  const origins = strings(value.origins).filter((origin) => ORIGIN_PATTERN.test(origin))
+  const signInUrl = str(value.signInUrl).trim()
+  const url = str(value.check.url).trim()
+  if (!withinOrigins(origins, signInUrl) || !withinOrigins(origins, url)) return undefined
+  return { signInUrl, origins, check: { url, identity: strings(value.check.identity) } }
+}
+
 /**
  * Read a declared auth block, or say nothing about how it signs in.
  *
@@ -289,6 +301,9 @@ function toAuth(value: unknown): SdkConnectorAuth | undefined {
   // the promise unbacked — better to say nothing than to offer a Sign in that
   // could not work.
   if (rung === 'cli' && !usable) return undefined
+  const browser = rung === 'browser' ? toBrowserSignIn(value.browser) : undefined
+  // The same unbacked promise for a window: nowhere to sign in, or pages outside its own origins.
+  if (rung === 'browser' && !browser) return undefined
 
   const borrow = isRecord(value.borrow) ? value.borrow : undefined
   const env = strings(borrow?.env)
@@ -308,7 +323,8 @@ function toAuth(value: unknown): SdkConnectorAuth | undefined {
         ...(tokenEnv !== undefined && { tokenEnv })
       }
     }),
-    ...(keys.length > 0 && { keys })
+    ...(keys.length > 0 && { keys }),
+    ...(browser && { browser })
   }
 }
 

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -198,8 +198,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const str = (value: unknown, fallback = ''): string =>
   typeof value === 'string' ? value : fallback
 
-const AUTH_RUNGS = CONNECTOR_AUTH_RUNGS
-
 /**
  * A bare executable name, which is all a probe command is allowed to be.
  *
@@ -290,7 +288,8 @@ function toBrowserSignIn(value: unknown): SdkBrowserSignIn | undefined {
 function toAuth(value: unknown): SdkConnectorAuth | undefined {
   if (!isRecord(value)) return undefined
   const rung = value.rung
-  if (typeof rung !== 'string' || !AUTH_RUNGS.includes(rung as ConnectorAuthRung)) return undefined
+  if (typeof rung !== 'string' || !CONNECTOR_AUTH_RUNGS.includes(rung as ConnectorAuthRung))
+    return undefined
 
   const probe = isRecord(value.probe) ? value.probe : undefined
   const command = str(probe?.command).trim()

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -13,6 +13,7 @@
  * right for polling and wrong for a probe of something the user may not
  * install. This spawns, asks, and exits.
  */
+import { CONNECTOR_AUTH_RUNGS } from '@vornrun/shared/types'
 import { ORIGIN_PATTERN, withinOrigins } from '@vornrun/shared/connector-origins'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
@@ -197,7 +198,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const str = (value: unknown, fallback = ''): string =>
   typeof value === 'string' ? value : fallback
 
-const AUTH_RUNGS: ConnectorAuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
+const AUTH_RUNGS = CONNECTOR_AUTH_RUNGS
 
 /**
  * A bare executable name, which is all a probe command is allowed to be.

--- a/packages/server/src/connectors/session-bridge.ts
+++ b/packages/server/src/connectors/session-bridge.ts
@@ -1,90 +1,140 @@
-import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { randomBytes } from 'node:crypto'
 import type { FastifyInstance, FastifyReply } from 'fastify'
-import type { SdkBrowserSignIn, SessionCall } from '@vornrun/shared/types'
+import {
+  SESSION_CALL_HEADER,
+  type ActionResult,
+  type SdkBrowserSignIn,
+  type SessionCall,
+  type SourceConnection
+} from '@vornrun/shared/types'
 import { withinOrigins } from '@vornrun/shared/connector-origins'
 import { browserBridge } from '../browser-bridge'
+import { dbSetConnectionSignIn, dbSignalChange } from '../database'
+import { constantTimeEqual } from '../token-manager'
+import { bearerFrom } from '../ws-auth'
 import { isLoopbackAddress } from '../ws-handler'
 import log from '../logger'
 
 /** One call in the window, well inside the tool call's own limit. */
 const CALL_TIMEOUT_MS = 20_000
 const MAX_REQUEST_BYTES = 1024 * 1024
-/** Enough recent calls to explain a failed step. */
+/** Enough of one tool call's requests to explain it failing. */
 const KEPT_CALLS = 50
 const METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'])
 
-interface Grant {
+/** What a browser connector's child was started with, kept beside the child and gone with it. */
+export interface SessionGrant {
   token: string
   browser: SdkBrowserSignIn
-  calls: Array<SessionCall & { at: number }>
+  /** The requests of each tool call in flight, keyed by the call's own key. */
+  calls: Map<string, SessionCall[]>
 }
 
-/** The connections whose child may call through a window, keyed by connection id. */
-const grants = new Map<string, Grant>()
 let origin = ''
 
 export function setSessionBridgeOrigin(value: string): void {
   origin = value
 }
 
-/** The endpoint and token a browser connector's child starts with; each spawn replaces the last token. */
-export function sessionEnvFor(
+/** A token for one child alone, and the environment that hands it the endpoint. */
+export function mintSessionGrant(
   connectionId: string,
   browser: SdkBrowserSignIn
-): Record<string, string> {
+): { grant: SessionGrant; env: Record<string, string> } {
   if (!origin) throw new Error('The signed-in window endpoint has no address yet')
   const token = randomBytes(32).toString('base64url')
-  grants.set(connectionId, { token, browser, calls: [] })
   return {
-    VORN_BROWSER_HOST: `${origin}/connections/${connectionId}/browser`,
-    VORN_BROWSER_TOKEN: token
+    grant: { token, browser, calls: new Map() },
+    env: {
+      VORN_BROWSER_HOST: `${origin}/connections/${connectionId}/browser`,
+      VORN_BROWSER_TOKEN: token
+    }
   }
 }
 
-export function browserSignInFor(connectionId: string): SdkBrowserSignIn | undefined {
-  return grants.get(connectionId)?.browser
+/** Start recording a tool call's requests; the key travels with the call to the child and back. */
+export function openSessionCall(grant: SessionGrant): string {
+  const key = randomBytes(12).toString('base64url')
+  grant.calls.set(key, [])
+  return key
 }
 
-export function forgetSessionGrant(connectionId: string): void {
-  grants.delete(connectionId)
+export function closeSessionCall(grant: SessionGrant, key: string): SessionCall[] {
+  const calls = grant.calls.get(key) ?? []
+  grant.calls.delete(key)
+  return calls
 }
 
-/** The calls a connection's child made through its window since `since`. */
-export function sessionCallsSince(connectionId: string, since: number): SessionCall[] {
-  return (grants.get(connectionId)?.calls ?? [])
-    .filter((call) => call.at >= since)
-    .map(({ method, path, status }) => ({ method, path, status }))
+export function markSignedOut(connectionId: string): void {
+  dbSetConnectionSignIn(connectionId, null, null)
+  dbSignalChange()
 }
 
-/** Whether the connection's window is still signed in, asked of the desktop that holds it; undefined when it cannot say. */
-export async function stillSignedIn(connectionId: string): Promise<boolean | undefined> {
-  const grant = grants.get(connectionId)
-  if (!grant || !browserBridge.isConnected) return undefined
-  try {
-    const answer = await browserBridge.request(
-      'session:check',
-      { connectionId, browser: grant.browser },
-      CALL_TIMEOUT_MS
-    )
-    return answer.signedIn
-  } catch {
-    return undefined
+const checking = new Map<string, Promise<boolean | undefined>>()
+
+/** Whether the window is still signed in, asked once however many calls failed together; undefined when no desktop can say. */
+export function stillSignedIn(
+  connectionId: string,
+  browser: SdkBrowserSignIn
+): Promise<boolean | undefined> {
+  const inFlight = checking.get(connectionId)
+  if (inFlight) return inFlight
+  const check = (async () => {
+    if (!browserBridge.isConnected) return undefined
+    try {
+      const answer = await browserBridge.request(
+        'session:check',
+        { connectionId, browser },
+        CALL_TIMEOUT_MS
+      )
+      return answer.signedIn
+    } catch {
+      return undefined
+    }
+  })().finally(() => checking.delete(connectionId))
+  checking.set(connectionId, check)
+  return check
+}
+
+/** A browser connection's result, with its window calls attached and a failure told apart: Vorn closed, or the site signed it out. */
+export async function sessionOutcome(
+  conn: SourceConnection,
+  grant: SessionGrant,
+  key: string,
+  result: ActionResult
+): Promise<ActionResult> {
+  const sessionCalls = closeSessionCall(grant, key)
+  const withCalls = sessionCalls.length > 0 ? { ...result, sessionCalls } : result
+  if (result.success) return withCalls
+  if (sessionCalls.some((call) => call.status === 'app-offline')) {
+    return {
+      ...withCalls,
+      errorKind: 'app-offline',
+      error: `Open Vorn on the desktop ${conn.name} signed in on, then run this step again.`
+    }
   }
+  const refused = sessionCalls.some((call) => call.status === 401 || call.status === 403)
+  if (refused && (await stillSignedIn(conn.id, grant.browser)) === false) {
+    markSignedOut(conn.id)
+    return {
+      ...withCalls,
+      errorKind: 'needs-sign-in',
+      error: `${conn.name} was signed out. Sign in again, and this step runs again.`
+    }
+  }
+  return withCalls
 }
 
-function record(grant: Grant, call: SessionCall): void {
-  grant.calls.push({ ...call, at: Date.now() })
-  if (grant.calls.length > KEPT_CALLS) grant.calls.splice(0, grant.calls.length - KEPT_CALLS)
+function record(grant: SessionGrant, key: string | undefined, call: SessionCall): void {
+  const calls = key === undefined ? undefined : grant.calls.get(key)
+  if (!calls) return
+  calls.push(call)
+  if (calls.length > KEPT_CALLS) calls.splice(0, calls.length - KEPT_CALLS)
 }
 
-function refuse(reply: FastifyReply, code: number, error: string): FastifyReply {
-  return reply.code(code).send({ error })
-}
-
-function sameToken(given: string, expected: string): boolean {
-  const a = Buffer.from(given)
-  const b = Buffer.from(expected)
-  return a.length === b.length && timingSafeEqual(a, b)
+function refuse(reply: FastifyReply, code: number, reason: string): FastifyReply {
+  // Plain text, like the extension bridge: the SDK reads a refusal's body verbatim into its error.
+  return reply.code(code).type('text/plain; charset=utf-8').send(reason)
 }
 
 interface CallRequest {
@@ -116,17 +166,23 @@ function readRequest(body: unknown): CallRequest | undefined {
 }
 
 /** A browser connector's child, calling through the window its connection signed in on. */
-export function registerSessionBridge(app: FastifyInstance): void {
+export function registerSessionBridge(
+  app: FastifyInstance,
+  grantFor: (connectionId: string) => SessionGrant | undefined
+): void {
   app.post(
     '/connections/:id/browser/fetch',
     { bodyLimit: MAX_REQUEST_BYTES },
     async (req, reply) => {
       if (!isLoopbackAddress(req.ip)) return refuse(reply, 403, 'Local machine only')
       const { id } = req.params as { id: string }
-      const grant = grants.get(id)
-      const auth = req.headers.authorization
-      const token = typeof auth === 'string' && auth.startsWith('Bearer ') ? auth.slice(7) : ''
-      if (!grant || !token || !sameToken(token, grant.token)) {
+      const grant = grantFor(id)
+      const token = bearerFrom(req.headers.authorization)
+      if (
+        !grant ||
+        !token ||
+        !constantTimeEqual(Buffer.from(token, 'utf8'), Buffer.from(grant.token, 'utf8'))
+      ) {
         return refuse(reply, 401, 'This endpoint does not know that caller')
       }
       const request = readRequest(req.body)
@@ -137,9 +193,11 @@ export function registerSessionBridge(app: FastifyInstance): void {
       if (!withinOrigins(grant.browser.origins, request.url)) {
         return refuse(reply, 403, `${request.url} is not on one of this connection's origins`)
       }
+      const header = req.headers[SESSION_CALL_HEADER]
+      const key = typeof header === 'string' ? header : undefined
       const path = new URL(request.url).pathname
       if (!browserBridge.isConnected) {
-        record(grant, { method: request.method, path, status: 'app-offline' })
+        record(grant, key, { method: request.method, path, status: 'app-offline' })
         return refuse(reply, 503, 'Open Vorn on the desktop this connection signed in on')
       }
       try {
@@ -148,10 +206,10 @@ export function registerSessionBridge(app: FastifyInstance): void {
           { connectionId: id, origins: grant.browser.origins, request },
           CALL_TIMEOUT_MS
         )
-        record(grant, { method: request.method, path, status: answer.status })
+        record(grant, key, { method: request.method, path, status: answer.status })
         return reply.code(200).send(answer)
       } catch (err) {
-        record(grant, { method: request.method, path, status: 'failed' })
+        record(grant, key, { method: request.method, path, status: 'failed' })
         return refuse(reply, 503, err instanceof Error ? err.message : String(err))
       }
     }

--- a/packages/server/src/connectors/session-bridge.ts
+++ b/packages/server/src/connectors/session-bridge.ts
@@ -52,14 +52,20 @@ export function mintSessionGrant(
   }
 }
 
-/** Start recording a tool call's requests; the key travels with the call to the child and back. */
-export function openSessionCall(grant: SessionGrant): string {
-  const key = randomBytes(12).toString('base64url')
-  grant.calls.set(key, [])
-  return key
+/** A tool call whose window requests are being recorded. */
+export interface OpenSessionCall {
+  grant: SessionGrant
+  key: string
 }
 
-export function closeSessionCall(grant: SessionGrant, key: string): SessionCall[] {
+/** Start recording a tool call's requests; the key travels with the call to the child and back. */
+export function openSessionCall(grant: SessionGrant): OpenSessionCall {
+  const key = randomBytes(12).toString('base64url')
+  grant.calls.set(key, [])
+  return { grant, key }
+}
+
+export function closeSessionCall({ grant, key }: OpenSessionCall): SessionCall[] {
   const calls = grant.calls.get(key) ?? []
   grant.calls.delete(key)
   return calls
@@ -99,11 +105,10 @@ export function stillSignedIn(
 /** A browser connection's result, with its window calls attached and a failure told apart: Vorn closed, or the site signed it out. */
 export async function sessionOutcome(
   conn: SourceConnection,
-  grant: SessionGrant,
-  key: string,
+  call: OpenSessionCall,
   result: ActionResult
 ): Promise<ActionResult> {
-  const sessionCalls = closeSessionCall(grant, key)
+  const sessionCalls = closeSessionCall(call)
   const withCalls = sessionCalls.length > 0 ? { ...result, sessionCalls } : result
   if (result.success) return withCalls
   if (sessionCalls.some((call) => call.status === 'app-offline')) {
@@ -114,7 +119,7 @@ export async function sessionOutcome(
     }
   }
   const refused = sessionCalls.some((call) => call.status === 401 || call.status === 403)
-  if (refused && (await stillSignedIn(conn.id, grant.browser)) === false) {
+  if (refused && (await stillSignedIn(conn.id, call.grant.browser)) === false) {
     markSignedOut(conn.id)
     return {
       ...withCalls,

--- a/packages/server/src/connectors/session-bridge.ts
+++ b/packages/server/src/connectors/session-bridge.ts
@@ -1,10 +1,11 @@
 import { randomBytes } from 'node:crypto'
-import type { FastifyInstance, FastifyReply } from 'fastify'
+import type { FastifyInstance } from 'fastify'
 import {
   SESSION_CALL_HEADER,
   type ActionResult,
   type SdkBrowserSignIn,
   type SessionCall,
+  type SessionRequest,
   type SourceConnection
 } from '@vornrun/shared/types'
 import { withinOrigins } from '@vornrun/shared/connector-origins'
@@ -13,6 +14,7 @@ import { dbSetConnectionSignIn, dbSignalChange } from '../database'
 import { constantTimeEqual } from '../token-manager'
 import { bearerFrom } from '../ws-auth'
 import { isLoopbackAddress } from '../ws-handler'
+import { refuse } from '../plain-refusal'
 import log from '../logger'
 
 /** One call in the window, well inside the tool call's own limit. */
@@ -137,19 +139,7 @@ function record(grant: SessionGrant, key: string | undefined, call: SessionCall)
   if (calls.length > KEPT_CALLS) calls.splice(0, calls.length - KEPT_CALLS)
 }
 
-function refuse(reply: FastifyReply, code: number, reason: string): FastifyReply {
-  // Plain text, like the extension bridge: the SDK reads a refusal's body verbatim into its error.
-  return reply.code(code).type('text/plain; charset=utf-8').send(reason)
-}
-
-interface CallRequest {
-  url: string
-  method: string
-  headers?: Record<string, string>
-  body?: string
-}
-
-function readRequest(body: unknown): CallRequest | undefined {
+function readRequest(body: unknown): SessionRequest | undefined {
   if (!body || typeof body !== 'object') return undefined
   const value = body as Record<string, unknown>
   if (typeof value.url !== 'string' || typeof value.method !== 'string') return undefined

--- a/packages/server/src/connectors/session-bridge.ts
+++ b/packages/server/src/connectors/session-bridge.ts
@@ -1,0 +1,160 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import type { SdkBrowserSignIn, SessionCall } from '@vornrun/shared/types'
+import { withinOrigins } from '@vornrun/shared/connector-origins'
+import { browserBridge } from '../browser-bridge'
+import { isLoopbackAddress } from '../ws-handler'
+import log from '../logger'
+
+/** One call in the window, well inside the tool call's own limit. */
+const CALL_TIMEOUT_MS = 20_000
+const MAX_REQUEST_BYTES = 1024 * 1024
+/** Enough recent calls to explain a failed step. */
+const KEPT_CALLS = 50
+const METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'])
+
+interface Grant {
+  token: string
+  browser: SdkBrowserSignIn
+  calls: Array<SessionCall & { at: number }>
+}
+
+/** The connections whose child may call through a window, keyed by connection id. */
+const grants = new Map<string, Grant>()
+let origin = ''
+
+export function setSessionBridgeOrigin(value: string): void {
+  origin = value
+}
+
+/** The endpoint and token a browser connector's child starts with; each spawn replaces the last token. */
+export function sessionEnvFor(
+  connectionId: string,
+  browser: SdkBrowserSignIn
+): Record<string, string> {
+  if (!origin) throw new Error('The signed-in window endpoint has no address yet')
+  const token = randomBytes(32).toString('base64url')
+  grants.set(connectionId, { token, browser, calls: [] })
+  return {
+    VORN_BROWSER_HOST: `${origin}/connections/${connectionId}/browser`,
+    VORN_BROWSER_TOKEN: token
+  }
+}
+
+export function browserSignInFor(connectionId: string): SdkBrowserSignIn | undefined {
+  return grants.get(connectionId)?.browser
+}
+
+export function forgetSessionGrant(connectionId: string): void {
+  grants.delete(connectionId)
+}
+
+/** The calls a connection's child made through its window since `since`. */
+export function sessionCallsSince(connectionId: string, since: number): SessionCall[] {
+  return (grants.get(connectionId)?.calls ?? [])
+    .filter((call) => call.at >= since)
+    .map(({ method, path, status }) => ({ method, path, status }))
+}
+
+/** Whether the connection's window is still signed in, asked of the desktop that holds it; undefined when it cannot say. */
+export async function stillSignedIn(connectionId: string): Promise<boolean | undefined> {
+  const grant = grants.get(connectionId)
+  if (!grant || !browserBridge.isConnected) return undefined
+  try {
+    const answer = await browserBridge.request(
+      'session:check',
+      { connectionId, browser: grant.browser },
+      CALL_TIMEOUT_MS
+    )
+    return answer.signedIn
+  } catch {
+    return undefined
+  }
+}
+
+function record(grant: Grant, call: SessionCall): void {
+  grant.calls.push({ ...call, at: Date.now() })
+  if (grant.calls.length > KEPT_CALLS) grant.calls.splice(0, grant.calls.length - KEPT_CALLS)
+}
+
+function refuse(reply: FastifyReply, code: number, error: string): FastifyReply {
+  return reply.code(code).send({ error })
+}
+
+function sameToken(given: string, expected: string): boolean {
+  const a = Buffer.from(given)
+  const b = Buffer.from(expected)
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+interface CallRequest {
+  url: string
+  method: string
+  headers?: Record<string, string>
+  body?: string
+}
+
+function readRequest(body: unknown): CallRequest | undefined {
+  if (!body || typeof body !== 'object') return undefined
+  const value = body as Record<string, unknown>
+  if (typeof value.url !== 'string' || typeof value.method !== 'string') return undefined
+  if (value.body !== undefined && typeof value.body !== 'string') return undefined
+  const headers =
+    value.headers && typeof value.headers === 'object'
+      ? Object.fromEntries(
+          Object.entries(value.headers as Record<string, unknown>).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string'
+          )
+        )
+      : undefined
+  return {
+    url: value.url,
+    method: value.method.toUpperCase(),
+    ...(headers && { headers }),
+    ...(value.body !== undefined && { body: value.body as string })
+  }
+}
+
+/** A browser connector's child, calling through the window its connection signed in on. */
+export function registerSessionBridge(app: FastifyInstance): void {
+  app.post(
+    '/connections/:id/browser/fetch',
+    { bodyLimit: MAX_REQUEST_BYTES },
+    async (req, reply) => {
+      if (!isLoopbackAddress(req.ip)) return refuse(reply, 403, 'Local machine only')
+      const { id } = req.params as { id: string }
+      const grant = grants.get(id)
+      const auth = req.headers.authorization
+      const token = typeof auth === 'string' && auth.startsWith('Bearer ') ? auth.slice(7) : ''
+      if (!grant || !token || !sameToken(token, grant.token)) {
+        return refuse(reply, 401, 'This endpoint does not know that caller')
+      }
+      const request = readRequest(req.body)
+      if (!request) return refuse(reply, 400, 'Send { url, method, headers?, body? }')
+      if (!METHODS.has(request.method)) {
+        return refuse(reply, 405, `${request.method} is not a method a signed-in call may use`)
+      }
+      if (!withinOrigins(grant.browser.origins, request.url)) {
+        return refuse(reply, 403, `${request.url} is not on one of this connection's origins`)
+      }
+      const path = new URL(request.url).pathname
+      if (!browserBridge.isConnected) {
+        record(grant, { method: request.method, path, status: 'app-offline' })
+        return refuse(reply, 503, 'Open Vorn on the desktop this connection signed in on')
+      }
+      try {
+        const answer = await browserBridge.request(
+          'session:fetch',
+          { connectionId: id, origins: grant.browser.origins, request },
+          CALL_TIMEOUT_MS
+        )
+        record(grant, { method: request.method, path, status: answer.status })
+        return reply.code(200).send(answer)
+      } catch (err) {
+        record(grant, { method: request.method, path, status: 'failed' })
+        return refuse(reply, 503, err instanceof Error ? err.message : String(err))
+      }
+    }
+  )
+  log.info('[connectors] signed-in window route registered')
+}

--- a/packages/server/src/connectors/stdio-clients.ts
+++ b/packages/server/src/connectors/stdio-clients.ts
@@ -36,6 +36,7 @@ export interface StdioClientCache<Meta> {
   stopWhere(matches: (meta: Meta) => boolean): Promise<void>
   stopAll(): Promise<void>
   has(key: string): boolean
+  get(key: string): Meta | undefined
   find(matches: (meta: Meta) => boolean): Meta | undefined
   entries(): Meta[]
 }
@@ -118,6 +119,7 @@ export function createStdioClientCache<Meta>(label: string): StdioClientCache<Me
       await Promise.allSettled([...live.keys()].map(stop))
     },
     has: (key) => live.has(key),
+    get: (key) => live.get(key)?.meta,
     find: (matches) => [...live.values()].map((entry) => entry.meta).find(matches),
     entries: () => [...live.values()].map((entry) => entry.meta)
   }

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -762,7 +762,9 @@ function migrateSchema(d: Database.Database): void {
           last_sync_at TEXT,
           last_sync_error TEXT,
           sync_cursor TEXT,
-          created_at TEXT NOT NULL
+          created_at TEXT NOT NULL,
+          signed_in_as TEXT,
+          signed_in_at TEXT
         )
       `)
 
@@ -1086,6 +1088,24 @@ function migrateSchema(d: Database.Database): void {
       ).run()
     })()
     log.info('[database] migrated schema to version 19 (worktrees on run steps)')
+  }
+
+  if (version < 20) {
+    d.transaction(() => {
+      const cols = d.prepare('PRAGMA table_info(source_connections)').all() as Array<{
+        name: string
+      }>
+      for (const column of ['signed_in_as', 'signed_in_at']) {
+        if (!cols.some((c) => c.name === column)) {
+          d.exec(`ALTER TABLE source_connections ADD COLUMN ${column} TEXT`)
+        }
+      }
+
+      d.prepare(
+        "INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('schema_version', '20')"
+      ).run()
+    })()
+    log.info('[database] migrated schema to version 20 (who a connection is signed in as)')
   }
 }
 
@@ -2066,6 +2086,8 @@ interface SourceConnectionRow {
   last_sync_error: string | null
   sync_cursor: string | null
   created_at: string
+  signed_in_as: string | null
+  signed_in_at: string | null
 }
 
 function rowToSourceConnection(r: SourceConnectionRow): SourceConnection {
@@ -2080,7 +2102,9 @@ function rowToSourceConnection(r: SourceConnectionRow): SourceConnection {
     ...(r.last_sync_at != null && { lastSyncAt: r.last_sync_at }),
     ...(r.last_sync_error != null && { lastSyncError: r.last_sync_error }),
     ...(r.sync_cursor != null && { syncCursor: r.sync_cursor }),
-    createdAt: r.created_at
+    createdAt: r.created_at,
+    ...(r.signed_in_as != null && { signedInAs: r.signed_in_as }),
+    ...(r.signed_in_at != null && { signedInAt: r.signed_in_at })
   }
 }
 
@@ -2106,8 +2130,8 @@ export function dbGetSourceConnection(id: string): SourceConnection | null {
 export function dbInsertSourceConnection(conn: SourceConnection): void {
   getDb()
     .prepare(
-      `INSERT INTO source_connections (id, connector_id, name, filters, sync_interval_minutes, status_mapping, execution_project, last_sync_at, last_sync_error, sync_cursor, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO source_connections (id, connector_id, name, filters, sync_interval_minutes, status_mapping, execution_project, last_sync_at, last_sync_error, sync_cursor, created_at, signed_in_as, signed_in_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       conn.id,
@@ -2120,7 +2144,9 @@ export function dbInsertSourceConnection(conn: SourceConnection): void {
       conn.lastSyncAt ?? null,
       conn.lastSyncError ?? null,
       conn.syncCursor ?? null,
-      conn.createdAt
+      conn.createdAt,
+      conn.signedInAs ?? null,
+      conn.signedInAt ?? null
     )
 }
 
@@ -2164,6 +2190,17 @@ export function dbUpdateSourceConnection(id: string, updates: Partial<SourceConn
   getDb()
     .prepare(`UPDATE source_connections SET ${sets.join(', ')} WHERE id = ?`)
     .run(...params)
+}
+
+/** Who a connection's window is signed in as; both null once it is signed out. */
+export function dbSetConnectionSignIn(
+  id: string,
+  signedInAs: string | null,
+  signedInAt: string | null
+): void {
+  getDb()
+    .prepare('UPDATE source_connections SET signed_in_as = ?, signed_in_at = ? WHERE id = ?')
+    .run(signedInAs, signedInAt, id)
 }
 
 export function dbDeleteSourceConnection(id: string): void {

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -3883,14 +3883,14 @@ export function listRunningRuns(): WorkflowExecution[] {
 // because gates pause execution. No LIMIT is intentional so the badge count
 // matches the real backlog. If this ever grows, cap with a LIMIT here and
 // chunk `fetchNodesByRunIds` to stay under SQLite's IN-clause variable cap.
-export function listRunsWithWaitingGates(): WorkflowExecution[] {
+export function listRunsWithWaitingGates(kind?: 'signIn'): WorkflowExecution[] {
   const d = getDb()
   const rows = d
     .prepare(
       `SELECT DISTINCT wr.*
        FROM workflow_runs wr
        JOIN workflow_run_nodes wrn ON wrn.run_id = wr.id
-       WHERE wrn.status = 'waiting'
+       WHERE wrn.status = 'waiting'${kind === 'signIn' ? " AND wrn.waiting_for = 'signIn'" : ''}
        ORDER BY wr.started_at DESC`
     )
     .all() as RunRow[]

--- a/packages/server/src/database.ts
+++ b/packages/server/src/database.ts
@@ -466,6 +466,7 @@ function createSchema(): void {
       worktree_path TEXT,
       worktree_name TEXT,
       worktree_origin TEXT,
+      waiting_for TEXT,
       FOREIGN KEY (run_id) REFERENCES workflow_runs(id) ON DELETE CASCADE
     );
 
@@ -1206,6 +1207,7 @@ function verifySchema(d: Database.Database): void {
       }
     ],
     workflow_run_nodes: [
+      { column: 'waiting_for', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN waiting_for TEXT' },
       { column: 'agent_type', ddl: 'ALTER TABLE workflow_run_nodes ADD COLUMN agent_type TEXT' },
       {
         column: 'project_name',
@@ -3570,8 +3572,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
     d.prepare('DELETE FROM workflow_run_nodes WHERE run_id = ?').run(runId)
 
     const insertNode = d.prepare(
-      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics, output, structured_output, iteration, worktree_path, worktree_name, worktree_origin)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO workflow_run_nodes (run_id, node_id, status, started_at, completed_at, session_id, error, logs, task_id, agent_session_id, agent_type, project_name, project_path, approved_at, diagnostics, output, structured_output, iteration, worktree_path, worktree_name, worktree_origin, waiting_for)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     for (const ns of execution.nodeStates) {
       insertNode.run(
@@ -3597,7 +3599,8 @@ export function saveWorkflowRun(execution: WorkflowExecution): void {
         ns.iteration ?? null,
         ns.worktreePath ?? null,
         ns.worktreeName ?? null,
-        ns.worktreeOrigin ?? null
+        ns.worktreeOrigin ?? null,
+        ns.waitingFor ?? null
       )
     }
 
@@ -3655,6 +3658,7 @@ type WorkflowRunNodeRow = {
   worktree_path: string | null
   worktree_name: string | null
   worktree_origin: string | null
+  waiting_for: string | null
 }
 
 function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
@@ -3686,7 +3690,8 @@ function mapNodeRow(n: WorkflowRunNodeRow): NodeExecutionState {
     ...(n.worktree_name != null && { worktreeName: n.worktree_name }),
     ...((n.worktree_origin === 'created' || n.worktree_origin === 'inherited') && {
       worktreeOrigin: n.worktree_origin
-    })
+    }),
+    ...(n.waiting_for === 'signIn' && { waitingFor: 'signIn' as const })
   }
 }
 

--- a/packages/server/src/extensions/bridge.ts
+++ b/packages/server/src/extensions/bridge.ts
@@ -1,6 +1,7 @@
 import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs'
 import { dirname, extname, resolve, sep } from 'node:path'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { refuse } from '../plain-refusal'
 import type {
   ExtensionPermission,
   InstalledConnectorPack,
@@ -94,11 +95,6 @@ interface Caller {
 function sessionOf(sessionId: unknown): TerminalSession | undefined {
   if (typeof sessionId !== 'string' || sessionId === '') return undefined
   return ptyManager.getLiveSessions().find((session) => session.id === sessionId)
-}
-
-function refuse(reply: FastifyReply, code: number, reason: string): FastifyReply {
-  // Plain text: the SDK reads a refusal's body verbatim into the error it raises.
-  return reply.code(code).type('text/plain; charset=utf-8').send(reason)
 }
 
 /** The extension's own reads, once the caller and the session are settled. */

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from './register-methods'
 import { registerWebhookRoute } from './webhook-trigger'
 import { registerExtensionBridge, type ExtensionRouteDeps } from './extensions/bridge'
+import { registerSessionBridge, setSessionBridgeOrigin } from './connectors/session-bridge'
 import { setExtensionBridgeOrigin, stopAllHosts } from './extensions/hosts'
 import { startExtensionPageServer, stopExtensionPageServer } from './extensions/page-server'
 import { stopAllFooters } from './extensions/footers'
@@ -282,6 +283,8 @@ export async function startServer(
   // was started with. The pages its panes are drawn from are served on their own
   // origin instead, so a page shares neither storage nor a socket with the app.
   registerExtensionBridge(app, extensionRouteDeps)
+  // A browser connector's child, calling through the window its connection signed in on.
+  registerSessionBridge(app)
 
   /**
    * Pairing, the phone's half.
@@ -498,6 +501,7 @@ export async function startServer(
   setServerPort(actualPort)
   // The address the extension children are given, known only once a port is won.
   setExtensionBridgeOrigin(`http://127.0.0.1:${actualPort}`)
+  setSessionBridgeOrigin(`http://127.0.0.1:${actualPort}`)
 
   // Pane pages, on a port of their own. The app frames them, so the app's origins
   // are the only ones allowed to; a page that fails to start costs its panes, not

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { registerWebhookRoute } from './webhook-trigger'
 import { registerExtensionBridge, type ExtensionRouteDeps } from './extensions/bridge'
 import { registerSessionBridge, setSessionBridgeOrigin } from './connectors/session-bridge'
+import { sessionGrantFor } from './connectors/mcp-clients'
 import { setExtensionBridgeOrigin, stopAllHosts } from './extensions/hosts'
 import { startExtensionPageServer, stopExtensionPageServer } from './extensions/page-server'
 import { stopAllFooters } from './extensions/footers'
@@ -283,8 +284,7 @@ export async function startServer(
   // was started with. The pages its panes are drawn from are served on their own
   // origin instead, so a page shares neither storage nor a socket with the app.
   registerExtensionBridge(app, extensionRouteDeps)
-  // A browser connector's child, calling through the window its connection signed in on.
-  registerSessionBridge(app)
+  registerSessionBridge(app, sessionGrantFor)
 
   /**
    * Pairing, the phone's half.

--- a/packages/server/src/plain-refusal.ts
+++ b/packages/server/src/plain-refusal.ts
@@ -1,0 +1,6 @@
+import type { FastifyReply } from 'fastify'
+
+/** Plain text: the SDK reads a refusal's body verbatim into the error it raises. */
+export function refuse(reply: FastifyReply, code: number, reason: string): FastifyReply {
+  return reply.code(code).type('text/plain; charset=utf-8').send(reason)
+}

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1,3 +1,4 @@
+import { SDK_FILTER_KEYS } from '@vornrun/shared/types'
 import fs from 'fs'
 import crypto from 'node:crypto'
 import { registerMethod, registerNotification } from './ws-handler'
@@ -120,6 +121,7 @@ import {
   dbGetSourceConnection,
   dbInsertSourceConnection,
   dbUpdateSourceConnection,
+  dbSetConnectionSignIn,
   dbDeleteSourceConnection,
   dbGetTaskSourceLink,
   dbGetTaskSourceLinkByExternalId,
@@ -358,6 +360,8 @@ function deleteConnectionRecord(id: string): void {
   dbDeleteSourceConnection(id)
   // Forget any decrypted plaintext for this connection.
   clearDecryptedCreds(id)
+  // Its signed-in profile goes too; the desktop that holds it may not be connected right now.
+  void browserBridge.request('session:forget', id).catch(() => {})
   // Terminate any live MCP stdio child for this connection.
   void stopMcpClient(id).catch((err) => log.warn(`[mcp] stopClient failed: ${err}`))
   dbSignalChange()
@@ -1712,6 +1716,26 @@ export function registerAllMethods(): void {
       throw new Error(`${conn.name} came with its connector. Remove the pack instead.`)
     }
     deleteConnectionRecord(id)
+  })
+
+  registerMethod('connection:browserAuth', async (id) => {
+    const conn = dbGetSourceConnection(id)
+    const sdkId = conn?.filters[SDK_FILTER_KEYS.connectorId]
+    if (!conn || typeof sdkId !== 'string') return null
+    const auth = (await resolveConnectorAuth(sdkId))?.auth
+    return auth?.rung === 'browser' && auth.browser
+      ? { name: conn.name, browser: auth.browser }
+      : null
+  })
+
+  registerMethod('connection:signedIn', ({ connectionId, identity }) => {
+    dbSetConnectionSignIn(connectionId, identity, new Date().toISOString())
+    dbSignalChange()
+  })
+
+  registerMethod('connection:signedOut', (id) => {
+    dbSetConnectionSignIn(id, null, null)
+    dbSignalChange()
   })
 
   registerMethod('workflow:runManual', ({ workflowId, inputs }) => {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -79,10 +79,7 @@ import type {
   WorkflowExecution,
   WorktreeRetentionConfig
 } from '@vornrun/shared/types'
-import {
-  connectionConnectorId,
-  DEFAULT_ARTIFACT_DIRS
-} from '@vornrun/shared/types'
+import { connectionConnectorId, DEFAULT_ARTIFACT_DIRS } from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
 import { detectRepoSlug } from './git-utils'
 import {

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -171,6 +171,7 @@ import {
   backfillMcpConnection,
   preflightMcpConnection
 } from './connectors/mcp'
+import { sdkIdOf } from './connectors/mcp-clients'
 import {
   httpConnector,
   httpProfileError,
@@ -185,8 +186,8 @@ import {
   rerunWorkflowRun,
   retryRunFromFailure,
   stopWorkflowRun,
-  isSignInWait,
-  resumeSignInWaits
+  resumeSignInWaits,
+  runWaitsForSignIn
 } from './workflows/engine'
 import { listKeys, passwordFields } from './connectors/keys'
 import { installedPack } from './connectors/packs'
@@ -819,7 +820,7 @@ export function registerAllMethods(): void {
 
   registerMethod('workflow:resolveGate', ({ runId, nodeId, decision }) => {
     // A sign-in wait ends when the connection signs in again, never by approval.
-    if (decision === 'approve' && isSignInWait(runId, nodeId)) return { accepted: false }
+    if (decision === 'approve' && runWaitsForSignIn(runId, nodeId)) return { accepted: false }
     // Applied here, where the run is. It used to be broadcast for whichever
     // window held the run to apply, which is why answering from a phone with
     // nothing open did nothing at all.
@@ -1728,8 +1729,8 @@ export function registerAllMethods(): void {
 
   registerMethod('connection:browserAuth', async (id) => {
     const conn = dbGetSourceConnection(id)
-    const sdkId = conn?.filters[SDK_FILTER_KEYS.connectorId]
-    if (!conn || typeof sdkId !== 'string') return null
+    const sdkId = conn ? sdkIdOf(conn) : ''
+    if (!conn || !sdkId) return null
     const auth = (await resolveConnectorAuth(sdkId))?.auth
     return auth?.rung === 'browser' && auth.browser
       ? { name: conn.name, browser: auth.browser }
@@ -1739,7 +1740,7 @@ export function registerAllMethods(): void {
   registerMethod('connection:signedIn', ({ connectionId, identity }) => {
     dbSetConnectionSignIn(connectionId, identity, new Date().toISOString())
     dbSignalChange()
-    void resumeSignInWaits(connectionId, listRunsWithWaitingGates()).catch((err) =>
+    void resumeSignInWaits(connectionId, listRunsWithWaitingGates('signIn')).catch((err) =>
       log.warn({ err }, '[workflow] resuming after a sign-in failed')
     )
   })

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -81,8 +81,7 @@ import type {
 } from '@vornrun/shared/types'
 import {
   connectionConnectorId,
-  DEFAULT_ARTIFACT_DIRS,
-  SDK_FILTER_KEYS
+  DEFAULT_ARTIFACT_DIRS
 } from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
 import { detectRepoSlug } from './git-utils'

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -184,7 +184,9 @@ import {
   executeWorkflow,
   rerunWorkflowRun,
   retryRunFromFailure,
-  stopWorkflowRun
+  stopWorkflowRun,
+  isSignInWait,
+  resumeSignInWaits
 } from './workflows/engine'
 import { listKeys, passwordFields } from './connectors/keys'
 import { installedPack } from './connectors/packs'
@@ -816,6 +818,8 @@ export function registerAllMethods(): void {
   })
 
   registerMethod('workflow:resolveGate', ({ runId, nodeId, decision }) => {
+    // A sign-in wait ends when the connection signs in again, never by approval.
+    if (decision === 'approve' && isSignInWait(runId, nodeId)) return { accepted: false }
     // Applied here, where the run is. It used to be broadcast for whichever
     // window held the run to apply, which is why answering from a phone with
     // nothing open did nothing at all.
@@ -1735,6 +1739,9 @@ export function registerAllMethods(): void {
   registerMethod('connection:signedIn', ({ connectionId, identity }) => {
     dbSetConnectionSignIn(connectionId, identity, new Date().toISOString())
     dbSignalChange()
+    void resumeSignInWaits(connectionId, listRunsWithWaitingGates()).catch((err) =>
+      log.warn({ err }, '[workflow] resuming after a sign-in failed')
+    )
   })
 
   registerMethod('connection:signedOut', (id) => markSignedOut(id))

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -194,6 +194,7 @@ import {
 } from './connectors/implicit-connection'
 import { probeAuth, type BorrowSource } from './connectors/auth-rung'
 import { resolveConnectorAuth } from './connectors/connector-auth'
+import { markSignedOut } from './connectors/session-bridge'
 import { probeSdkConnector, type SdkProbeRequest } from './connectors/sdk-probe'
 import { isImplicitConnection, type ConnectorPackSource } from '@vornrun/shared/types'
 import { catalogEvents, catalogSnapshot, refreshCatalog } from './connectors/catalog'
@@ -1736,10 +1737,7 @@ export function registerAllMethods(): void {
     dbSignalChange()
   })
 
-  registerMethod('connection:signedOut', (id) => {
-    dbSetConnectionSignIn(id, null, null)
-    dbSignalChange()
-  })
+  registerMethod('connection:signedOut', (id) => markSignedOut(id))
 
   registerMethod('workflow:runManual', ({ workflowId, inputs }) => {
     const wf = dbGetWorkflow(workflowId)

--- a/packages/server/src/register-methods.ts
+++ b/packages/server/src/register-methods.ts
@@ -1,4 +1,3 @@
-import { SDK_FILTER_KEYS } from '@vornrun/shared/types'
 import fs from 'fs'
 import crypto from 'node:crypto'
 import { registerMethod, registerNotification } from './ws-handler'
@@ -80,7 +79,11 @@ import type {
   WorkflowExecution,
   WorktreeRetentionConfig
 } from '@vornrun/shared/types'
-import { connectionConnectorId, DEFAULT_ARTIFACT_DIRS } from '@vornrun/shared/types'
+import {
+  connectionConnectorId,
+  DEFAULT_ARTIFACT_DIRS,
+  SDK_FILTER_KEYS
+} from '@vornrun/shared/types'
 import * as gitUtils from './git-utils'
 import { detectRepoSlug } from './git-utils'
 import {

--- a/packages/server/src/workflows/engine.ts
+++ b/packages/server/src/workflows/engine.ts
@@ -22,7 +22,11 @@ import {
   resolveTemplateVars,
   StepOutputs
 } from '@vornrun/shared/template-vars'
-import { getWorktreeMode, webhookTriggerFromItem } from '@vornrun/shared/workflow-graph'
+import {
+  getWorktreeMode,
+  webhookTriggerFromItem,
+  isSignInWait
+} from '@vornrun/shared/workflow-graph'
 import { buildTaskPrompt, buildWorkflowPrompt } from '@vornrun/shared/prompt-builder'
 import { extractStructuredOutput } from '@vornrun/shared/structured-output'
 import {
@@ -526,9 +530,9 @@ async function executeLoop(
       const stepOutputs = buildStepOutputsMap(execution, nodeMap)
       await executeNode(step, workflow, execution, context, stepOutputs, active)
 
-      const parked = execution.nodeStates.find((s) => s.nodeId === step.id)
+      const state = execution.nodeStates.find((s) => s.nodeId === step.id)
       // A loop cannot wait mid-pass, so a step that would wait for a sign-in fails the pass instead.
-      if (parked?.status === 'waiting' && parked.waitingFor === 'signIn') {
+      if (state && isSignInWait(state)) {
         updateNodeState(execution, step.id, {
           status: 'error',
           waitingFor: undefined,
@@ -538,7 +542,6 @@ async function executeLoop(
         })
         persistExecution(execution)
       }
-      const state = execution.nodeStates.find((s) => s.nodeId === step.id)
       updateNodeState(execution, step.id, { iteration })
       summary.push(`  ${step.label}: ${state?.status ?? 'unknown'}`)
       // Same policy as the main graph: a body step that fails ends the pass
@@ -713,10 +716,6 @@ async function executeNode(
         action: cfg.action,
         args: resolvedArgs
       })
-      // Only persist plain objects as structuredOutput. Arrays would land
-      // here under `typeof === 'object'` but break `buildStepOutputsMap`
-      // which spreads the value into a string-keyed map (the array
-      // indices `0`, `1`, … would become bogus step keys).
       // A signed-out window waits for the person to sign in again rather than failing the step.
       if (!result.success && result.errorKind === 'needs-sign-in') {
         updateNodeState(execution, node.id, {
@@ -728,6 +727,10 @@ async function executeNode(
         persistExecution(execution)
         return
       }
+      // Only persist plain objects as structuredOutput. Arrays would land
+      // here under `typeof === 'object'` but break `buildStepOutputsMap`
+      // which spreads the value into a string-keyed map (the array
+      // indices `0`, `1`, … would become bogus step keys).
       const isPlainObject =
         !!result.output && typeof result.output === 'object' && !Array.isArray(result.output)
       updateNodeState(execution, node.id, {
@@ -1958,7 +1961,7 @@ function resolveWaitingGate(
     return null
   }
   // Only signing in again ends a sign-in wait; approving it would skip the step it waits to run.
-  if (caller === 'approve' && ns.waitingFor === 'signIn') {
+  if (caller === 'approve' && isSignInWait(ns)) {
     log.warn(`[workflow] approveWorkflowGate: node ${nodeId} waits for a sign-in, not an approval`)
     return null
   }
@@ -2036,9 +2039,10 @@ export async function rejectWorkflowGate(
 }
 
 /** Whether a waiting step waits for its connection to sign in again, not for an approval. */
-export function isSignInWait(runId: string, nodeId: string): boolean {
+export function runWaitsForSignIn(runId: string, nodeId: string): boolean {
   const execution = activeRuns.get(runId)?.execution ?? runById(runId)
-  return execution?.nodeStates.find((state) => state.nodeId === nodeId)?.waitingFor === 'signIn'
+  const state = execution?.nodeStates.find((ns) => ns.nodeId === nodeId)
+  return state !== undefined && isSignInWait(state)
 }
 
 /** Run again the steps that waited for this connection to sign in; what ran before them is kept. */
@@ -2052,7 +2056,7 @@ export async function resumeSignInWaits(
     const workflow = workflowById(execution.workflowId)
     if (!workflow) continue
     const waiting = execution.nodeStates.filter((state) => {
-      if (state.status !== 'waiting' || state.waitingFor !== 'signIn') return false
+      if (!isSignInWait(state)) return false
       const node = workflow.nodes.find((n) => n.id === state.nodeId)
       return (node?.config as { connectionId?: string } | undefined)?.connectionId === connectionId
     })

--- a/packages/server/src/workflows/engine.ts
+++ b/packages/server/src/workflows/engine.ts
@@ -524,7 +524,7 @@ async function executeLoop(
       persistExecution(execution)
 
       const stepOutputs = buildStepOutputsMap(execution, nodeMap)
-      await executeNode(step, workflow, execution, context, stepOutputs, active)
+      await executeNode(step, workflow, execution, context, stepOutputs, active, true)
 
       const state = execution.nodeStates.find((s) => s.nodeId === step.id)
       updateNodeState(execution, step.id, { iteration })
@@ -584,7 +584,8 @@ async function executeNode(
   execution: WorkflowExecution,
   context?: WorkflowExecutionContext,
   stepOutputs?: StepOutputs,
-  active?: ActiveRun
+  active?: ActiveRun,
+  inLoop = false
 ): Promise<void> {
   if (node.type === 'loop') {
     await executeLoop(node, workflow, execution, context, active)
@@ -705,6 +706,17 @@ async function executeNode(
       // here under `typeof === 'object'` but break `buildStepOutputsMap`
       // which spreads the value into a string-keyed map (the array
       // indices `0`, `1`, … would become bogus step keys).
+      // A signed-out window waits for the person; a loop cannot wait, so there it stays an error.
+      if (!result.success && result.errorKind === 'needs-sign-in' && !inLoop) {
+        updateNodeState(execution, node.id, {
+          status: 'waiting',
+          waitingFor: 'signIn',
+          logs: JSON.stringify(result, null, 2),
+          ...(result.error && { error: result.error })
+        })
+        persistExecution(execution)
+        return
+      }
       const isPlainObject =
         !!result.output && typeof result.output === 'object' && !Array.isArray(result.output)
       updateNodeState(execution, node.id, {
@@ -713,7 +725,12 @@ async function executeNode(
         output: result.success ? `${cfg.action} succeeded` : `${cfg.action} failed`,
         logs: JSON.stringify(result, null, 2),
         ...(isPlainObject && { structuredOutput: result.output }),
-        ...(result.error && { error: result.error })
+        ...(result.error && {
+          error:
+            inLoop && result.errorKind === 'needs-sign-in'
+              ? `${result.error} It repeats inside a loop, so run the workflow again once signed in.`
+              : result.error
+        })
       })
     } catch (err) {
       updateNodeState(execution, node.id, {
@@ -1458,6 +1475,10 @@ export async function applyGateDecision(
     publishRun(execution)
     return
   }
+  if (decision === 'approve' && node.waitingFor === 'signIn') {
+    publishRun(execution)
+    return
+  }
 
   if (decision === 'approve') await approveWorkflowGate(execution, nodeId)
   else await rejectWorkflowGate(execution, nodeId)
@@ -1935,6 +1956,11 @@ function resolveWaitingGate(
     log.warn(`[workflow] ${caller}WorkflowGate: node ${nodeId} not waiting (status=${ns?.status})`)
     return null
   }
+  // Only signing in again ends a sign-in wait; approving it would skip the step it waits to run.
+  if (caller === 'approve' && ns.waitingFor === 'signIn') {
+    log.warn(`[workflow] approveWorkflowGate: node ${nodeId} waits for a sign-in, not an approval`)
+    return null
+  }
 
   const key = gateKey(execution.runId, nodeId)
   const timer = gateTimers.get(key)
@@ -2006,4 +2032,44 @@ export async function rejectWorkflowGate(
 
   const context = rebuildContextForResume(execution)
   return runExecution(workflow, execution, context)
+}
+
+/** Whether a waiting step waits for its connection to sign in again, not for an approval. */
+export function isSignInWait(runId: string, nodeId: string): boolean {
+  const execution = activeRuns.get(runId)?.execution ?? runById(runId)
+  return execution?.nodeStates.find((state) => state.nodeId === nodeId)?.waitingFor === 'signIn'
+}
+
+/** Run again the steps that waited for this connection to sign in; what ran before them is kept. */
+export async function resumeSignInWaits(
+  connectionId: string,
+  parked: WorkflowExecution[]
+): Promise<void> {
+  const resumes: Array<Promise<WorkflowExecution>> = []
+  for (const stored of parked) {
+    const execution = activeRuns.get(stored.runId)?.execution ?? stored
+    const workflow = workflowById(execution.workflowId)
+    if (!workflow) continue
+    const waiting = execution.nodeStates.filter((state) => {
+      if (state.status !== 'waiting' || state.waitingFor !== 'signIn') return false
+      const node = workflow.nodes.find((n) => n.id === state.nodeId)
+      return (node?.config as { connectionId?: string } | undefined)?.connectionId === connectionId
+    })
+    if (waiting.length === 0) continue
+    for (const state of waiting) {
+      updateNodeState(execution, state.nodeId, {
+        status: 'pending',
+        waitingFor: undefined,
+        error: undefined,
+        logs: undefined,
+        startedAt: undefined
+      })
+    }
+    persistExecution(execution)
+    log.info(
+      `[workflow] run ${execution.runId}: ${waiting.length} step(s) run again after a sign-in`
+    )
+    resumes.push(runExecution(workflow, execution, rebuildContextForResume(execution)))
+  }
+  await Promise.all(resumes)
 }

--- a/packages/server/src/workflows/engine.ts
+++ b/packages/server/src/workflows/engine.ts
@@ -524,8 +524,20 @@ async function executeLoop(
       persistExecution(execution)
 
       const stepOutputs = buildStepOutputsMap(execution, nodeMap)
-      await executeNode(step, workflow, execution, context, stepOutputs, active, true)
+      await executeNode(step, workflow, execution, context, stepOutputs, active)
 
+      const parked = execution.nodeStates.find((s) => s.nodeId === step.id)
+      // A loop cannot wait mid-pass, so a step that would wait for a sign-in fails the pass instead.
+      if (parked?.status === 'waiting' && parked.waitingFor === 'signIn') {
+        updateNodeState(execution, step.id, {
+          status: 'error',
+          waitingFor: undefined,
+          completedAt: new Date().toISOString(),
+          error:
+            'Its connection was signed out inside a loop, which cannot wait. Sign in, then run the workflow again.'
+        })
+        persistExecution(execution)
+      }
       const state = execution.nodeStates.find((s) => s.nodeId === step.id)
       updateNodeState(execution, step.id, { iteration })
       summary.push(`  ${step.label}: ${state?.status ?? 'unknown'}`)
@@ -584,8 +596,7 @@ async function executeNode(
   execution: WorkflowExecution,
   context?: WorkflowExecutionContext,
   stepOutputs?: StepOutputs,
-  active?: ActiveRun,
-  inLoop = false
+  active?: ActiveRun
 ): Promise<void> {
   if (node.type === 'loop') {
     await executeLoop(node, workflow, execution, context, active)
@@ -706,8 +717,8 @@ async function executeNode(
       // here under `typeof === 'object'` but break `buildStepOutputsMap`
       // which spreads the value into a string-keyed map (the array
       // indices `0`, `1`, … would become bogus step keys).
-      // A signed-out window waits for the person; a loop cannot wait, so there it stays an error.
-      if (!result.success && result.errorKind === 'needs-sign-in' && !inLoop) {
+      // A signed-out window waits for the person to sign in again rather than failing the step.
+      if (!result.success && result.errorKind === 'needs-sign-in') {
         updateNodeState(execution, node.id, {
           status: 'waiting',
           waitingFor: 'signIn',
@@ -725,12 +736,7 @@ async function executeNode(
         output: result.success ? `${cfg.action} succeeded` : `${cfg.action} failed`,
         logs: JSON.stringify(result, null, 2),
         ...(isPlainObject && { structuredOutput: result.output }),
-        ...(result.error && {
-          error:
-            inLoop && result.errorKind === 'needs-sign-in'
-              ? `${result.error} It repeats inside a loop, so run the workflow again once signed in.`
-              : result.error
-        })
+        ...(result.error && { error: result.error })
       })
     } catch (err) {
       updateNodeState(execution, node.id, {
@@ -1475,11 +1481,6 @@ export async function applyGateDecision(
     publishRun(execution)
     return
   }
-  if (decision === 'approve' && node.waitingFor === 'signIn') {
-    publishRun(execution)
-    return
-  }
-
   if (decision === 'approve') await approveWorkflowGate(execution, nodeId)
   else await rejectWorkflowGate(execution, nodeId)
 }

--- a/packages/server/src/workflows/host.ts
+++ b/packages/server/src/workflows/host.ts
@@ -1,5 +1,6 @@
 import {
   IPC,
+  type ActionResult,
   type AppConfig,
   type ConnectorItemContext,
   type CreateTerminalPayload,
@@ -58,8 +59,7 @@ export const api = {
     connectionId: string
     action: string
     args: Record<string, unknown>
-  }): Promise<{ success: boolean; output?: Record<string, unknown>; error?: string }> =>
-    callMethod('connection:executeAction', params),
+  }): Promise<ActionResult> => callMethod('connection:executeAction', params),
 
   httpRequest: (params: {
     profileConnectionId?: string

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,6 +22,7 @@
     "./viewer-settings-store": "./src/viewer-settings-store.ts",
     "./template-vars": "./src/template-vars.ts",
     "./workflow-graph": "./src/workflow-graph.ts",
-    "./terminal-frame": "./src/terminal-frame.ts"
+    "./terminal-frame": "./src/terminal-frame.ts",
+    "./connector-origins": "./src/connector-origins.ts"
   }
 }

--- a/packages/shared/src/connector-origins.ts
+++ b/packages/shared/src/connector-origins.ts
@@ -3,6 +3,11 @@
 /** An origin a connector may act on: `https://host`, or `https://*.host` for every subdomain. */
 export const ORIGIN_PATTERN = /^https:\/\/(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/i
 
+/** How an origin reads to a person: its host, `*.` kept for a wildcard. */
+export function originLabel(origin: string): string {
+  return origin.replace(/^https:\/\//, '')
+}
+
 /** Whether `url` is on one of the declared origins. */
 export function withinOrigins(origins: readonly string[], url: string): boolean {
   let parsed: URL

--- a/packages/shared/src/connector-origins.ts
+++ b/packages/shared/src/connector-origins.ts
@@ -1,0 +1,22 @@
+// Mirrors the connector SDK's origin rule, which the published SDK cannot import from here.
+
+/** An origin a connector may act on: `https://host`, or `https://*.host` for every subdomain. */
+export const ORIGIN_PATTERN = /^https:\/\/(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/i
+
+/** Whether `url` is on one of the declared origins. */
+export function withinOrigins(origins: readonly string[], url: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  if (parsed.protocol !== 'https:' || parsed.port !== '') return false
+  const target = parsed.hostname.toLowerCase()
+  return origins.some((origin) => {
+    if (!ORIGIN_PATTERN.test(origin)) return false
+    const wildcard = origin.startsWith('https://*.')
+    const host = origin.slice(wildcard ? 'https://*.'.length : 'https://'.length).toLowerCase()
+    return wildcard ? target.endsWith(`.${host}`) : target === host
+  })
+}

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,5 +1,6 @@
 import type { AgentModelRequest, AgentModelCatalog } from './agent-models'
 import type {
+  ActionResult,
   AuthProbeReport,
   CreateTerminalPayload,
   RestoredSession,
@@ -1000,7 +1001,7 @@ export interface RequestMethods {
       action: string
       args: Record<string, unknown>
     }
-    result: { success: boolean; output?: Record<string, unknown>; error?: string }
+    result: ActionResult
   }
   /** One-shot backfill of existing items for a connection — bypasses the
    *  "since" cursor that poll() uses, calling listItems() directly. Respects

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,6 +1,8 @@
 import type { AgentModelRequest, AgentModelCatalog } from './agent-models'
 import type {
   ActionResult,
+  SessionAnswer,
+  SessionRequest,
   AuthProbeReport,
   CreateTerminalPayload,
   RestoredSession,
@@ -926,9 +928,9 @@ export interface RequestMethods {
     params: {
       connectionId: string
       origins: string[]
-      request: { url: string; method: string; headers?: Record<string, string>; body?: string }
+      request: SessionRequest
     }
-    result: { status: number; headers: Record<string, string>; body: string }
+    result: SessionAnswer
   }
   'session:check': {
     params: { connectionId: string; browser: SdkBrowserSignIn }

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -921,6 +921,18 @@ export interface RequestMethods {
     params: string
     result: void
   }
+  'session:fetch': {
+    params: {
+      connectionId: string
+      origins: string[]
+      request: { url: string; method: string; headers?: Record<string, string>; body?: string }
+    }
+    result: { status: number; headers: Record<string, string>; body: string }
+  }
+  'session:check': {
+    params: { connectionId: string; browser: SdkBrowserSignIn }
+    result: { signedIn: boolean; identity: string | null }
+  }
   /** Trigger a workflow manually via the scheduler — same dispatch path as
    *  cron, so connectorPoll triggers do their full poll+fan-out. */
   'workflow:runManual': {

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -68,7 +68,8 @@ import type {
   SdkProbeResult,
   InstalledShell,
   TailscaleStatus,
-  RemoteHost
+  RemoteHost,
+  SdkBrowserSignIn
 } from './types'
 
 // ─── Runtime Protocol Version ───────────────────────────────────
@@ -901,6 +902,22 @@ export interface RequestMethods {
     result: SourceConnection | null
   }
   'connection:delete': {
+    params: string
+    result: void
+  }
+  'connection:browserAuth': {
+    params: string
+    result: { name: string; browser: SdkBrowserSignIn } | null
+  }
+  'connection:signedIn': {
+    params: { connectionId: string; identity: string | null }
+    result: void
+  }
+  'connection:signedOut': {
+    params: string
+    result: void
+  }
+  'session:forget': {
     params: string
     result: void
   }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2172,7 +2172,14 @@ export interface ConnectorCatalogSnapshot {
  * installed, and show an identity instead of a token field where one is
  * already signed in.
  */
-export type ConnectorAuthRung = 'none' | 'cli' | 'key' | 'oauth'
+export type ConnectorAuthRung = 'none' | 'cli' | 'key' | 'browser' | 'oauth'
+
+/** Where a `browser` connector signs in, the only origins it may act on, and how to tell who is signed in. */
+export interface SdkBrowserSignIn {
+  signInUrl: string
+  origins: string[]
+  check: { url: string; identity: string[] }
+}
 
 export interface SdkConnectorAuth {
   rung: ConnectorAuthRung
@@ -2182,6 +2189,8 @@ export interface SdkConnectorAuth {
   borrow?: { env?: string[]; tokenArgs?: string[]; tokenEnv?: string }
   /** Config field keys holding the credential. Present for `key`. */
   keys?: string[]
+  /** Present for `browser`. */
+  browser?: SdkBrowserSignIn
 }
 
 /** An argument a packaged connector's action takes. */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2174,6 +2174,15 @@ export interface ConnectorCatalogSnapshot {
  */
 export type ConnectorAuthRung = 'none' | 'cli' | 'key' | 'browser' | 'oauth'
 
+/** Every rung this build can describe, lowest first; the SDK keeps its own copy. */
+export const CONNECTOR_AUTH_RUNGS: readonly ConnectorAuthRung[] = [
+  'none',
+  'cli',
+  'key',
+  'browser',
+  'oauth'
+]
+
 /** Where a `browser` connector signs in, the only origins it may act on, and how to tell who is signed in. */
 export interface SdkBrowserSignIn {
   signInUrl: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -530,6 +530,9 @@ export interface SourceConnection {
   lastSyncError?: string
   syncCursor?: string
   createdAt: string
+  /** Who the connection's Vorn window is signed in as, for a connector that signs in through one. */
+  signedInAs?: string
+  signedInAt?: string
 }
 
 /** One stored secret on a connection, described without being disclosed. */
@@ -1895,6 +1898,8 @@ export const IPC = {
   CONNECTION_CREATE: 'connection:create',
   CONNECTION_UPDATE: 'connection:update',
   CONNECTION_DELETE: 'connection:delete',
+  CONNECTION_SIGN_IN: 'connection:signIn',
+  CONNECTION_SIGN_OUT: 'connection:signOut',
   CONNECTION_GET_SOURCE_LINK: 'connection:getSourceLink',
   CONNECTOR_DETECT_REPO: 'connector:detectRepo',
   CONNECTOR_SEED_WORKFLOW: 'connector:seedWorkflow',
@@ -2587,6 +2592,11 @@ export interface BrowserNetworkRequest {
  */
 export function browserPartition(sessionId: string): string {
   return `persist:vorn-browser-${sessionId}`
+}
+
+/** The browser profile a connection signs in through; it is that connection's secret. */
+export function connectionPartition(connectionId: string): string {
+  return `persist:vorn-connection-${connectionId}`
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1105,6 +1105,8 @@ export interface NodeExecutionState {
   status: NodeExecutionStatus
   /** Why a skipped node was skipped: a condition branch or a partial run's target slice. */
   skipReason?: 'branch' | 'target'
+  /** Why a waiting step waits: absent for an approval gate, `signIn` for a connection signed out. */
+  waitingFor?: 'signIn'
   startedAt?: string
   completedAt?: string
   sessionId?: string

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -428,6 +428,21 @@ export interface ActionResult {
 export const SESSION_CALL_META = 'vorn/sessionCall'
 export const SESSION_CALL_HEADER = 'x-vorn-session-call'
 
+/** A call a connector asks its signed-in window to make. */
+export interface SessionRequest {
+  url: string
+  method: string
+  headers?: Record<string, string>
+  body?: string
+}
+
+/** How the site answered a call made in the signed-in window. */
+export interface SessionAnswer {
+  status: number
+  headers: Record<string, string>
+  body: string
+}
+
 /** One call a browser connection made through its window: what, where, and how it was answered. */
 export interface SessionCall {
   method: string
@@ -2612,8 +2627,11 @@ export function browserPartition(sessionId: string): string {
 }
 
 /** The browser profile a connection signs in through; it is that connection's secret. */
+/** The folder name every connection's profile starts with under the app's Partitions. */
+export const CONNECTION_PROFILE_PREFIX = 'vorn-connection-'
+
 export function connectionPartition(connectionId: string): string {
-  return `persist:vorn-connection-${connectionId}`
+  return `persist:${CONNECTION_PROFILE_PREFIX}${connectionId}`
 }
 
 /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -418,6 +418,17 @@ export interface ActionResult {
   success: boolean
   output?: Record<string, unknown>
   error?: string
+  /** Why a browser connection's call failed, when Vorn can tell. */
+  errorKind?: 'needs-sign-in' | 'app-offline'
+  /** The calls it made through its signed-in window, kept for the step's log. */
+  sessionCalls?: SessionCall[]
+}
+
+/** One call a browser connection made through its window: what, where, and how it was answered. */
+export interface SessionCall {
+  method: string
+  path: string
+  status: number | 'app-offline' | 'failed'
 }
 
 export interface ConnectorConfigField {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -424,6 +424,10 @@ export interface ActionResult {
   sessionCalls?: SessionCall[]
 }
 
+/** Where a tool call's key travels: in the call's MCP metadata, then on each request the child makes through its window. */
+export const SESSION_CALL_META = 'vorn/sessionCall'
+export const SESSION_CALL_HEADER = 'x-vorn-session-call'
+
 /** One call a browser connection made through its window: what, where, and how it was answered. */
 export interface SessionCall {
   method: string

--- a/packages/shared/src/workflow-graph.ts
+++ b/packages/shared/src/workflow-graph.ts
@@ -252,6 +252,11 @@ export function stopsRunOnError(node: Partial<Pick<WorkflowNode, 'onError'>>): b
 }
 
 /** A step the engine wrote off rather than ran: the reconciler never saw it start. */
+/** A step parked until its connection signs in again, not on an approval. */
+export function isSignInWait(state: { status: string; waitingFor?: string }): boolean {
+  return state.status === 'waiting' && state.waitingFor === 'signIn'
+}
+
 export const ABANDONED = 'Run abandoned (no session id recorded)'
 
 /** A step that never ran, so no policy of its own has anything to say about it. */

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -855,10 +855,8 @@ export function createApiShim(wsUrl: string) {
     getConnectorStatus: () => rpc.invoke('connector:status'),
     probeConnectorAuth: (connectorId: string) => rpc.invoke('connector:probeAuth', connectorId),
     // A connection's signed-in profile lives on the desktop, so the web client cannot open one.
-    signInConnection: async () => ({ ok: false, message: 'Sign in from the Vorn desktop app.' }),
-    signOutConnection: async () => {
-      throw new Error('Sign out from the Vorn desktop app.')
-    },
+    signInConnection: async () => ({ ok: false, error: 'Sign in from the Vorn desktop app.' }),
+    signOutConnection: async () => {},
     listConnectorCatalog: () => rpc.invoke('connector:catalog'),
     refreshConnectorCatalog: () => rpc.invoke('connector:catalogRefresh'),
     probeSdkConnector: (request: unknown) => rpc.invoke('connector:probeSdk', request),

--- a/packages/web/src/api-shim.ts
+++ b/packages/web/src/api-shim.ts
@@ -854,6 +854,11 @@ export function createApiShim(wsUrl: string) {
     getConnector: (id: string) => rpc.invoke('connector:get', id),
     getConnectorStatus: () => rpc.invoke('connector:status'),
     probeConnectorAuth: (connectorId: string) => rpc.invoke('connector:probeAuth', connectorId),
+    // A connection's signed-in profile lives on the desktop, so the web client cannot open one.
+    signInConnection: async () => ({ ok: false, message: 'Sign in from the Vorn desktop app.' }),
+    signOutConnection: async () => {
+      throw new Error('Sign out from the Vorn desktop app.')
+    },
     listConnectorCatalog: () => rpc.invoke('connector:catalog'),
     refreshConnectorCatalog: () => rpc.invoke('connector:catalogRefresh'),
     probeSdkConnector: (request: unknown) => rpc.invoke('connector:probeSdk', request),

--- a/src/main/connection-session-script.ts
+++ b/src/main/connection-session-script.ts
@@ -3,18 +3,9 @@
 /** The largest body a signed-in call hands back, so a runaway page cannot fill memory. */
 export const MAX_SESSION_BODY = 4 * 1024 * 1024
 
-export interface SessionRequest {
-  url: string
-  method: string
-  headers?: Record<string, string>
-  body?: string
-}
+import { CONNECTION_PROFILE_PREFIX, type SessionAnswer, type SessionRequest } from '../shared/types'
 
-export interface SessionAnswer {
-  status: number
-  headers: Record<string, string>
-  body: string
-}
+export type { SessionAnswer, SessionRequest }
 
 /** The only request headers a call may set; the page supplies the rest itself, cookies included. */
 const ALLOWED_HEADERS = new Set(['accept', 'content-type'])
@@ -53,7 +44,9 @@ function valueAt(value: unknown, path: string): unknown {
     .split('.')
     .reduce<unknown>(
       (at, key) =>
-        at && typeof at === 'object' ? (at as Record<string, unknown>)[key] : undefined,
+        at && typeof at === 'object' && Object.prototype.hasOwnProperty.call(at, key)
+          ? (at as Record<string, unknown>)[key]
+          : undefined,
       value
     )
 }
@@ -82,6 +75,6 @@ export function staleConnectionFolders(
   folders: readonly string[],
   connectionIds: readonly string[]
 ): string[] {
-  const live = new Set(connectionIds.map((id) => `vorn-connection-${id}`))
-  return folders.filter((name) => name.startsWith('vorn-connection-') && !live.has(name))
+  const live = new Set(connectionIds.map((id) => `${CONNECTION_PROFILE_PREFIX}${id}`))
+  return folders.filter((name) => name.startsWith(CONNECTION_PROFILE_PREFIX) && !live.has(name))
 }

--- a/src/main/connection-session-script.ts
+++ b/src/main/connection-session-script.ts
@@ -1,0 +1,87 @@
+// The pure half of a connection's signed-in profile, kept apart from Electron so it can be tested.
+
+/** The largest body a signed-in call hands back, so a runaway page cannot fill memory. */
+export const MAX_SESSION_BODY = 4 * 1024 * 1024
+
+export interface SessionRequest {
+  url: string
+  method: string
+  headers?: Record<string, string>
+  body?: string
+}
+
+export interface SessionAnswer {
+  status: number
+  headers: Record<string, string>
+  body: string
+}
+
+/** The only request headers a call may set; the page supplies the rest itself, cookies included. */
+const ALLOWED_HEADERS = new Set(['accept', 'content-type'])
+
+export function allowedHeaders(headers: Record<string, string> = {}): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => ALLOWED_HEADERS.has(name.toLowerCase()))
+  )
+}
+
+/** The script a runner page executes, built from JSON so nothing a connector sends runs as code. */
+export function fetchScript(request: SessionRequest): string {
+  const init = {
+    method: request.method.toUpperCase(),
+    headers: allowedHeaders(request.headers),
+    credentials: 'include',
+    ...(request.body !== undefined && { body: request.body })
+  }
+  return `(async () => {
+  const res = await fetch(${JSON.stringify(request.url)}, ${JSON.stringify(init)})
+  const text = await res.text()
+  return { status: res.status, headers: Object.fromEntries(res.headers), body: text.slice(0, ${MAX_SESSION_BODY}) }
+})()`
+}
+
+/** Electron's user agent without the tokens that name Electron and Vorn, which some sign-in pages refuse. */
+export function plainUserAgent(agent: string): string {
+  return agent
+    .replace(/\s(?:Electron|vorn)\/\S+/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+function valueAt(value: unknown, path: string): unknown {
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (at, key) =>
+        at && typeof at === 'object' ? (at as Record<string, unknown>)[key] : undefined,
+      value
+    )
+}
+
+/** Who the check's answer says is signed in, from the manifest's identity fields; null when it names no one. */
+export function identityFrom(body: string, paths: readonly string[]): string | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(body)
+  } catch {
+    return null
+  }
+  const values = paths
+    .map((path) => valueAt(parsed, path))
+    .filter(
+      (value) => (typeof value === 'string' && value.trim() !== '') || typeof value === 'number'
+    )
+    .map(String)
+  if (values.length === 0) return null
+  const [first, ...rest] = values
+  return rest.length > 0 ? `${first} (${rest.join(', ')})` : first!
+}
+
+/** Profile folders under userData/Partitions that belong to no connection any more. */
+export function staleConnectionFolders(
+  folders: readonly string[],
+  connectionIds: readonly string[]
+): string[] {
+  const live = new Set(connectionIds.map((id) => `vorn-connection-${id}`))
+  return folders.filter((name) => name.startsWith('vorn-connection-') && !live.has(name))
+}

--- a/src/main/connection-sessions.ts
+++ b/src/main/connection-sessions.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, app, session, type Session } from 'electron'
-import { readdir, rm } from 'node:fs/promises'
+import { readdir, rm, stat } from 'node:fs/promises'
 import path from 'node:path'
 import { withinOrigins } from '@vornrun/shared/connector-origins'
 import {
@@ -21,29 +21,23 @@ import {
 import log from './logger'
 
 const CHECK_EVERY_MS = 2_000
+/** A runner nobody has used for this long is closed; the next call opens it again. */
+const RUNNER_IDLE_MS = 60_000
 /** Long enough to type a password and pass a second factor. */
 const SIGN_IN_TIMEOUT_MS = 10 * 60_000
 
 export interface SignInResult {
   ok: boolean
   identity?: string
-  message?: string
+  error?: string
 }
 
 const prepared = new Set<string>()
 /** Hidden pages, one per connection and origin, that make the signed-in calls. */
 const runners = new Map<string, BrowserWindow>()
+const idle = new Map<string, NodeJS.Timeout>()
 const signInWindows = new Map<string, BrowserWindow>()
 const signing = new Map<string, Promise<SignInResult>>()
-
-function webPreferences(connectionId: string): Electron.WebPreferences {
-  return {
-    partition: connectionPartition(connectionId),
-    sandbox: true,
-    contextIsolation: true,
-    nodeIntegration: false
-  }
-}
 
 /** The connection's profile, set up once: a plain user agent, no permissions, no downloads. */
 function profile(connectionId: string): Session {
@@ -59,6 +53,24 @@ function profile(connectionId: string): Session {
   return ses
 }
 
+function webPreferences(connectionId: string): Electron.WebPreferences {
+  profile(connectionId)
+  return {
+    partition: connectionPartition(connectionId),
+    sandbox: true,
+    contextIsolation: true,
+    nodeIntegration: false
+  }
+}
+
+function originOf(url: string): string | null {
+  try {
+    return new URL(url).origin
+  } catch {
+    return null
+  }
+}
+
 async function runner(connectionId: string, origin: string): Promise<BrowserWindow> {
   const key = `${connectionId} ${origin}`
   const existing = runners.get(key)
@@ -66,7 +78,6 @@ async function runner(connectionId: string, origin: string): Promise<BrowserWind
     return existing
   }
   existing?.destroy()
-  profile(connectionId)
   const win = new BrowserWindow({
     show: false,
     webPreferences: { ...webPreferences(connectionId), backgroundThrottling: false }
@@ -80,12 +91,15 @@ async function runner(connectionId: string, origin: string): Promise<BrowserWind
   return win
 }
 
-function originOf(url: string): string | null {
-  try {
-    return new URL(url).origin
-  } catch {
-    return null
-  }
+function rest(key: string, win: BrowserWindow): void {
+  clearTimeout(idle.get(key))
+  const timer = setTimeout(() => {
+    idle.delete(key)
+    if (runners.get(key) === win) runners.delete(key)
+    if (!win.isDestroyed()) win.destroy()
+  }, RUNNER_IDLE_MS)
+  timer.unref()
+  idle.set(key, timer)
 }
 
 /** Make one call inside the connection's signed-in profile, from a page on the call's own origin. */
@@ -99,14 +113,18 @@ export async function fetchInSession(
   }
   const origin = originOf(request.url)!
   const win = await runner(connectionId, origin)
-  if (originOf(win.webContents.getURL()) !== origin) {
-    throw new Error(`The signed-in window for ${origin} ended up somewhere else`)
+  try {
+    if (originOf(win.webContents.getURL()) !== origin) {
+      throw new Error(`The signed-in window for ${origin} ended up somewhere else`)
+    }
+    const answer = (await win.webContents.executeJavaScript(
+      fetchScript(request),
+      true
+    )) as SessionAnswer
+    return { ...answer, body: answer.body.slice(0, MAX_SESSION_BODY) }
+  } finally {
+    rest(`${connectionId} ${origin}`, win)
   }
-  const answer = (await win.webContents.executeJavaScript(
-    fetchScript(request),
-    true
-  )) as SessionAnswer
-  return { ...answer, body: answer.body.slice(0, MAX_SESSION_BODY) }
 }
 
 /** Whether the connection is signed in, and as whom, from the check the connector declared. */
@@ -148,15 +166,13 @@ async function openSignIn(
     'connection:browserAuth',
     connectionId
   )
-  if (!target) {
-    return { ok: false, message: 'This connection does not sign in through a Vorn window.' }
-  }
+  if (!target)
+    return { ok: false, error: 'This connection does not sign in through a Vorn window.' }
   const { browser } = target
   if (link !== undefined && !withinOrigins(browser.origins, link)) {
-    return { ok: false, message: `That link is not on ${browser.origins.join(', ')}.` }
+    return { ok: false, error: `That link is not on ${browser.origins.join(', ')}.` }
   }
 
-  profile(connectionId)
   const win = new BrowserWindow({
     width: 520,
     height: 720,
@@ -211,24 +227,50 @@ async function openSignIn(
         })
     }, CHECK_EVERY_MS)
     const limit = setTimeout(
-      () => finish({ ok: false, message: 'Sign-in timed out. Try again.' }),
+      () => finish({ ok: false, error: 'Sign-in timed out. Try again.' }),
       SIGN_IN_TIMEOUT_MS
     )
     win.on('closed', () =>
-      finish({ ok: false, message: 'The sign-in window closed before anyone signed in.' })
+      finish({ ok: false, error: 'The sign-in window closed before anyone signed in.' })
     )
   })
 }
 
-/** Drop the connection's windows and everything its profile holds. */
-export async function forget(connectionId: string): Promise<void> {
+function closeRunners(connectionId?: string): void {
   for (const [key, win] of runners) {
-    if (!key.startsWith(`${connectionId} `)) continue
+    if (connectionId !== undefined && !key.startsWith(`${connectionId} `)) continue
     runners.delete(key)
+    clearTimeout(idle.get(key))
+    idle.delete(key)
     if (!win.isDestroyed()) win.destroy()
   }
+}
+
+/** Close every window a connection keeps, so hidden ones never hold the app open once its own window closes. */
+export function closeConnectionWindows(): void {
+  closeRunners()
+  for (const win of signInWindows.values()) if (!win.isDestroyed()) win.destroy()
+}
+
+function partitionsRoot(): string {
+  return path.join(app.getPath('userData'), 'Partitions')
+}
+
+async function profileOnDisk(connectionId: string): Promise<boolean> {
+  return stat(path.join(partitionsRoot(), `vorn-connection-${connectionId}`)).then(
+    () => true,
+    () => false
+  )
+}
+
+/** Drop the connection's windows and everything its profile holds. */
+export async function forget(connectionId: string): Promise<void> {
+  closeRunners(connectionId)
   signInWindows.get(connectionId)?.destroy()
-  const ses = session.fromPartition(connectionPartition(connectionId))
+  const partition = connectionPartition(connectionId)
+  // Asking for a profile that was never made would create one just to clear it.
+  if (!prepared.has(partition) && !(await profileOnDisk(connectionId))) return
+  const ses = session.fromPartition(partition)
   await ses.clearStorageData()
   await ses.clearCache()
 }
@@ -240,7 +282,7 @@ export async function signOut(bridge: ServerBridge, connectionId: string): Promi
 
 /** Delete the profile folders of connections that no longer exist; Electron has no call for it. */
 async function sweepConnectionProfiles(bridge: ServerBridge): Promise<void> {
-  const root = path.join(app.getPath('userData'), 'Partitions')
+  const root = partitionsRoot()
   const folders = await readdir(root).catch(() => [] as string[])
   if (!folders.some((name) => name.startsWith('vorn-connection-'))) return
   const connections = await bridge.request<SourceConnection[]>(IPC.CONNECTION_LIST, {
@@ -256,10 +298,12 @@ async function sweepConnectionProfiles(bridge: ServerBridge): Promise<void> {
   }
 }
 
-export function installConnectionSessions(bridge: ServerBridge): void {
+/** `sweep` is off when this desktop talks to another machine's server, whose list is not this machine's. */
+export function installConnectionSessions(bridge: ServerBridge, options: { sweep: boolean }): void {
+  if (!options.sweep) return
   setTimeout(() => {
     void sweepConnectionProfiles(bridge).catch((err) =>
       log.warn({ err }, '[sign-in] profile sweep failed')
     )
-  }, 2_000)
+  }, 500)
 }

--- a/src/main/connection-sessions.ts
+++ b/src/main/connection-sessions.ts
@@ -1,0 +1,265 @@
+import { BrowserWindow, app, session, type Session } from 'electron'
+import { readdir, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { withinOrigins } from '@vornrun/shared/connector-origins'
+import {
+  IPC,
+  connectionPartition,
+  type SdkBrowserSignIn,
+  type SourceConnection
+} from '../shared/types'
+import type { ServerBridge } from './server/server-bridge'
+import {
+  MAX_SESSION_BODY,
+  fetchScript,
+  identityFrom,
+  plainUserAgent,
+  staleConnectionFolders,
+  type SessionAnswer,
+  type SessionRequest
+} from './connection-session-script'
+import log from './logger'
+
+const CHECK_EVERY_MS = 2_000
+/** Long enough to type a password and pass a second factor. */
+const SIGN_IN_TIMEOUT_MS = 10 * 60_000
+
+export interface SignInResult {
+  ok: boolean
+  identity?: string
+  message?: string
+}
+
+const prepared = new Set<string>()
+/** Hidden pages, one per connection and origin, that make the signed-in calls. */
+const runners = new Map<string, BrowserWindow>()
+const signInWindows = new Map<string, BrowserWindow>()
+const signing = new Map<string, Promise<SignInResult>>()
+
+function webPreferences(connectionId: string): Electron.WebPreferences {
+  return {
+    partition: connectionPartition(connectionId),
+    sandbox: true,
+    contextIsolation: true,
+    nodeIntegration: false
+  }
+}
+
+/** The connection's profile, set up once: a plain user agent, no permissions, no downloads. */
+function profile(connectionId: string): Session {
+  const partition = connectionPartition(connectionId)
+  const ses = session.fromPartition(partition)
+  if (!prepared.has(partition)) {
+    prepared.add(partition)
+    ses.setUserAgent(plainUserAgent(ses.getUserAgent()))
+    ses.setPermissionRequestHandler((_contents, _permission, callback) => callback(false))
+    ses.setPermissionCheckHandler(() => false)
+    ses.on('will-download', (event) => event.preventDefault())
+  }
+  return ses
+}
+
+async function runner(connectionId: string, origin: string): Promise<BrowserWindow> {
+  const key = `${connectionId} ${origin}`
+  const existing = runners.get(key)
+  if (existing && !existing.isDestroyed() && originOf(existing.webContents.getURL()) === origin) {
+    return existing
+  }
+  existing?.destroy()
+  profile(connectionId)
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: { ...webPreferences(connectionId), backgroundThrottling: false }
+  })
+  runners.set(key, win)
+  win.on('closed', () => {
+    if (runners.get(key) === win) runners.delete(key)
+  })
+  // A small same-origin page to stand on, so every call is one the site's own page could make.
+  await win.loadURL(`${origin}/robots.txt`)
+  return win
+}
+
+function originOf(url: string): string | null {
+  try {
+    return new URL(url).origin
+  } catch {
+    return null
+  }
+}
+
+/** Make one call inside the connection's signed-in profile, from a page on the call's own origin. */
+export async function fetchInSession(
+  connectionId: string,
+  origins: readonly string[],
+  request: SessionRequest
+): Promise<SessionAnswer> {
+  if (!withinOrigins(origins, request.url)) {
+    throw new Error(`${request.url} is not on one of this connection's origins`)
+  }
+  const origin = originOf(request.url)!
+  const win = await runner(connectionId, origin)
+  if (originOf(win.webContents.getURL()) !== origin) {
+    throw new Error(`The signed-in window for ${origin} ended up somewhere else`)
+  }
+  const answer = (await win.webContents.executeJavaScript(
+    fetchScript(request),
+    true
+  )) as SessionAnswer
+  return { ...answer, body: answer.body.slice(0, MAX_SESSION_BODY) }
+}
+
+/** Whether the connection is signed in, and as whom, from the check the connector declared. */
+export async function checkSession(
+  connectionId: string,
+  browser: SdkBrowserSignIn
+): Promise<{ signedIn: boolean; identity: string | null }> {
+  const answer = await fetchInSession(connectionId, browser.origins, {
+    url: browser.check.url,
+    method: 'GET',
+    headers: { accept: 'application/json' }
+  })
+  const signedIn = answer.status >= 200 && answer.status < 300
+  return { signedIn, identity: signedIn ? identityFrom(answer.body, browser.check.identity) : null }
+}
+
+/** Open the connection's sign-in window and settle when the check says someone is signed in. */
+export function signIn(
+  bridge: ServerBridge,
+  connectionId: string,
+  link?: string
+): Promise<SignInResult> {
+  const pending = signing.get(connectionId)
+  if (pending) {
+    signInWindows.get(connectionId)?.focus()
+    return pending
+  }
+  const run = openSignIn(bridge, connectionId, link).finally(() => signing.delete(connectionId))
+  signing.set(connectionId, run)
+  return run
+}
+
+async function openSignIn(
+  bridge: ServerBridge,
+  connectionId: string,
+  link?: string
+): Promise<SignInResult> {
+  const target = await bridge.request<{ name: string; browser: SdkBrowserSignIn } | null>(
+    'connection:browserAuth',
+    connectionId
+  )
+  if (!target) {
+    return { ok: false, message: 'This connection does not sign in through a Vorn window.' }
+  }
+  const { browser } = target
+  if (link !== undefined && !withinOrigins(browser.origins, link)) {
+    return { ok: false, message: `That link is not on ${browser.origins.join(', ')}.` }
+  }
+
+  profile(connectionId)
+  const win = new BrowserWindow({
+    width: 520,
+    height: 720,
+    title: `Sign in · ${target.name}`,
+    autoHideMenuBar: true,
+    webPreferences: webPreferences(connectionId)
+  })
+  signInWindows.set(connectionId, win)
+  // Sign-in providers open windows of their own; they share the profile so the session lands in it.
+  win.webContents.setWindowOpenHandler(({ url }) =>
+    url.startsWith('https://')
+      ? {
+          action: 'allow',
+          overrideBrowserWindowOptions: {
+            parent: win,
+            width: 480,
+            height: 640,
+            autoHideMenuBar: true,
+            webPreferences: webPreferences(connectionId)
+          }
+        }
+      : { action: 'deny' }
+  )
+  void win
+    .loadURL(link ?? browser.signInUrl)
+    .catch((err) => log.warn({ err }, '[sign-in] load failed'))
+
+  return new Promise<SignInResult>((resolve) => {
+    let settled = false
+    let checking = false
+    const finish = (result: SignInResult): void => {
+      if (settled) return
+      settled = true
+      clearInterval(timer)
+      clearTimeout(limit)
+      signInWindows.delete(connectionId)
+      if (!win.isDestroyed()) win.close()
+      resolve(result)
+    }
+    const timer = setInterval(() => {
+      if (checking) return
+      checking = true
+      void checkSession(connectionId, browser)
+        .then(async ({ signedIn, identity }) => {
+          if (!signedIn) return
+          await bridge.request('connection:signedIn', { connectionId, identity })
+          finish({ ok: true, ...(identity && { identity }) })
+        })
+        .catch((err) => log.warn({ err }, '[sign-in] check failed'))
+        .finally(() => {
+          checking = false
+        })
+    }, CHECK_EVERY_MS)
+    const limit = setTimeout(
+      () => finish({ ok: false, message: 'Sign-in timed out. Try again.' }),
+      SIGN_IN_TIMEOUT_MS
+    )
+    win.on('closed', () =>
+      finish({ ok: false, message: 'The sign-in window closed before anyone signed in.' })
+    )
+  })
+}
+
+/** Drop the connection's windows and everything its profile holds. */
+export async function forget(connectionId: string): Promise<void> {
+  for (const [key, win] of runners) {
+    if (!key.startsWith(`${connectionId} `)) continue
+    runners.delete(key)
+    if (!win.isDestroyed()) win.destroy()
+  }
+  signInWindows.get(connectionId)?.destroy()
+  const ses = session.fromPartition(connectionPartition(connectionId))
+  await ses.clearStorageData()
+  await ses.clearCache()
+}
+
+export async function signOut(bridge: ServerBridge, connectionId: string): Promise<void> {
+  await forget(connectionId)
+  await bridge.request('connection:signedOut', connectionId)
+}
+
+/** Delete the profile folders of connections that no longer exist; Electron has no call for it. */
+async function sweepConnectionProfiles(bridge: ServerBridge): Promise<void> {
+  const root = path.join(app.getPath('userData'), 'Partitions')
+  const folders = await readdir(root).catch(() => [] as string[])
+  if (!folders.some((name) => name.startsWith('vorn-connection-'))) return
+  const connections = await bridge.request<SourceConnection[]>(IPC.CONNECTION_LIST, {
+    connectorId: undefined
+  })
+  for (const folder of staleConnectionFolders(
+    folders,
+    connections.map((c) => c.id)
+  )) {
+    await rm(path.join(root, folder), { recursive: true, force: true }).catch((err) =>
+      log.warn({ err, folder }, '[sign-in] could not remove a stale profile')
+    )
+  }
+}
+
+export function installConnectionSessions(bridge: ServerBridge): void {
+  setTimeout(() => {
+    void sweepConnectionProfiles(bridge).catch((err) =>
+      log.warn({ err }, '[sign-in] profile sweep failed')
+    )
+  }, 2_000)
+}

--- a/src/main/connection-sessions.ts
+++ b/src/main/connection-sessions.ts
@@ -3,9 +3,12 @@ import { readdir, rm, stat } from 'node:fs/promises'
 import path from 'node:path'
 import { withinOrigins } from '@vornrun/shared/connector-origins'
 import {
+  CONNECTION_PROFILE_PREFIX,
   IPC,
   connectionPartition,
   type SdkBrowserSignIn,
+  type SessionAnswer,
+  type SessionRequest,
   type SourceConnection
 } from '../shared/types'
 import type { ServerBridge } from './server/server-bridge'
@@ -14,9 +17,7 @@ import {
   fetchScript,
   identityFrom,
   plainUserAgent,
-  staleConnectionFolders,
-  type SessionAnswer,
-  type SessionRequest
+  staleConnectionFolders
 } from './connection-session-script'
 import log from './logger'
 
@@ -33,13 +34,15 @@ export interface SignInResult {
 }
 
 const prepared = new Set<string>()
-/** Hidden pages, one per connection and origin, that make the signed-in calls. */
-const runners = new Map<string, BrowserWindow>()
-/** A runner still loading its page, shared by every call that arrives meanwhile. */
-const opening = new Map<string, Promise<BrowserWindow>>()
-/** Calls in flight on each runner; it only starts idling once the last one ends. */
-const inFlight = new Map<string, number>()
-const idle = new Map<string, NodeJS.Timeout>()
+/** A hidden page, one per connection and origin, that makes the signed-in calls. */
+interface Runner {
+  win: BrowserWindow
+  ready: Promise<void>
+  /** Calls in flight; the page only starts idling once the last one ends. */
+  busy: number
+  idle?: NodeJS.Timeout
+}
+const runners = new Map<string, Runner>()
 const signInWindows = new Map<string, BrowserWindow>()
 const signing = new Map<string, Promise<SignInResult>>()
 
@@ -75,54 +78,28 @@ function originOf(url: string): string | null {
   }
 }
 
-async function runner(connectionId: string, origin: string): Promise<BrowserWindow> {
-  const key = `${connectionId} ${origin}`
-  const pending = opening.get(key)
-  if (pending) return pending
-  const existing = runners.get(key)
-  if (existing && !existing.isDestroyed() && originOf(existing.webContents.getURL()) === origin) {
-    return existing
-  }
-  existing?.destroy()
-  const open = openRunner(key, connectionId, origin).finally(() => opening.delete(key))
-  opening.set(key, open)
-  return open
+function closeRunner(key: string, runner: Runner): void {
+  if (runners.get(key) === runner) runners.delete(key)
+  clearTimeout(runner.idle)
+  if (!runner.win.isDestroyed()) runner.win.destroy()
 }
 
-async function openRunner(
-  key: string,
-  connectionId: string,
-  origin: string
-): Promise<BrowserWindow> {
+/** The page for this origin, opened once and shared by every call that arrives while it loads. */
+function runnerFor(key: string, connectionId: string, origin: string): Runner {
+  const existing = runners.get(key)
+  if (existing && !existing.win.isDestroyed()) return existing
   const win = new BrowserWindow({
     show: false,
     webPreferences: { ...webPreferences(connectionId), backgroundThrottling: false }
   })
-  runners.set(key, win)
-  win.on('closed', () => {
-    if (runners.get(key) === win) runners.delete(key)
-  })
   // A small same-origin page to stand on, so every call is one the site's own page could make.
-  await win.loadURL(`${origin}/robots.txt`)
-  return win
-}
-
-function rest(key: string, win: BrowserWindow | undefined): void {
-  const left = (inFlight.get(key) ?? 1) - 1
-  if (left > 0) {
-    inFlight.set(key, left)
-    return
-  }
-  inFlight.delete(key)
-  if (!win) return
-  clearTimeout(idle.get(key))
-  const timer = setTimeout(() => {
-    idle.delete(key)
-    if (runners.get(key) === win) runners.delete(key)
-    if (!win.isDestroyed()) win.destroy()
-  }, RUNNER_IDLE_MS)
-  timer.unref()
-  idle.set(key, timer)
+  const runner: Runner = { win, ready: win.loadURL(`${origin}/robots.txt`), busy: 0 }
+  runners.set(key, runner)
+  win.on('closed', () => {
+    if (runners.get(key) === runner) runners.delete(key)
+  })
+  runner.ready.catch(() => closeRunner(key, runner))
+  return runner
 }
 
 /** Make one call inside the connection's signed-in profile, from a page on the call's own origin. */
@@ -136,22 +113,26 @@ export async function fetchInSession(
   }
   const origin = originOf(request.url)!
   const key = `${connectionId} ${origin}`
-  clearTimeout(idle.get(key))
-  idle.delete(key)
-  inFlight.set(key, (inFlight.get(key) ?? 0) + 1)
-  let win: BrowserWindow | undefined
+  const runner = runnerFor(key, connectionId, origin)
+  clearTimeout(runner.idle)
+  runner.busy++
   try {
-    win = await runner(connectionId, origin)
-    if (originOf(win.webContents.getURL()) !== origin) {
+    await runner.ready
+    if (originOf(runner.win.webContents.getURL()) !== origin) {
+      closeRunner(key, runner)
       throw new Error(`The signed-in window for ${origin} ended up somewhere else`)
     }
-    const answer = (await win.webContents.executeJavaScript(
+    const answer = (await runner.win.webContents.executeJavaScript(
       fetchScript(request),
       true
     )) as SessionAnswer
     return { ...answer, body: answer.body.slice(0, MAX_SESSION_BODY) }
   } finally {
-    rest(key, win)
+    runner.busy--
+    if (runner.busy === 0 && runners.get(key) === runner) {
+      runner.idle = setTimeout(() => closeRunner(key, runner), RUNNER_IDLE_MS)
+      runner.idle.unref()
+    }
   }
 }
 
@@ -265,13 +246,8 @@ async function openSignIn(
 }
 
 function closeRunners(connectionId?: string): void {
-  for (const [key, win] of runners) {
-    if (connectionId !== undefined && !key.startsWith(`${connectionId} `)) continue
-    runners.delete(key)
-    opening.delete(key)
-    clearTimeout(idle.get(key))
-    idle.delete(key)
-    if (!win.isDestroyed()) win.destroy()
+  for (const [key, runner] of runners) {
+    if (connectionId === undefined || key.startsWith(`${connectionId} `)) closeRunner(key, runner)
   }
 }
 
@@ -286,7 +262,7 @@ function partitionsRoot(): string {
 }
 
 async function profileOnDisk(connectionId: string): Promise<boolean> {
-  return stat(path.join(partitionsRoot(), `vorn-connection-${connectionId}`)).then(
+  return stat(path.join(partitionsRoot(), `${CONNECTION_PROFILE_PREFIX}${connectionId}`)).then(
     () => true,
     () => false
   )
@@ -300,8 +276,7 @@ export async function forget(connectionId: string): Promise<void> {
   // Asking for a profile that was never made would create one just to clear it.
   if (!prepared.has(partition) && !(await profileOnDisk(connectionId))) return
   const ses = session.fromPartition(partition)
-  await ses.clearStorageData()
-  await ses.clearCache()
+  await Promise.all([ses.clearStorageData(), ses.clearCache()])
 }
 
 export async function signOut(bridge: ServerBridge, connectionId: string): Promise<void> {
@@ -313,18 +288,21 @@ export async function signOut(bridge: ServerBridge, connectionId: string): Promi
 async function sweepConnectionProfiles(bridge: ServerBridge): Promise<void> {
   const root = partitionsRoot()
   const folders = await readdir(root).catch(() => [] as string[])
-  if (!folders.some((name) => name.startsWith('vorn-connection-'))) return
+  if (!folders.some((name) => name.startsWith(CONNECTION_PROFILE_PREFIX))) return
   const connections = await bridge.request<SourceConnection[]>(IPC.CONNECTION_LIST, {
     connectorId: undefined
   })
-  for (const folder of staleConnectionFolders(
+  const stale = staleConnectionFolders(
     folders,
     connections.map((c) => c.id)
-  )) {
-    await rm(path.join(root, folder), { recursive: true, force: true }).catch((err) =>
-      log.warn({ err, folder }, '[sign-in] could not remove a stale profile')
+  )
+  await Promise.all(
+    stale.map((folder) =>
+      rm(path.join(root, folder), { recursive: true, force: true }).catch((err) =>
+        log.warn({ err, folder }, '[sign-in] could not remove a stale profile')
+      )
     )
-  }
+  )
 }
 
 /** `sweep` is off when this desktop talks to another machine's server, whose list is not this machine's. */

--- a/src/main/connection-sessions.ts
+++ b/src/main/connection-sessions.ts
@@ -35,6 +35,10 @@ export interface SignInResult {
 const prepared = new Set<string>()
 /** Hidden pages, one per connection and origin, that make the signed-in calls. */
 const runners = new Map<string, BrowserWindow>()
+/** A runner still loading its page, shared by every call that arrives meanwhile. */
+const opening = new Map<string, Promise<BrowserWindow>>()
+/** Calls in flight on each runner; it only starts idling once the last one ends. */
+const inFlight = new Map<string, number>()
 const idle = new Map<string, NodeJS.Timeout>()
 const signInWindows = new Map<string, BrowserWindow>()
 const signing = new Map<string, Promise<SignInResult>>()
@@ -73,11 +77,23 @@ function originOf(url: string): string | null {
 
 async function runner(connectionId: string, origin: string): Promise<BrowserWindow> {
   const key = `${connectionId} ${origin}`
+  const pending = opening.get(key)
+  if (pending) return pending
   const existing = runners.get(key)
   if (existing && !existing.isDestroyed() && originOf(existing.webContents.getURL()) === origin) {
     return existing
   }
   existing?.destroy()
+  const open = openRunner(key, connectionId, origin).finally(() => opening.delete(key))
+  opening.set(key, open)
+  return open
+}
+
+async function openRunner(
+  key: string,
+  connectionId: string,
+  origin: string
+): Promise<BrowserWindow> {
   const win = new BrowserWindow({
     show: false,
     webPreferences: { ...webPreferences(connectionId), backgroundThrottling: false }
@@ -91,7 +107,14 @@ async function runner(connectionId: string, origin: string): Promise<BrowserWind
   return win
 }
 
-function rest(key: string, win: BrowserWindow): void {
+function rest(key: string, win: BrowserWindow | undefined): void {
+  const left = (inFlight.get(key) ?? 1) - 1
+  if (left > 0) {
+    inFlight.set(key, left)
+    return
+  }
+  inFlight.delete(key)
+  if (!win) return
   clearTimeout(idle.get(key))
   const timer = setTimeout(() => {
     idle.delete(key)
@@ -112,8 +135,13 @@ export async function fetchInSession(
     throw new Error(`${request.url} is not on one of this connection's origins`)
   }
   const origin = originOf(request.url)!
-  const win = await runner(connectionId, origin)
+  const key = `${connectionId} ${origin}`
+  clearTimeout(idle.get(key))
+  idle.delete(key)
+  inFlight.set(key, (inFlight.get(key) ?? 0) + 1)
+  let win: BrowserWindow | undefined
   try {
+    win = await runner(connectionId, origin)
     if (originOf(win.webContents.getURL()) !== origin) {
       throw new Error(`The signed-in window for ${origin} ended up somewhere else`)
     }
@@ -123,7 +151,7 @@ export async function fetchInSession(
     )) as SessionAnswer
     return { ...answer, body: answer.body.slice(0, MAX_SESSION_BODY) }
   } finally {
-    rest(`${connectionId} ${origin}`, win)
+    rest(key, win)
   }
 }
 
@@ -240,6 +268,7 @@ function closeRunners(connectionId?: string): void {
   for (const [key, win] of runners) {
     if (connectionId !== undefined && !key.startsWith(`${connectionId} `)) continue
     runners.delete(key)
+    opening.delete(key)
     clearTimeout(idle.get(key))
     idle.delete(key)
     if (!win.isDestroyed()) win.destroy()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import * as browserRegistry from './browser-registry'
 import * as deviceRegistry from './device-registry'
 import { installCompanionQuitHook } from './device-companion'
 import { installConnectorCredentialsSync } from './connector-credentials-sync'
-import { installConnectionSessions } from './connection-sessions'
+import { closeConnectionWindows, installConnectionSessions } from './connection-sessions'
 import { createMenu } from './menu'
 import { updateManager } from './update-manager'
 import {
@@ -139,6 +139,8 @@ function createWindow(): void {
   })
 
   mainWindow.on('closed', () => {
+    // Hidden connection windows would otherwise keep Windows and Linux from quitting.
+    closeConnectionWindows()
     mainWindow = null
     if (widgetWindow && !widgetWindow.isDestroyed()) {
       widgetWindow.destroy()
@@ -619,7 +621,7 @@ app.whenReady().then(async () => {
   // the server's in-memory store. Runs once on boot, re-syncs on every
   // config change so newly added connections are picked up without restart.
   installConnectorCredentialsSync(bridge)
-  installConnectionSessions(bridge)
+  installConnectionSessions(bridge, { sweep: readHostSettings().mode !== 'host' })
 
   // Load config for widget + update channel
   let updateChannel: 'stable' | 'beta' = 'stable'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import * as browserRegistry from './browser-registry'
 import * as deviceRegistry from './device-registry'
 import { installCompanionQuitHook } from './device-companion'
 import { installConnectorCredentialsSync } from './connector-credentials-sync'
+import { installConnectionSessions } from './connection-sessions'
 import { createMenu } from './menu'
 import { updateManager } from './update-manager'
 import {
@@ -618,6 +619,7 @@ app.whenReady().then(async () => {
   // the server's in-memory store. Runs once on boot, re-syncs on every
   // config change so newly added connections are picked up without restart.
   installConnectorCredentialsSync(bridge)
+  installConnectionSessions(bridge)
 
   // Load config for widget + update channel
   let updateChannel: 'stable' | 'beta' = 'stable'

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,4 +1,9 @@
 import { app, dialog, BrowserWindow, session, shell } from 'electron'
+import {
+  forget as forgetConnectionSession,
+  signIn as signInConnection,
+  signOut as signOutConnection
+} from './connection-sessions'
 import { ipcMain } from 'electron'
 import { writeFile } from 'node:fs/promises'
 import { safeHandle } from './ipc-safe-handle'
@@ -64,6 +69,9 @@ function registerInboundHandlers(b: ServerBridge): void {
   b.handle('device:openUrl', (p) => deviceRegistry.openUrl(p as P<'device:openUrl'>))
   b.handle('device:logs', (p) => deviceRegistry.logsFor(p as P<'device:logs'>))
   b.handle('device:openPane', (p) => deviceRegistry.openPane(p as P<'device:openPane'>))
+
+  // A connection's signed-in profile lives here, beside the windows that use it.
+  b.handle('session:forget', (p) => forgetConnectionSession(p as P<'session:forget'>))
 }
 
 function requireBridge(): ServerBridge {
@@ -352,6 +360,12 @@ export function registerIpcHandlers(): void {
     requireBridge().request(IPC.CONNECTION_UPDATE, params)
   )
   safeHandle(IPC.CONNECTION_DELETE, (_, id) => requireBridge().request(IPC.CONNECTION_DELETE, id))
+  safeHandle(IPC.CONNECTION_SIGN_IN, (_, { connectionId, link }) =>
+    signInConnection(requireBridge(), connectionId, link)
+  )
+  safeHandle(IPC.CONNECTION_SIGN_OUT, (_, connectionId) =>
+    signOutConnection(requireBridge(), connectionId)
+  )
   safeHandle(IPC.CONNECTION_UPSERT_FROM_ITEM, (_, params) =>
     requireBridge().request(IPC.CONNECTION_UPSERT_FROM_ITEM, params)
   )

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,5 +1,7 @@
 import { app, dialog, BrowserWindow, session, shell } from 'electron'
 import {
+  checkSession as checkConnectionSession,
+  fetchInSession as fetchInConnectionSession,
   forget as forgetConnectionSession,
   signIn as signInConnection,
   signOut as signOutConnection
@@ -72,6 +74,14 @@ function registerInboundHandlers(b: ServerBridge): void {
 
   // A connection's signed-in profile lives here, beside the windows that use it.
   b.handle('session:forget', (p) => forgetConnectionSession(p as P<'session:forget'>))
+  b.handle('session:fetch', (p) => {
+    const { connectionId, origins, request } = p as P<'session:fetch'>
+    return fetchInConnectionSession(connectionId, origins, request)
+  })
+  b.handle('session:check', (p) => {
+    const { connectionId, browser } = p as P<'session:check'>
+    return checkConnectionSession(connectionId, browser)
+  })
 }
 
 function requireBridge(): ServerBridge {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -884,6 +884,16 @@ const api = {
 
   deleteConnection: (id: string): Promise<void> => ipcRenderer.invoke(IPC.CONNECTION_DELETE, id),
 
+  /** Opens the connection's sign-in window, settling once someone is signed in or the window closes. */
+  signInConnection: (
+    connectionId: string,
+    link?: string
+  ): Promise<{ ok: boolean; identity?: string; message?: string }> =>
+    ipcRenderer.invoke(IPC.CONNECTION_SIGN_IN, { connectionId, link }),
+
+  signOutConnection: (connectionId: string): Promise<void> =>
+    ipcRenderer.invoke(IPC.CONNECTION_SIGN_OUT, connectionId),
+
   /**
    * Run controls, now that runs happen in the server.
    *

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -888,7 +888,7 @@ const api = {
   signInConnection: (
     connectionId: string,
     link?: string
-  ): Promise<{ ok: boolean; identity?: string; message?: string }> =>
+  ): Promise<{ ok: boolean; identity?: string; error?: string }> =>
     ipcRenderer.invoke(IPC.CONNECTION_SIGN_IN, { connectionId, link }),
 
   signOutConnection: (connectionId: string): Promise<void> =>

--- a/src/renderer/components/settings/ConnectionGroups.tsx
+++ b/src/renderer/components/settings/ConnectionGroups.tsx
@@ -118,6 +118,7 @@ export function ConnectionGroups({
                   key={conn.id}
                   conn={conn}
                   manifest={manifest}
+                  browserSignIn={group.listing?.pack?.auth?.browser}
                   seededWorkflows={seededFor(workflows, conn)}
                   missingEvents={missingFor(workflows, conn, manifest)}
                   activity={activity}

--- a/src/renderer/components/settings/ConnectionRow.tsx
+++ b/src/renderer/components/settings/ConnectionRow.tsx
@@ -1,3 +1,5 @@
+import { originLabel } from '@vornrun/shared/connector-origins'
+import { isElectron } from '../../lib/platform'
 import { useState } from 'react'
 import { Play, Trash2, AlertCircle, Workflow, Import, Activity } from 'lucide-react'
 import { Tooltip } from '../Tooltip'
@@ -60,35 +62,28 @@ export function ConnectionRow({
   const backfilling = Boolean(activity.state(conn.id, ['backfill']).phrase)
   const deleting = Boolean(activity.state(conn.id, ['delete']).phrase)
   // One line for whichever of this connection's actions is working or last failed.
-  const reporting = activity.state(conn.id, ['backfill', 'delete'])
+  const reporting = activity.state(conn.id, ['backfill', 'delete', 'signIn', 'signOut'])
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean | null; message?: string } | null>(
     null
   )
 
-  const [signingIn, setSigningIn] = useState(false)
-  const [signInNote, setSignInNote] = useState<string | null>(null)
   const [link, setLink] = useState<string | null>(null)
+  const signingIn = Boolean(activity.state(conn.id, ['signIn']).phrase)
 
-  const signIn = async (withLink?: string) => {
-    setSigningIn(true)
-    setSignInNote(null)
-    try {
+  const signIn = (withLink?: string) =>
+    activity.run('signIn', conn.id, async () => {
       const result = await window.api.signInConnection(conn.id, withLink)
-      if (!result.ok) setSignInNote(result.message ?? 'Not signed in.')
       setLink(null)
-    } catch (err) {
-      setSignInNote(err instanceof Error ? err.message : String(err))
-    } finally {
-      setSigningIn(false)
       onRefresh()
-    }
-  }
+      return result.ok ? { ok: true } : { ok: false, error: result.error ?? 'Not signed in.' }
+    })
 
-  const signOut = async () => {
-    await window.api.signOutConnection(conn.id)
-    onRefresh()
-  }
+  const signOut = () =>
+    activity.run('signOut', conn.id, async () => {
+      await window.api.signOutConnection(conn.id)
+      onRefresh()
+    })
 
   const runTest = async () => {
     setTesting(true)
@@ -166,35 +161,38 @@ export function ConnectionRow({
                 ? `Signed in${conn.signedInAs ? ` as ${conn.signedInAs}` : ''}`
                 : 'Not signed in'}
             </span>
-            <button
-              onClick={() => void signIn()}
-              disabled={signingIn}
-              className="text-gray-500 hover:text-gray-200 transition-colors disabled:opacity-50"
-            >
-              {signingIn
-                ? 'Waiting for the sign-in window…'
-                : conn.signedInAt
-                  ? 'Sign in again'
-                  : 'Sign in'}
-            </button>
-            {!signingIn && link === null && (
-              <button
-                onClick={() => setLink('')}
-                className="text-gray-600 hover:text-gray-300 transition-colors"
-              >
-                Use a sign-in link
-              </button>
+            {!isElectron && (
+              <span className="text-gray-600">· sign in from the Vorn desktop app</span>
             )}
-            {conn.signedInAt && !signingIn && (
-              <button
-                onClick={() => void signOut()}
-                className="text-gray-500 hover:text-gray-200 transition-colors"
-              >
-                Sign out
-              </button>
+            {isElectron && (
+              <>
+                <button
+                  onClick={() => void signIn()}
+                  disabled={signingIn}
+                  className="text-gray-500 hover:text-gray-200 transition-colors disabled:opacity-50"
+                >
+                  {conn.signedInAt ? 'Sign in again' : 'Sign in'}
+                </button>
+                {!signingIn && link === null && (
+                  <button
+                    onClick={() => setLink('')}
+                    className="text-gray-600 hover:text-gray-300 transition-colors"
+                  >
+                    Use a sign-in link
+                  </button>
+                )}
+                {conn.signedInAt && !signingIn && (
+                  <button
+                    onClick={() => void signOut()}
+                    className="text-gray-500 hover:text-gray-200 transition-colors"
+                  >
+                    Sign out
+                  </button>
+                )}
+              </>
             )}
           </div>
-          {link !== null && (
+          {isElectron && link !== null && (
             <input
               autoFocus
               value={link}
@@ -203,12 +201,11 @@ export function ConnectionRow({
                 if (e.key === 'Enter' && link.trim()) void signIn(link.trim())
                 if (e.key === 'Escape') setLink(null)
               }}
-              placeholder={`Paste the sign-in link emailed by ${browserSignIn.origins[0]?.replace('https://', '')}`}
+              placeholder={`Paste the sign-in link emailed by ${originLabel(browserSignIn.origins[0] ?? '')}`}
               aria-label="Sign-in link"
               className="w-full px-2 py-1 bg-white/[0.05] border border-white/[0.1] rounded-sm text-[11px] text-gray-200 font-mono focus:border-white/[0.2] outline-none"
             />
           )}
-          {signInNote && <div className="text-gray-500">{signInNote}</div>}
         </div>
       )}
 

--- a/src/renderer/components/settings/ConnectionRow.tsx
+++ b/src/renderer/components/settings/ConnectionRow.tsx
@@ -11,6 +11,7 @@ import { BusyIcon } from './BusyIcon'
 import {
   isImplicitConnection,
   type ConnectorManifest,
+  type SdkBrowserSignIn,
   type SourceConnection,
   type WorkflowDefinition
 } from '../../../shared/types'
@@ -37,10 +38,13 @@ export function ConnectionRow({
   onDelete,
   onResetWorkflow,
   onOpenWorkflow,
-  onRefresh
+  onRefresh,
+  browserSignIn
 }: {
   conn: SourceConnection
   manifest?: ConnectorManifest
+  /** Set when the connector signs in through a Vorn window. */
+  browserSignIn?: SdkBrowserSignIn
   seededWorkflows: WorkflowDefinition[]
   missingEvents: Array<{ name: string; event: string }>
   activity: RowActivity
@@ -61,6 +65,30 @@ export function ConnectionRow({
   const [testResult, setTestResult] = useState<{ ok: boolean | null; message?: string } | null>(
     null
   )
+
+  const [signingIn, setSigningIn] = useState(false)
+  const [signInNote, setSignInNote] = useState<string | null>(null)
+  const [link, setLink] = useState<string | null>(null)
+
+  const signIn = async (withLink?: string) => {
+    setSigningIn(true)
+    setSignInNote(null)
+    try {
+      const result = await window.api.signInConnection(conn.id, withLink)
+      if (!result.ok) setSignInNote(result.message ?? 'Not signed in.')
+      setLink(null)
+    } catch (err) {
+      setSignInNote(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSigningIn(false)
+      onRefresh()
+    }
+  }
+
+  const signOut = async () => {
+    await window.api.signOutConnection(conn.id)
+    onRefresh()
+  }
 
   const runTest = async () => {
     setTesting(true)
@@ -126,6 +154,63 @@ export function ConnectionRow({
           </Tooltip>
         </div>
       </div>
+
+      {browserSignIn && (
+        <div className="mt-1 space-y-1 text-[11px]">
+          <div className="flex items-center gap-2">
+            <span
+              className={`w-1.5 h-1.5 rounded-full shrink-0 ${conn.signedInAt ? 'bg-status-sage' : 'bg-ink-ghost'}`}
+            />
+            <span className={conn.signedInAt ? 'text-gray-300' : 'text-gray-500'}>
+              {conn.signedInAt
+                ? `Signed in${conn.signedInAs ? ` as ${conn.signedInAs}` : ''}`
+                : 'Not signed in'}
+            </span>
+            <button
+              onClick={() => void signIn()}
+              disabled={signingIn}
+              className="text-gray-500 hover:text-gray-200 transition-colors disabled:opacity-50"
+            >
+              {signingIn
+                ? 'Waiting for the sign-in window…'
+                : conn.signedInAt
+                  ? 'Sign in again'
+                  : 'Sign in'}
+            </button>
+            {!signingIn && link === null && (
+              <button
+                onClick={() => setLink('')}
+                className="text-gray-600 hover:text-gray-300 transition-colors"
+              >
+                Use a sign-in link
+              </button>
+            )}
+            {conn.signedInAt && !signingIn && (
+              <button
+                onClick={() => void signOut()}
+                className="text-gray-500 hover:text-gray-200 transition-colors"
+              >
+                Sign out
+              </button>
+            )}
+          </div>
+          {link !== null && (
+            <input
+              autoFocus
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && link.trim()) void signIn(link.trim())
+                if (e.key === 'Escape') setLink(null)
+              }}
+              placeholder={`Paste the sign-in link emailed by ${browserSignIn.origins[0]?.replace('https://', '')}`}
+              aria-label="Sign-in link"
+              className="w-full px-2 py-1 bg-white/[0.05] border border-white/[0.1] rounded-sm text-[11px] text-gray-200 font-mono focus:border-white/[0.2] outline-none"
+            />
+          )}
+          {signInNote && <div className="text-gray-500">{signInNote}</div>}
+        </div>
+      )}
 
       {testResult && (
         <div className={`mt-1 text-[11px] ${testResult.ok ? 'text-green-400' : 'text-red-400'}`}>

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -1,3 +1,4 @@
+import { originLabel } from '@vornrun/shared/connector-origins'
 import {
   Plus,
   ArrowLeft,
@@ -178,10 +179,7 @@ export function ConnectorDetail({
           )}
           {listing.pack?.auth?.browser && (
             <p className="text-[12.5px] text-gray-500">
-              Acts as you on{' '}
-              {listing.pack.auth.browser.origins
-                .map((origin) => origin.replace('https://', ''))
-                .join(', ')}
+              Acts as you on {listing.pack.auth.browser.origins.map(originLabel).join(', ')}
             </p>
           )}
           {entry?.auth && <p className="text-[12.5px] text-gray-500">{entry.auth}</p>}

--- a/src/renderer/components/settings/ConnectorDetail.tsx
+++ b/src/renderer/components/settings/ConnectorDetail.tsx
@@ -176,6 +176,14 @@ export function ConnectorDetail({
           {listing.authRung && (
             <p className="text-[12.5px] text-gray-300">{AUTH_RUNG[listing.authRung].detail}</p>
           )}
+          {listing.pack?.auth?.browser && (
+            <p className="text-[12.5px] text-gray-500">
+              Acts as you on{' '}
+              {listing.pack.auth.browser.origins
+                .map((origin) => origin.replace('https://', ''))
+                .join(', ')}
+            </p>
+          )}
           {entry?.auth && <p className="text-[12.5px] text-gray-500">{entry.auth}</p>}
           {listing.kind === 'extension' && !listing.authRung && !entry?.auth && (
             <p className="text-[12.5px] text-gray-300">

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -80,6 +80,9 @@ export function ConnectorSettings() {
     void load()
   }, [load])
 
+  // A sign-in finishes in its own window, so the rows follow the server rather than the press.
+  useEffect(() => window.api.onConfigChanged?.(() => void load()), [load])
+
   // Installing changes what is on disk, which the library reads too, so the shared cache is told as well.
   const install = usePackInstall(
     useCallback(async () => {

--- a/src/renderer/components/settings/ConnectorSettings.tsx
+++ b/src/renderer/components/settings/ConnectorSettings.tsx
@@ -81,7 +81,11 @@ export function ConnectorSettings() {
   }, [load])
 
   // A sign-in finishes in its own window, so the rows follow the server rather than the press.
-  useEffect(() => window.api.onConfigChanged?.(() => void load()), [load])
+  useEffect(
+    () =>
+      window.api.onConfigChanged?.(() => void window.api.listConnections().then(setConnections)),
+    []
+  )
 
   // Installing changes what is on disk, which the library reads too, so the shared cache is told as well.
   const install = usePackInstall(

--- a/src/renderer/components/settings/SdkConnectorForm.tsx
+++ b/src/renderer/components/settings/SdkConnectorForm.tsx
@@ -183,7 +183,7 @@ export function SdkConnectorForm({
       // connection that polls and never fires.
       if (trigger) Object.assign(filters, trigger.filters)
 
-      await window.api.createConnection({
+      const created = await window.api.createConnection({
         connectorId: 'mcp',
         name: trigger ? `${manifest.name}: ${trigger.label}` : manifest.name,
         filters,
@@ -196,6 +196,8 @@ export function SdkConnectorForm({
         ...(trigger?.defaultWorkflow && { seedWorkflow: trigger.defaultWorkflow }),
         executionProject: selectedProject
       })
+      // Signing in takes as long as it takes, so the connection's row carries on from here.
+      if (rung === 'browser') void window.api.signInConnection?.(created.id)
       onDone()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -375,6 +377,24 @@ export function SdkConnectorForm({
             </div>
           )}
 
+          {rung === 'browser' && manifest.auth?.browser && (
+            <div className="px-3 py-2 bg-white/[0.03] border border-white/[0.08] rounded-sm">
+              <div className="flex items-center gap-1.5 text-sm text-gray-200">
+                <span className="w-1.5 h-1.5 rounded-full bg-ink-ghost shrink-0" />
+                <span>Signs in through a Vorn window</span>
+              </div>
+              <p className="text-[11px] text-gray-600 mt-1">
+                After Connect, a window opens on {new URL(manifest.auth.browser.signInUrl).host}.
+                The login stays in a browser profile only this connection uses, and it acts as you
+                on{' '}
+                {manifest.auth.browser.origins
+                  .map((origin) => origin.replace('https://', ''))
+                  .join(', ')}
+                .
+              </p>
+            </div>
+          )}
+
           {fields.map((entry) => (
             <div key={entry.name}>
               <label className="text-xs text-gray-500 mb-1 flex items-center gap-1.5">
@@ -415,7 +435,13 @@ export function SdkConnectorForm({
           className="px-4 py-1.5 text-sm bg-white/[0.1] hover:bg-white/[0.15] text-white rounded-sm transition-colors disabled:opacity-50 inline-flex items-center justify-center gap-1.5"
         >
           <BusyIcon busy={saving} size={12} />
-          {rung === 'none' ? 'Done' : saving ? 'Connecting…' : 'Connect'}
+          {rung === 'none'
+            ? 'Done'
+            : saving
+              ? 'Connecting…'
+              : rung === 'browser'
+                ? 'Connect and sign in'
+                : 'Connect'}
         </button>
         <button
           onClick={onCancel}

--- a/src/renderer/components/settings/SdkConnectorForm.tsx
+++ b/src/renderer/components/settings/SdkConnectorForm.tsx
@@ -1,3 +1,5 @@
+import { originLabel } from '@vornrun/shared/connector-origins'
+import { isElectron } from '../../lib/platform'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AlertCircle, Check, Loader2, Search } from 'lucide-react'
 import { BusyIcon } from './BusyIcon'
@@ -197,7 +199,7 @@ export function SdkConnectorForm({
         executionProject: selectedProject
       })
       // Signing in takes as long as it takes, so the connection's row carries on from here.
-      if (rung === 'browser') void window.api.signInConnection?.(created.id)
+      if (rung === 'browser' && isElectron) void window.api.signInConnection(created.id)
       onDone()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -386,11 +388,7 @@ export function SdkConnectorForm({
               <p className="text-[11px] text-gray-600 mt-1">
                 After Connect, a window opens on {new URL(manifest.auth.browser.signInUrl).host}.
                 The login stays in a browser profile only this connection uses, and it acts as you
-                on{' '}
-                {manifest.auth.browser.origins
-                  .map((origin) => origin.replace('https://', ''))
-                  .join(', ')}
-                .
+                on {manifest.auth.browser.origins.map(originLabel).join(', ')}.
               </p>
             </div>
           )}

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -1,15 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { GATE_APPROVE, GATE_REJECT } from '../../lib/gate-affordance'
-import {
-  ChevronDown,
-  ChevronRight,
-  Maximize2,
-  Play,
-  RotateCcw,
-  Check,
-  X,
-  LogIn
-} from 'lucide-react'
+import { ChevronDown, ChevronRight, Maximize2, Play, RotateCcw, Check, X } from 'lucide-react'
 import {
   WorkflowExecution,
   WorkflowNode,
@@ -23,10 +14,11 @@ import {
 import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import { WORKFLOW_STATUS_DOT_PULSE, WORKFLOW_STATUS_DOT } from '../../lib/workflow-status'
 import { Tooltip } from '../Tooltip'
-import { hasFailedStep } from '@vornrun/shared/workflow-graph'
+import { hasFailedStep, isSignInWait } from '@vornrun/shared/workflow-graph'
 import { StopRunButton } from '../workflow-runs/StopRunButton'
 import { ConnectorIcon } from '../ConnectorIcon'
 import { connectorLookFor, useConnections, type ConnectorLook } from '../../lib/use-connections'
+import { SignInButton } from '../workflow-runs/SignInButton'
 import {
   NODE_TYPE_ICON,
   TASK_CHIP,
@@ -250,8 +242,7 @@ export function RunStepsList({
           const timeline = isExpanded ? stepTimeline(ns.logs, ns.diagnostics) : []
 
           const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
-          const isSignInWait = ns.status === 'waiting' && ns.waitingFor === 'signIn'
-          const signInConnectionId = isSignInWait ? nodeConnectionId(node) : undefined
+          const signInWait = isSignInWait(ns)
           const approvalMessage =
             node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
 
@@ -367,20 +358,12 @@ export function RunStepsList({
                   </div>
                 )}
 
-                {isSignInWait && (
+                {signInWait && (
                   <div className="px-3 pb-3 -mt-0.5 flex items-start gap-2">
                     <div className="flex-1 min-w-0 text-[11px] text-bronzo">
                       {ns.error || 'Signed out. Sign in, and this step runs again.'}
                     </div>
-                    {signInConnectionId && (
-                      <button
-                        onClick={() => void window.api.signInConnection(signInConnectionId)}
-                        className={`flex items-center gap-1 px-2 py-1 text-[11px] shrink-0 ${GATE_APPROVE}`}
-                      >
-                        <LogIn size={11} strokeWidth={2.5} />
-                        Sign in
-                      </button>
-                    )}
+                    <SignInButton connectionId={nodeConnectionId(node)} compact />
                   </div>
                 )}
 

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -1,6 +1,15 @@
 import { useState, useEffect, useRef } from 'react'
 import { GATE_APPROVE, GATE_REJECT } from '../../lib/gate-affordance'
-import { ChevronDown, ChevronRight, Maximize2, Play, RotateCcw, Check, X } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronRight,
+  Maximize2,
+  Play,
+  RotateCcw,
+  Check,
+  X,
+  LogIn
+} from 'lucide-react'
 import {
   WorkflowExecution,
   WorkflowNode,
@@ -241,6 +250,10 @@ export function RunStepsList({
           const timeline = isExpanded ? stepTimeline(ns.logs, ns.diagnostics) : []
 
           const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
+          const isSignInWait = ns.status === 'waiting' && ns.waitingFor === 'signIn'
+          const signInConnectionId = isSignInWait
+            ? (node?.config as { connectionId?: string } | undefined)?.connectionId
+            : undefined
           const approvalMessage =
             node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
 
@@ -353,6 +366,23 @@ export function RunStepsList({
                       <X size={11} strokeWidth={2.5} />
                       Reject
                     </button>
+                  </div>
+                )}
+
+                {isSignInWait && (
+                  <div className="px-3 pb-3 -mt-0.5 flex items-start gap-2">
+                    <div className="flex-1 min-w-0 text-[11px] text-bronzo">
+                      {ns.error || 'Signed out. Sign in, and this step runs again.'}
+                    </div>
+                    {signInConnectionId && (
+                      <button
+                        onClick={() => void window.api.signInConnection(signInConnectionId)}
+                        className={`flex items-center gap-1 px-2 py-1 text-[11px] shrink-0 ${GATE_APPROVE}`}
+                      >
+                        <LogIn size={11} strokeWidth={2.5} />
+                        Sign in
+                      </button>
+                    )}
                   </div>
                 )}
 

--- a/src/renderer/components/workflow-editor/RunEntry.tsx
+++ b/src/renderer/components/workflow-editor/RunEntry.tsx
@@ -251,9 +251,7 @@ export function RunStepsList({
 
           const isWaitingGate = ns.status === 'waiting' && node?.type === 'approval'
           const isSignInWait = ns.status === 'waiting' && ns.waitingFor === 'signIn'
-          const signInConnectionId = isSignInWait
-            ? (node?.config as { connectionId?: string } | undefined)?.connectionId
-            : undefined
+          const signInConnectionId = isSignInWait ? nodeConnectionId(node) : undefined
           const approvalMessage =
             node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
 

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useAppStore } from '../../stores'
 import { toast } from '../Toast'
-import { Check, X, Inbox, Play, RotateCcw } from 'lucide-react'
+import { Check, X, Inbox, LogIn, Play, RotateCcw } from 'lucide-react'
 import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import {
   completedStageCount,
@@ -15,7 +15,7 @@ import {
 import { hasFailedStep } from '@vornrun/shared/workflow-graph'
 import { RunStepsList, StatusDot } from '../workflow-editor/RunEntry'
 import { RunIcon } from './RunIcon'
-import { useConnectorLook } from '../../lib/use-connections'
+import { useConnectorLook, useConnections } from '../../lib/use-connections'
 import { StopRunButton } from './StopRunButton'
 import { workflowRunId, type TaskConfig } from '../../../shared/types'
 import type { RunListEntry } from '../../hooks/useAllWorkflowRuns'
@@ -66,13 +66,19 @@ export function RunDetailPane({
   const done = completedStageCount(stages)
   const summary = runSummaryText(run)
   const waitingGate = run.nodeStates.find((ns) => ns.status === 'waiting')
+  const signInWait = waitingGate?.waitingFor === 'signIn'
+  const signInConnectionId = (
+    nodes.find((n) => n.id === waitingGate?.nodeId)?.config as { connectionId?: string } | undefined
+  )?.connectionId
+  const connections = useConnections()
+  const signInName = connections.find((c) => c.id === signInConnectionId)?.name ?? 'the connection'
 
   // Keyboard approval mirrors the two visible actions, and only while a gate is
   // actually open — otherwise a stray "r" in the app would resolve nothing.
   // `shortcutsEnabled` lets the view mute them behind a modal, and `repeat` is
   // ignored so holding a key can't reject the run that auto-selects next.
   useEffect(() => {
-    if (!waitingGate || !shortcutsEnabled) return undefined
+    if (!waitingGate || signInWait || !shortcutsEnabled) return undefined
     const onKeyDown = (e: KeyboardEvent): void => {
       if (e.repeat) return
       const target = e.target as HTMLElement | null
@@ -97,7 +103,7 @@ export function RunDetailPane({
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [run, waitingGate, shortcutsEnabled])
+  }, [run, waitingGate, signInWait, shortcutsEnabled])
 
   return (
     <div className="h-full flex flex-col min-h-0 overflow-y-auto">
@@ -164,7 +170,11 @@ export function RunDetailPane({
               <span
                 className={`text-[12.5px] ${waitingGate ? WORKFLOW_STATUS_TEXT.waiting : WORKFLOW_STATUS_TEXT[run.status]}`}
               >
-                {waitingGate ? 'waiting for approval' : outcome.label}
+                {waitingGate
+                  ? signInWait
+                    ? 'waiting for sign-in'
+                    : 'waiting for approval'
+                  : outcome.label}
               </span>
             )}
           </div>
@@ -173,7 +183,11 @@ export function RunDetailPane({
               ? 'ran end to end'
               : `${done} of ${stages.length} stages`}
             {' · '}
-            {ranUninterrupted(run) ? 'never paused' : 'paused for review'}
+            {ranUninterrupted(run)
+              ? 'never paused'
+              : signInWait
+                ? 'paused until signed in'
+                : 'paused for review'}
             {' · '}
             {formatRelativeTime(run.startedAt)}
           </p>
@@ -187,24 +201,38 @@ export function RunDetailPane({
 
       {waitingGate && (
         <div className="px-5 pb-4 shrink-0 flex flex-col gap-1.5">
-          <button
-            type="button"
-            onClick={() =>
-              void window.api.resolveWorkflowGate({
-                runId: run.runId,
-                nodeId: waitingGate.nodeId,
-                decision: 'approve'
-              })
-            }
-            className={`flex items-center gap-2 px-4 py-2.5 text-[13px] ${GATE_APPROVE}`}
-          >
-            <Check size={14} strokeWidth={2} />
-            Approve &amp; continue
-            <span className="flex-1" />
-            <kbd className="text-[10px] font-mono text-gray-500 border border-white/[0.08] rounded px-1 py-0.5">
-              ⌘↵
-            </kbd>
-          </button>
+          {signInWait ? (
+            <button
+              type="button"
+              disabled={!signInConnectionId}
+              onClick={() =>
+                signInConnectionId && void window.api.signInConnection(signInConnectionId)
+              }
+              className={`flex items-center gap-2 px-4 py-2.5 text-[13px] ${GATE_APPROVE} disabled:opacity-50`}
+            >
+              <LogIn size={14} strokeWidth={2} />
+              Sign in to {signInName}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() =>
+                void window.api.resolveWorkflowGate({
+                  runId: run.runId,
+                  nodeId: waitingGate.nodeId,
+                  decision: 'approve'
+                })
+              }
+              className={`flex items-center gap-2 px-4 py-2.5 text-[13px] ${GATE_APPROVE}`}
+            >
+              <Check size={14} strokeWidth={2} />
+              Approve &amp; continue
+              <span className="flex-1" />
+              <kbd className="text-[10px] font-mono text-gray-500 border border-white/[0.08] rounded px-1 py-0.5">
+                ⌘↵
+              </kbd>
+            </button>
+          )}
           <button
             type="button"
             onClick={() =>
@@ -219,9 +247,11 @@ export function RunDetailPane({
             <X size={14} strokeWidth={2} />
             Reject run
             <span className="flex-1" />
-            <kbd className="text-[10px] font-mono text-gray-500 border border-white/[0.08] rounded px-1 py-0.5">
-              R
-            </kbd>
+            {!signInWait && (
+              <kbd className="text-[10px] font-mono text-gray-500 border border-white/[0.08] rounded px-1 py-0.5">
+                R
+              </kbd>
+            )}
           </button>
         </div>
       )}

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -16,6 +16,7 @@ import { hasFailedStep } from '@vornrun/shared/workflow-graph'
 import { RunStepsList, StatusDot } from '../workflow-editor/RunEntry'
 import { RunIcon } from './RunIcon'
 import { useConnectorLook, useConnections } from '../../lib/use-connections'
+import { nodeConnectionId } from '../workflow-editor/node-visuals'
 import { StopRunButton } from './StopRunButton'
 import { workflowRunId, type TaskConfig } from '../../../shared/types'
 import type { RunListEntry } from '../../hooks/useAllWorkflowRuns'
@@ -43,6 +44,11 @@ interface Props {
   onViewFullOutput?: (logs: string) => void
 }
 
+const WAIT_LABELS = {
+  approval: { status: 'waiting for approval', paused: 'paused for review' },
+  signIn: { status: 'waiting for sign-in', paused: 'paused until signed in' }
+} as const
+
 export function RunDetailPane({
   run,
   workflow,
@@ -65,20 +71,16 @@ export function RunDetailPane({
   const stages = runStages(run, nodes)
   const done = completedStageCount(stages)
   const summary = runSummaryText(run)
-  const waitingGate = run.nodeStates.find((ns) => ns.status === 'waiting')
-  const signInWait = waitingGate?.waitingFor === 'signIn'
-  const signInConnectionId = (
-    nodes.find((n) => n.id === waitingGate?.nodeId)?.config as { connectionId?: string } | undefined
-  )?.connectionId
-  const connections = useConnections()
-  const signInName = connections.find((c) => c.id === signInConnectionId)?.name ?? 'the connection'
+  const waitingStep = run.nodeStates.find((ns) => ns.status === 'waiting')
+  const signInWait = waitingStep?.waitingFor === 'signIn'
+  const wait = WAIT_LABELS[signInWait ? 'signIn' : 'approval']
 
   // Keyboard approval mirrors the two visible actions, and only while a gate is
   // actually open — otherwise a stray "r" in the app would resolve nothing.
   // `shortcutsEnabled` lets the view mute them behind a modal, and `repeat` is
   // ignored so holding a key can't reject the run that auto-selects next.
   useEffect(() => {
-    if (!waitingGate || signInWait || !shortcutsEnabled) return undefined
+    if (!waitingStep || signInWait || !shortcutsEnabled) return undefined
     const onKeyDown = (e: KeyboardEvent): void => {
       if (e.repeat) return
       const target = e.target as HTMLElement | null
@@ -89,21 +91,21 @@ export function RunDetailPane({
         e.preventDefault()
         void window.api.resolveWorkflowGate({
           runId: run.runId,
-          nodeId: waitingGate.nodeId,
+          nodeId: waitingStep.nodeId,
           decision: 'approve'
         })
       } else if (!e.metaKey && !e.ctrlKey && !e.altKey && e.key.toLowerCase() === 'r') {
         e.preventDefault()
         void window.api.resolveWorkflowGate({
           runId: run.runId,
-          nodeId: waitingGate.nodeId,
+          nodeId: waitingStep.nodeId,
           decision: 'reject'
         })
       }
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [run, waitingGate, signInWait, shortcutsEnabled])
+  }, [run, waitingStep, signInWait, shortcutsEnabled])
 
   return (
     <div className="h-full flex flex-col min-h-0 overflow-y-auto">
@@ -165,16 +167,12 @@ export function RunDetailPane({
       <div className="px-5 pb-4 shrink-0">
         <div className="rounded-md border border-white/[0.06] bg-white/[0.02] px-4 py-3">
           <div className="flex items-center gap-2">
-            <StatusDot status={waitingGate ? 'waiting' : run.status} />
-            {(waitingGate || outcome.label) && (
+            <StatusDot status={waitingStep ? 'waiting' : run.status} />
+            {(waitingStep || outcome.label) && (
               <span
-                className={`text-[12.5px] ${waitingGate ? WORKFLOW_STATUS_TEXT.waiting : WORKFLOW_STATUS_TEXT[run.status]}`}
+                className={`text-[12.5px] ${waitingStep ? WORKFLOW_STATUS_TEXT.waiting : WORKFLOW_STATUS_TEXT[run.status]}`}
               >
-                {waitingGate
-                  ? signInWait
-                    ? 'waiting for sign-in'
-                    : 'waiting for approval'
-                  : outcome.label}
+                {waitingStep ? wait.status : outcome.label}
               </span>
             )}
           </div>
@@ -183,11 +181,7 @@ export function RunDetailPane({
               ? 'ran end to end'
               : `${done} of ${stages.length} stages`}
             {' · '}
-            {ranUninterrupted(run)
-              ? 'never paused'
-              : signInWait
-                ? 'paused until signed in'
-                : 'paused for review'}
+            {ranUninterrupted(run) ? 'never paused' : wait.paused}
             {' · '}
             {formatRelativeTime(run.startedAt)}
           </p>
@@ -199,27 +193,19 @@ export function RunDetailPane({
         </div>
       </div>
 
-      {waitingGate && (
+      {waitingStep && (
         <div className="px-5 pb-4 shrink-0 flex flex-col gap-1.5">
           {signInWait ? (
-            <button
-              type="button"
-              disabled={!signInConnectionId}
-              onClick={() =>
-                signInConnectionId && void window.api.signInConnection(signInConnectionId)
-              }
-              className={`flex items-center gap-2 px-4 py-2.5 text-[13px] ${GATE_APPROVE} disabled:opacity-50`}
-            >
-              <LogIn size={14} strokeWidth={2} />
-              Sign in to {signInName}
-            </button>
+            <SignInButton
+              connectionId={nodeConnectionId(nodes.find((n) => n.id === waitingStep.nodeId))}
+            />
           ) : (
             <button
               type="button"
               onClick={() =>
                 void window.api.resolveWorkflowGate({
                   runId: run.runId,
-                  nodeId: waitingGate.nodeId,
+                  nodeId: waitingStep.nodeId,
                   decision: 'approve'
                 })
               }
@@ -238,7 +224,7 @@ export function RunDetailPane({
             onClick={() =>
               void window.api.resolveWorkflowGate({
                 runId: run.runId,
-                nodeId: waitingGate.nodeId,
+                nodeId: waitingStep.nodeId,
                 decision: 'reject'
               })
             }
@@ -286,5 +272,22 @@ export function RunDetailPane({
         </div>
       </div>
     </div>
+  )
+}
+
+/** Opens the sign-in window of the connection a parked step acts through. */
+function SignInButton({ connectionId }: { connectionId: string | undefined }) {
+  const connections = useConnections()
+  const name = connections.find((c) => c.id === connectionId)?.name ?? 'the connection'
+  return (
+    <button
+      type="button"
+      disabled={!connectionId}
+      onClick={() => connectionId && void window.api.signInConnection(connectionId)}
+      className={`flex items-center gap-2 px-4 py-2.5 text-[13px] ${GATE_APPROVE} disabled:opacity-50`}
+    >
+      <LogIn size={14} strokeWidth={2} />
+      Sign in to {name}
+    </button>
   )
 }

--- a/src/renderer/components/workflow-runs/RunDetailPane.tsx
+++ b/src/renderer/components/workflow-runs/RunDetailPane.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useAppStore } from '../../stores'
 import { toast } from '../Toast'
-import { Check, X, Inbox, LogIn, Play, RotateCcw } from 'lucide-react'
+import { Check, X, Inbox, Play, RotateCcw } from 'lucide-react'
 import { formatRelativeTime, formatRunDuration } from '../../lib/format-time'
 import {
   completedStageCount,
@@ -12,11 +12,12 @@ import {
   runSummaryText,
   type RunWorkflowRef
 } from '../../lib/run-presentation'
-import { hasFailedStep } from '@vornrun/shared/workflow-graph'
+import { hasFailedStep, isSignInWait } from '@vornrun/shared/workflow-graph'
 import { RunStepsList, StatusDot } from '../workflow-editor/RunEntry'
 import { RunIcon } from './RunIcon'
-import { useConnectorLook, useConnections } from '../../lib/use-connections'
+import { useConnectorLook } from '../../lib/use-connections'
 import { nodeConnectionId } from '../workflow-editor/node-visuals'
+import { SignInButton } from './SignInButton'
 import { StopRunButton } from './StopRunButton'
 import { workflowRunId, type TaskConfig } from '../../../shared/types'
 import type { RunListEntry } from '../../hooks/useAllWorkflowRuns'
@@ -72,7 +73,7 @@ export function RunDetailPane({
   const done = completedStageCount(stages)
   const summary = runSummaryText(run)
   const waitingStep = run.nodeStates.find((ns) => ns.status === 'waiting')
-  const signInWait = waitingStep?.waitingFor === 'signIn'
+  const signInWait = waitingStep !== undefined && isSignInWait(waitingStep)
   const wait = WAIT_LABELS[signInWait ? 'signIn' : 'approval']
 
   // Keyboard approval mirrors the two visible actions, and only while a gate is
@@ -272,22 +273,5 @@ export function RunDetailPane({
         </div>
       </div>
     </div>
-  )
-}
-
-/** Opens the sign-in window of the connection a parked step acts through. */
-function SignInButton({ connectionId }: { connectionId: string | undefined }) {
-  const connections = useConnections()
-  const name = connections.find((c) => c.id === connectionId)?.name ?? 'the connection'
-  return (
-    <button
-      type="button"
-      disabled={!connectionId}
-      onClick={() => connectionId && void window.api.signInConnection(connectionId)}
-      className={`flex items-center gap-2 px-4 py-2.5 text-[13px] ${GATE_APPROVE} disabled:opacity-50`}
-    >
-      <LogIn size={14} strokeWidth={2} />
-      Sign in to {name}
-    </button>
   )
 }

--- a/src/renderer/components/workflow-runs/SignInButton.tsx
+++ b/src/renderer/components/workflow-runs/SignInButton.tsx
@@ -1,0 +1,26 @@
+import { LogIn } from 'lucide-react'
+import { GATE_APPROVE } from '../../lib/gate-affordance'
+import { useConnections } from '../../lib/use-connections'
+
+/** Opens the sign-in window of the connection a parked step acts through. */
+export function SignInButton({
+  connectionId,
+  compact = false
+}: {
+  connectionId: string | undefined
+  compact?: boolean
+}) {
+  const connections = useConnections()
+  const name = connections.find((c) => c.id === connectionId)?.name ?? 'the connection'
+  return (
+    <button
+      type="button"
+      disabled={!connectionId}
+      onClick={() => connectionId && void window.api.signInConnection(connectionId)}
+      className={`flex items-center ${compact ? 'gap-1 px-2 py-1 text-[11px] shrink-0' : 'gap-2 px-4 py-2.5 text-[13px]'} ${GATE_APPROVE} disabled:opacity-50`}
+    >
+      <LogIn size={compact ? 11 : 14} strokeWidth={compact ? 2.5 : 2} />
+      Sign in to {name}
+    </button>
+  )
+}

--- a/src/renderer/hooks/useWaitingApprovals.ts
+++ b/src/renderer/hooks/useWaitingApprovals.ts
@@ -16,12 +16,15 @@ const EMPTY: WaitingApproval[] = []
  * mutation of `workflowExecutions`.
  */
 function waitingSignature(
-  workflowExecutions: Map<string, { nodeStates: Array<{ nodeId: string; status: string }> }>
+  workflowExecutions: Map<
+    string,
+    { nodeStates: Array<{ nodeId: string; status: string; waitingFor?: string }> }
+  >
 ): string {
   const parts: string[] = []
   for (const [id, exec] of workflowExecutions) {
     for (const ns of exec.nodeStates) {
-      if (ns.status === 'waiting') parts.push(`${id}:${ns.nodeId}`)
+      if (ns.status === 'waiting' && ns.waitingFor !== 'signIn') parts.push(`${id}:${ns.nodeId}`)
     }
   }
   parts.sort()
@@ -41,7 +44,7 @@ export function useWaitingApprovals(): WaitingApproval[] {
       const workflow = workflows?.find((w) => w.id === execution.workflowId)
       if (workflow && (workflow.workspaceId ?? 'personal') !== activeWorkspace) continue
       for (const ns of execution.nodeStates) {
-        if (ns.status === 'waiting') {
+        if (ns.status === 'waiting' && ns.waitingFor !== 'signIn') {
           out.push({ execution, nodeState: ns, workflow })
         }
       }

--- a/src/renderer/hooks/useWaitingApprovals.ts
+++ b/src/renderer/hooks/useWaitingApprovals.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { isSignInWait } from '@vornrun/shared/workflow-graph'
 import { useAppStore } from '../stores'
 import type { WorkflowExecution, NodeExecutionState, WorkflowDefinition } from '../../shared/types'
 
@@ -24,7 +25,7 @@ function waitingSignature(
   const parts: string[] = []
   for (const [id, exec] of workflowExecutions) {
     for (const ns of exec.nodeStates) {
-      if (ns.status === 'waiting' && ns.waitingFor !== 'signIn') parts.push(`${id}:${ns.nodeId}`)
+      if (ns.status === 'waiting' && !isSignInWait(ns)) parts.push(`${id}:${ns.nodeId}`)
     }
   }
   parts.sort()
@@ -44,7 +45,7 @@ export function useWaitingApprovals(): WaitingApproval[] {
       const workflow = workflows?.find((w) => w.id === execution.workflowId)
       if (workflow && (workflow.workspaceId ?? 'personal') !== activeWorkspace) continue
       for (const ns of execution.nodeStates) {
-        if (ns.status === 'waiting' && ns.waitingFor !== 'signIn') {
+        if (ns.status === 'waiting' && !isSignInWait(ns)) {
           out.push({ execution, nodeState: ns, workflow })
         }
       }

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -1,3 +1,4 @@
+import { CONNECTOR_AUTH_RUNGS } from '../../shared/types'
 import type {
   ConnectorAuthRung,
   ConnectorCatalogActionInput,
@@ -487,8 +488,9 @@ export const AUTH_RUNG: Record<
 
 /** The rungs actually present, so the filter never offers an empty answer. */
 export function connectorAuthRungs(listings: ConnectorListing[]): ConnectorAuthRung[] {
-  const order: ConnectorAuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
-  return order.filter((rung) => listings.some((listing) => listing.authRung === rung))
+  return CONNECTOR_AUTH_RUNGS.filter((rung) =>
+    listings.some((listing) => listing.authRung === rung)
+  )
 }
 
 /** What a kind is called where a person picks one. */

--- a/src/renderer/lib/connector-browse.ts
+++ b/src/renderer/lib/connector-browse.ts
@@ -473,16 +473,21 @@ export const AUTH_RUNG: Record<
     detail: 'Signs in with a CLI'
   },
   key: { label: 'Needs a key', badge: 'key', detail: 'Needs a key' },
+  browser: {
+    label: 'Signs in through a Vorn window',
+    badge: 'browser',
+    detail: 'Signs in through a Vorn window'
+  },
   oauth: {
-    label: 'Signs in through a browser',
+    label: 'Signs in with OAuth',
     badge: 'OAuth',
-    detail: 'Signs in through a browser'
+    detail: 'Signs in with OAuth'
   }
 }
 
 /** The rungs actually present, so the filter never offers an empty answer. */
 export function connectorAuthRungs(listings: ConnectorListing[]): ConnectorAuthRung[] {
-  const order: ConnectorAuthRung[] = ['none', 'cli', 'key', 'oauth']
+  const order: ConnectorAuthRung[] = ['none', 'cli', 'key', 'browser', 'oauth']
   return order.filter((rung) => listings.some((listing) => listing.authRung === rung))
 }
 

--- a/src/renderer/lib/notifications.ts
+++ b/src/renderer/lib/notifications.ts
@@ -142,3 +142,24 @@ export function sendWorkflowGateNotification(
     onClick
   )
 }
+
+export function sendWorkflowSignInNotification(
+  workflow: WorkflowDefinition,
+  nodeId: string,
+  nodeLabel: string,
+  message: string | undefined,
+  config: AppConfig | null,
+  onClick?: () => void
+): void {
+  const prefs = config?.defaults.notifications
+  if (!prefs?.enabled || prefs.onWaiting === false) return
+
+  dispatch(
+    'waiting',
+    `workflow-sign-in:${workflow.id}:${nodeId}`,
+    prefs,
+    `${workflow.name} · awaiting sign-in`,
+    message || `${nodeLabel} is waiting for you to sign in again`,
+    onClick
+  )
+}

--- a/src/renderer/lib/notifications.ts
+++ b/src/renderer/lib/notifications.ts
@@ -122,6 +122,18 @@ export function sendAgentNotification(
   dispatch(reason, terminal.id, prefs, title, body, onClick)
 }
 
+function dispatchWorkflowWait(
+  tag: string,
+  title: string,
+  body: string,
+  config: AppConfig | null,
+  onClick?: () => void
+): void {
+  const prefs = config?.defaults.notifications
+  if (!prefs?.enabled || prefs.onWaiting === false) return
+  dispatch('waiting', tag, prefs, title, body, onClick)
+}
+
 export function sendWorkflowGateNotification(
   workflow: WorkflowDefinition,
   nodeId: string,
@@ -130,15 +142,11 @@ export function sendWorkflowGateNotification(
   config: AppConfig | null,
   onClick?: () => void
 ): void {
-  const prefs = config?.defaults.notifications
-  if (!prefs?.enabled || prefs.onWaiting === false) return
-
-  dispatch(
-    'waiting',
+  dispatchWorkflowWait(
     `workflow-gate:${workflow.id}:${nodeId}`,
-    prefs,
     `${workflow.name} · awaiting approval`,
     message || `${nodeLabel} is waiting for your approval`,
+    config,
     onClick
   )
 }
@@ -151,15 +159,11 @@ export function sendWorkflowSignInNotification(
   config: AppConfig | null,
   onClick?: () => void
 ): void {
-  const prefs = config?.defaults.notifications
-  if (!prefs?.enabled || prefs.onWaiting === false) return
-
-  dispatch(
-    'waiting',
+  dispatchWorkflowWait(
     `workflow-sign-in:${workflow.id}:${nodeId}`,
-    prefs,
     `${workflow.name} · awaiting sign-in`,
     message || `${nodeLabel} is waiting for you to sign in again`,
+    config,
     onClick
   )
 }

--- a/src/renderer/lib/run-notifications.ts
+++ b/src/renderer/lib/run-notifications.ts
@@ -1,6 +1,6 @@
 import type { WorkflowExecution } from '../../shared/types'
 import { useAppStore } from '../stores'
-import { sendWorkflowGateNotification } from './notifications'
+import { sendWorkflowGateNotification, sendWorkflowSignInNotification } from './notifications'
 
 /**
  * The window's half of a run that is happening somewhere else.
@@ -30,6 +30,22 @@ export function announceRun(execution: WorkflowExecution): void {
     for (const nodeId of waiting) {
       if (previous?.waiting.has(nodeId)) continue
       const node = workflow.nodes.find((n) => n.id === nodeId)
+      const openWorkflow = () => {
+        useAppStore.getState().setEditingWorkflowId(workflow.id)
+        useAppStore.getState().setWorkflowEditorOpen(true)
+      }
+      const state = execution.nodeStates.find((ns) => ns.nodeId === nodeId)
+      if (state?.waitingFor === 'signIn') {
+        sendWorkflowSignInNotification(
+          workflow,
+          nodeId,
+          node?.label ?? 'A step',
+          state.error,
+          store.config ?? null,
+          openWorkflow
+        )
+        continue
+      }
       sendWorkflowGateNotification(
         workflow,
         nodeId,

--- a/src/renderer/lib/run-notifications.ts
+++ b/src/renderer/lib/run-notifications.ts
@@ -52,10 +52,7 @@ export function announceRun(execution: WorkflowExecution): void {
         node?.label ?? 'Approval',
         (node?.config as { message?: string } | undefined)?.message,
         store.config ?? null,
-        () => {
-          useAppStore.getState().setEditingWorkflowId(workflow.id)
-          useAppStore.getState().setWorkflowEditorOpen(true)
-        }
+        openWorkflow
       )
     }
   }

--- a/src/renderer/lib/run-notifications.ts
+++ b/src/renderer/lib/run-notifications.ts
@@ -1,4 +1,5 @@
 import type { WorkflowExecution } from '../../shared/types'
+import { isSignInWait } from '@vornrun/shared/workflow-graph'
 import { useAppStore } from '../stores'
 import { sendWorkflowGateNotification, sendWorkflowSignInNotification } from './notifications'
 
@@ -35,7 +36,7 @@ export function announceRun(execution: WorkflowExecution): void {
         useAppStore.getState().setWorkflowEditorOpen(true)
       }
       const state = execution.nodeStates.find((ns) => ns.nodeId === nodeId)
-      if (state?.waitingFor === 'signIn') {
+      if (state && isSignInWait(state)) {
         sendWorkflowSignInNotification(
           workflow,
           nodeId,

--- a/src/renderer/lib/run-presentation.ts
+++ b/src/renderer/lib/run-presentation.ts
@@ -1,4 +1,5 @@
 import { Zap, Clock, CheckSquare, Play, type LucideIcon, RotateCcw } from 'lucide-react'
+import { isSignInWait } from '@vornrun/shared/workflow-graph'
 import type {
   ApprovalConfig,
   NodeExecutionState,
@@ -287,7 +288,7 @@ export interface RunOutcome {
 export function describeOutcome(execution: WorkflowExecution, nodes: WorkflowNode[]): RunOutcome {
   const gate = execution.nodeStates.find((ns) => ns.status === 'waiting')
   if (gate) {
-    if (gate.waitingFor === 'signIn') return { label: 'needs sign-in', tone: 'waiting' }
+    if (isSignInWait(gate)) return { label: 'needs sign-in', tone: 'waiting' }
     const node = nodes.find((n) => n.id === gate.nodeId)
     const message = node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
     return {

--- a/src/renderer/lib/run-presentation.ts
+++ b/src/renderer/lib/run-presentation.ts
@@ -287,6 +287,7 @@ export interface RunOutcome {
 export function describeOutcome(execution: WorkflowExecution, nodes: WorkflowNode[]): RunOutcome {
   const gate = execution.nodeStates.find((ns) => ns.status === 'waiting')
   if (gate) {
+    if (gate.waitingFor === 'signIn') return { label: 'needs sign-in', tone: 'waiting' }
     const node = nodes.find((n) => n.id === gate.nodeId)
     const message = node?.type === 'approval' ? (node.config as ApprovalConfig).message : undefined
     return {

--- a/src/renderer/lib/use-row-action.ts
+++ b/src/renderer/lib/use-row-action.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 
 // What a row's own actions report while they run: a phrase while busy, and a refusal that lands where the press was.
-export type RowAction = 'backfill' | 'delete' | 'run' | 'rollback' | 'remove'
+export type RowAction = 'backfill' | 'delete' | 'run' | 'rollback' | 'remove' | 'signIn' | 'signOut'
 
 /** Present tense, so a row says what is happening rather than what was pressed. */
 const PHRASES: Record<RowAction, string> = {
@@ -9,7 +9,9 @@ const PHRASES: Record<RowAction, string> = {
   delete: 'Removing…',
   run: 'Polling…',
   rollback: 'Rolling back…',
-  remove: 'Removing…'
+  remove: 'Removing…',
+  signIn: 'Waiting for the sign-in window…',
+  signOut: 'Signing out…'
 }
 
 /** A call that answers with a refusal rather than throwing one. */

--- a/tests/connection-row-sign-in.test.tsx
+++ b/tests/connection-row-sign-in.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ConnectionRow } from '../src/renderer/components/settings/ConnectionRow'
+import type { SdkBrowserSignIn, SourceConnection } from '../src/shared/types'
+
+const browser: SdkBrowserSignIn = {
+  signInUrl: 'https://substack.com/sign-in',
+  origins: ['https://substack.com', 'https://*.substack.com'],
+  check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name', 'handle'] }
+}
+
+const signInConnection = vi.fn()
+const signOutConnection = vi.fn()
+
+beforeEach(() => {
+  signInConnection.mockReset().mockResolvedValue({ ok: true, identity: 'Javier Canizalez' })
+  signOutConnection.mockReset().mockResolvedValue(undefined)
+  ;(window as unknown as { api: unknown }).api = { signInConnection, signOutConnection }
+})
+
+function setup(conn: Partial<SourceConnection> = {}) {
+  const onRefresh = vi.fn()
+  const utils = render(
+    <ConnectionRow
+      conn={
+        {
+          id: 'c1',
+          connectorId: 'mcp',
+          name: 'Substack',
+          filters: {},
+          syncIntervalMinutes: 5,
+          statusMapping: {},
+          createdAt: '2026-09-10T20:00:00.000Z',
+          ...conn
+        } as SourceConnection
+      }
+      browserSignIn={browser}
+      seededWorkflows={[]}
+      missingEvents={[]}
+      activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
+      backfillResult={{}}
+      onRun={vi.fn()}
+      onBackfill={vi.fn()}
+      onDelete={vi.fn()}
+      onResetWorkflow={vi.fn()}
+      onOpenWorkflow={vi.fn()}
+      onRefresh={onRefresh}
+    />
+  )
+  return { ...utils, onRefresh }
+}
+
+describe('a connection that signs in through a Vorn window', () => {
+  it('says who it is signed in as, and offers to sign in again or out', async () => {
+    const { getByText, getByRole, onRefresh } = setup({
+      signedInAs: 'Javier Canizalez (javiercanizalez)',
+      signedInAt: '2026-09-10T20:05:00.000Z'
+    })
+    expect(getByText('Signed in as Javier Canizalez (javiercanizalez)')).toBeInTheDocument()
+    expect(getByRole('button', { name: 'Sign in again' })).toBeInTheDocument()
+    fireEvent.click(getByRole('button', { name: 'Sign out' }))
+    await waitFor(() => expect(signOutConnection).toHaveBeenCalledWith('c1'))
+    await waitFor(() => expect(onRefresh).toHaveBeenCalled())
+  })
+
+  it('says when no one is signed in, and opens the window when asked', async () => {
+    const { getByText, getByRole, onRefresh } = setup()
+    expect(getByText('Not signed in')).toBeInTheDocument()
+    fireEvent.click(getByRole('button', { name: 'Sign in' }))
+    await waitFor(() => expect(signInConnection).toHaveBeenCalledWith('c1', undefined))
+    await waitFor(() => expect(onRefresh).toHaveBeenCalled())
+  })
+
+  it('takes an emailed sign-in link, for a site that signs in by email', async () => {
+    const { getByRole } = setup()
+    fireEvent.click(getByRole('button', { name: 'Use a sign-in link' }))
+    const field = getByRole('textbox', { name: 'Sign-in link' })
+    fireEvent.change(field, { target: { value: 'https://substack.com/sign-in?token=abc' } })
+    fireEvent.keyDown(field, { key: 'Enter' })
+    await waitFor(() =>
+      expect(signInConnection).toHaveBeenCalledWith('c1', 'https://substack.com/sign-in?token=abc')
+    )
+  })
+
+  it("shows the window's answer when no one signed in", async () => {
+    signInConnection.mockResolvedValue({
+      ok: false,
+      message: 'The sign-in window closed before anyone signed in.'
+    })
+    const { getByRole, findByText } = setup()
+    fireEvent.click(getByRole('button', { name: 'Sign in' }))
+    expect(
+      await findByText('The sign-in window closed before anyone signed in.')
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/connection-row-sign-in.test.tsx
+++ b/tests/connection-row-sign-in.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { ConnectionRow } from '../src/renderer/components/settings/ConnectionRow'
+import { useRowAction } from '../src/renderer/lib/use-row-action'
 import type { SdkBrowserSignIn, SourceConnection } from '../src/shared/types'
 
 const browser: SdkBrowserSignIn = {
@@ -20,10 +21,14 @@ beforeEach(() => {
   ;(window as unknown as { api: unknown }).api = { signInConnection, signOutConnection }
 })
 
+function Row(props: Omit<Parameters<typeof ConnectionRow>[0], 'activity'>) {
+  return <ConnectionRow {...props} activity={useRowAction()} />
+}
+
 function setup(conn: Partial<SourceConnection> = {}) {
   const onRefresh = vi.fn()
   const utils = render(
-    <ConnectionRow
+    <Row
       conn={
         {
           id: 'c1',
@@ -39,7 +44,6 @@ function setup(conn: Partial<SourceConnection> = {}) {
       browserSignIn={browser}
       seededWorkflows={[]}
       missingEvents={[]}
-      activity={{ busy: {}, failed: {}, run: async () => {}, state: () => ({}) }}
       backfillResult={{}}
       onRun={vi.fn()}
       onBackfill={vi.fn()}
@@ -87,7 +91,7 @@ describe('a connection that signs in through a Vorn window', () => {
   it("shows the window's answer when no one signed in", async () => {
     signInConnection.mockResolvedValue({
       ok: false,
-      message: 'The sign-in window closed before anyone signed in.'
+      error: 'The sign-in window closed before anyone signed in.'
     })
     const { getByRole, findByText } = setup()
     fireEvent.click(getByRole('button', { name: 'Sign in' }))

--- a/tests/connection-runner.test.ts
+++ b/tests/connection-runner.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface FakeWindow {
+  destroyed: boolean
+  load(): void
+  webContents: { executeJavaScript: ReturnType<typeof vi.fn> }
+}
+
+const windows = vi.hoisted(() => [] as FakeWindow[])
+
+vi.mock('electron', () => {
+  class BrowserWindow {
+    destroyed = false
+    url = ''
+    load = (): void => {}
+    private closed: (() => void) | undefined
+    webContents = {
+      getURL: (): string => this.url,
+      executeJavaScript: vi.fn(async () => ({ status: 200, headers: {}, body: '{}' }))
+    }
+    constructor() {
+      windows.push(this as unknown as FakeWindow)
+    }
+    loadURL(url: string): Promise<void> {
+      return new Promise((resolve) => {
+        this.load = () => {
+          this.url = url
+          resolve()
+        }
+      })
+    }
+    on(event: string, fn: () => void): void {
+      if (event === 'closed') this.closed = fn
+    }
+    isDestroyed(): boolean {
+      return this.destroyed
+    }
+    destroy(): void {
+      this.destroyed = true
+      this.closed?.()
+    }
+  }
+  const profile = {
+    setUserAgent: vi.fn(),
+    getUserAgent: () => 'Mozilla/5.0 Electron/41.0.0',
+    setPermissionRequestHandler: vi.fn(),
+    setPermissionCheckHandler: vi.fn(),
+    on: vi.fn()
+  }
+  return {
+    BrowserWindow,
+    app: { getPath: () => '/tmp/vorn-test' },
+    session: { fromPartition: () => profile }
+  }
+})
+
+vi.mock('../src/main/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+
+const { closeConnectionWindows, fetchInSession } = await import('../src/main/connection-sessions')
+
+const origins = ['https://substack.com']
+const request = { url: 'https://substack.com/api/v1/user/profile/self', method: 'GET' }
+
+beforeEach(() => {
+  closeConnectionWindows()
+  windows.length = 0
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('the hidden page a signed-in call runs in', () => {
+  it('opens once for calls that arrive while it is still loading, and answers them all', async () => {
+    const calls = Promise.all([
+      fetchInSession('c1', origins, request),
+      fetchInSession('c1', origins, request)
+    ])
+    await vi.waitFor(() => expect(windows).toHaveLength(1))
+    windows[0]!.load()
+    await expect(calls).resolves.toHaveLength(2)
+    expect(windows).toHaveLength(1)
+    expect(windows[0]!.destroyed).toBe(false)
+  })
+
+  it('stays open while a call is running, and closes once it has been idle', async () => {
+    vi.useFakeTimers()
+    const first = fetchInSession('c1', origins, request)
+    await vi.waitFor(() => expect(windows).toHaveLength(1))
+    windows[0]!.load()
+    await first
+
+    await vi.advanceTimersByTimeAsync(59_000)
+    let finish: (answer: unknown) => void = () => {}
+    windows[0]!.webContents.executeJavaScript.mockImplementationOnce(
+      () => new Promise((resolve) => (finish = resolve))
+    )
+    const slow = fetchInSession('c1', origins, request)
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(windows[0]!.destroyed).toBe(false)
+
+    finish({ status: 200, headers: {}, body: '' })
+    await slow
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(windows[0]!.destroyed).toBe(true)
+  })
+})

--- a/tests/connection-session-script.test.ts
+++ b/tests/connection-session-script.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  allowedHeaders,
+  fetchScript,
+  identityFrom,
+  plainUserAgent,
+  staleConnectionFolders
+} from '../src/main/connection-session-script'
+
+describe("the script a connection's hidden page runs", () => {
+  it('carries the call as data, so nothing a connector sends is ever run as code', () => {
+    const script = fetchScript({
+      url: 'https://novumai.substack.com/api/v1/drafts/1',
+      method: 'put',
+      headers: { 'content-type': 'application/json', cookie: 'sid=stolen', authorization: 'x' },
+      body: '"); alert(1); ("'
+    })
+    expect(script).toContain('fetch("https://novumai.substack.com/api/v1/drafts/1", ')
+    expect(script).toContain('"method":"PUT"')
+    expect(script).toContain('"credentials":"include"')
+    expect(script).toContain('"body":"\\"); alert(1); (\\""')
+    expect(script).not.toContain('stolen')
+    expect(script).not.toContain('authorization')
+  })
+
+  it('keeps only the headers a call may set', () => {
+    expect(allowedHeaders({ Accept: 'application/json', Cookie: 'a', 'X-Csrf': 'b' })).toEqual({
+      Accept: 'application/json'
+    })
+  })
+})
+
+describe('the user agent a connection presents', () => {
+  it('drops the tokens that name Electron and Vorn, and keeps the browser underneath', () => {
+    const electron =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) vorn/0.7.0-beta.17 Chrome/140.0.7339.41 Electron/44.1.1 Safari/537.36'
+    expect(plainUserAgent(electron)).toBe(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.7339.41 Safari/537.36'
+    )
+  })
+})
+
+describe('who the check says is signed in', () => {
+  const profile = JSON.stringify({ name: 'Javier Canizalez', handle: 'javiercanizalez', id: 7 })
+
+  it('reads the declared fields, naming the first and the rest beside it', () => {
+    expect(identityFrom(profile, ['name', 'handle'])).toBe('Javier Canizalez (javiercanizalez)')
+    expect(identityFrom(profile, ['name'])).toBe('Javier Canizalez')
+    expect(identityFrom(JSON.stringify({ user: { email: 'a@b.c' } }), ['user.email'])).toBe('a@b.c')
+  })
+
+  it('names no one when the answer does not say', () => {
+    expect(identityFrom(profile, ['missing'])).toBeNull()
+    expect(identityFrom('<html>', ['name'])).toBeNull()
+  })
+})
+
+describe('which profile folders the sweep removes', () => {
+  it("removes only a connection profile whose connection is gone, never a pane's", () => {
+    const folders = ['vorn-connection-a', 'vorn-connection-b', 'vorn-browser-a', 'Default']
+    expect(staleConnectionFolders(folders, ['a'])).toEqual(['vorn-connection-b'])
+  })
+})

--- a/tests/connector-browse-browser-rung.test.ts
+++ b/tests/connector-browse-browser-rung.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AUTH_RUNG,
+  connectorAuthRungs,
+  type ConnectorListing
+} from '../src/renderer/lib/connector-browse'
+
+describe('how the directory names a browser sign-in', () => {
+  it('offers it among the sign-in filters, before OAuth', () => {
+    const listings = [{ authRung: 'oauth' }, { authRung: 'browser' }, { authRung: 'key' }]
+    expect(connectorAuthRungs(listings as ConnectorListing[])).toEqual(['key', 'browser', 'oauth'])
+  })
+
+  it('does not read like OAuth, which also opens a browser', () => {
+    expect(AUTH_RUNG.browser).toEqual({
+      label: 'Signs in through a Vorn window',
+      badge: 'browser',
+      detail: 'Signs in through a Vorn window'
+    })
+    expect(AUTH_RUNG.oauth.label).not.toBe(AUTH_RUNG.browser.label)
+  })
+})

--- a/tests/connector-catalog-factory-fields.test.ts
+++ b/tests/connector-catalog-factory-fields.test.ts
@@ -15,7 +15,7 @@ const first = (raw: Record<string, unknown>) =>
 
 describe('the rung a catalog entry declares', () => {
   it('is carried when this build knows how to describe it', () => {
-    for (const authRung of ['none', 'cli', 'key', 'oauth']) {
+    for (const authRung of ['none', 'cli', 'key', 'browser', 'oauth']) {
       expect(first({ authRung })?.authRung).toBe(authRung)
     }
   })

--- a/tests/connector-sdk-auth.test.ts
+++ b/tests/connector-sdk-auth.test.ts
@@ -64,3 +64,59 @@ describe('what each rung has to back up', () => {
     expect(() => withAuth({ rung: 'oauth' })).not.toThrow()
   })
 })
+
+describe('a connector that signs in through a Vorn window', () => {
+  const browser = {
+    signInUrl: 'https://substack.com/sign-in',
+    origins: ['https://substack.com', 'https://*.substack.com'],
+    check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name', 'handle'] }
+  }
+
+  it('reaches the manifest whole, so the app knows where to sign in and what to check', () => {
+    expect(connectorManifest(withAuth({ rung: 'browser', browser })).auth).toEqual({
+      rung: 'browser',
+      browser
+    })
+  })
+
+  it('has to say where it signs in', () => {
+    expect(() => withAuth({ rung: 'browser' })).toThrow(/declares no browser sign-in/)
+  })
+
+  it('names its origins as https hosts', () => {
+    expect(() => withAuth({ rung: 'browser', browser: { ...browser, origins: [] } })).toThrow(
+      /must name its origins/
+    )
+    expect(() =>
+      withAuth({ rung: 'browser', browser: { ...browser, origins: ['http://substack.com'] } })
+    ).toThrow(/"http:\/\/substack\.com" is neither/)
+  })
+
+  it('keeps its sign-in page and its check inside those origins', () => {
+    expect(() =>
+      withAuth({ rung: 'browser', browser: { ...browser, signInUrl: 'https://evil.io/login' } })
+    ).toThrow(/sign-in page .* outside its origins/)
+    expect(() =>
+      withAuth({
+        rung: 'browser',
+        browser: { ...browser, check: { ...browser.check, url: 'https://evil.io/me' } }
+      })
+    ).toThrow(/signed-in check .* outside its origins/)
+  })
+
+  it('names the fields that say who is signed in as words', () => {
+    expect(() =>
+      withAuth({
+        rung: 'browser',
+        browser: { ...browser, check: { ...browser.check, identity: [' '] } }
+      })
+    ).toThrow(/identity fields/)
+  })
+
+  it('keeps no secret of its own, since the signed-in window is the secret', () => {
+    const secret: ConnectorConfigField = { key: 'apiToken', label: 'API token', secret: true }
+    expect(() => withAuth({ rung: 'browser', browser }, [secret])).toThrow(
+      /signs in through a Vorn window but declares secret field "apiToken"/
+    )
+  })
+})

--- a/tests/connector-sdk-integration.test.ts
+++ b/tests/connector-sdk-integration.test.ts
@@ -14,6 +14,7 @@ vi.mock('../packages/server/src/logger', () => ({
 
 const getOrStartClient = vi.fn()
 vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  sessionGrantFor: () => undefined,
   getOrStartClient: (conn: SourceConnection) => getOrStartClient(conn)
 }))
 

--- a/tests/connector-sdk-session-call.test.ts
+++ b/tests/connector-sdk-session-call.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import {
+  createConnectorServer,
+  defineConnector,
+  SESSION_CALL_HEADER,
+  SESSION_CALL_META
+} from '../packages/connector-sdk/src/index'
+import {
+  SESSION_CALL_HEADER as SHARED_HEADER,
+  SESSION_CALL_META as SHARED_META
+} from '../packages/shared/src/types'
+
+const connector = defineConnector({
+  id: 'pub',
+  name: 'Pub',
+  auth: {
+    rung: 'browser',
+    browser: {
+      signInUrl: 'https://example.com/login',
+      origins: ['https://example.com'],
+      check: { url: 'https://example.com/me', identity: ['name'] }
+    }
+  },
+  actions: [
+    {
+      type: 'peek',
+      label: 'Peek',
+      run: async (_args, ctx) => ({
+        status: (await ctx.session!.fetch('https://example.com/archive')).status
+      })
+    }
+  ]
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+})
+
+describe('the key Vorn gives a tool call', () => {
+  it('rides on each request the call makes through the window', async () => {
+    vi.stubEnv('VORN_BROWSER_HOST', 'http://127.0.0.1:4100/connections/c1/browser')
+    vi.stubEnv('VORN_BROWSER_TOKEN', 't0k')
+    const endpoint = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ status: 200, body: '{}' }))
+    )
+    vi.stubGlobal('fetch', endpoint)
+    const server = createConnectorServer(connector, { config: {} })
+    const client = new Client({ name: 'test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+    await client.callTool({ name: 'peek', arguments: {}, _meta: { [SESSION_CALL_META]: 'k1' } })
+
+    expect(endpoint.mock.calls[0]?.[1]?.headers).toMatchObject({ [SESSION_CALL_HEADER]: 'k1' })
+    await client.close()
+  })
+
+  it('is named the way the app reads it', () => {
+    expect(SESSION_CALL_META).toBe(SHARED_META)
+    expect(SESSION_CALL_HEADER).toBe(SHARED_HEADER)
+  })
+})

--- a/tests/connector-sdk-session-call.test.ts
+++ b/tests/connector-sdk-session-call.test.ts
@@ -4,6 +4,7 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import {
   createConnectorServer,
   defineConnector,
+  pollToolName,
   SESSION_CALL_HEADER,
   SESSION_CALL_META
 } from '../packages/connector-sdk/src/index'
@@ -11,6 +12,8 @@ import {
   SESSION_CALL_HEADER as SHARED_HEADER,
   SESSION_CALL_META as SHARED_META
 } from '../packages/shared/src/types'
+
+const archive = 'https://example.com/archive'
 
 const connector = defineConnector({
   id: 'pub',
@@ -23,13 +26,22 @@ const connector = defineConnector({
       check: { url: 'https://example.com/me', identity: ['name'] }
     }
   },
+  triggers: [
+    {
+      type: 'changed',
+      label: 'Changed',
+      dedupe: 'lastItem',
+      fetch: async (ctx) => {
+        await ctx.session!.fetch(archive)
+        return []
+      }
+    }
+  ],
   actions: [
     {
       type: 'peek',
       label: 'Peek',
-      run: async (_args, ctx) => ({
-        status: (await ctx.session!.fetch('https://example.com/archive')).status
-      })
+      run: async (_args, ctx) => ({ status: (await ctx.session!.fetch(archive)).status })
     }
   ]
 })
@@ -39,22 +51,37 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+/** The connector served in memory, with its window endpoint answered by a stub. */
+async function served() {
+  vi.stubEnv('VORN_BROWSER_HOST', 'http://127.0.0.1:4100/connections/c1/browser')
+  vi.stubEnv('VORN_BROWSER_TOKEN', 't0k')
+  const endpoint = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify({ status: 200, body: '{}' }))
+  )
+  vi.stubGlobal('fetch', endpoint)
+  const server = createConnectorServer(connector, { config: {} })
+  const client = new Client({ name: 'test', version: '1.0.0' })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+  return { client, endpoint }
+}
+
 describe('the key Vorn gives a tool call', () => {
-  it('rides on each request the call makes through the window', async () => {
-    vi.stubEnv('VORN_BROWSER_HOST', 'http://127.0.0.1:4100/connections/c1/browser')
-    vi.stubEnv('VORN_BROWSER_TOKEN', 't0k')
-    const endpoint = vi.fn<typeof fetch>(
-      async () => new Response(JSON.stringify({ status: 200, body: '{}' }))
-    )
-    vi.stubGlobal('fetch', endpoint)
-    const server = createConnectorServer(connector, { config: {} })
-    const client = new Client({ name: 'test', version: '1.0.0' })
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
-    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
-
+  it('rides on each request an action makes through the window', async () => {
+    const { client, endpoint } = await served()
     await client.callTool({ name: 'peek', arguments: {}, _meta: { [SESSION_CALL_META]: 'k1' } })
-
     expect(endpoint.mock.calls[0]?.[1]?.headers).toMatchObject({ [SESSION_CALL_HEADER]: 'k1' })
+    await client.close()
+  })
+
+  it('rides on a poll too, so a poll that meets a sign-out is told apart', async () => {
+    const { client, endpoint } = await served()
+    await client.callTool({
+      name: pollToolName('changed'),
+      arguments: {},
+      _meta: { [SESSION_CALL_META]: 'k2' }
+    })
+    expect(endpoint.mock.calls[0]?.[1]?.headers).toMatchObject({ [SESSION_CALL_HEADER]: 'k2' })
     await client.close()
   })
 

--- a/tests/connector-sdk-session-check.test.ts
+++ b/tests/connector-sdk-session-check.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { checkConnector, defineConnector } from '../packages/connector-sdk/src/index'
+
+const connector = defineConnector({
+  id: 'acme',
+  name: 'Acme',
+  auth: {
+    rung: 'browser',
+    browser: {
+      signInUrl: 'https://example.com/login',
+      origins: ['https://example.com'],
+      check: { url: 'https://example.com/me', identity: ['name'] }
+    }
+  },
+  actions: [
+    {
+      type: 'me',
+      label: 'Me',
+      idempotent: true,
+      run: async (_args, ctx) => ({
+        status: (await ctx.session!.fetch('https://example.com/me')).status
+      })
+    }
+  ]
+})
+
+describe('checking a connector that acts through a signed-in window', () => {
+  it('serves its signed-in calls from the mock, so a conformance run reaches no real service', async () => {
+    const codes = (await checkConnector(connector, { mock: true })).map((finding) => finding.code)
+    expect(codes).not.toContain('mock-action-failed')
+    expect(codes).not.toContain('mock-network-escape')
+  })
+
+  it('skips its signed-in calls in a live run from a terminal, which has no Vorn window', async () => {
+    const codes = (await checkConnector(connector, { live: true })).map((finding) => finding.code)
+    expect(codes).not.toContain('live-action-failed')
+  })
+})

--- a/tests/connector-sdk-session-runtime.test.ts
+++ b/tests/connector-sdk-session-runtime.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createConnectorHarness,
+  defineConnector,
+  runAction,
+  runOptions,
+  runPoll
+} from '../packages/connector-sdk/src/index'
+import type { ConnectorAuth, SessionContext } from '../packages/connector-sdk/src/types'
+
+const signedIn: ConnectorAuth = {
+  rung: 'browser',
+  browser: {
+    signInUrl: 'https://example.com/login',
+    origins: ['https://example.com'],
+    check: { url: 'https://example.com/me', identity: ['name'] }
+  }
+}
+
+const answer = (from: string) =>
+  vi.fn<typeof fetch>(
+    async () =>
+      new Response(JSON.stringify({ from }), { headers: { 'content-type': 'application/json' } })
+  )
+
+function acme(auth?: ConnectorAuth) {
+  const seen: Array<SessionContext | undefined> = []
+  const connector = defineConnector({
+    id: 'acme',
+    name: 'Acme',
+    ...(auth && { auth }),
+    options: {
+      things: (ctx) => {
+        seen.push(ctx.session)
+        return ['one']
+      }
+    },
+    triggers: [
+      {
+        type: 'changed',
+        label: 'Changed',
+        description: 'Something changed.',
+        dedupe: 'lastItem',
+        fetch: (ctx) => {
+          seen.push(ctx.session)
+          return []
+        }
+      }
+    ],
+    actions: [
+      {
+        type: 'peek',
+        label: 'Peek',
+        run: (_args, ctx) => {
+          seen.push(ctx.session)
+          return {}
+        }
+      },
+      { type: 'me', label: 'Me', idempotent: true, request: { url: 'https://example.com/me' } }
+    ]
+  })
+  return { connector, seen }
+}
+
+describe('the signed-in window a connector is handed', () => {
+  it('goes only to a connector that signs in through one', async () => {
+    const plain = acme()
+    await runAction(plain.connector, 'peek', {}, { sessionFetchImpl: answer('window') })
+    expect(plain.seen).toEqual([undefined])
+
+    const browser = acme(signedIn)
+    await runAction(browser.connector, 'peek', {}, { sessionFetchImpl: answer('window') })
+    expect(browser.seen[0]?.fetch).toBeTypeOf('function')
+  })
+
+  it("carries a browser connector's declared calls, and leaves another connector's alone", async () => {
+    const plain = answer('plain')
+    const window = answer('window')
+    await runAction(
+      acme(signedIn).connector,
+      'me',
+      {},
+      { fetchImpl: plain, sessionFetchImpl: window }
+    )
+    expect(window).toHaveBeenCalledOnce()
+    expect(plain).not.toHaveBeenCalled()
+
+    const plainAgain = answer('plain')
+    const windowAgain = answer('window')
+    await runAction(
+      acme().connector,
+      'me',
+      {},
+      { fetchImpl: plainAgain, sessionFetchImpl: windowAgain }
+    )
+    expect(plainAgain).toHaveBeenCalledOnce()
+    expect(windowAgain).not.toHaveBeenCalled()
+  })
+
+  it('reaches polls and option lists too, so a trigger can read a signed-in page', async () => {
+    const { connector, seen } = acme(signedIn)
+    await runOptions(connector, 'things', { sessionFetchImpl: answer('window') })
+    await runPoll(connector, 'changed', { sessionFetchImpl: answer('window') })
+    expect(seen).toHaveLength(2)
+    expect(seen.every((session) => typeof session?.fetch === 'function')).toBe(true)
+  })
+
+  it('lets one harness stub answer both kinds of call', async () => {
+    const stub = answer('stub')
+    await createConnectorHarness(acme(signedIn).connector, { fetchImpl: stub }).execute('me')
+    expect(stub).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/connector-sdk-session.test.ts
+++ b/tests/connector-sdk-session.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   createSessionFetch,
+  ORIGIN_PATTERN,
+  SessionRefusedError,
   SessionUnavailableError,
   withinOrigins
 } from '../packages/connector-sdk/src/index'
-import { withinOrigins as sharedWithinOrigins } from '../packages/shared/src/connector-origins'
+import {
+  ORIGIN_PATTERN as SHARED_ORIGIN_PATTERN,
+  withinOrigins as sharedWithinOrigins
+} from '../packages/shared/src/connector-origins'
 
 const env = {
-  VORN_SESSION_HOST: 'http://127.0.0.1:4100/connections/c1/session',
-  VORN_SESSION_TOKEN: 't0k'
+  VORN_BROWSER_HOST: 'http://127.0.0.1:4100/connections/c1/session',
+  VORN_BROWSER_TOKEN: 't0k'
 }
 
 const answering = (status: number, body: unknown) =>
@@ -49,7 +54,7 @@ describe('the signed-in fetch a browser connector gets', () => {
   it('never sends its token to a host that is not this machine', async () => {
     const call = answering(200, {})
     const fetch = createSessionFetch({
-      env: { ...env, VORN_SESSION_HOST: 'http://collector.example/session' },
+      env: { ...env, VORN_BROWSER_HOST: 'http://collector.example/session' },
       fetchImpl: call
     })
     await expect(fetch('https://substack.com/')).rejects.toThrow(/served on this machine/)
@@ -69,7 +74,7 @@ describe('the signed-in fetch a browser connector gets', () => {
       fetchImpl: answering(403, { error: 'https://evil.io is not one of its origins' })
     })
     const error = await refused('https://evil.io/').catch((e: unknown) => e)
-    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(SessionRefusedError)
     expect(error).not.toBeInstanceOf(SessionUnavailableError)
     expect((error as Error).message).toMatch(/not one of its origins/)
   })
@@ -102,8 +107,25 @@ describe('which pages a browser connector may reach', () => {
   })
 
   it('draws the same line in the app as in the SDK', () => {
+    expect(SHARED_ORIGIN_PATTERN.source).toBe(ORIGIN_PATTERN.source)
+    expect(sharedWithinOrigins.toString()).toBe(withinOrigins.toString())
     for (const [url] of cases) {
       expect([url, sharedWithinOrigins(origins, url)]).toEqual([url, withinOrigins(origins, url)])
     }
+  })
+})
+
+describe('a signed-in call that cannot be helped by asking again', () => {
+  it('fails at once instead of waiting through the retries', async () => {
+    const { resilientFetch } = await import('../packages/connector-sdk/src/index')
+    const closed = vi.fn<typeof fetch>(async () => {
+      throw new SessionUnavailableError('Open Vorn')
+    })
+    const sleep = vi.fn(async () => {})
+    await expect(
+      resilientFetch({ fetchImpl: closed, retryable: true, sleep })('https://x.io/')
+    ).rejects.toThrow('Open Vorn')
+    expect(closed).toHaveBeenCalledOnce()
+    expect(sleep).not.toHaveBeenCalled()
   })
 })

--- a/tests/connector-sdk-session.test.ts
+++ b/tests/connector-sdk-session.test.ts
@@ -18,6 +18,8 @@ const env = {
 
 const answering = (status: number, body: unknown) =>
   vi.fn<typeof fetch>(async () => new Response(JSON.stringify(body), { status }))
+const refusing = (status: number, reason: string) =>
+  vi.fn<typeof fetch>(async () => new Response(reason, { status }))
 
 describe('the signed-in fetch a browser connector gets', () => {
   it('asks Vorn to make the call, carrying the request whole', async () => {
@@ -46,6 +48,12 @@ describe('the signed-in fetch a browser connector gets', () => {
     })
   })
 
+  it('names the tool call its requests belong to, when Vorn gave it one', async () => {
+    const call = answering(200, { status: 200 })
+    await createSessionFetch({ env, fetchImpl: call, call: 'k1' })('https://substack.com/')
+    expect(call.mock.calls[0]?.[1]?.headers).toMatchObject({ 'x-vorn-session-call': 'k1' })
+  })
+
   it('says it needs Vorn when Vorn did not start it', async () => {
     const fetch = createSessionFetch({ env: {}, fetchImpl: answering(200, {}) })
     await expect(fetch('https://substack.com/')).rejects.toBeInstanceOf(SessionUnavailableError)
@@ -64,14 +72,14 @@ describe('the signed-in fetch a browser connector gets', () => {
   it('reads a closed app as unavailable, and any other refusal as an error', async () => {
     const closed = createSessionFetch({
       env,
-      fetchImpl: answering(503, { error: 'Open Vorn on the desktop this connection signed in on' })
+      fetchImpl: refusing(503, 'Open Vorn on the desktop this connection signed in on')
     })
     await expect(closed('https://substack.com/')).rejects.toThrow(SessionUnavailableError)
     await expect(closed('https://substack.com/')).rejects.toThrow(/Open Vorn on the desktop/)
 
     const refused = createSessionFetch({
       env,
-      fetchImpl: answering(403, { error: 'https://evil.io is not one of its origins' })
+      fetchImpl: refusing(403, 'https://evil.io is not one of its origins')
     })
     const error = await refused('https://evil.io/').catch((e: unknown) => e)
     expect(error).toBeInstanceOf(SessionRefusedError)

--- a/tests/connector-sdk-session.test.ts
+++ b/tests/connector-sdk-session.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createSessionFetch,
+  SessionUnavailableError,
+  withinOrigins
+} from '../packages/connector-sdk/src/index'
+import { withinOrigins as sharedWithinOrigins } from '../packages/shared/src/connector-origins'
+
+const env = {
+  VORN_SESSION_HOST: 'http://127.0.0.1:4100/connections/c1/session',
+  VORN_SESSION_TOKEN: 't0k'
+}
+
+const answering = (status: number, body: unknown) =>
+  vi.fn<typeof fetch>(async () => new Response(JSON.stringify(body), { status }))
+
+describe('the signed-in fetch a browser connector gets', () => {
+  it('asks Vorn to make the call, carrying the request whole', async () => {
+    const call = answering(200, {
+      status: 201,
+      headers: { 'content-type': 'application/json' },
+      body: '{"id":7}'
+    })
+    const fetch = createSessionFetch({ env, fetchImpl: call })
+    const res = await fetch('https://novumai.substack.com/api/v1/drafts', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"draft_title":"t"}'
+    })
+
+    expect(res.status).toBe(201)
+    expect(await res.json()).toEqual({ id: 7 })
+    const [url, init] = call.mock.calls[0]!
+    expect(url).toBe('http://127.0.0.1:4100/connections/c1/session/fetch')
+    expect(init?.headers).toMatchObject({ authorization: 'Bearer t0k' })
+    expect(JSON.parse(init?.body as string)).toEqual({
+      url: 'https://novumai.substack.com/api/v1/drafts',
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"draft_title":"t"}'
+    })
+  })
+
+  it('says it needs Vorn when Vorn did not start it', async () => {
+    const fetch = createSessionFetch({ env: {}, fetchImpl: answering(200, {}) })
+    await expect(fetch('https://substack.com/')).rejects.toBeInstanceOf(SessionUnavailableError)
+  })
+
+  it('never sends its token to a host that is not this machine', async () => {
+    const call = answering(200, {})
+    const fetch = createSessionFetch({
+      env: { ...env, VORN_SESSION_HOST: 'http://collector.example/session' },
+      fetchImpl: call
+    })
+    await expect(fetch('https://substack.com/')).rejects.toThrow(/served on this machine/)
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('reads a closed app as unavailable, and any other refusal as an error', async () => {
+    const closed = createSessionFetch({
+      env,
+      fetchImpl: answering(503, { error: 'Open Vorn on the desktop this connection signed in on' })
+    })
+    await expect(closed('https://substack.com/')).rejects.toThrow(SessionUnavailableError)
+    await expect(closed('https://substack.com/')).rejects.toThrow(/Open Vorn on the desktop/)
+
+    const refused = createSessionFetch({
+      env,
+      fetchImpl: answering(403, { error: 'https://evil.io is not one of its origins' })
+    })
+    const error = await refused('https://evil.io/').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(SessionUnavailableError)
+    expect((error as Error).message).toMatch(/not one of its origins/)
+  })
+
+  it('hands back a no-content answer with no body', async () => {
+    const fetch = createSessionFetch({ env, fetchImpl: answering(200, { status: 204 }) })
+    const res = await fetch('https://substack.com/api/v1/comment/1', { method: 'DELETE' })
+    expect(res.status).toBe(204)
+    expect(await res.text()).toBe('')
+  })
+})
+
+describe('which pages a browser connector may reach', () => {
+  const origins = ['https://substack.com', 'https://*.substack.com']
+  const cases: Array<[string, boolean]> = [
+    ['https://substack.com/api/v1/user/profile/self', true],
+    ['https://novumai.substack.com/feed', true],
+    ['https://SUBSTACK.com/sign-in', true],
+    ['https://substack.com.evil.io/', false],
+    ['https://evilsubstack.com/', false],
+    ['http://substack.com/', false],
+    ['https://substack.com:8443/', false],
+    ['not a url', false]
+  ]
+
+  it('takes the named host and every subdomain of a wildcard, and nothing that only looks like them', () => {
+    for (const [url, allowed] of cases)
+      expect([url, withinOrigins(origins, url)]).toEqual([url, allowed])
+    expect(withinOrigins(['https://*.substack.com'], 'https://substack.com/')).toBe(false)
+  })
+
+  it('draws the same line in the app as in the SDK', () => {
+    for (const [url] of cases) {
+      expect([url, sharedWithinOrigins(origins, url)]).toEqual([url, withinOrigins(origins, url)])
+    }
+  })
+})

--- a/tests/connector-session-bridge.test.ts
+++ b/tests/connector-session-bridge.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import type { SdkBrowserSignIn } from '@vornrun/shared/types'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+const bridge = vi.hoisted(() => ({ isConnected: true, request: vi.fn() }))
+vi.mock('../packages/server/src/browser-bridge', () => ({ browserBridge: bridge }))
+
+const {
+  registerSessionBridge,
+  sessionEnvFor,
+  setSessionBridgeOrigin,
+  sessionCallsSince,
+  forgetSessionGrant,
+  stillSignedIn
+} = await import('../packages/server/src/connectors/session-bridge')
+
+const browser: SdkBrowserSignIn = {
+  signInUrl: 'https://substack.com/sign-in',
+  origins: ['https://substack.com', 'https://*.substack.com'],
+  check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name'] }
+}
+
+let app: FastifyInstance
+let token: string
+
+beforeEach(async () => {
+  bridge.isConnected = true
+  bridge.request.mockReset()
+  setSessionBridgeOrigin('http://127.0.0.1:4100')
+  token = sessionEnvFor('c1', browser).VORN_BROWSER_TOKEN!
+  app = Fastify()
+  registerSessionBridge(app)
+  await app.ready()
+})
+
+afterEach(async () => {
+  forgetSessionGrant('c1')
+  await app.close()
+})
+
+const call = (body: unknown, auth = `Bearer ${token}`, id = 'c1') =>
+  app.inject({
+    method: 'POST',
+    url: `/connections/${id}/browser/fetch`,
+    headers: { authorization: auth, 'content-type': 'application/json' },
+    payload: JSON.stringify(body)
+  })
+
+describe('the endpoint a browser connector calls through', () => {
+  it('hands each child its own address and a token of its own', () => {
+    const env = sessionEnvFor('c2', browser)
+    expect(env.VORN_BROWSER_HOST).toBe('http://127.0.0.1:4100/connections/c2/browser')
+    expect(env.VORN_BROWSER_TOKEN).not.toBe(token)
+    forgetSessionGrant('c2')
+  })
+
+  it('runs a call in the window and records what it asked and how it was answered', async () => {
+    bridge.request.mockResolvedValue({ status: 201, headers: {}, body: '{"id":7}' })
+    const since = Date.now()
+    const res = await call({
+      url: 'https://novumai.substack.com/api/v1/drafts',
+      method: 'post',
+      headers: { 'content-type': 'application/json' },
+      body: '{}'
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ status: 201, headers: {}, body: '{"id":7}' })
+    expect(bridge.request).toHaveBeenCalledWith(
+      'session:fetch',
+      {
+        connectionId: 'c1',
+        origins: browser.origins,
+        request: {
+          url: 'https://novumai.substack.com/api/v1/drafts',
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}'
+        }
+      },
+      20_000
+    )
+    expect(sessionCallsSince('c1', since)).toEqual([
+      { method: 'POST', path: '/api/v1/drafts', status: 201 }
+    ])
+  })
+
+  it("refuses a caller without the token, or one holding another connection's", async () => {
+    expect(
+      (await call({ url: 'https://substack.com/', method: 'GET' }, 'Bearer wrong')).statusCode
+    ).toBe(401)
+    expect(
+      (await call({ url: 'https://substack.com/', method: 'GET' }, `Bearer ${token}`, 'c9'))
+        .statusCode
+    ).toBe(401)
+    expect(bridge.request).not.toHaveBeenCalled()
+  })
+
+  it("refuses a page outside the connection's origins, and a method it may not use", async () => {
+    const elsewhere = await call({ url: 'https://evil.io/', method: 'GET' })
+    expect(elsewhere.statusCode).toBe(403)
+    expect(elsewhere.json().error).toMatch(/not on one of this connection's origins/)
+    expect((await call({ url: 'https://substack.com/', method: 'TRACE' })).statusCode).toBe(405)
+    expect(bridge.request).not.toHaveBeenCalled()
+  })
+
+  it('says to open Vorn when no desktop holds the window, and remembers that it could not', async () => {
+    bridge.isConnected = false
+    const since = Date.now()
+    const res = await call({ url: 'https://substack.com/api/v1/user/profile/self', method: 'GET' })
+    expect(res.statusCode).toBe(503)
+    expect(res.json().error).toMatch(/Open Vorn on the desktop/)
+    expect(sessionCallsSince('c1', since)).toEqual([
+      { method: 'GET', path: '/api/v1/user/profile/self', status: 'app-offline' }
+    ])
+  })
+
+  it('asks the desktop whether the window is still signed in, and says nothing when it cannot', async () => {
+    bridge.request.mockResolvedValue({ signedIn: false, identity: null })
+    expect(await stillSignedIn('c1')).toBe(false)
+    expect(bridge.request).toHaveBeenCalledWith(
+      'session:check',
+      { connectionId: 'c1', browser },
+      20_000
+    )
+    bridge.isConnected = false
+    expect(await stillSignedIn('c1')).toBeUndefined()
+  })
+})

--- a/tests/connector-session-bridge.test.ts
+++ b/tests/connector-session-bridge.test.ts
@@ -69,7 +69,7 @@ describe('the endpoint a browser connector calls through', () => {
 
   it('runs a call in the window and records it under the tool call it belongs to', async () => {
     bridge.request.mockResolvedValue({ status: 201, headers: {}, body: '{"id":7}' })
-    const key = openSessionCall(grant)
+    const open = openSessionCall(grant)
     const res = await call(
       {
         url: 'https://novumai.substack.com/api/v1/drafts',
@@ -77,7 +77,7 @@ describe('the endpoint a browser connector calls through', () => {
         headers: { 'content-type': 'application/json' },
         body: '{}'
       },
-      { key }
+      { key: open.key }
     )
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({ status: 201, headers: {}, body: '{"id":7}' })
@@ -95,7 +95,7 @@ describe('the endpoint a browser connector calls through', () => {
       },
       20_000
     )
-    expect(closeSessionCall(grant, key)).toEqual([
+    expect(closeSessionCall(open)).toEqual([
       { method: 'POST', path: '/api/v1/drafts', status: 201 }
     ])
     expect(grant.calls.size).toBe(0)
@@ -107,12 +107,15 @@ describe('the endpoint a browser connector calls through', () => {
       .mockResolvedValueOnce({ status: 401, headers: {}, body: '' })
     const search = openSessionCall(grant)
     const draft = openSessionCall(grant)
-    await call({ url: 'https://substack.com/api/v1/post/search', method: 'GET' }, { key: search })
-    await call({ url: 'https://substack.com/api/v1/drafts', method: 'POST' }, { key: draft })
-    expect(closeSessionCall(grant, search)).toEqual([
+    await call(
+      { url: 'https://substack.com/api/v1/post/search', method: 'GET' },
+      { key: search.key }
+    )
+    await call({ url: 'https://substack.com/api/v1/drafts', method: 'POST' }, { key: draft.key })
+    expect(closeSessionCall(search)).toEqual([
       { method: 'GET', path: '/api/v1/post/search', status: 200 }
     ])
-    expect(closeSessionCall(grant, draft)).toEqual([
+    expect(closeSessionCall(draft)).toEqual([
       { method: 'POST', path: '/api/v1/drafts', status: 401 }
     ])
   })
@@ -143,14 +146,14 @@ describe('the endpoint a browser connector calls through', () => {
 
   it('says to open Vorn when no desktop holds the window, and remembers that it could not', async () => {
     bridge.isConnected = false
-    const key = openSessionCall(grant)
+    const open = openSessionCall(grant)
     const res = await call(
       { url: 'https://substack.com/api/v1/user/profile/self', method: 'GET' },
-      { key }
+      { key: open.key }
     )
     expect(res.statusCode).toBe(503)
     expect(res.body).toMatch(/Open Vorn on the desktop/)
-    expect(closeSessionCall(grant, key)).toEqual([
+    expect(closeSessionCall(open)).toEqual([
       { method: 'GET', path: '/api/v1/user/profile/self', status: 'app-offline' }
     ])
   })

--- a/tests/connector-session-bridge.test.ts
+++ b/tests/connector-session-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import Fastify, { type FastifyInstance } from 'fastify'
-import type { SdkBrowserSignIn } from '@vornrun/shared/types'
+import { SESSION_CALL_HEADER, type SdkBrowserSignIn } from '@vornrun/shared/types'
+import type { SessionGrant } from '../packages/server/src/connectors/session-bridge'
 
 vi.mock('../packages/server/src/logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
@@ -11,10 +12,10 @@ vi.mock('../packages/server/src/browser-bridge', () => ({ browserBridge: bridge 
 
 const {
   registerSessionBridge,
-  sessionEnvFor,
+  mintSessionGrant,
   setSessionBridgeOrigin,
-  sessionCallsSince,
-  forgetSessionGrant,
+  openSessionCall,
+  closeSessionCall,
   stillSignedIn
 } = await import('../packages/server/src/connectors/session-bridge')
 
@@ -25,48 +26,59 @@ const browser: SdkBrowserSignIn = {
 }
 
 let app: FastifyInstance
+let grant: SessionGrant
 let token: string
 
 beforeEach(async () => {
   bridge.isConnected = true
   bridge.request.mockReset()
   setSessionBridgeOrigin('http://127.0.0.1:4100')
-  token = sessionEnvFor('c1', browser).VORN_BROWSER_TOKEN!
+  const minted = mintSessionGrant('c1', browser)
+  grant = minted.grant
+  token = minted.env.VORN_BROWSER_TOKEN!
   app = Fastify()
-  registerSessionBridge(app)
+  registerSessionBridge(app, (id) => (id === 'c1' ? grant : undefined))
   await app.ready()
 })
 
 afterEach(async () => {
-  forgetSessionGrant('c1')
   await app.close()
 })
 
-const call = (body: unknown, auth = `Bearer ${token}`, id = 'c1') =>
+const call = (
+  body: unknown,
+  { auth = `Bearer ${token}`, id = 'c1', key }: { auth?: string; id?: string; key?: string } = {}
+) =>
   app.inject({
     method: 'POST',
     url: `/connections/${id}/browser/fetch`,
-    headers: { authorization: auth, 'content-type': 'application/json' },
+    headers: {
+      authorization: auth,
+      'content-type': 'application/json',
+      ...(key && { [SESSION_CALL_HEADER]: key })
+    },
     payload: JSON.stringify(body)
   })
 
 describe('the endpoint a browser connector calls through', () => {
   it('hands each child its own address and a token of its own', () => {
-    const env = sessionEnvFor('c2', browser)
+    const { env } = mintSessionGrant('c2', browser)
     expect(env.VORN_BROWSER_HOST).toBe('http://127.0.0.1:4100/connections/c2/browser')
     expect(env.VORN_BROWSER_TOKEN).not.toBe(token)
-    forgetSessionGrant('c2')
   })
 
-  it('runs a call in the window and records what it asked and how it was answered', async () => {
+  it('runs a call in the window and records it under the tool call it belongs to', async () => {
     bridge.request.mockResolvedValue({ status: 201, headers: {}, body: '{"id":7}' })
-    const since = Date.now()
-    const res = await call({
-      url: 'https://novumai.substack.com/api/v1/drafts',
-      method: 'post',
-      headers: { 'content-type': 'application/json' },
-      body: '{}'
-    })
+    const key = openSessionCall(grant)
+    const res = await call(
+      {
+        url: 'https://novumai.substack.com/api/v1/drafts',
+        method: 'post',
+        headers: { 'content-type': 'application/json' },
+        body: '{}'
+      },
+      { key }
+    )
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({ status: 201, headers: {}, body: '{"id":7}' })
     expect(bridge.request).toHaveBeenCalledWith(
@@ -83,50 +95,79 @@ describe('the endpoint a browser connector calls through', () => {
       },
       20_000
     )
-    expect(sessionCallsSince('c1', since)).toEqual([
+    expect(closeSessionCall(grant, key)).toEqual([
       { method: 'POST', path: '/api/v1/drafts', status: 201 }
+    ])
+    expect(grant.calls.size).toBe(0)
+  })
+
+  it('keeps two tool calls on one connection apart, however their requests interleave', async () => {
+    bridge.request
+      .mockResolvedValueOnce({ status: 200, headers: {}, body: '[]' })
+      .mockResolvedValueOnce({ status: 401, headers: {}, body: '' })
+    const search = openSessionCall(grant)
+    const draft = openSessionCall(grant)
+    await call({ url: 'https://substack.com/api/v1/post/search', method: 'GET' }, { key: search })
+    await call({ url: 'https://substack.com/api/v1/drafts', method: 'POST' }, { key: draft })
+    expect(closeSessionCall(grant, search)).toEqual([
+      { method: 'GET', path: '/api/v1/post/search', status: 200 }
+    ])
+    expect(closeSessionCall(grant, draft)).toEqual([
+      { method: 'POST', path: '/api/v1/drafts', status: 401 }
     ])
   })
 
+  it('answers a request from no known tool call without keeping it', async () => {
+    bridge.request.mockResolvedValue({ status: 200, headers: {}, body: '' })
+    expect((await call({ url: 'https://substack.com/', method: 'GET' })).statusCode).toBe(200)
+    expect(
+      (await call({ url: 'https://substack.com/', method: 'GET' }, { key: 'finished' })).statusCode
+    ).toBe(200)
+    expect(grant.calls.size).toBe(0)
+  })
+
   it("refuses a caller without the token, or one holding another connection's", async () => {
-    expect(
-      (await call({ url: 'https://substack.com/', method: 'GET' }, 'Bearer wrong')).statusCode
-    ).toBe(401)
-    expect(
-      (await call({ url: 'https://substack.com/', method: 'GET' }, `Bearer ${token}`, 'c9'))
-        .statusCode
-    ).toBe(401)
+    const url = 'https://substack.com/'
+    expect((await call({ url, method: 'GET' }, { auth: 'Bearer wrong' })).statusCode).toBe(401)
+    expect((await call({ url, method: 'GET' }, { id: 'c9' })).statusCode).toBe(401)
     expect(bridge.request).not.toHaveBeenCalled()
   })
 
   it("refuses a page outside the connection's origins, and a method it may not use", async () => {
     const elsewhere = await call({ url: 'https://evil.io/', method: 'GET' })
     expect(elsewhere.statusCode).toBe(403)
-    expect(elsewhere.json().error).toMatch(/not on one of this connection's origins/)
+    expect(elsewhere.body).toMatch(/not on one of this connection's origins/)
     expect((await call({ url: 'https://substack.com/', method: 'TRACE' })).statusCode).toBe(405)
     expect(bridge.request).not.toHaveBeenCalled()
   })
 
   it('says to open Vorn when no desktop holds the window, and remembers that it could not', async () => {
     bridge.isConnected = false
-    const since = Date.now()
-    const res = await call({ url: 'https://substack.com/api/v1/user/profile/self', method: 'GET' })
+    const key = openSessionCall(grant)
+    const res = await call(
+      { url: 'https://substack.com/api/v1/user/profile/self', method: 'GET' },
+      { key }
+    )
     expect(res.statusCode).toBe(503)
-    expect(res.json().error).toMatch(/Open Vorn on the desktop/)
-    expect(sessionCallsSince('c1', since)).toEqual([
+    expect(res.body).toMatch(/Open Vorn on the desktop/)
+    expect(closeSessionCall(grant, key)).toEqual([
       { method: 'GET', path: '/api/v1/user/profile/self', status: 'app-offline' }
     ])
   })
+})
 
-  it('asks the desktop whether the window is still signed in, and says nothing when it cannot', async () => {
+describe('asking whether a window is still signed in', () => {
+  it('asks the desktop once for calls that failed together, and says nothing when it cannot', async () => {
     bridge.request.mockResolvedValue({ signedIn: false, identity: null })
-    expect(await stillSignedIn('c1')).toBe(false)
+    const answers = await Promise.all([stillSignedIn('c1', browser), stillSignedIn('c1', browser)])
+    expect(answers).toEqual([false, false])
+    expect(bridge.request).toHaveBeenCalledTimes(1)
     expect(bridge.request).toHaveBeenCalledWith(
       'session:check',
       { connectionId: 'c1', browser },
       20_000
     )
     bridge.isConnected = false
-    expect(await stillSignedIn('c1')).toBeUndefined()
+    expect(await stillSignedIn('c1', browser)).toBeUndefined()
   })
 })

--- a/tests/connector-spawn-borrow.test.ts
+++ b/tests/connector-spawn-borrow.test.ts
@@ -166,15 +166,29 @@ describe('a connector that signs in through a Vorn window', () => {
     env: []
   }
 
-  it('is handed the address and a token for its own window', async () => {
+  const spawnedEnv = (): Record<string, string> =>
+    (transportInstances.at(-1) as { opts: { env: Record<string, string> } }).opts.env
+
+  it('is handed the address and a token for its own window, kept beside its child', async () => {
     pack.current = BROWSER_PACK
-    const { buildSpawnConfig } = await load()
+    const { getOrStartClient, sessionGrantFor } = await load()
     const { setSessionBridgeOrigin } =
       await import('../packages/server/src/connectors/session-bridge')
     setSessionBridgeOrigin('http://127.0.0.1:4100')
-    const spawn = await buildSpawnConfig(connection({ sdkConnectorId: 'acme' }))
-    expect(spawn.env.VORN_BROWSER_HOST).toBe('http://127.0.0.1:4100/connections/conn-1/browser')
-    expect(spawn.env.VORN_BROWSER_TOKEN).toBeTruthy()
+    await getOrStartClient(connection({ sdkConnectorId: 'acme' }))
+    expect(spawnedEnv().VORN_BROWSER_HOST).toBe('http://127.0.0.1:4100/connections/conn-1/browser')
+    expect(spawnedEnv().VORN_BROWSER_TOKEN).toBe(sessionGrantFor('conn-1')?.token)
+  })
+
+  it('loses its token when its child exits', async () => {
+    pack.current = BROWSER_PACK
+    const { getOrStartClient, sessionGrantFor } = await load()
+    const { setSessionBridgeOrigin } =
+      await import('../packages/server/src/connectors/session-bridge')
+    setSessionBridgeOrigin('http://127.0.0.1:4100')
+    await getOrStartClient(connection({ sdkConnectorId: 'acme' }))
+    ;(transportInstances.at(-1) as { onclose: () => void }).onclose()
+    expect(sessionGrantFor('conn-1')).toBeUndefined()
   })
 
   it('hands a connector that signs in with a key no window at all', async () => {

--- a/tests/connector-spawn-borrow.test.ts
+++ b/tests/connector-spawn-borrow.test.ts
@@ -152,3 +152,36 @@ describe('two callers arriving together', () => {
     expect(transportInstances).toHaveLength(1)
   })
 })
+
+describe('a connector that signs in through a Vorn window', () => {
+  const BROWSER_PACK: { auth: SdkConnectorAuth; env: Array<{ name: string }> } = {
+    auth: {
+      rung: 'browser',
+      browser: {
+        signInUrl: 'https://substack.com/sign-in',
+        origins: ['https://substack.com'],
+        check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name'] }
+      }
+    },
+    env: []
+  }
+
+  it('is handed the address and a token for its own window', async () => {
+    pack.current = BROWSER_PACK
+    const { buildSpawnConfig } = await load()
+    const { setSessionBridgeOrigin } =
+      await import('../packages/server/src/connectors/session-bridge')
+    setSessionBridgeOrigin('http://127.0.0.1:4100')
+    const spawn = await buildSpawnConfig(connection({ sdkConnectorId: 'acme' }))
+    expect(spawn.env.VORN_BROWSER_HOST).toBe('http://127.0.0.1:4100/connections/conn-1/browser')
+    expect(spawn.env.VORN_BROWSER_TOKEN).toBeTruthy()
+  })
+
+  it('hands a connector that signs in with a key no window at all', async () => {
+    pack.current = { auth: { rung: 'key', keys: ['token'] }, env: [] }
+    const { buildSpawnConfig } = await load()
+    const spawn = await buildSpawnConfig(connection({ sdkConnectorId: 'acme' }))
+    expect(spawn.env.VORN_BROWSER_HOST).toBeUndefined()
+    expect(spawn.env.VORN_BROWSER_TOKEN).toBeUndefined()
+  })
+})

--- a/tests/database-connection-sign-in.test.ts
+++ b/tests/database-connection-sign-in.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../packages/server/src/logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return { ...actual, existsSync: vi.fn(() => true), mkdirSync: vi.fn() }
+})
+
+import {
+  initTestDatabase,
+  dbInsertSourceConnection,
+  dbGetSourceConnection,
+  dbSetConnectionSignIn,
+  dbUpdateSourceConnection
+} from '../packages/server/src/database'
+
+let teardown: () => void
+
+beforeEach(() => {
+  teardown = initTestDatabase()
+  dbInsertSourceConnection({
+    id: 'substack',
+    connectorId: 'mcp',
+    name: 'Substack',
+    filters: { sdkConnectorId: 'substack' },
+    syncIntervalMinutes: 5,
+    statusMapping: {},
+    createdAt: '2026-09-10T20:00:00.000Z'
+  })
+})
+
+afterEach(() => {
+  teardown()
+})
+
+describe('who a connection is signed in as', () => {
+  it('is kept once the window signs in, and cleared when it signs out', () => {
+    expect(dbGetSourceConnection('substack')?.signedInAs).toBeUndefined()
+
+    dbSetConnectionSignIn(
+      'substack',
+      'Javier Canizalez (javiercanizalez)',
+      '2026-09-10T20:05:00.000Z'
+    )
+    expect(dbGetSourceConnection('substack')).toMatchObject({
+      signedInAs: 'Javier Canizalez (javiercanizalez)',
+      signedInAt: '2026-09-10T20:05:00.000Z'
+    })
+
+    dbSetConnectionSignIn('substack', null, null)
+    const signedOut = dbGetSourceConnection('substack')
+    expect(signedOut?.signedInAs).toBeUndefined()
+    expect(signedOut?.signedInAt).toBeUndefined()
+  })
+
+  it('survives an edit to the connection, which rewrites its filters whole', () => {
+    dbSetConnectionSignIn('substack', 'Javier Canizalez', '2026-09-10T20:05:00.000Z')
+    dbUpdateSourceConnection('substack', {
+      filters: { sdkConnectorId: 'substack', publication: 'novumai' }
+    })
+    expect(dbGetSourceConnection('substack')?.signedInAs).toBe('Javier Canizalez')
+  })
+})

--- a/tests/database-waiting-gates.test.ts
+++ b/tests/database-waiting-gates.test.ts
@@ -106,3 +106,13 @@ describe('listRunsWithWaitingGates', () => {
     expect(got.triggerTaskId).toBe('trig-1')
   })
 })
+
+describe('a step waiting for a sign-in', () => {
+  it('comes back from storage still saying what it waits for', () => {
+    saveWorkflowRun({
+      ...run('wf-9', 'running', 'waiting'),
+      nodeStates: [{ nodeId: 'draft', status: 'waiting', waitingFor: 'signIn' }]
+    })
+    expect(listRunsWithWaitingGates()[0]?.nodeStates[0]?.waitingFor).toBe('signIn')
+  })
+})

--- a/tests/mcp-backfill.test.ts
+++ b/tests/mcp-backfill.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // spawns a server.
 const callTool = vi.fn()
 vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  sessionGrantFor: () => undefined,
   getOrStartClient: vi.fn(async () => ({ callTool }))
 }))
 

--- a/tests/mcp-connector.test.ts
+++ b/tests/mcp-connector.test.ts
@@ -7,6 +7,7 @@ vi.mock('../packages/server/src/logger', () => ({
 
 const getOrStartClientMock = vi.fn()
 vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  sessionGrantFor: () => undefined,
   getOrStartClient: (...args: unknown[]) => getOrStartClientMock(...args),
   stopClient: vi.fn(),
   stopAllClients: vi.fn(),

--- a/tests/mcp-poll.test.ts
+++ b/tests/mcp-poll.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // returns our canned tool result instead of spawning a real server.
 const callTool = vi.fn()
 vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  sessionGrantFor: () => undefined,
   getOrStartClient: vi.fn(async () => ({ callTool }))
 }))
 

--- a/tests/mcp-preflight.test.ts
+++ b/tests/mcp-preflight.test.ts
@@ -9,6 +9,7 @@ const listTools = vi.fn()
 const callTool = vi.fn()
 
 vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  sessionGrantFor: () => undefined,
   getOrStartClient: vi.fn(async () => ({ listTools, callTool })),
   stopClient: vi.fn(),
   stopAllClients: vi.fn()

--- a/tests/mcp-session-outcome.test.ts
+++ b/tests/mcp-session-outcome.test.ts
@@ -1,21 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SESSION_CALL_META } from '../packages/shared/src/types'
 import type { SdkBrowserSignIn, SessionCall, SourceConnection } from '../src/shared/types'
+import type { SessionGrant } from '../packages/server/src/connectors/session-bridge'
 
 const callTool = vi.fn()
+const grants = vi.hoisted(() => ({ current: undefined as SessionGrant | undefined }))
 vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
-  getOrStartClient: vi.fn(async () => ({ callTool }))
+  getOrStartClient: vi.fn(async () => ({ callTool })),
+  sessionGrantFor: () => grants.current
 }))
 
-const session = vi.hoisted(() => ({
-  browser: undefined as SdkBrowserSignIn | undefined,
-  calls: [] as SessionCall[],
-  signedIn: undefined as boolean | undefined
-}))
-vi.mock('../packages/server/src/connectors/session-bridge', () => ({
-  browserSignInFor: () => session.browser,
-  sessionCallsSince: () => session.calls,
-  stillSignedIn: async () => session.signedIn
-}))
+const bridge = vi.hoisted(() => ({ isConnected: true, request: vi.fn() }))
+vi.mock('../packages/server/src/browser-bridge', () => ({ browserBridge: bridge }))
 
 const signIns = vi.hoisted(() => vi.fn())
 vi.mock('../packages/server/src/database', async (importOriginal) => ({
@@ -42,20 +38,33 @@ const browser: SdkBrowserSignIn = {
   check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name'] }
 }
 
-const failing = () =>
-  callTool.mockResolvedValue({ isError: true, content: [{ type: 'text', text: 'HTTP 401' }] })
+const refused = { isError: true, content: [{ type: 'text', text: 'HTTP 401' }] }
+
+/** The child answering each tool, after making these requests through its window under the call's key. */
+function child(tools: Record<string, { calls: SessionCall[]; answer: object }>): void {
+  callTool.mockImplementation(async (params: { name: string; _meta?: Record<string, unknown> }) => {
+    const { calls, answer } = tools[params.name]!
+    const key = params._meta?.[SESSION_CALL_META]
+    if (typeof key === 'string') grants.current?.calls.get(key)?.push(...calls)
+    return answer
+  })
+}
+
+const signedInThroughWindow = () => {
+  grants.current = { token: 't', browser, calls: new Map() }
+}
 
 beforeEach(() => {
   callTool.mockReset()
   signIns.mockReset()
-  session.browser = undefined
-  session.calls = []
-  session.signedIn = undefined
+  bridge.request.mockReset()
+  bridge.isConnected = true
+  grants.current = undefined
 })
 
 describe('what a failed call of a browser connection says', () => {
   it('leaves an ordinary connection exactly as it was', async () => {
-    failing()
+    child({ createDraft: { calls: [], answer: refused } })
     const result = await invokeMcpTool(conn, 'createDraft', {})
     expect(result).toMatchObject({ success: false, error: 'HTTP 401' })
     expect(result.errorKind).toBeUndefined()
@@ -64,44 +73,79 @@ describe('what a failed call of a browser connection says', () => {
   })
 
   it('says to open Vorn when no desktop held the window', async () => {
-    session.browser = browser
-    session.calls = [{ method: 'POST', path: '/api/v1/drafts', status: 'app-offline' }]
-    failing()
+    signedInThroughWindow()
+    child({
+      createDraft: {
+        calls: [{ method: 'POST', path: '/api/v1/drafts', status: 'app-offline' }],
+        answer: refused
+      }
+    })
     const result = await invokeMcpTool(conn, 'createDraft', {})
     expect(result.errorKind).toBe('app-offline')
     expect(result.error).toMatch(/Open Vorn on the desktop Substack signed in on/)
   })
 
   it('says it needs signing in when the site refused and the window is signed out', async () => {
-    session.browser = browser
-    session.calls = [{ method: 'POST', path: '/api/v1/drafts', status: 401 }]
-    session.signedIn = false
-    failing()
+    signedInThroughWindow()
+    const calls: SessionCall[] = [{ method: 'POST', path: '/api/v1/drafts', status: 401 }]
+    child({ createDraft: { calls, answer: refused } })
+    bridge.request.mockResolvedValue({ signedIn: false, identity: null })
     const result = await invokeMcpTool(conn, 'createDraft', {})
     expect(result.errorKind).toBe('needs-sign-in')
-    expect(result.sessionCalls).toEqual(session.calls)
+    expect(result.sessionCalls).toEqual(calls)
     expect(signIns).toHaveBeenCalledWith('c1', null, null)
   })
 
   it('keeps a refusal a plain error while the window is still signed in', async () => {
-    session.browser = browser
-    session.calls = [{ method: 'DELETE', path: '/api/v1/comment/9', status: 403 }]
-    session.signedIn = true
-    failing()
+    signedInThroughWindow()
+    child({
+      deleteComment: {
+        calls: [{ method: 'DELETE', path: '/api/v1/comment/9', status: 403 }],
+        answer: refused
+      }
+    })
+    bridge.request.mockResolvedValue({ signedIn: true, identity: 'Javier' })
     const result = await invokeMcpTool(conn, 'deleteComment', {})
     expect(result.errorKind).toBeUndefined()
     expect(result.error).toBe('HTTP 401')
     expect(signIns).not.toHaveBeenCalled()
   })
 
-  it('gives a browser call longer to finish, and keeps its calls for the log', async () => {
-    session.browser = browser
-    session.calls = [{ method: 'GET', path: '/api/v1/post/search', status: 200 }]
-    callTool.mockResolvedValue({ isError: false, structuredContent: { posts: [] } })
-    const result = await invokeMcpTool(conn, 'searchPosts', {})
-    expect(result).toMatchObject({ success: true, sessionCalls: session.calls })
-    expect(callTool).toHaveBeenCalledWith({ name: 'searchPosts', arguments: {} }, undefined, {
-      timeout: 120_000
+  it("never blames one step for another step's refusal on the same connection", async () => {
+    signedInThroughWindow()
+    child({
+      createDraft: {
+        calls: [{ method: 'POST', path: '/api/v1/drafts', status: 401 }],
+        answer: refused
+      },
+      searchPosts: {
+        calls: [{ method: 'GET', path: '/api/v1/post/search', status: 200 }],
+        answer: { isError: true, content: [{ type: 'text', text: 'No query given' }] }
+      }
     })
+    bridge.request.mockResolvedValue({ signedIn: false, identity: null })
+    const [draft, search] = await Promise.all([
+      invokeMcpTool(conn, 'createDraft', {}),
+      invokeMcpTool(conn, 'searchPosts', {})
+    ])
+    expect(draft.errorKind).toBe('needs-sign-in')
+    expect(search.errorKind).toBeUndefined()
+    expect(search.sessionCalls).toEqual([
+      { method: 'GET', path: '/api/v1/post/search', status: 200 }
+    ])
+  })
+
+  it('gives a browser call longer to finish, keeps its calls for the log, then lets them go', async () => {
+    signedInThroughWindow()
+    const calls: SessionCall[] = [{ method: 'GET', path: '/api/v1/post/search', status: 200 }]
+    child({ searchPosts: { calls, answer: { isError: false, structuredContent: { posts: [] } } } })
+    const result = await invokeMcpTool(conn, 'searchPosts', {})
+    expect(result).toMatchObject({ success: true, sessionCalls: calls })
+    expect(callTool).toHaveBeenCalledWith(
+      { name: 'searchPosts', arguments: {}, _meta: { [SESSION_CALL_META]: expect.any(String) } },
+      undefined,
+      { timeout: 120_000 }
+    )
+    expect(grants.current?.calls.size).toBe(0)
   })
 })

--- a/tests/mcp-session-outcome.test.ts
+++ b/tests/mcp-session-outcome.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SdkBrowserSignIn, SessionCall, SourceConnection } from '../src/shared/types'
+
+const callTool = vi.fn()
+vi.mock('../packages/server/src/connectors/mcp-clients', () => ({
+  getOrStartClient: vi.fn(async () => ({ callTool }))
+}))
+
+const session = vi.hoisted(() => ({
+  browser: undefined as SdkBrowserSignIn | undefined,
+  calls: [] as SessionCall[],
+  signedIn: undefined as boolean | undefined
+}))
+vi.mock('../packages/server/src/connectors/session-bridge', () => ({
+  browserSignInFor: () => session.browser,
+  sessionCallsSince: () => session.calls,
+  stillSignedIn: async () => session.signedIn
+}))
+
+const signIns = vi.hoisted(() => vi.fn())
+vi.mock('../packages/server/src/database', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  dbSetConnectionSignIn: signIns,
+  dbSignalChange: vi.fn()
+}))
+
+import { invokeMcpTool } from '../packages/server/src/connectors/mcp'
+
+const conn = {
+  id: 'c1',
+  connectorId: 'mcp',
+  name: 'Substack',
+  filters: { command: 'node', args: '[]' },
+  syncIntervalMinutes: 5,
+  statusMapping: {},
+  createdAt: '2026-09-10T20:00:00Z'
+} as SourceConnection
+
+const browser: SdkBrowserSignIn = {
+  signInUrl: 'https://substack.com/sign-in',
+  origins: ['https://substack.com'],
+  check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name'] }
+}
+
+const failing = () =>
+  callTool.mockResolvedValue({ isError: true, content: [{ type: 'text', text: 'HTTP 401' }] })
+
+beforeEach(() => {
+  callTool.mockReset()
+  signIns.mockReset()
+  session.browser = undefined
+  session.calls = []
+  session.signedIn = undefined
+})
+
+describe('what a failed call of a browser connection says', () => {
+  it('leaves an ordinary connection exactly as it was', async () => {
+    failing()
+    const result = await invokeMcpTool(conn, 'createDraft', {})
+    expect(result).toMatchObject({ success: false, error: 'HTTP 401' })
+    expect(result.errorKind).toBeUndefined()
+    expect(result.sessionCalls).toBeUndefined()
+    expect(callTool).toHaveBeenCalledWith({ name: 'createDraft', arguments: {} })
+  })
+
+  it('says to open Vorn when no desktop held the window', async () => {
+    session.browser = browser
+    session.calls = [{ method: 'POST', path: '/api/v1/drafts', status: 'app-offline' }]
+    failing()
+    const result = await invokeMcpTool(conn, 'createDraft', {})
+    expect(result.errorKind).toBe('app-offline')
+    expect(result.error).toMatch(/Open Vorn on the desktop Substack signed in on/)
+  })
+
+  it('says it needs signing in when the site refused and the window is signed out', async () => {
+    session.browser = browser
+    session.calls = [{ method: 'POST', path: '/api/v1/drafts', status: 401 }]
+    session.signedIn = false
+    failing()
+    const result = await invokeMcpTool(conn, 'createDraft', {})
+    expect(result.errorKind).toBe('needs-sign-in')
+    expect(result.sessionCalls).toEqual(session.calls)
+    expect(signIns).toHaveBeenCalledWith('c1', null, null)
+  })
+
+  it('keeps a refusal a plain error while the window is still signed in', async () => {
+    session.browser = browser
+    session.calls = [{ method: 'DELETE', path: '/api/v1/comment/9', status: 403 }]
+    session.signedIn = true
+    failing()
+    const result = await invokeMcpTool(conn, 'deleteComment', {})
+    expect(result.errorKind).toBeUndefined()
+    expect(result.error).toBe('HTTP 401')
+    expect(signIns).not.toHaveBeenCalled()
+  })
+
+  it('gives a browser call longer to finish, and keeps its calls for the log', async () => {
+    session.browser = browser
+    session.calls = [{ method: 'GET', path: '/api/v1/post/search', status: 200 }]
+    callTool.mockResolvedValue({ isError: false, structuredContent: { posts: [] } })
+    const result = await invokeMcpTool(conn, 'searchPosts', {})
+    expect(result).toMatchObject({ success: true, sessionCalls: session.calls })
+    expect(callTool).toHaveBeenCalledWith({ name: 'searchPosts', arguments: {} }, undefined, {
+      timeout: 120_000
+    })
+  })
+})

--- a/tests/mcp-sign-in-wait.test.ts
+++ b/tests/mcp-sign-in-wait.test.ts
@@ -20,6 +20,11 @@ describe('a run waiting for a sign-in, seen by an agent', () => {
     })
   })
 
+  it('can still be rejected, which ends the run rather than skipping the step', () => {
+    expect(resolveGateTarget(run, undefined, 'reject')).toEqual({ nodeId: 'draft' })
+    expect(resolveGateTarget(run, 'draft', 'reject')).toEqual({ nodeId: 'draft' })
+  })
+
   it('says what it waits for', () => {
     const [annotated] = annotateWaitingGates([run], [])
     expect(annotated?.nodeStates[0]).toMatchObject({

--- a/tests/mcp-sign-in-wait.test.ts
+++ b/tests/mcp-sign-in-wait.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import type { WorkflowExecution } from '../src/shared/types'
+import { annotateWaitingGates, resolveGateTarget } from '../packages/mcp/src/tools/workflows'
+
+const run = {
+  runId: 'run-1',
+  workflowId: 'wf-post',
+  startedAt: '2026-09-10T20:00:00Z',
+  status: 'running',
+  nodeStates: [{ nodeId: 'draft', status: 'waiting', waitingFor: 'signIn' }]
+} as WorkflowExecution
+
+describe('a run waiting for a sign-in, seen by an agent', () => {
+  it('is not a gate an agent can answer', () => {
+    expect(resolveGateTarget(run)).toEqual({
+      error: 'this run is waiting for a sign-in in the Vorn app, not for an approval'
+    })
+    expect(resolveGateTarget(run, 'draft')).toEqual({
+      error: 'node "draft" is waiting for a sign-in in the Vorn app, not for an approval'
+    })
+  })
+
+  it('says what it waits for', () => {
+    const [annotated] = annotateWaitingGates([run], [])
+    expect(annotated?.nodeStates[0]).toMatchObject({
+      asks: 'Sign in to its connection in the Vorn app, and this step runs again'
+    })
+  })
+})

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -96,3 +96,34 @@ describe('RunEntry — approval gate controls', () => {
     expect(queryByText('Approve')).toBeNull()
   })
 })
+
+describe('RunEntry — a step waiting for a sign-in', () => {
+  const draftNode = {
+    id: 'draft',
+    type: 'callConnectorAction',
+    label: 'Draft',
+    position: { x: 0, y: 0 },
+    config: { connectionId: 'conn-sub', action: 'createDraft', args: {} }
+  } as unknown as WorkflowNode
+  const signedOut = 'Substack was signed out. Sign in again, and this step runs again.'
+  const exec = makeExec({
+    nodeStates: [{ nodeId: 'draft', status: 'waiting', waitingFor: 'signIn', error: signedOut }]
+  })
+
+  it('offers the sign-in window instead of an approval', () => {
+    const signInConnection = vi.fn()
+    ;(window as unknown as { api: unknown }).api = {
+      resolveWorkflowGate,
+      stopWorkflowRun: vi.fn(),
+      signInConnection
+    }
+    const { getAllByText, getByText, queryByText } = render(
+      <RunEntry execution={exec} nodes={[draftNode]} />
+    )
+    expect(getAllByText(signedOut).length).toBeGreaterThan(0)
+    expect(queryByText('Approve')).toBeNull()
+    fireEvent.click(getByText('Sign in'))
+    expect(signInConnection).toHaveBeenCalledWith('conn-sub')
+    expect(resolveWorkflowGate).not.toHaveBeenCalled()
+  })
+})

--- a/tests/run-entry-approval.test.tsx
+++ b/tests/run-entry-approval.test.tsx
@@ -122,7 +122,7 @@ describe('RunEntry — a step waiting for a sign-in', () => {
     )
     expect(getAllByText(signedOut).length).toBeGreaterThan(0)
     expect(queryByText('Approve')).toBeNull()
-    fireEvent.click(getByText('Sign in'))
+    fireEvent.click(getByText(/^Sign in to/))
     expect(signInConnection).toHaveBeenCalledWith('conn-sub')
     expect(resolveWorkflowGate).not.toHaveBeenCalled()
   })

--- a/tests/run-notifications.test.ts
+++ b/tests/run-notifications.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { WorkflowExecution } from '../src/shared/types'
 
 const sendWorkflowGateNotification = vi.hoisted(() => vi.fn())
-vi.mock('../src/renderer/lib/notifications', () => ({ sendWorkflowGateNotification }))
+const sendWorkflowSignInNotification = vi.hoisted(() => vi.fn())
+vi.mock('../src/renderer/lib/notifications', () => ({
+  sendWorkflowGateNotification,
+  sendWorkflowSignInNotification
+}))
 
 const setEditingWorkflowId = vi.fn()
 const setWorkflowEditorOpen = vi.fn()
@@ -13,7 +17,10 @@ const mockState = {
       {
         id: 'wf-1',
         name: 'Nightly review',
-        nodes: [{ id: 'gate', type: 'approval', label: 'Ship it?', config: { message: 'ok?' } }]
+        nodes: [
+          { id: 'gate', type: 'approval', label: 'Ship it?', config: { message: 'ok?' } },
+          { id: 'draft', type: 'callConnectorAction', label: 'Draft', config: {} }
+        ]
       }
     ]
   },
@@ -49,6 +56,7 @@ const waiting = (): WorkflowExecution =>
 beforeEach(() => {
   resetAnnouncedRuns()
   sendWorkflowGateNotification.mockClear()
+  sendWorkflowSignInNotification.mockClear()
   setEditingWorkflowId.mockClear()
   ;(globalThis as unknown as { Notification: unknown }).Notification = { permission: 'denied' }
 })
@@ -86,6 +94,25 @@ describe('a gate that starts waiting', () => {
     )
 
     expect(sendWorkflowGateNotification).not.toHaveBeenCalled()
+  })
+})
+
+describe('a step that waits for a sign-in', () => {
+  it('asks to sign in, not to approve', () => {
+    const error = 'Substack was signed out. Sign in again, and this step runs again.'
+    announceRun(
+      run({ nodeStates: [{ nodeId: 'draft', status: 'waiting', waitingFor: 'signIn', error }] })
+    )
+
+    expect(sendWorkflowGateNotification).not.toHaveBeenCalled()
+    expect(sendWorkflowSignInNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-1' }),
+      'draft',
+      'Draft',
+      error,
+      mockState.config,
+      expect.any(Function)
+    )
   })
 })
 

--- a/tests/sdk-connector-form-rungs.test.tsx
+++ b/tests/sdk-connector-form-rungs.test.tsx
@@ -260,3 +260,40 @@ describe('a connector that asks for a key', () => {
     expect(probeConnectorAuth).not.toHaveBeenCalled()
   })
 })
+
+describe('a connector that signs in through a Vorn window', () => {
+  const signInConnection = vi.fn()
+
+  beforeEach(() => {
+    signInConnection.mockReset().mockResolvedValue({ ok: true })
+    ;(window as unknown as { api: Record<string, unknown> }).api.signInConnection = signInConnection
+    probeSdkConnector.mockResolvedValue({
+      ok: true,
+      manifest: {
+        ...manifest({
+          rung: 'browser',
+          browser: {
+            signInUrl: 'https://substack.com/sign-in',
+            origins: ['https://substack.com', 'https://*.substack.com'],
+            check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name'] }
+          }
+        }),
+        env: []
+      }
+    })
+  })
+
+  it('says a window will open and which sites the connection acts on', async () => {
+    const { findByText, getByText } = setup()
+    await findByText('Signs in through a Vorn window')
+    expect(getByText(/a window opens on substack\.com/)).toBeInTheDocument()
+    expect(getByText(/acts as you on substack\.com, \*\.substack\.com/)).toBeInTheDocument()
+  })
+
+  it('opens the sign-in window for the connection it just made', async () => {
+    const { findByRole, onDone } = setup()
+    fireEvent.click(await findByRole('button', { name: 'Connect and sign in' }))
+    await waitFor(() => expect(onDone).toHaveBeenCalled())
+    expect(signInConnection).toHaveBeenCalledWith('c1')
+  })
+})

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -455,6 +455,27 @@ describe('how a probed connector says it signs in', () => {
     })
   })
 
+  const browser = {
+    rung: 'browser',
+    browser: {
+      signInUrl: 'https://substack.com/sign-in',
+      origins: ['https://substack.com', 'https://*.substack.com'],
+      check: { url: 'https://substack.com/api/v1/user/profile/self', identity: ['name', 'handle'] }
+    }
+  }
+
+  it('carries a browser sign-in whole, so the app knows where to sign in and what to check', async () => {
+    expect(await probeAuth(browser)).toEqual(browser)
+  })
+
+  it('drops a browser sign-in whose pages sit outside its own origins', async () => {
+    expect(await probeAuth({ rung: 'browser' })).toBeUndefined()
+    const elsewhere = { ...browser.browser, signInUrl: 'https://evil.io/login' }
+    expect(await probeAuth({ ...browser, browser: elsewhere })).toBeUndefined()
+    const plainHttp = { ...browser.browser, origins: ['http://substack.com'] }
+    expect(await probeAuth({ ...browser, browser: plainHttp })).toBeUndefined()
+  })
+
   it('carries what to borrow, since the token is fetched fresh at spawn', async () => {
     const auth = { ...cli, borrow: { env: ['GITLAB_HOST'], tokenArgs: ['auth', 'token'] } }
     expect(await probeAuth(auth)).toEqual(auth)

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -1013,6 +1013,30 @@ describe('a step whose connection signed out', () => {
     expect(execute).toHaveBeenCalledTimes(1)
   })
 
+  it('fails inside a loop, which cannot wait, and says to run the workflow again', async () => {
+    const base = postWorkflow()
+    const loop = {
+      id: 'loop',
+      type: 'loop',
+      label: 'Each draft',
+      position: { x: 0, y: 1 },
+      config: { nodeType: 'loop', bodyNodeIds: ['draft'], maxIterations: 1 }
+    }
+    const workflow = {
+      ...base,
+      id: 'wf-post-loop',
+      nodes: [base.nodes[0], loop, base.nodes[1]],
+      edges: [{ id: 'e1', source: 'trigger', target: 'loop' }]
+    } as unknown as WorkflowDefinition
+    mockState.config.workflows = [workflow]
+    hostApi.executeConnectorAction = vi.fn().mockResolvedValue(signedOut)
+    const run = await executeWorkflow(workflow)
+    expect(stateOf(run, 'draft')).toMatchObject({ status: 'error' })
+    expect(stateOf(run, 'draft')?.waitingFor).toBeUndefined()
+    expect(stateOf(run, 'draft')?.error).toMatch(/inside a loop/)
+    expect(run.status).not.toBe('running')
+  })
+
   it('runs the step again once its connection signs in, and carries on from there', async () => {
     const workflow = postWorkflow()
     mockState.config.workflows = [workflow]

--- a/tests/workflow-run-lifecycle.test.ts
+++ b/tests/workflow-run-lifecycle.test.ts
@@ -121,8 +121,10 @@ vi.mock('../packages/server/src/logger', () => ({
 
 const {
   adoptConnectorInboxLease,
+  applyGateDecision,
   approveWorkflowGate,
   executeWorkflow,
+  resumeSignInWaits,
   reconcileRunningExecutions,
   rejectWorkflowGate,
   stopWorkflowRun
@@ -948,5 +950,87 @@ describe('step diagnostics', () => {
     expect(agent?.status).toBe('error')
     // The timeline survives the throw path, so it still says how far it got.
     expect(agent?.diagnostics).toContain('Could not start: git worktree add failed')
+  })
+})
+
+describe('a step whose connection signed out', () => {
+  function postWorkflow(): WorkflowDefinition {
+    return {
+      id: 'wf-post',
+      name: 'Post to Substack',
+      icon: 'Rocket',
+      enabled: true,
+      nodes: [
+        { id: 'trigger', type: 'trigger', label: 'Trigger', position: { x: 0, y: 0 }, config: {} },
+        {
+          id: 'draft',
+          type: 'callConnectorAction',
+          label: 'Draft',
+          position: { x: 0, y: 1 },
+          config: { connectionId: 'conn-sub', action: 'createDraft', args: {} }
+        },
+        {
+          id: 'tell',
+          type: 'callConnectorAction',
+          label: 'Tell',
+          position: { x: 0, y: 2 },
+          config: { connectionId: 'conn-other', action: 'post', args: {} }
+        }
+      ],
+      edges: [
+        { id: 'e1', source: 'trigger', target: 'draft' },
+        { id: 'e2', source: 'draft', target: 'tell' }
+      ]
+    } as unknown as WorkflowDefinition
+  }
+
+  const signedOut = {
+    success: false,
+    error: 'Substack was signed out. Sign in again, and this step runs again.',
+    errorKind: 'needs-sign-in'
+  }
+  const stateOf = (run: WorkflowExecution, nodeId: string) =>
+    run.nodeStates.find((ns) => ns.nodeId === nodeId)
+
+  it('waits for the sign-in instead of failing, and runs nothing after it', async () => {
+    const workflow = postWorkflow()
+    mockState.config.workflows = [workflow]
+    hostApi.executeConnectorAction = vi.fn().mockResolvedValue(signedOut)
+    const run = await executeWorkflow(workflow)
+    expect(stateOf(run, 'draft')).toMatchObject({ status: 'waiting', waitingFor: 'signIn' })
+    expect(stateOf(run, 'tell')?.status).toBe('pending')
+    expect(run.status).toBe('running')
+  })
+
+  it('cannot be approved past, since only signing in again ends it', async () => {
+    const workflow = postWorkflow()
+    mockState.config.workflows = [workflow]
+    const execute = vi.fn().mockResolvedValue(signedOut)
+    hostApi.executeConnectorAction = execute
+    const run = await executeWorkflow(workflow)
+    await applyGateDecision(run.runId, 'draft', 'approve')
+    expect(stateOf(mockState.workflowExecutions.get(run.runId)!, 'draft')?.status).toBe('waiting')
+    expect(execute).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs the step again once its connection signs in, and carries on from there', async () => {
+    const workflow = postWorkflow()
+    mockState.config.workflows = [workflow]
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(signedOut)
+      .mockResolvedValue({ success: true, output: { id: 7 } })
+    hostApi.executeConnectorAction = execute
+    const run = await executeWorkflow(workflow)
+
+    await resumeSignInWaits('conn-other', [run])
+    expect(execute).toHaveBeenCalledTimes(1)
+
+    await resumeSignInWaits('conn-sub', [run])
+    const finished = mockState.workflowExecutions.get(run.runId)!
+    expect(stateOf(finished, 'draft')?.status).toBe('success')
+    expect(stateOf(finished, 'draft')?.waitingFor).toBeUndefined()
+    expect(stateOf(finished, 'tell')?.status).toBe('success')
+    expect(execute).toHaveBeenCalledTimes(3)
   })
 })


### PR DESCRIPTION
## Summary

Connectors for services with no API can now sign in the way a person does, in a Vorn window, and act as that person from inside it. Substack is the first (vorn-run/connectors, branch `connector/substack`).

- **SDK**: a `browser` auth rung (`signInUrl`, `origins`, and a `check` URL whose answer names who is signed in) and `ctx.session.fetch`. Session errors are never retried. Each tool call's requests carry that call's key, so the server can tell them apart.
- **Sign-in**: Connect opens a visible window on a browser profile kept for that connection alone (plain user agent, no permissions, no downloads). It closes once the connector's check says someone is signed in, and the row shows "Signed in as …" with Sign in again, Sign out and a sign-in-link field. Deleting a connection clears its profile, and leftover profiles are swept at startup.
- **Calls**: a loopback route checks the child's token, the method and the origin list, then runs each call in a hidden page on the call's own origin. No cookie reaches the connector. A failed call says why: Vorn is closed on the desktop that signed in, or the site signed the connection out (confirmed by the check before the row flips).
- **Runs**: a step whose connection was signed out waits as "waiting for sign-in" and sends a notification. Signing in runs it again. Only rejecting ends that wait early, in the app and for an agent. Inside a loop it fails, because a loop cannot wait.

## Testing

- `yarn typecheck` across every project, lint with no errors, full suite: 538 files, 6829 tests.
- A dev build with the Substack connector ran a workflow of all eight actions on the author's own publication: read feed, search, read comments, save and delete a draft, comment, like, unlike and delete the comment. Every step succeeded, the signed-in calls went through the window, and the draft and comment were confirmed gone.
- Reviewed with bug hunts and cleanup passes. They caught and fixed a cold-page race, polls not reporting a sign-out, and an agent being unable to reject a sign-in wait.

## Follow-ups

- vorn-mobile treats every run from `workflowRun:listWaiting` as an approval. It should skip steps whose `waitingFor` is `signIn`.
- The connectors PR waits for the release that publishes this SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE