### PR TITLE
Let a browser connector's sign-in check and signed-in calls carry the headers a site needs

### DIFF
--- a/packages/connector-sdk/README.md
+++ b/packages/connector-sdk/README.md
@@ -217,6 +217,8 @@ auth: {
 }
 ```
 
+Add `headers` to `check` for a site whose reads need one, such as a CSRF flag. Headers the browser sets itself or that carry who you are, such as `cookie`, `authorization`, `origin` or any `sec-` header, are refused.
+
 Vorn opens a window on a browser profile that belongs to one connection, and the person signs in there. The connector's code then gets `ctx.session.fetch` beside `ctx.fetch`. A call through `ctx.session.fetch` runs inside that signed-in window as a same-origin request, so the service sees its own page asking and no cookie reaches the connector. Calls outside `origins` are refused. `ctx.fetch` stays a plain fetch for public reads, such as a feed, which work before anyone signs in. A `browser` connector's declared `request` actions go through the window.
 
 `--mock` serves signed-in calls from the same routes as every other call. A `--live` run from a terminal has no window, so it skips them.

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -14,7 +14,7 @@ import type {
   ExtensionPlatform,
   PaneContribution
 } from './types'
-import { ORIGIN_PATTERN, withinOrigins } from './origins'
+import { ORIGIN_PATTERN, allowedCheckHeader, withinOrigins } from './origins'
 
 const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 
@@ -225,6 +225,19 @@ function assertBrowserSignIn(id: string, browser: BrowserSignIn | undefined): vo
     identity.some((path) => typeof path !== 'string' || !path.trim())
   ) {
     throw new Error(`Connector ${id} must name its identity fields as non-empty strings`)
+  }
+  const headers: unknown = browser.check?.headers
+  if (headers === undefined) return
+  const entries =
+    headers && typeof headers === 'object' && !Array.isArray(headers) ? Object.entries(headers) : []
+  const badHeader = entries.find(
+    ([name, value]) => typeof value !== 'string' || !allowedCheckHeader(name)
+  )
+  if (entries.length === 0 || badHeader) {
+    throw new Error(
+      `Connector ${id} may add only plain string headers to its signed-in check` +
+        (badHeader ? `; ${JSON.stringify(badHeader[0])} is not one` : '')
+    )
   }
 }
 

--- a/packages/connector-sdk/src/define.ts
+++ b/packages/connector-sdk/src/define.ts
@@ -14,7 +14,8 @@ import type {
   ExtensionPlatform,
   PaneContribution
 } from './types'
-import { ORIGIN_PATTERN, allowedCheckHeader, withinOrigins } from './origins'
+import { ORIGIN_PATTERN, allowedSessionHeader, withinOrigins } from './origins'
+import { isRecord } from './post-receive'
 
 const KEY_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/
 
@@ -228,12 +229,12 @@ function assertBrowserSignIn(id: string, browser: BrowserSignIn | undefined): vo
   }
   const headers: unknown = browser.check?.headers
   if (headers === undefined) return
-  const entries =
-    headers && typeof headers === 'object' && !Array.isArray(headers) ? Object.entries(headers) : []
-  const badHeader = entries.find(
-    ([name, value]) => typeof value !== 'string' || !allowedCheckHeader(name)
-  )
-  if (entries.length === 0 || badHeader) {
+  const badHeader = isRecord(headers)
+    ? Object.entries(headers).find(
+        ([name, value]) => typeof value !== 'string' || !allowedSessionHeader(name)
+      )
+    : undefined
+  if (!isRecord(headers) || badHeader) {
     throw new Error(
       `Connector ${id} may add only plain string headers to its signed-in check` +
         (badHeader ? `; ${JSON.stringify(badHeader[0])} is not one` : '')

--- a/packages/connector-sdk/src/origins.ts
+++ b/packages/connector-sdk/src/origins.ts
@@ -19,12 +19,11 @@ export function withinOrigins(origins: readonly string[], url: string): boolean 
   })
 }
 
-/** Header names a signed-in check may never carry: the browser sets them, or they carry who you are. */
-const FORBIDDEN_CHECK_HEADERS = new Set([
+/** Header names a connector may never send: the browser sets them, or they carry who you are. */
+const FORBIDDEN_SESSION_HEADERS = new Set([
   'cookie',
   'cookie2',
   'authorization',
-  'proxy-authorization',
   'host',
   'origin',
   'referer',
@@ -33,12 +32,12 @@ const FORBIDDEN_CHECK_HEADERS = new Set([
 
 const HEADER_NAME = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/
 
-/** Whether a connector may add this header to its signed-in check. */
-export function allowedCheckHeader(name: string): boolean {
+/** Whether `name` is a header a connector may send inside its signed-in window, on a call or its check. */
+export function allowedSessionHeader(name: string): boolean {
   const lower = name.toLowerCase()
   return (
     HEADER_NAME.test(name) &&
-    !FORBIDDEN_CHECK_HEADERS.has(lower) &&
+    !FORBIDDEN_SESSION_HEADERS.has(lower) &&
     !lower.startsWith('sec-') &&
     !lower.startsWith('proxy-')
   )

--- a/packages/connector-sdk/src/origins.ts
+++ b/packages/connector-sdk/src/origins.ts
@@ -18,3 +18,28 @@ export function withinOrigins(origins: readonly string[], url: string): boolean 
     return wildcard ? target.endsWith(`.${host}`) : target === host
   })
 }
+
+/** Header names a signed-in check may never carry: the browser sets them, or they carry who you are. */
+const FORBIDDEN_CHECK_HEADERS = new Set([
+  'cookie',
+  'cookie2',
+  'authorization',
+  'proxy-authorization',
+  'host',
+  'origin',
+  'referer',
+  'content-length'
+])
+
+const HEADER_NAME = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/
+
+/** Whether a connector may add this header to its signed-in check. */
+export function allowedCheckHeader(name: string): boolean {
+  const lower = name.toLowerCase()
+  return (
+    HEADER_NAME.test(name) &&
+    !FORBIDDEN_CHECK_HEADERS.has(lower) &&
+    !lower.startsWith('sec-') &&
+    !lower.startsWith('proxy-')
+  )
+}

--- a/packages/connector-sdk/src/post-receive.ts
+++ b/packages/connector-sdk/src/post-receive.ts
@@ -14,7 +14,7 @@ import type { PostReceiveOp } from './types'
 /** Keys that would reach through an object into its prototype. */
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 

--- a/packages/connector-sdk/src/types.ts
+++ b/packages/connector-sdk/src/types.ts
@@ -390,7 +390,12 @@ export interface BrowserSignIn {
   /** `https://host` or `https://*.host`; the sign-in page and the check must sit inside them. */
   origins: string[]
   /** Answers 2xx only when signed in; `identity` names the fields of its JSON that say who. */
