### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vorn",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "packageManager": "yarn@4.13.0",
   "author": "Javier Canizalez <javier-canizalez@outlook.com>",
   "description": "AI Agent Terminal Manager - Stage Manager for coding agents",

--- a/packages/connector-sdk/package.json
+++ b/packages/connector-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/connector-sdk",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "description": "Build and share Vorn pull connectors as ordinary npm packages",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/desktop",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "private": true,
   "main": "./out/main/index.js",
   "dependencies": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/mcp",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "description": "Vorn MCP server — task management, git, and workflow tools for AI coding agents",
   "type": "module",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/server",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/shared",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vornrun/web",
-  "version": "0.7.0-beta.19",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bump every package to 0.7.0, the first stable release of the 0.7 line.

The release notes below will replace the generated ones on the v0.7.0 release.

---

# Vorn v0.7.0

The first stable release of the 0.7 line, closing a beta that ran from beta.1 through beta.19.

## Highlights

### Sessions that outlive the app
- **Quitting Vorn no longer ends your sessions** — the server runs on its own with a port and a name it keeps, the app adopts it when it opens again, and it leaves by itself once nothing needs it. (#490, #494, #495, #497 by @jcanizalez)
- **A session outlives the window, the server and a crash** — and comes back in the atelier it was in. (#506, #535 by @jcanizalez)
- **An update hands your terminals to the new version instead of ending them** — shells and agents keep running across the update. On Windows the server has to stop first, and Vorn says the sessions will end. (#552, #580, #604 by @jcanizalez)
- **Resuming checks before it acts** — Vorn checks a worktree before resuming into it, tells a reboot from a quit, attaches only the terminals you can see, and can open at sign-in. (#554, #556, #559 by @jcanizalez)

### Workflows
- **A free canvas** — workflows are drawn on a canvas instead of a fixed rail, open at 100% where you left them, and every add button opens a docked step library, folded by connector with your recent picks on top. (#509, #510, #608 by @jcanizalez)
- **Workflows run in the server** — they run with nothing open, and more than once at a time. (#568, #586 by @jcanizalez)
- **Triggers, webhooks and any API** — pick a trigger from the library, receive webhooks, and call any HTTP API from a step. (#513 by @jcanizalez)
- **Templates, and workflows as files** — start from a template that can hand you its fix, and carry a workflow as a file. (#517, #519 by @jcanizalez)
- **A run says what happened** — the last run's data sits at every node, the colour says how a run ended, and All runs shows one line per run over a flat trace. (#512, #578, #608 by @jcanizalez)
- **Steps that wait, fail and resume sensibly** — a gate can be answered from MCP and still runs in the worktree its step made; a step can call its failure survivable; a launch can name its model. (#564, #565, #602, #603 by @jcanizalez)
- **Script steps that hold up** — a script gets its own file, can borrow a key by choice, runs where its agent did, and its request outlives the old thirty-second deadline. (#541, #563, #569 by @jcanizalez)

### Connectors
- **Connectors install as versioned packs that run offline** — from a catalog that shows every connector and offers its steps before it is installed. (#515, #533, #566, #567 by @jcanizalez)
- **Signing in takes the easy way first** — borrow the login the machine already has, sign in through a Vorn window, or keep keys on a page of their own; connectors that need nothing just connect. (#521, #522, #532, #606 by @jcanizalez)
- **Declared, checked and proven** — a connector can be declared instead of written, carries a receipt of the checks that ran, and a pack proves it starts from its own files before it is vouched for. (#530, #531, #558 by @jcanizalez)
- **Connector actions say what they are doing, and where they failed.** (#561 by @jcanizalez)

### Extensions
- **Extensions add to the app** — an extension declares what it contributes, is hosted the way a connector is, shows in the status bar and in a pane beside the terminal, and is listed in a Plugins section with what it adds and asks for. (#571, #573, #575, #583 by @jcanizalez)

### Terminal
- **Snappier, truer output** — a keystroke's echo is sent at once, output travels as bytes, a resize reaches the process once, and a carriage return reads the way a terminal does. (#470, #587, #589, #590, #593 by @jcanizalez)

### Phone
- **Pair a phone by showing it a code** — and the phone asks the server for only what it needs. (#469, #478, #484, #562 by @jcanizalez)

## Under the Hood
- **A `vorn` command on your PATH beside the app.** (#540, #574 by @jcanizalez)
- **Groups hold sessions from any repo or worktree; a task can move to another project, and the socket can write tasks and hand over a workflow.** (#487, #488, #493, #579 by @jcanizalez)
- **The server starts without waiting on the login shell, and hook registration follows the server that outlives it.** (#591, #595 by @jcanizalez)
- **One bad hook payload no longer ends a session, and a session opened after launch counts as one that exists.** (#492, #550 by @jcanizalez)
- **The cookies Vorn keeps on disk are encrypted.** (#605 by @jcanizalez)
- **The connector SDK scaffolds a package the connectors repository accepts, and packs claim the ado and kusto ids.** (#534, #537, #555, #557 by @jcanizalez)
- **A focused session's header acts like the titlebar it replaced; the plugin is handed out instead of a bare mcp add; a claim takes the conversation, not the pane.** (#477, #503, #511 by @jcanizalez)
- **Runs on Electron 44, with type-checked tests and patched dependencies.** (#508, #539, #581, #588 by @jcanizalez)

**Full Changelog**: https://github.com/vorn-run/vorn/compare/v0.6.1...v0.7.0

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXFfahTmd8UPzvvjrByUGE