-  check: { url: string; identity: string[] }
+  check: {
+    url: string
+    identity: string[]
+    /** Sent with the check, for a site whose reads need a header such as a CSRF flag. */
+    headers?: Record<string, string>
+  }
 }
 
 /** The signed-in window, offered to a `browser` connector's code. */

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -14,7 +14,7 @@
  * install. This spawns, asks, and exits.
  */
 import { CONNECTOR_AUTH_RUNGS } from '@vornrun/shared/types'
-import { ORIGIN_PATTERN, checkHeaders, withinOrigins } from '@vornrun/shared/connector-origins'
+import { ORIGIN_PATTERN, sessionHeaders, withinOrigins } from '@vornrun/shared/connector-origins'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type {
@@ -275,11 +275,15 @@ function toBrowserSignIn(value: unknown): SdkBrowserSignIn | undefined {
   const signInUrl = str(value.signInUrl).trim()
   const url = str(value.check.url).trim()
   if (!withinOrigins(origins, signInUrl) || !withinOrigins(origins, url)) return undefined
-  const headers = checkHeaders(value.check.headers)
+  const headers = sessionHeaders(value.check.headers)
   return {
     signInUrl,
     origins,
-    check: { url, identity: strings(value.check.identity), ...(headers && { headers }) }
+    check: {
+      url,
+      identity: strings(value.check.identity),
+      ...(Object.keys(headers).length > 0 && { headers })
+    }
   }
 }
 

--- a/packages/server/src/connectors/sdk-probe.ts
+++ b/packages/server/src/connectors/sdk-probe.ts
@@ -14,7 +14,7 @@
  * install. This spawns, asks, and exits.
  */
 import { CONNECTOR_AUTH_RUNGS } from '@vornrun/shared/types'
-import { ORIGIN_PATTERN, withinOrigins } from '@vornrun/shared/connector-origins'
+import { ORIGIN_PATTERN, checkHeaders, withinOrigins } from '@vornrun/shared/connector-origins'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type {
@@ -275,7 +275,12 @@ function toBrowserSignIn(value: unknown): SdkBrowserSignIn | undefined {
   const signInUrl = str(value.signInUrl).trim()
   const url = str(value.check.url).trim()
   if (!withinOrigins(origins, signInUrl) || !withinOrigins(origins, url)) return undefined
-  return { signInUrl, origins, check: { url, identity: strings(value.check.identity) } }
+  const headers = checkHeaders(value.check.headers)
+  return {
+    signInUrl,
+    origins,
+    check: { url, identity: strings(value.check.identity), ...(headers && { headers }) }
+  }
 }
 
 /**

--- a/packages/shared/src/connector-origins.ts
+++ b/packages/shared/src/connector-origins.ts
@@ -1,4 +1,4 @@
-// Mirrors the connector SDK's origin rule, which the published SDK cannot import from here.
+// Mirrors the connector SDK's origin and header rules, which the published SDK cannot import from here.
 
 /** An origin a connector may act on: `https://host`, or `https://*.host` for every subdomain. */
 export const ORIGIN_PATTERN = /^https:\/\/(\*\.)?[a-z0-9-]+(\.[a-z0-9-]+)+$/i
@@ -26,12 +26,11 @@ export function withinOrigins(origins: readonly string[], url: string): boolean 
   })
 }
 
-/** Header names a signed-in call may never carry: the browser sets them, or they carry who you are. */
-const FORBIDDEN_CHECK_HEADERS = new Set([
+/** Header names a connector may never send: the browser sets them, or they carry who you are. */
+const FORBIDDEN_SESSION_HEADERS = new Set([
   'cookie',
   'cookie2',
   'authorization',
-  'proxy-authorization',
   'host',
   'origin',
   'referer',
@@ -40,23 +39,24 @@ const FORBIDDEN_CHECK_HEADERS = new Set([
 
 const HEADER_NAME = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/
 
-/** Whether a connector may add this header to a signed-in call or its check. */
+/** Whether `name` is a header a connector may send inside its signed-in window, on a call or its check. */
 export function allowedSessionHeader(name: string): boolean {
   const lower = name.toLowerCase()
   return (
     HEADER_NAME.test(name) &&
-    !FORBIDDEN_CHECK_HEADERS.has(lower) &&
+    !FORBIDDEN_SESSION_HEADERS.has(lower) &&
     !lower.startsWith('sec-') &&
     !lower.startsWith('proxy-')
   )
 }
 
-/** The headers a declared check may carry, or nothing when none are left. */
-export function checkHeaders(value: unknown): Record<string, string> | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
-  const kept = Object.entries(value).filter(
-    (entry): entry is [string, string] =>
-      typeof entry[1] === 'string' && allowedSessionHeader(entry[0])
+/** The headers a connector may send inside its signed-in window, and none of the rest. */
+export function sessionHeaders(value: unknown): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === 'string' && allowedSessionHeader(entry[0])
+    )
   )
-  return kept.length > 0 ? Object.fromEntries(kept) : undefined
 }

--- a/packages/shared/src/connector-origins.ts
+++ b/packages/shared/src/connector-origins.ts
@@ -25,3 +25,38 @@ export function withinOrigins(origins: readonly string[], url: string): boolean 
     return wildcard ? target.endsWith(`.${host}`) : target === host
   })
 }
+
+/** Header names a signed-in call may never carry: the browser sets them, or they carry who you are. */
+const FORBIDDEN_CHECK_HEADERS = new Set([
+  'cookie',
+  'cookie2',
+  'authorization',
+  'proxy-authorization',
+  'host',
+  'origin',
+  'referer',
+  'content-length'
+])
+
+const HEADER_NAME = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/
+
+/** Whether a connector may add this header to a signed-in call or its check. */
+export function allowedSessionHeader(name: string): boolean {
+  const lower = name.toLowerCase()
+  return (
+    HEADER_NAME.test(name) &&
+    !FORBIDDEN_CHECK_HEADERS.has(lower) &&
+    !lower.startsWith('sec-') &&
+    !lower.startsWith('proxy-')
+  )
+}
+
+/** The headers a declared check may carry, or nothing when none are left. */
+export function checkHeaders(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const kept = Object.entries(value).filter(
+    (entry): entry is [string, string] =>
+      typeof entry[1] === 'string' && allowedSessionHeader(entry[0])
+  )
+  return kept.length > 0 ? Object.fromEntries(kept) : undefined
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2224,7 +2224,7 @@ export const CONNECTOR_AUTH_RUNGS: readonly ConnectorAuthRung[] = [
 export interface SdkBrowserSignIn {
   signInUrl: string
   origins: string[]
-  check: { url: string; identity: string[] }
+  check: { url: string; identity: string[]; headers?: Record<string, string> }
 }
 
 export interface SdkConnectorAuth {

--- a/src/main/connection-session-script.ts
+++ b/src/main/connection-session-script.ts
@@ -4,16 +4,13 @@
 export const MAX_SESSION_BODY = 4 * 1024 * 1024
 
 import { CONNECTION_PROFILE_PREFIX, type SessionAnswer, type SessionRequest } from '../shared/types'
+import { allowedSessionHeader } from '@vornrun/shared/connector-origins'
 
 export type { SessionAnswer, SessionRequest }
 
-/** The only request headers a call may set; the page supplies the rest itself, cookies included. */
-const ALLOWED_HEADERS = new Set(['accept', 'content-type'])
-
+/** The request headers a call may set; the page supplies the rest itself, cookies included. */
 export function allowedHeaders(headers: Record<string, string> = {}): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(headers).filter(([name]) => ALLOWED_HEADERS.has(name.toLowerCase()))
-  )
+  return Object.fromEntries(Object.entries(headers).filter(([name]) => allowedSessionHeader(name)))
 }
 
 /** The script a runner page executes, built from JSON so nothing a connector sends runs as code. */

--- a/src/main/connection-session-script.ts
+++ b/src/main/connection-session-script.ts
@@ -4,13 +4,13 @@
 export const MAX_SESSION_BODY = 4 * 1024 * 1024
 
 import { CONNECTION_PROFILE_PREFIX, type SessionAnswer, type SessionRequest } from '../shared/types'
-import { allowedSessionHeader } from '@vornrun/shared/connector-origins'
+import { sessionHeaders } from '@vornrun/shared/connector-origins'
 
 export type { SessionAnswer, SessionRequest }
 
 /** The request headers a call may set; the page supplies the rest itself, cookies included. */
 export function allowedHeaders(headers: Record<string, string> = {}): Record<string, string> {
-  return Object.fromEntries(Object.entries(headers).filter(([name]) => allowedSessionHeader(name)))
+  return sessionHeaders(headers)
 }
 
 /** The script a runner page executes, built from JSON so nothing a connector sends runs as code. */

--- a/src/main/connection-sessions.ts
+++ b/src/main/connection-sessions.ts
@@ -144,7 +144,7 @@ export async function checkSession(
   const answer = await fetchInSession(connectionId, browser.origins, {
     url: browser.check.url,
     method: 'GET',
-    headers: { accept: 'application/json' }
+    headers: { accept: 'application/json', ...browser.check.headers }
   })
   const signedIn = answer.status >= 200 && answer.status < 300
   return { signedIn, identity: signedIn ? identityFrom(answer.body, browser.check.identity) : null }

--- a/src/main/connection-sessions.ts
+++ b/src/main/connection-sessions.ts
@@ -141,10 +141,12 @@ export async function checkSession(
   connectionId: string,
   browser: SdkBrowserSignIn
 ): Promise<{ signedIn: boolean; identity: string | null }> {
+  const declared = browser.check.headers ?? {}
+  const hasAccept = Object.keys(declared).some((name) => name.toLowerCase() === 'accept')
   const answer = await fetchInSession(connectionId, browser.origins, {
     url: browser.check.url,
     method: 'GET',
-    headers: { accept: 'application/json', ...browser.check.headers }
+    headers: { ...(!hasAccept && { accept: 'application/json' }), ...declared }
   })
   const signedIn = answer.status >= 200 && answer.status < 300
   return { signedIn, identity: signedIn ? identityFrom(answer.body, browser.check.identity) : null }

--- a/tests/connection-runner.test.ts
+++ b/tests/connection-runner.test.ts
@@ -121,4 +121,18 @@ describe('the check that says whether a connection is signed in', () => {
     expect(script).toContain('"X-CSRF-Protection":"1"')
     expect(script).toContain('"accept":"application/json"')
   })
+
+  it('sends the accept a connector declared instead of its own, in any letter case', async () => {
+    const check = checkSession('c1', {
+      signInUrl: 'https://substack.com/sign-in',
+      origins,
+      check: { url: request.url, identity: ['name'], headers: { Accept: 'text/plain' } }
+    })
+    await vi.waitFor(() => expect(windows).toHaveLength(1))
+    windows[0]!.load()
+    await check
+    const script = windows[0]!.webContents.executeJavaScript.mock.calls[0]![0] as string
+    expect(script).toContain('"Accept":"text/plain"')
+    expect(script).not.toContain('"accept":"application/json"')
+  })
 })

--- a/tests/connection-runner.test.ts
+++ b/tests/connection-runner.test.ts
@@ -56,7 +56,8 @@ vi.mock('electron', () => {
 
 vi.mock('../src/main/logger', () => ({ default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
 
-const { closeConnectionWindows, fetchInSession } = await import('../src/main/connection-sessions')
+const { checkSession, closeConnectionWindows, fetchInSession } =
+  await import('../src/main/connection-sessions')
 
 const origins = ['https://substack.com']
 const request = { url: 'https://substack.com/api/v1/user/profile/self', method: 'GET' }
@@ -103,5 +104,21 @@ describe('the hidden page a signed-in call runs in', () => {
     await slow
     await vi.advanceTimersByTimeAsync(60_000)
     expect(windows[0]!.destroyed).toBe(true)
+  })
+})
+
+describe('the check that says whether a connection is signed in', () => {
+  it('sends the headers the connector declared, beside accept', async () => {
+    const check = checkSession('c1', {
+      signInUrl: 'https://substack.com/sign-in',
+      origins,
+      check: { url: request.url, identity: ['name'], headers: { 'X-CSRF-Protection': '1' } }
+    })
+    await vi.waitFor(() => expect(windows).toHaveLength(1))
+    windows[0]!.load()
+    await expect(check).resolves.toEqual({ signedIn: true, identity: null })
+    const script = windows[0]!.webContents.executeJavaScript.mock.calls[0]![0] as string
+    expect(script).toContain('"X-CSRF-Protection":"1"')
+    expect(script).toContain('"accept":"application/json"')
   })
 })

--- a/tests/connection-session-script.test.ts
+++ b/tests/connection-session-script.test.ts
@@ -24,17 +24,7 @@ describe("the script a connection's hidden page runs", () => {
   })
 
   it('keeps the headers a call may set, such as a CSRF flag, and drops the rest', () => {
-    expect(
-      allowedHeaders({
-        Accept: 'application/json',
-        'X-Csrf': 'b',
-        Cookie: 'a',
-        Authorization: 'x',
-        Origin: 'https://evil.io',
-        'sec-fetch-site': 'cross-site',
-        'bad name': 'c'
-      })
-    ).toEqual({ Accept: 'application/json', 'X-Csrf': 'b' })
+    expect(allowedHeaders({ 'X-Csrf': 'b', Cookie: 'a' })).toEqual({ 'X-Csrf': 'b' })
   })
 })
 

--- a/tests/connection-session-script.test.ts
+++ b/tests/connection-session-script.test.ts
@@ -23,10 +23,18 @@ describe("the script a connection's hidden page runs", () => {
     expect(script).not.toContain('authorization')
   })
 
-  it('keeps only the headers a call may set', () => {
-    expect(allowedHeaders({ Accept: 'application/json', Cookie: 'a', 'X-Csrf': 'b' })).toEqual({
-      Accept: 'application/json'
-    })
+  it('keeps the headers a call may set, such as a CSRF flag, and drops the rest', () => {
+    expect(
+      allowedHeaders({
+        Accept: 'application/json',
+        'X-Csrf': 'b',
+        Cookie: 'a',
+        Authorization: 'x',
+        Origin: 'https://evil.io',
+        'sec-fetch-site': 'cross-site',
+        'bad name': 'c'
+      })
+    ).toEqual({ Accept: 'application/json', 'X-Csrf': 'b' })
   })
 })
 

--- a/tests/connector-sdk-auth.test.ts
+++ b/tests/connector-sdk-auth.test.ts
@@ -124,26 +124,13 @@ describe('a connector that signs in through a Vorn window', () => {
   })
 
   it('refuses a check header the browser sets itself or that says who you are', () => {
-    for (const name of [
-      'Cookie',
-      'authorization',
-      'Origin',
-      'sec-fetch-site',
-      'proxy-connection',
-      'bad name'
-    ]) {
-      const check = { ...browser.check, headers: { [name]: '1' } }
-      expect(() => withAuth({ rung: 'browser', browser: { ...browser, check } })).toThrow(
-        /only plain string headers/
-      )
-    }
+    const cookie = { ...browser.check, headers: { Cookie: '1' } }
+    expect(() => withAuth({ rung: 'browser', browser: { ...browser, check: cookie } })).toThrow(
+      /"Cookie" is not one/
+    )
     const notText = { ...browser.check, headers: { 'X-Count': 2 as unknown as string } }
     expect(() => withAuth({ rung: 'browser', browser: { ...browser, check: notText } })).toThrow(
       /"X-Count" is not one/
-    )
-    const empty = { ...browser.check, headers: {} }
-    expect(() => withAuth({ rung: 'browser', browser: { ...browser, check: empty } })).toThrow(
-      /only plain string headers/
     )
   })
 

--- a/tests/connector-sdk-auth.test.ts
+++ b/tests/connector-sdk-auth.test.ts
@@ -113,6 +113,40 @@ describe('a connector that signs in through a Vorn window', () => {
     ).toThrow(/identity fields/)
   })
 
+  it('carries headers for its check, for a site whose reads need a CSRF header', () => {
+    const check = { ...browser.check, headers: { 'X-CSRF-Protection': '1' } }
+    expect(
+      connectorManifest(withAuth({ rung: 'browser', browser: { ...browser, check } })).auth
+    ).toEqual({
+      rung: 'browser',
+      browser: { ...browser, check }
+    })
+  })
+
+  it('refuses a check header the browser sets itself or that says who you are', () => {
+    for (const name of [
+      'Cookie',
+      'authorization',
+      'Origin',
+      'sec-fetch-site',
+      'proxy-connection',
+      'bad name'
+    ]) {
+      const check = { ...browser.check, headers: { [name]: '1' } }
+      expect(() => withAuth({ rung: 'browser', browser: { ...browser, check } })).toThrow(
+        /only plain string headers/
+      )
+    }
+    const notText = { ...browser.check, headers: { 'X-Count': 2 as unknown as string } }
+    expect(() => withAuth({ rung: 'browser', browser: { ...browser, check: notText } })).toThrow(
+      /"X-Count" is not one/
+    )
+    const empty = { ...browser.check, headers: {} }
+    expect(() => withAuth({ rung: 'browser', browser: { ...browser, check: empty } })).toThrow(
+      /only plain string headers/
+    )
+  })
+
   it('keeps no secret of its own, since the signed-in window is the secret', () => {
     const secret: ConnectorConfigField = { key: 'apiToken', label: 'API token', secret: true }
     expect(() => withAuth({ rung: 'browser', browser }, [secret])).toThrow(

--- a/tests/connector-sdk-session.test.ts
+++ b/tests/connector-sdk-session.test.ts
@@ -6,7 +6,9 @@ import {
   SessionUnavailableError,
   withinOrigins
 } from '../packages/connector-sdk/src/index'
+import { allowedSessionHeader } from '../packages/connector-sdk/src/origins'
 import {
+  allowedSessionHeader as sharedAllowedSessionHeader,
   ORIGIN_PATTERN as SHARED_ORIGIN_PATTERN,
   withinOrigins as sharedWithinOrigins
 } from '../packages/shared/src/connector-origins'
@@ -119,6 +121,29 @@ describe('which pages a browser connector may reach', () => {
     expect(sharedWithinOrigins.toString()).toBe(withinOrigins.toString())
     for (const [url] of cases) {
       expect([url, sharedWithinOrigins(origins, url)]).toEqual([url, withinOrigins(origins, url)])
+    }
+    expect(sharedAllowedSessionHeader.toString()).toBe(allowedSessionHeader.toString())
+    const headers: Array<[string, boolean]> = [
+      ['x-csrf-protection', true],
+      ['accept', true],
+      ['content-type', true],
+      ['X-Custom', true],
+      ['Cookie', false],
+      ['cookie2', false],
+      ['Authorization', false],
+      ['Proxy-Authorization', false],
+      ['Host', false],
+      ['Origin', false],
+      ['Referer', false],
+      ['Content-Length', false],
+      ['Sec-Fetch-Mode', false],
+      ['proxy-connection', false],
+      ['bad name', false],
+      ['', false]
+    ]
+    for (const [name, allowed] of headers) {
+      expect([name, allowedSessionHeader(name)]).toEqual([name, allowed])
+      expect([name, sharedAllowedSessionHeader(name)]).toEqual([name, allowed])
     }
   })
 })

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -476,6 +476,29 @@ describe('how a probed connector says it signs in', () => {
     expect(await probeAuth({ ...browser, browser: plainHttp })).toBeUndefined()
   })
 
+  it('keeps the headers a check declares, and drops any a connector may not set', async () => {
+    const headers = {
+      'X-CSRF-Protection': '1',
+      Cookie: 'sid=1',
+      Authorization: 'Bearer x',
+      'sec-fetch-site': 'same-origin',
+      'Proxy-Connection': 'keep-alive',
+      'bad name': '1',
+      'X-Count': 2
+    }
+    const declared = { ...browser.browser, check: { ...browser.browser.check, headers } }
+    const auth = await probeAuth({ ...browser, browser: declared })
+    expect(auth?.browser?.check.headers).toEqual({ 'X-CSRF-Protection': '1' })
+  })
+
+  it('leaves headers out when none of them may be sent', async () => {
+    const declared = {
+      ...browser.browser,
+      check: { ...browser.browser.check, headers: { Cookie: 'sid=1' } }
+    }
+    expect(await probeAuth({ ...browser, browser: declared })).toEqual(browser)
+  })
+
   it('carries what to borrow, since the token is fetched fresh at spawn', async () => {
     const auth = { ...cli, borrow: { env: ['GITLAB_HOST'], tokenArgs: ['auth', 'token'] } }
     expect(await probeAuth(auth)).toEqual(auth)

--- a/tests/sdk-probe.test.ts
+++ b/tests/sdk-probe.test.ts
@@ -477,15 +477,7 @@ describe('how a probed connector says it signs in', () => {
   })
 
   it('keeps the headers a check declares, and drops any a connector may not set', async () => {
-    const headers = {
-      'X-CSRF-Protection': '1',
-      Cookie: 'sid=1',
-      Authorization: 'Bearer x',
-      'sec-fetch-site': 'same-origin',
-      'Proxy-Connection': 'keep-alive',
-      'bad name': '1',
-      'X-Count': 2
-    }
+    const headers = { 'X-CSRF-Protection': '1', Cookie: 'sid=1' }
     const declared = { ...browser.browser, check: { ...browser.browser.check, headers } }
     const auth = await probeAuth({ ...browser, browser: declared })
     expect(auth?.browser?.check.headers).toEqual({ 'X-CSRF-Protection': '1' })


### PR DESCRIPTION
A browser connector could not sign in to a site whose reads need a request header, such as a CSRF flag. The sign-in check always sent only `accept: application/json`, and the signed-in window forwarded only `accept` and `content-type`, so the header never reached the site and the connection never read as signed in.

## What changes

- `BrowserSignIn.check` takes an optional `headers` map, sent with the sign-in check. A declared `accept` replaces the default one.
- Signed-in calls carry any header the connector sets that passes one allow rule, instead of only `accept` and `content-type`.
- The rule accepts valid header tokens and refuses `cookie`, `cookie2`, `authorization`, `host`, `origin`, `referer`, `content-length`, and anything starting with `sec-` or `proxy-`. It is written once in the SDK and once in shared, and the existing parity test now holds the two copies to the same source and runs one table of names through both.
- The app enforces the rule where every request enters the window, so a manifest that skipped the SDK's checks is still filtered. The SDK refuses a bad header when the connector is defined, and the server's probe keeps only allowed headers.

## Checks

- `yarn typecheck` (tests included) passes.
- 335 tests pass across the connector SDK, SDK, probe and connection suites.
- ESLint and Prettier clean.
- `/review`, `/simplify` and `/security-review` ran on the branch: no issues from review or security review; the simplify findings are applied in the second commit.
